### PR TITLE
Add parallel pocket and surface clean patterns

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -125,6 +125,8 @@ This file tracks follow-up work, open issues, and design questions that come up 
 - Notes:
   - Current finish supports separate wall and floor toggles.
   - Future improvements include smarter floor-finish patterns, better finish ordering, and richer finish linking.
+  - When a preserved island only exists in upper bands, finish-floor cleanup should avoid recutting the already-cleared air around that island at deeper bands.
+  - Desired behavior: only clean the top surface that still exists at that band, instead of tracing stale island keep-out space below it.
 
 ### Configurable arc / chord tolerance for CAM flattening
 - Status: Open

--- a/planning/POCKET_PARALLEL_Implementation_Plan.md
+++ b/planning/POCKET_PARALLEL_Implementation_Plan.md
@@ -1,0 +1,344 @@
+# Pocket Parallel Implementation Plan
+
+Legend:
+- `[ ]` not started
+- `[~]` in progress / partial
+- `[x]` complete
+- `[>]` deferred / moved to backlog
+
+## Goal
+Add a second pocket floor-clearing strategy that uses parallel lines instead of repeated contour offsets.
+
+This should be available as a pattern selection inside the existing `pocket` operation, not as a separate operation kind.
+
+The first target is:
+- rough pocket floor clearing with parallel lines
+- finish pocket floor clearing with parallel lines
+- configurable line angle
+
+Wall finishing should remain contour-based.
+
+## Why This Is Needed
+The current pocket generator is purely offset-contour based:
+- rough pocket repeatedly insets the target region and cuts each contour
+- finish floor also reuses inset contours
+
+That works, but it does not give the user a raster / parallel pocket pattern, which is often preferable for:
+- wood
+- soft materials
+- visible floor finish control
+- directional chip evacuation
+- alignment with grain or part geometry
+
+There is already a similar clipped line-fill idea in `surface_clean`, so this feature should reuse that style of geometry generation where possible.
+
+## Confirmed Product Decisions
+
+### 1. This is a pattern choice on `pocket`, not a new operation
+Pocket remains one operation kind:
+
+```ts
+kind: 'pocket'
+```
+
+Pattern becomes an operation property.
+
+Reason:
+- avoids duplicating pocket UI and validation
+- keeps target/tool/pass behavior identical
+- lets rough/finish use the same operation kind with different floor behavior
+
+### 2. Pattern affects floor clearing only
+The new setting changes how the floor is cleared.
+
+It does **not** change:
+- target resolution
+- depth stepping
+- safe-Z behavior
+- wall finishing contours
+
+Reason:
+- simpler mental model
+- avoids conflating floor finish strategy with wall finish strategy
+
+### 3. Finish walls stay contour-based
+For `pass: 'finish'`:
+- `Finish Walls` continues to mean contour finishing along boundaries
+- `Finish Floor` uses the selected pocket pattern
+
+So if the user selects:
+- `Finish Walls = true`
+- `Finish Floor = true`
+- `Pattern = Parallel`
+
+then the finish op will do:
+- contour wall finishing
+- parallel floor clearing
+
+### 4. Angle is only meaningful for parallel pattern
+`Parallel` uses an angle in degrees.
+`Offset` ignores the angle.
+
+Reason:
+- keep the UI clean
+- avoid fake parameters on contour pockets
+
+### 5. First pass uses one angle for the whole operation
+No cross-hatch or alternating-angle pass in v1.
+
+Reason:
+- much smaller scope
+- enough to validate the geometry and machining behavior
+- cross-hatch can be added later if needed
+
+## Data Model Changes
+
+Add a pocket-specific floor pattern field to `Operation`.
+
+Recommended shape:
+
+```ts
+export type PocketPattern = 'offset' | 'parallel'
+```
+
+```ts
+interface Operation {
+  ...
+  pocketPattern: PocketPattern
+  pocketAngle: number
+}
+```
+
+### Semantics
+- `pocketPattern`
+  - `offset`: current behavior
+  - `parallel`: new clipped line-fill behavior
+- `pocketAngle`
+  - degrees
+  - interpreted in sketch XY space
+  - `0` means fill lines parallel to +X
+  - `90` means fill lines parallel to +Y
+
+### Defaults
+- `pocketPattern: 'offset'`
+- `pocketAngle: 0`
+
+Reason:
+- preserves existing projects/behavior
+- keeps backward compatibility simple
+
+## UI / Workflow
+
+### CAM Properties
+For `kind === 'pocket'`:
+
+- show `Pattern`
+  - `Offset`
+  - `Parallel`
+- when `Pattern === 'parallel'`, show `Angle`
+
+For `pass === 'finish'`:
+- existing `Finish Walls`
+- existing `Finish Floor`
+- these stay unchanged
+
+### Rough Pocket
+Rough pocket with:
+- `Pattern = Offset`
+  - current contour-inset behavior
+- `Pattern = Parallel`
+  - fill each machinable region at each Z with clipped parallel lines
+
+### Finish Pocket
+Finish pocket with:
+- `Finish Walls = true`
+  - contour wall finish
+- `Finish Floor = true`
+  - floor finish using selected pattern
+
+## Geometry Design
+
+### 1. Reuse resolved pocket bands
+Do not invent a second region resolver.
+
+Parallel pocket should use the same resolved pocket band structure the current pocket operation already uses:
+- target region
+- islands
+- band top/bottom
+
+Then build a different floor path pattern on top of those regions.
+
+### 2. Parallel fill is generated in local rotated scan space
+Recommended approach:
+
+1. Rotate region geometry by `-angle`
+2. Generate horizontal scan segments in rotated space
+3. Clip scanlines against:
+   - outer region
+   - minus islands
+4. Rotate resulting segment endpoints back by `+angle`
+
+Reason:
+- keeps segment generation simple
+- reuses the proven `surface_clean` scanline idea
+- avoids special-case line equations for arbitrary angles
+
+### 3. Tool-center region must respect cutter radius
+Parallel fill must run inside the same effective machining region as contour pocketing.
+
+That means:
+- inset outer boundary by tool radius plus radial stock-to-leave
+- expand islands by tool radius plus radial stock-to-leave
+- then clip the parallel lines to that effective region
+
+This should mirror the existing `buildInsetRegions(...)` logic rather than inventing different clearance rules.
+
+### 4. Stepover stays the spacing control
+For parallel pocket:
+- `stepoverDistance = tool.diameter * operation.stepover`
+- neighboring parallel lines are spaced by that distance
+
+This means the existing `Stepover Ratio` field remains meaningful for both patterns.
+
+### 5. Segment ordering should be serpentine
+After clipped line segments are generated:
+- alternate direction between neighboring scan rows when possible
+- process them in scan order
+
+Reason:
+- reduces rapids
+- produces the expected raster pocket feel
+
+This can be done exactly as `surface_clean` currently alternates segment direction.
+
+## Toolpath Behavior
+
+### Rough Parallel Pocket
+For each step level:
+1. build the effective tool-center regions for that band
+2. generate clipped parallel segments
+3. transition between segments using existing safe-Z / short-link logic
+4. retract at the end of the Z level
+
+Short-term note:
+- we can initially use the existing `transitionToCutEntry(...)`
+- if this creates too many cut-links across open air, we can tighten that later specifically for parallel fill
+
+### Finish Parallel Floor
+At final finish depth:
+1. compute finish regions using current finish inset rules
+2. if `Finish Floor` is enabled and `Pattern = Parallel`, generate parallel segments there
+3. if `Finish Walls` is enabled, still cut contour walls
+
+Order recommendation:
+1. finish walls
+2. finish floor
+
+This matches the current finish implementation shape and keeps the change isolated.
+
+## Module / Code Structure
+
+Recommended extraction:
+
+- keep `pocket.ts` as the main pocket generator
+- add focused helpers in the same module first
+
+Suggested helper names:
+
+```ts
+buildPocketParallelSegments(
+  regions: ResolvedPocketRegion[],
+  stepoverDistance: number,
+  angleDeg: number,
+): Point[][]
+```
+
+```ts
+toOpenCutMoves(points: Point[], z: number): ToolpathMove[]
+```
+
+Potential later extraction if it grows:
+- `src/engine/toolpaths/patterns/parallel.ts`
+
+But for first pass, keeping it near pocket generation is better for iteration speed.
+
+## Validation Rules
+
+### Operation validation
+- `pocketPattern` must be one of `offset | parallel`
+- `stepover` must still be `> 0` and `<= 1`
+- `pocketAngle` can be any finite number; normalize to `[0, 180)` for behavior if desired
+
+### Geometry validation
+- if clipped parallel segments are empty for a region, warn but do not fail the whole op
+- if finish floor is enabled but no floor segments survive clipping, surface the warning in CAM
+
+## Expected Limitations in First Pass
+
+### 1. No cross-hatch
+Only one angle.
+
+### 2. No island-optimized linking
+First pass will likely retract more than ideal around fragmented regions.
+
+### 3. No adaptive direction changes per island/region
+Whole operation uses one angle.
+
+### 4. No separate rough-angle / finish-angle
+One angle field only.
+
+## Tracked Implementation Steps
+
+### PP1. Schema + defaults
+- [x] Add `PocketPattern`
+- [x] Add `pocketPattern` to `Operation`
+- [x] Add `pocketAngle` to `Operation`
+- [x] Set defaults in operation creation / migration path
+
+### PP2. CAM UI
+- [x] Add `Pattern` field to pocket properties
+- [x] Add `Angle` field when `Pattern === 'parallel'`
+- [x] Keep finish walls/floor toggles unchanged
+
+### PP3. Parallel segment generation
+- [x] Add rotated scanline helper for arbitrary angle
+- [x] Clip segments to effective tool-center regions
+- [x] Return open line segments in serpentine order
+
+### PP4. Rough pocket integration
+- [x] Use `parallel` floor pattern in rough pocket generation
+- [x] Keep `offset` roughing as current behavior
+
+### PP5. Finish pocket integration
+- [x] Use selected floor pattern for `Finish Floor`
+- [x] Keep wall finishing contour-based
+
+### PP6. Validation + warnings
+- [x] Surface empty-region / empty-floor warnings clearly
+- [x] Confirm bad input angles or spacing fail safely
+
+### PP7. Verification
+- [~] Rough pocket, rectangular region, `Offset`
+- [x] Rough pocket, rectangular region, `Parallel 0°`
+- [x] Rough pocket, rectangular region, `Parallel 45°`
+- [x] Pocket with islands using `Parallel`
+- [ ] Finish pocket with:
+  - [ ] walls only
+  - [ ] floor only
+  - [ ] walls + floor
+
+## Exit Criteria
+This first pass is good enough when:
+- pocket operations can choose `Offset` or `Parallel`
+- `Parallel` produces clipped, non-destructive floor-clearing lines
+- angle is user-controlled
+- finish walls still behave exactly as before
+- finish floor respects the selected pattern
+- existing offset pocket behavior is unchanged when the new pattern is not selected
+
+## Follow-Ups / Backlog
+- [>] Cross-hatch pocket pattern
+- [>] Separate rough-angle and finish-angle
+- [>] Better linking / fewer retracts for fragmented parallel fill
+- [>] Optional climb/conventional pass-direction control
+- [>] Adaptive angle suggestions based on region aspect ratio

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -6,6 +6,7 @@ import { loadBundledToolLibrary, type ToolLibraryEntry } from '../../toolLibrary
 import type {
   OperationKind,
   OperationPass,
+  PocketPattern,
   OperationTarget,
   Project,
   Tool,
@@ -239,6 +240,15 @@ function operationTargetSummary(project: Project, target: OperationTarget): stri
     .filter((name): name is string => Boolean(name))
 
   return names.length > 0 ? names.join(', ') : 'No features'
+}
+
+function pocketPatternLabel(pattern: PocketPattern): string {
+  switch (pattern) {
+    case 'offset':
+      return 'Offset'
+    case 'parallel':
+      return 'Parallel'
+  }
 }
 
 function operationRequiresClosedProfiles(kind: OperationKind): boolean {
@@ -980,6 +990,27 @@ export function CAMPanel({
                         units={project.meta.units}
                         min={0.0001}
                         onCommit={(value) => updateOperation(selectedOperation.id, { maxCarveDepth: value })}
+                      />
+                    </label>
+                  ) : null}
+                  {selectedOperation.kind === 'pocket' ? (
+                    <label className="properties-field">
+                      <span>Pattern</span>
+                      <select
+                        value={selectedOperation.pocketPattern}
+                        onChange={(event) => updateOperation(selectedOperation.id, { pocketPattern: event.target.value as PocketPattern })}
+                      >
+                        <option value="offset">{pocketPatternLabel('offset')}</option>
+                        <option value="parallel">{pocketPatternLabel('parallel')}</option>
+                      </select>
+                    </label>
+                  ) : null}
+                  {selectedOperation.kind === 'pocket' && selectedOperation.pocketPattern === 'parallel' ? (
+                    <label className="properties-field">
+                      <span>Angle</span>
+                      <DraftNumberInput
+                        value={selectedOperation.pocketAngle}
+                        onCommit={(value) => updateOperation(selectedOperation.id, { pocketAngle: value })}
                       />
                     </label>
                   ) : null}

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -993,7 +993,7 @@ export function CAMPanel({
                       />
                     </label>
                   ) : null}
-                  {selectedOperation.kind === 'pocket' ? (
+                  {selectedOperation.kind === 'pocket' || selectedOperation.kind === 'surface_clean' ? (
                     <label className="properties-field">
                       <span>Pattern</span>
                       <select
@@ -1005,7 +1005,7 @@ export function CAMPanel({
                       </select>
                     </label>
                   ) : null}
-                  {selectedOperation.kind === 'pocket' && selectedOperation.pocketPattern === 'parallel' ? (
+                  {(selectedOperation.kind === 'pocket' || selectedOperation.kind === 'surface_clean') && selectedOperation.pocketPattern === 'parallel' ? (
                     <label className="properties-field">
                       <span>Angle</span>
                       <DraftNumberInput

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -3435,7 +3435,23 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     }
   }, [copyCountPromptActive, pendingMove, pendingTransform, selection.mode, selection.selectedFeatureId, selection.selectedFeatureIds.length, zoomWindowActive])
 
-  function canvasCoordinates(event: Pick<MouseEvent<HTMLCanvasElement> | WheelEvent<HTMLCanvasElement>, 'clientX' | 'clientY'>): CanvasPoint {
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) {
+      return
+    }
+
+    function handleNativeWheel(event: globalThis.WheelEvent) {
+      handleWheelEvent(event)
+    }
+
+    canvas.addEventListener('wheel', handleNativeWheel, { passive: false })
+    return () => {
+      canvas.removeEventListener('wheel', handleNativeWheel)
+    }
+  }, [zoomWindowActive])
+
+  function canvasCoordinates(event: Pick<MouseEvent<HTMLCanvasElement> | WheelEvent<HTMLCanvasElement> | globalThis.WheelEvent, 'clientX' | 'clientY'>): CanvasPoint {
     const rect = canvasRef.current!.getBoundingClientRect()
     return { cx: event.clientX - rect.left, cy: event.clientY - rect.top }
   }
@@ -4200,7 +4216,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     }
   }
 
-  function handleWheel(event: WheelEvent<HTMLCanvasElement>) {
+  function handleWheelEvent(event: Pick<globalThis.WheelEvent, 'clientX' | 'clientY' | 'deltaY' | 'preventDefault'>) {
     if (zoomWindowActive) {
       return
     }
@@ -4810,7 +4826,6 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         onMouseDown={handleMouseDown}
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseLeave}
-        onWheel={handleWheel}
         onClick={handleClick}
         onDoubleClick={handleDoubleClick}
         onKeyDown={handleKeyDown}

--- a/src/engine/toolpaths/pocket.ts
+++ b/src/engine/toolpaths/pocket.ts
@@ -351,6 +351,214 @@ export function buildPocketFloorContours(
   return contours
 }
 
+function pointEpsilonEqual(a: Point, b: Point): boolean {
+  return Math.abs(a.x - b.x) <= 1e-9 && Math.abs(a.y - b.y) <= 1e-9
+}
+
+function polygonYBounds(points: Point[]): { minY: number; maxY: number } | null {
+  if (points.length < 3) {
+    return null
+  }
+
+  let minY = Number.POSITIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+  for (const point of points) {
+    minY = Math.min(minY, point.y)
+    maxY = Math.max(maxY, point.y)
+  }
+
+  return Number.isFinite(minY) && Number.isFinite(maxY) ? { minY, maxY } : null
+}
+
+function scanlineIntervals(points: Point[], y: number): Array<[number, number]> {
+  const intersections: number[] = []
+  const closed =
+    points.length > 0 && pointEpsilonEqual(points[0], points[points.length - 1])
+      ? points
+      : [...points, points[0]]
+
+  for (let index = 0; index < closed.length - 1; index += 1) {
+    const a = closed[index]
+    const b = closed[index + 1]
+
+    if (Math.abs(a.y - b.y) <= 1e-9) {
+      continue
+    }
+
+    const intersects =
+      (a.y <= y && b.y > y) ||
+      (b.y <= y && a.y > y)
+
+    if (!intersects) {
+      continue
+    }
+
+    const t = (y - a.y) / (b.y - a.y)
+    intersections.push(a.x + (b.x - a.x) * t)
+  }
+
+  intersections.sort((left, right) => left - right)
+
+  const intervals: Array<[number, number]> = []
+  for (let index = 0; index + 1 < intersections.length; index += 2) {
+    const start = intersections[index]
+    const end = intersections[index + 1]
+    if (end - start > 1e-9) {
+      intervals.push([start, end])
+    }
+  }
+
+  return intervals
+}
+
+function subtractIntervals(
+  baseIntervals: Array<[number, number]>,
+  clipIntervals: Array<[number, number]>,
+): Array<[number, number]> {
+  let remaining = [...baseIntervals]
+
+  for (const [clipStart, clipEnd] of clipIntervals) {
+    const next: Array<[number, number]> = []
+    for (const [start, end] of remaining) {
+      if (clipEnd <= start || clipStart >= end) {
+        next.push([start, end])
+        continue
+      }
+
+      if (clipStart > start) {
+        next.push([start, clipStart])
+      }
+      if (clipEnd < end) {
+        next.push([clipEnd, end])
+      }
+    }
+    remaining = next
+  }
+
+  return remaining.filter(([start, end]) => end - start > 1e-9)
+}
+
+function rotatePoint(point: Point, cosTheta: number, sinTheta: number): Point {
+  return {
+    x: point.x * cosTheta - point.y * sinTheta,
+    y: point.x * sinTheta + point.y * cosTheta,
+  }
+}
+
+function distanceSquared(a: Point, b: Point): number {
+  const dx = a.x - b.x
+  const dy = a.y - b.y
+  return dx * dx + dy * dy
+}
+
+function orderOpenSegmentsGreedy(segments: Point[][], start: Point | null): Point[][] {
+  if (segments.length <= 1 || start === null) {
+    return segments
+  }
+
+  const remaining = segments
+    .filter((segment) => segment.length >= 2)
+    .map((segment) => [...segment])
+  const ordered: Point[][] = []
+  let current = start
+
+  while (remaining.length > 0) {
+    let bestIndex = 0
+    let bestReverse = false
+    let bestDistance = Number.POSITIVE_INFINITY
+
+    for (let index = 0; index < remaining.length; index += 1) {
+      const segment = remaining[index]
+      const first = segment[0]
+      const last = segment[segment.length - 1]
+      const forwardDistance = distanceSquared(current, first)
+      if (forwardDistance < bestDistance) {
+        bestIndex = index
+        bestReverse = false
+        bestDistance = forwardDistance
+      }
+
+      const reverseDistance = distanceSquared(current, last)
+      if (reverseDistance < bestDistance) {
+        bestIndex = index
+        bestReverse = true
+        bestDistance = reverseDistance
+      }
+    }
+
+    const [nextSegment] = remaining.splice(bestIndex, 1)
+    const orderedSegment = bestReverse ? [...nextSegment].reverse() : nextSegment
+    ordered.push(orderedSegment)
+    current = orderedSegment[orderedSegment.length - 1]
+  }
+
+  return ordered
+}
+
+export function buildPocketParallelSegments(
+  regions: ResolvedPocketRegion[],
+  stepoverDistance: number,
+  angleDeg: number,
+): Point[][] {
+  const segments: Point[][] = []
+  const minStepover = 1 / DEFAULT_CLIPPER_SCALE
+  const step = Math.max(stepoverDistance, minStepover)
+  const angleRad = (angleDeg * Math.PI) / 180
+  const cosForward = Math.cos(angleRad)
+  const sinForward = Math.sin(angleRad)
+  const cosInverse = Math.cos(-angleRad)
+  const sinInverse = Math.sin(-angleRad)
+
+  regions.forEach((region, regionIndex) => {
+    const rotatedOuter = region.outer.map((point) => rotatePoint(point, cosInverse, sinInverse))
+    const rotatedIslands = region.islands.map((island) => island.map((point) => rotatePoint(point, cosInverse, sinInverse)))
+    const bounds = polygonYBounds(rotatedOuter)
+    if (!bounds) {
+      return
+    }
+
+    let scanIndex = 0
+    for (let y = bounds.minY + step / 2; y < bounds.maxY - step / 2 + 1e-9; y += step) {
+      const outerIntervals = scanlineIntervals(rotatedOuter, y)
+      if (outerIntervals.length === 0) {
+        scanIndex += 1
+        continue
+      }
+
+      const islandIntervals = rotatedIslands.flatMap((island) => scanlineIntervals(island, y))
+      const fillIntervals = subtractIntervals(outerIntervals, islandIntervals)
+
+      for (const [startX, endX] of fillIntervals) {
+        const left = rotatePoint({ x: startX, y }, cosForward, sinForward)
+        const right = rotatePoint({ x: endX, y }, cosForward, sinForward)
+        const reverse = (regionIndex + scanIndex) % 2 === 1
+        segments.push(reverse ? [right, left] : [left, right])
+      }
+
+      scanIndex += 1
+    }
+  })
+
+  return segments
+}
+
+export function toOpenCutMoves(points: Point[], z: number): ToolpathMove[] {
+  if (points.length < 2) {
+    return []
+  }
+
+  const moves: ToolpathMove[] = []
+  for (let index = 0; index < points.length - 1; index += 1) {
+    moves.push({
+      kind: 'cut',
+      from: { x: points[index].x, y: points[index].y, z },
+      to: { x: points[index + 1].x, y: points[index + 1].y, z },
+    })
+  }
+
+  return moves
+}
+
 function generateRoughBandMoves(
   band: ResolvedPocketBand,
   operation: Operation,
@@ -377,6 +585,54 @@ function generateRoughBandMoves(
   const minStepover = 1 / DEFAULT_CLIPPER_SCALE
   const effectiveStepover = Math.max(stepoverDistance, minStepover)
   let currentPosition: ToolpathPoint | null = null
+
+  if (operation.kind === 'pocket' && operation.pocketPattern === 'parallel') {
+    const roughRegions = band.regions.flatMap((region) => buildInsetRegions(region, initialInset))
+    if (roughRegions.length === 0) {
+      return {
+        moves,
+        stepLevels,
+        warnings: [`No machinable parallel floor region for band ${band.topZ} -> ${band.bottomZ}`],
+      }
+    }
+
+    const boundaryContours = buildContourLoops(roughRegions)
+    const segments = buildPocketParallelSegments(roughRegions, effectiveStepover, operation.pocketAngle)
+    if (segments.length === 0) {
+      return {
+        moves,
+        stepLevels,
+        warnings: [`No machinable parallel floor segments for band ${band.topZ} -> ${band.bottomZ}`],
+      }
+    }
+
+    for (const z of stepLevels) {
+      for (const contour of boundaryContours) {
+        const entryPoint = contourStartPoint(contour, z)
+        currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
+        const cutMoves = toClosedCutMoves(contour, z)
+        moves.push(...cutMoves)
+        currentPosition = cutMoves.at(-1)?.to ?? currentPosition
+      }
+
+      const orderedSegments = orderOpenSegmentsGreedy(
+        segments,
+        currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
+      )
+
+      for (const segment of orderedSegments) {
+        const entryPoint = contourStartPoint(segment, z)
+        currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
+        const cutMoves = toOpenCutMoves(segment, z)
+        moves.push(...cutMoves)
+        currentPosition = cutMoves.at(-1)?.to ?? currentPosition
+      }
+
+      currentPosition = retractToSafe(moves, currentPosition, safeZ)
+    }
+
+    return { moves, stepLevels, warnings }
+  }
 
   for (const z of stepLevels) {
     let currentRegions = band.regions.flatMap((region) => buildInsetRegions(region, initialInset))
@@ -436,10 +692,13 @@ function generateFinishBandMoves(
   const finishDelta = toolRadius + radialLeave
   const finishRegions = band.regions.flatMap((region) => buildInsetRegions(region, finishDelta))
   const wallContours = operation.finishWalls ? buildContourLoops(finishRegions) : []
-  const floorContours = operation.finishFloor
+  const floorContours = operation.finishFloor && !(operation.kind === 'pocket' && operation.pocketPattern === 'parallel')
     ? buildPocketFloorContours(finishRegions, 0, stepoverDistance)
     : []
-  if (wallContours.length === 0 && floorContours.length === 0) {
+  const floorSegments = operation.finishFloor && operation.kind === 'pocket' && operation.pocketPattern === 'parallel'
+    ? buildPocketParallelSegments(finishRegions, stepoverDistance, operation.pocketAngle)
+    : []
+  if (wallContours.length === 0 && floorContours.length === 0 && floorSegments.length === 0) {
     return {
       moves,
       stepLevels: [],
@@ -468,6 +727,19 @@ function generateFinishBandMoves(
       const entryPoint = contourStartPoint(contour, z)
       currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
       const cutMoves = toClosedCutMoves(contour, z)
+      moves.push(...cutMoves)
+      currentPosition = cutMoves.at(-1)?.to ?? currentPosition
+    }
+
+    const orderedFloorSegments = orderOpenSegmentsGreedy(
+      floorSegments,
+      currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
+    )
+
+    for (const segment of orderedFloorSegments) {
+      const entryPoint = contourStartPoint(segment, z)
+      currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
+      const cutMoves = toOpenCutMoves(segment, z)
       moves.push(...cutMoves)
       currentPosition = cutMoves.at(-1)?.to ?? currentPosition
     }

--- a/src/engine/toolpaths/surface.ts
+++ b/src/engine/toolpaths/surface.ts
@@ -1,5 +1,5 @@
 import ClipperLib from 'clipper-lib'
-import type { Operation, Point, Project, SketchFeature } from '../../types/project'
+import type { Operation, Project, SketchFeature } from '../../types/project'
 import type {
   ClipperPath,
   PocketToolpathResult,
@@ -22,6 +22,8 @@ import {
 import {
   buildContourLoops,
   buildInsetRegions,
+  buildPocketFloorContours,
+  buildPocketParallelSegments,
   contourStartPoint,
   generateStepLevels,
   polyTreeToRegions,
@@ -29,6 +31,7 @@ import {
   resolveBandBottomZ,
   transitionToCutEntry,
   toClosedCutMoves,
+  toOpenCutMoves,
   updateBounds,
 } from './pocket'
 import { expandFeatureGeometry, featureHasClosedGeometry } from '../../text'
@@ -120,146 +123,6 @@ function buildSurfaceCoverageRegions(
 
   return polyTreeToRegions(polyTree, targetFeatureIds, islandFeatureIds, scale)
     .filter((region) => region.outer.length >= 3)
-}
-
-function pointEpsilonEqual(a: Point, b: Point): boolean {
-  return Math.abs(a.x - b.x) <= 1e-9 && Math.abs(a.y - b.y) <= 1e-9
-}
-
-function polygonYBounds(points: Point[]): { minY: number; maxY: number } | null {
-  if (points.length < 3) {
-    return null
-  }
-
-  let minY = Number.POSITIVE_INFINITY
-  let maxY = Number.NEGATIVE_INFINITY
-  for (const point of points) {
-    minY = Math.min(minY, point.y)
-    maxY = Math.max(maxY, point.y)
-  }
-
-  return Number.isFinite(minY) && Number.isFinite(maxY) ? { minY, maxY } : null
-}
-
-function scanlineIntervals(points: Point[], y: number): Array<[number, number]> {
-  const intersections: number[] = []
-  const closed =
-    points.length > 0 && pointEpsilonEqual(points[0], points[points.length - 1])
-      ? points
-      : [...points, points[0]]
-
-  for (let index = 0; index < closed.length - 1; index += 1) {
-    const a = closed[index]
-    const b = closed[index + 1]
-
-    if (Math.abs(a.y - b.y) <= 1e-9) {
-      continue
-    }
-
-    const intersects =
-      (a.y <= y && b.y > y) ||
-      (b.y <= y && a.y > y)
-
-    if (!intersects) {
-      continue
-    }
-
-    const t = (y - a.y) / (b.y - a.y)
-    intersections.push(a.x + (b.x - a.x) * t)
-  }
-
-  intersections.sort((left, right) => left - right)
-
-  const intervals: Array<[number, number]> = []
-  for (let index = 0; index + 1 < intersections.length; index += 2) {
-    const start = intersections[index]
-    const end = intersections[index + 1]
-    if (end - start > 1e-9) {
-      intervals.push([start, end])
-    }
-  }
-
-  return intervals
-}
-
-function subtractIntervals(
-  baseIntervals: Array<[number, number]>,
-  clipIntervals: Array<[number, number]>,
-): Array<[number, number]> {
-  let remaining = [...baseIntervals]
-
-  for (const [clipStart, clipEnd] of clipIntervals) {
-    const next: Array<[number, number]> = []
-    for (const [start, end] of remaining) {
-      if (clipEnd <= start || clipStart >= end) {
-        next.push([start, end])
-        continue
-      }
-
-      if (clipStart > start) {
-        next.push([start, clipStart])
-      }
-      if (clipEnd < end) {
-        next.push([clipEnd, end])
-      }
-    }
-    remaining = next
-  }
-
-  return remaining.filter(([start, end]) => end - start > 1e-9)
-}
-
-function buildSurfaceFloorSegments(regions: ResolvedPocketBand['regions'], stepoverDistance: number): Point[][] {
-  const segments: Point[][] = []
-  const minStepover = 1 / DEFAULT_CLIPPER_SCALE
-  const step = Math.max(stepoverDistance, minStepover)
-
-  regions.forEach((region, regionIndex) => {
-    const bounds = polygonYBounds(region.outer)
-    if (!bounds) {
-      return
-    }
-
-    let scanIndex = 0
-    for (let y = bounds.minY + step / 2; y < bounds.maxY - step / 2 + 1e-9; y += step) {
-      const outerIntervals = scanlineIntervals(region.outer, y)
-      if (outerIntervals.length === 0) {
-        scanIndex += 1
-        continue
-      }
-
-      const islandIntervals = region.islands.flatMap((island) => scanlineIntervals(island, y))
-      const fillIntervals = subtractIntervals(outerIntervals, islandIntervals)
-
-      for (const [startX, endX] of fillIntervals) {
-        const left: Point = { x: startX, y }
-        const right: Point = { x: endX, y }
-        const reverse = (regionIndex + scanIndex) % 2 === 1
-        segments.push(reverse ? [right, left] : [left, right])
-      }
-
-      scanIndex += 1
-    }
-  })
-
-  return segments
-}
-
-function toOpenCutMoves(points: Point[], z: number): ToolpathMove[] {
-  if (points.length < 2) {
-    return []
-  }
-
-  const moves: ToolpathMove[] = []
-  for (let index = 0; index < points.length - 1; index += 1) {
-    moves.push({
-      kind: 'cut',
-      from: { x: points[index].x, y: points[index].y, z },
-      to: { x: points[index + 1].x, y: points[index + 1].y, z },
-    })
-  }
-
-  return moves
 }
 
 function resolveSurfaceCleanRegions(project: Project, operation: Operation): SurfaceCleanResult {
@@ -406,6 +269,49 @@ function generateRoughBandMoves(
   const effectiveStepover = Math.max(stepoverDistance, minStepover)
   let currentPosition: ToolpathPoint | null = null
 
+  if (operation.pocketPattern === 'parallel') {
+    const roughRegions = coverageRegions.flatMap((region) => buildInsetRegions(region, initialInset))
+    if (roughRegions.length === 0) {
+      return {
+        moves,
+        stepLevels,
+        warnings: [`No machinable parallel cleanup region for band ${band.topZ} -> ${band.bottomZ}`],
+      }
+    }
+
+    const boundaryContours = buildContourLoops(roughRegions)
+    const segments = buildPocketParallelSegments(roughRegions, effectiveStepover, operation.pocketAngle)
+    if (segments.length === 0) {
+      return {
+        moves,
+        stepLevels,
+        warnings: [`No machinable parallel cleanup segments for band ${band.topZ} -> ${band.bottomZ}`],
+      }
+    }
+
+    for (const z of stepLevels) {
+      for (const contour of boundaryContours) {
+        const entryPoint = contourStartPoint(contour, z)
+        currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
+        const cutMoves = toClosedCutMoves(contour, z)
+        moves.push(...cutMoves)
+        currentPosition = cutMoves.at(-1)?.to ?? currentPosition
+      }
+
+      for (const segment of segments) {
+        const entryPoint = contourStartPoint(segment, z)
+        currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
+        const cutMoves = toOpenCutMoves(segment, z)
+        moves.push(...cutMoves)
+        currentPosition = cutMoves.at(-1)?.to ?? currentPosition
+      }
+
+      currentPosition = retractToSafe(moves, currentPosition, safeZ)
+    }
+
+    return { moves, stepLevels, warnings }
+  }
+
   for (const z of stepLevels) {
     let currentRegions = coverageRegions.flatMap((region) => buildInsetRegions(region, initialInset))
     while (currentRegions.length > 0) {
@@ -465,10 +371,13 @@ function generateFinishBandMoves(
   const finishDelta = radialLeave
   const finishRegions = coverageRegions.flatMap((region) => buildInsetRegions(region, finishDelta))
   const wallContours = operation.finishWalls ? buildContourLoops(finishRegions) : []
-  const floorSegments = operation.finishFloor
-    ? buildSurfaceFloorSegments(finishRegions, stepoverDistance)
+  const floorContours = operation.finishFloor && operation.pocketPattern === 'offset'
+    ? buildPocketFloorContours(finishRegions, 0, stepoverDistance)
     : []
-  if (wallContours.length === 0 && floorSegments.length === 0) {
+  const floorSegments = operation.finishFloor && operation.pocketPattern === 'parallel'
+    ? buildPocketParallelSegments(finishRegions, stepoverDistance, operation.pocketAngle)
+    : []
+  if (wallContours.length === 0 && floorContours.length === 0 && floorSegments.length === 0) {
     return {
       moves,
       stepLevels: [],
@@ -493,6 +402,14 @@ function generateFinishBandMoves(
   }
 
   for (const z of floorStepLevels) {
+    for (const contour of floorContours) {
+      const entryPoint = contourStartPoint(contour, z)
+      currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
+      const cutMoves = toClosedCutMoves(contour, z)
+      moves.push(...cutMoves)
+      currentPosition = cutMoves.at(-1)?.to ?? currentPosition
+    }
+
     for (const segment of floorSegments) {
       const entryPoint = contourStartPoint(segment, z)
       currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -2165,6 +2165,8 @@ function defaultOperationForTarget(
     feed: tool.defaultFeed,
     plungeFeed: tool.defaultPlungeFeed,
     rpm: tool.defaultRpm,
+    pocketPattern: 'offset',
+    pocketAngle: 0,
     stockToLeaveRadial: 0,
     stockToLeaveAxial: 0,
     finishWalls: true,

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -215,6 +215,7 @@ export type OperationKind =
   | 'follow_line'
 
 export type OperationPass = 'rough' | 'finish'
+export type PocketPattern = 'offset' | 'parallel'
 
 export type OperationTarget =
   | { source: 'features'; featureIds: string[] }
@@ -234,6 +235,8 @@ export interface Operation {
   feed: number
   plungeFeed: number
   rpm: number
+  pocketPattern: PocketPattern
+  pocketAngle: number
   stockToLeaveRadial: number
   stockToLeaveAxial: number
   finishWalls: boolean

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,29 @@
-import { defineConfig } from 'vite'
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig, searchForWorkspaceRoot } from 'vite'
 import react from '@vitejs/plugin-react'
+
+const configDir = dirname(fileURLToPath(import.meta.url))
+const candidateSharedRoots = [
+  resolve(configDir, '..'),
+  resolve(configDir, '../..'),
+  resolve(configDir, '../../..'),
+]
+
+const sharedProjectRoot = candidateSharedRoots.find((candidate) => (
+  existsSync(resolve(candidate, 'package.json')) && existsSync(resolve(candidate, 'node_modules'))
+)) ?? configDir
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    fs: {
+      allow: [
+        searchForWorkspaceRoot(configDir),
+        sharedProjectRoot,
+      ],
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add a first-pass Parallel pattern option to pocket operations with configurable angle
- apply the same pattern model to surface clean operations so both Pocket and Surface Clean can use Offset or Parallel
- keep finish walls contour-based while letting finish-floor cleanup follow the selected pattern
- improve parallel path quality with boundary cleanup contours and greedy open-segment ordering to reduce long moves
- fix nested worktree dev runtime issues by allowing shared parent node_modules access in Vite, restoring Manifold WASM loading and proper 3D boolean preview
- move sketch wheel zoom off the passive React wheel path to remove repeated console errors
- add a backlog note for pocket finish behavior around upper-band islands that should only get top-surface cleanup

## Verification
- npm run build passed in the pocket-parallel worktree

## Notes
- this is a first pass of parallel floor-clearing patterns
- the new pattern support is intentionally scoped to floor clearing; wall cleanup remains a finish concern
- the worktree Vite fix is included because it was required to make 3D preview behave correctly when running from nested worktrees