### PR TITLE
Add backspace support to spline creation tool

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,14 +29,6 @@ This file tracks follow-up work, open issues, and design questions that come up 
   - Flat shading fixed the worst artifacts.
   - The final look likely still needs another pass once the modeling flow stabilizes.
 
-### Spline creation backspace support
-- Status: Open
-- Priority: Medium
-- Summary: Spline creation tool does not support backspace for deleting the last added node.
-- Notes:
-  - This functionality already exists in the composite feature tool.
-  - Revisit the spline placement interaction to handle the backspace key by removing the last placed point.
-
 ### Origin placement preview responsiveness
 - Status: Open
 - Priority: Low
@@ -434,6 +426,10 @@ This file tracks follow-up work, open issues, and design questions that come up 
     - consider moving simulation replay/mesh generation off the main thread
 
 ## Done
+
+### Spline creation backspace support
+- Status: Done
+- Summary: Spline creation tool now supports backspace to remove the last placed node, matching the composite feature tool behavior.
 
 ### Ball endmill / V-bit simulation
 - Status: Done

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -2154,6 +2154,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     placePendingTextAt,
     placeOriginAt,
     addPendingPolygonPoint,
+    undoPendingPolygonPoint,
     completePendingPolygon,
     completePendingOpenPath,
     cancelPendingAdd,
@@ -4340,6 +4341,16 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         }
         return
       }
+    }
+
+    if (
+      event.key === 'Backspace'
+      && (pendingAdd?.shape === 'polygon' || pendingAdd?.shape === 'spline')
+      && !event.repeat
+    ) {
+      event.preventDefault()
+      undoPendingPolygonPoint()
+      return
     }
 
     if (

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -243,6 +243,7 @@ export interface ProjectStore {
   placePendingAddAt: (point: Point) => void
   placePendingTextAt: (point: Point) => string[]
   addPendingPolygonPoint: (point: Point) => void
+  undoPendingPolygonPoint: () => void
   completePendingPolygon: () => void
   completePendingOpenPath: () => void
   setPendingCompositeMode: (mode: CompositeSegmentMode) => void
@@ -5869,6 +5870,19 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
           ? { ...s.pendingAdd, points: [...s.pendingAdd.points, point] }
           : s.pendingAdd,
     })),
+
+  undoPendingPolygonPoint: () =>
+    set((s) => {
+      if (!s.pendingAdd || !('points' in s.pendingAdd)) {
+        return {}
+      }
+      return {
+        pendingAdd: {
+          ...s.pendingAdd,
+          points: s.pendingAdd.points.slice(0, -1),
+        },
+      }
+    }),
 
   completePendingPolygon: () => {
     const state = get()


### PR DESCRIPTION
## Changes

- **SketchCanvas.tsx**: Added keyboard event handler for Backspace key to support undoing the last placed point in polygon and spline creation modes
- **projectStore.ts**: Implemented `undoPendingPolygonPoint()` action that removes the last point from the pending polygon/spline
- **TODO.md**: Moved "Spline creation backspace support" from Open to Done section

## Details

The spline creation tool now supports the Backspace key to remove the last placed node, matching the existing behavior in the composite feature tool. This improves the user experience by allowing quick corrections during point placement.