### PR TITLE
Optimize pocket path ordering and direction previews

### DIFF
--- a/planning/POCKET_RECURSIVE_Optimization_Plan.md
+++ b/planning/POCKET_RECURSIVE_Optimization_Plan.md
@@ -1,0 +1,112 @@
+# Pocket Recursive Optimization Plan
+
+Legend:
+- `[ ]` not started
+- `[~]` in progress / partial
+- `[x]` complete
+- `[>]` deferred / moved to backlog
+
+## Goal
+Reduce unnecessary travel in offset-style pocket toolpaths when the pocket contains islands or splits into multiple offset branches.
+
+The current offset pocket generator is breadth-first:
+- cut every contour from the current inset level
+- then compute the next inset level
+- then cut every contour from that next level
+
+That works, but it creates long cross-pocket links when one inset level contains several independent branches.
+
+## Problem
+For complex pockets:
+- offsetting one level often returns multiple independent regions
+- the current generator walks all same-depth contours before descending into any branch
+- this makes the tool bounce between branches instead of finishing one local cavity before moving away
+
+The problem is mostly ordering, not geometry.
+
+## Product Decision
+Keep the existing offset geometry and cutter-clearance rules.
+
+This pass changes only:
+- contour ordering
+- branch traversal order
+- closed-loop entry point selection
+
+It does **not** change:
+- region resolver behavior
+- stepover math
+- wall vs floor semantics
+- safe-Z rules
+- parallel pattern generation
+
+## Proposed Strategy
+
+### 1. Use branch-first recursion for offset regions
+When an inset region produces child inset regions, descend each child immediately instead of flattening all children from the same depth into one global list.
+
+Conceptually:
+
+```ts
+cut(region)
+for child in orderedChildren(region):
+  cut(child)
+```
+
+This gives the desired behavior:
+- if a region keeps collapsing as one branch, follow it inward
+- if it splits, finish one branch locally, then move to the next sibling
+
+### 2. Order sibling branches greedily from the current tool position
+When a region splits into multiple children:
+- pick the next child whose outer contour is closest to the current XY position
+
+This is local greedy ordering, not a global TSP solve.
+
+Reason:
+- cheap
+- deterministic
+- enough to reduce the most obvious long moves
+
+### 3. Re-index closed contours to the nearest entry point
+For each closed contour:
+- find the nearest existing contour vertex to the current XY position
+- rotate the point list so cutting starts there
+
+This keeps the contour geometry unchanged while reducing unnecessary link distance caused by arbitrary contour start indices.
+
+### 4. Keep global reconnecting out of scope for v1
+The user suggested a second pass to reconnect the generated branches more efficiently.
+
+That is reasonable, but the first pass should stop at:
+- branch-first recursion
+- greedy sibling selection
+- nearest-start closed contour rotation
+
+If the result is still too jumpy, a later pass can build a higher-level reconnect graph over branch endpoints.
+
+## Implementation Plan
+
+### Phase 1: Pocket offset ordering [~]
+- [x] Identify the breadth-first hotspot in `src/engine/toolpaths/pocket.ts`
+- [ ] Add contour-distance / region-distance helpers
+- [ ] Add nearest-start closed contour rotation
+- [ ] Replace breadth-first offset traversal with recursive region descent
+- [ ] Keep parallel pocket logic unchanged
+
+### Phase 2: Finish floor ordering [ ]
+- [ ] Apply the same recursive ordering to offset-style finish floor contours
+
+### Phase 3: Validation [ ]
+- [ ] Build the app
+- [ ] Test simple rectangle pocket
+- [ ] Test pocket with islands
+- [ ] Test pocket that splits into multiple branches
+- [ ] Confirm no regressions in parallel pocket pattern
+
+## Expected Outcome
+Compared with the current offset generator:
+- fewer long dashed link moves across the pocket
+- more locally coherent spiral / nested behavior
+- better behavior around islands and split branches
+- no UI or project-format changes
+

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -1049,6 +1049,14 @@ export function CAMPanel({
                     <span>Target</span>
                     <input type="text" value={operationTargetSummary(project, selectedOperation.target)} readOnly />
                   </label>
+                  <label className="properties-check">
+                    <input
+                      type="checkbox"
+                      checked={selectedOperation.debugToolpath}
+                      onChange={(event) => updateOperation(selectedOperation.id, { debugToolpath: event.target.checked })}
+                    />
+                    <span>Debug toolpath</span>
+                  </label>
                   <div className="properties-field">
                     <span>Target Source</span>
                     <button

--- a/src/components/canvas/previewPrimitives.ts
+++ b/src/components/canvas/previewPrimitives.ts
@@ -440,6 +440,132 @@ export function drawToolpath(
     ctx.setLineDash([])
     ctx.globalAlpha = 1
   }
+
+  if (!emphasized || !toolpath.bounds) {
+    return
+  }
+
+  const span = Math.max(
+    toolpath.bounds.maxX - toolpath.bounds.minX,
+    toolpath.bounds.maxY - toolpath.bounds.minY,
+    toolpath.bounds.maxZ - toolpath.bounds.minZ,
+  )
+  const preferredSpacing = Math.max(12, Math.min(40, span * vt.scale * 0.09))
+  const preferredArrowLength = Math.max(8.5, Math.min(18, span * vt.scale * 0.03))
+  const distanceSinceLastArrowByKind: Record<'cut' | 'rapid', number> = {
+    cut: 0,
+    rapid: 0,
+  }
+
+  function drawDirectionArrow(fromX: number, fromY: number, toX: number, toY: number, color: string) {
+    const dx = toX - fromX
+    const dy = toY - fromY
+    const length = Math.hypot(dx, dy)
+    if (length <= 0.001) {
+      return
+    }
+
+    const ux = dx / length
+    const uy = dy / length
+    const markerLength = Math.max(6.5, Math.min(preferredArrowLength, Math.max(length * 0.6, preferredArrowLength * 0.58)))
+    const headLength = markerLength * 0.52
+    const headWidth = markerLength * 0.28
+    const centerX = (fromX + toX) / 2
+    const centerY = (fromY + toY) / 2
+    const tailX = centerX - ux * markerLength * 0.5
+    const tailY = centerY - uy * markerLength * 0.5
+    const tipX = centerX + ux * markerLength * 0.5
+    const tipY = centerY + uy * markerLength * 0.5
+    const leftX = tipX - ux * headLength - uy * headWidth
+    const leftY = tipY - uy * headLength + ux * headWidth
+    const rightX = tipX - ux * headLength + uy * headWidth
+    const rightY = tipY - uy * headLength - ux * headWidth
+
+    ctx.save()
+    ctx.strokeStyle = color
+    ctx.fillStyle = color
+    ctx.lineWidth = 1.4
+    ctx.globalAlpha = 0.95
+    ctx.beginPath()
+    ctx.moveTo(tailX, tailY)
+    ctx.lineTo(tipX, tipY)
+    ctx.stroke()
+    ctx.beginPath()
+    ctx.moveTo(tipX, tipY)
+    ctx.lineTo(leftX, leftY)
+    ctx.lineTo(rightX, rightY)
+    ctx.closePath()
+    ctx.fill()
+    ctx.restore()
+  }
+
+  function moveCanvasDelta(move: ToolpathResult['moves'][number]) {
+    const from = worldToCanvas({ x: move.from.x, y: move.from.y }, vt)
+    const to = worldToCanvas({ x: move.to.x, y: move.to.y }, vt)
+    return {
+      from,
+      to,
+      dx: to.cx - from.cx,
+      dy: to.cy - from.cy,
+      length: Math.hypot(to.cx - from.cx, to.cy - from.cy),
+    }
+  }
+
+  function normalizedMoveDirection(move: ToolpathResult['moves'][number] | undefined): { x: number; y: number } | null {
+    if (!move || (move.kind !== 'cut' && move.kind !== 'rapid')) {
+      return null
+    }
+
+    const delta = moveCanvasDelta(move)
+    if (delta.length <= 0.001) {
+      return null
+    }
+
+    return { x: delta.dx / delta.length, y: delta.dy / delta.length }
+  }
+
+  for (let moveIndex = 0; moveIndex < toolpath.moves.length; moveIndex += 1) {
+    const move = toolpath.moves[moveIndex]
+    if (move.kind !== 'cut' && move.kind !== 'rapid') {
+      continue
+    }
+
+    const delta = moveCanvasDelta(move)
+    if (delta.length < 0.5) {
+      continue
+    }
+
+    distanceSinceLastArrowByKind[move.kind] += delta.length
+    const previousDirection = normalizedMoveDirection(toolpath.moves[moveIndex - 1])
+    const nextDirection = normalizedMoveDirection(toolpath.moves[moveIndex + 1])
+    const direction = { x: delta.dx / delta.length, y: delta.dy / delta.length }
+    const directionTurn = previousDirection && nextDirection
+      ? Math.min(
+        Math.acos(Math.max(-1, Math.min(1, direction.x * previousDirection.x + direction.y * previousDirection.y))),
+        Math.acos(Math.max(-1, Math.min(1, direction.x * nextDirection.x + direction.y * nextDirection.y))),
+      )
+      : null
+    const isConnectorCut =
+      move.kind === 'cut'
+      && delta.length <= preferredSpacing * 0.8
+      && directionTurn !== null
+      && directionTurn >= Math.PI / 10
+    const shouldForceArrow = delta.length >= preferredArrowLength * 1.1
+    const shouldPlaceBySpacing = distanceSinceLastArrowByKind[move.kind] >= preferredSpacing
+
+    if (!shouldForceArrow && !shouldPlaceBySpacing && !isConnectorCut) {
+      continue
+    }
+
+    drawDirectionArrow(
+      delta.from.cx,
+      delta.from.cy,
+      delta.to.cx,
+      delta.to.cy,
+      move.kind === 'rapid' ? 'rgba(124, 184, 222, 0.95)' : 'rgba(255, 115, 92, 0.98)',
+    )
+    distanceSinceLastArrowByKind[move.kind] = 0
+  }
 }
 
 export function hexToRgba(hex: string, alpha: number): string {

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -96,6 +96,171 @@ function toolpathPointToWorld(point: ToolpathResult['moves'][number]['from']): T
   return new THREE.Vector3(point.x, point.z, point.y)
 }
 
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+function buildToolpathEndpointMarkers(toolpath: ToolpathResult, emphasized: boolean): THREE.Object3D[] {
+  if (toolpath.moves.length === 0) {
+    return []
+  }
+
+  const firstPoint = toolpathPointToWorld(toolpath.moves[0].from)
+  const lastPoint = toolpathPointToWorld(toolpath.moves[toolpath.moves.length - 1].to)
+  const bounds = toolpath.bounds
+  const span = bounds
+    ? Math.max(bounds.maxX - bounds.minX, bounds.maxY - bounds.minY, bounds.maxZ - bounds.minZ)
+    : 10
+  const markerLength = clamp(span * 0.08, 0.2, 8)
+  const headLength = markerLength * 0.38
+  const headWidth = markerLength * 0.16
+  const lineOpacity = emphasized ? 0.96 : 0.6
+
+  const startArrow = new THREE.ArrowHelper(
+    new THREE.Vector3(0, -1, 0),
+    firstPoint.clone().add(new THREE.Vector3(0, markerLength, 0)),
+    markerLength,
+    0xd583df,
+    headLength,
+    headWidth,
+  )
+  const endArrow = new THREE.ArrowHelper(
+    new THREE.Vector3(0, 1, 0),
+    lastPoint,
+    markerLength,
+    0x78b8de,
+    headLength,
+    headWidth,
+  )
+
+  const markers = [startArrow, endArrow]
+  for (const marker of markers) {
+    marker.traverse((entry) => {
+      if (entry instanceof THREE.Line || entry instanceof THREE.Mesh) {
+        const material = Array.isArray(entry.material) ? entry.material : [entry.material]
+        material.forEach((item) => {
+          item.transparent = true
+          item.opacity = lineOpacity
+          item.depthWrite = false
+          item.depthTest = false
+        })
+      }
+    })
+  }
+
+  return markers
+}
+
+function buildToolpathDirectionMarkers(toolpath: ToolpathResult, emphasized: boolean): THREE.Object3D[] {
+  if (!emphasized || toolpath.moves.length === 0) {
+    return []
+  }
+
+  const bounds = toolpath.bounds
+  const span = bounds
+    ? Math.max(bounds.maxX - bounds.minX, bounds.maxY - bounds.minY, bounds.maxZ - bounds.minZ)
+    : 10
+  const preferredMarkerLength = clamp(span * 0.028, 0.04, 2.4)
+  const preferredSpacing = clamp(span * 0.09, 0.12, 8)
+  const horizontalTolerance = 1e-6
+  const objects: THREE.Object3D[] = []
+  const distanceSinceLastArrowByKind: Record<'cut' | 'rapid', number> = {
+    cut: 0,
+    rapid: 0,
+  }
+
+  function getHorizontalDirection(move: ToolpathResult['moves'][number] | undefined): THREE.Vector3 | null {
+    if (!move || (move.kind !== 'cut' && move.kind !== 'rapid')) {
+      return null
+    }
+
+    const from = toolpathPointToWorld(move.from)
+    const to = toolpathPointToWorld(move.to)
+    const delta = to.clone().sub(from)
+    if (Math.abs(delta.y) > horizontalTolerance || delta.length() <= 1e-6) {
+      return null
+    }
+
+    return delta.normalize()
+  }
+
+  for (let moveIndex = 0; moveIndex < toolpath.moves.length; moveIndex += 1) {
+    const move = toolpath.moves[moveIndex]
+    if (move.kind !== 'cut' && move.kind !== 'rapid') {
+      continue
+    }
+
+    const from = toolpathPointToWorld(move.from)
+    const to = toolpathPointToWorld(move.to)
+    const delta = to.clone().sub(from)
+    if (Math.abs(delta.y) > horizontalTolerance) {
+      distanceSinceLastArrowByKind[move.kind] = 0
+      continue
+    }
+
+    const length = delta.length()
+    if (!(length >= 0.001)) {
+      continue
+    }
+
+    const direction = delta.clone().normalize()
+    distanceSinceLastArrowByKind[move.kind] += length
+
+    const previousDirection = getHorizontalDirection(toolpath.moves[moveIndex - 1])
+    const nextDirection = getHorizontalDirection(toolpath.moves[moveIndex + 1])
+    const directionTurn =
+      previousDirection && nextDirection
+        ? Math.min(
+          direction.angleTo(previousDirection),
+          direction.angleTo(nextDirection),
+        )
+        : null
+    const isConnectorCut =
+      move.kind === 'cut'
+      && length <= preferredSpacing * 0.8
+      && directionTurn !== null
+      && directionTurn >= Math.PI / 10
+
+    const shouldForceArrow = length >= preferredMarkerLength * 1.1
+    const shouldPlaceBySpacing = distanceSinceLastArrowByKind[move.kind] >= preferredSpacing
+    if (!shouldForceArrow && !shouldPlaceBySpacing && !isConnectorCut) {
+      continue
+    }
+
+    const markerLength = clamp(Math.min(preferredMarkerLength, Math.max(length * 0.55, preferredMarkerLength * 0.45)), 0.02, 2.4)
+    const headLength = markerLength * 0.45
+    const headWidth = markerLength * 0.18
+    const center = from.clone().add(to).multiplyScalar(0.5)
+    const origin = center.clone().sub(direction.clone().multiplyScalar(markerLength * 0.5))
+    const color = move.kind === 'rapid' ? 0x78b8de : 0xff735c
+    const arrow = new THREE.ArrowHelper(
+      direction,
+      origin,
+      markerLength,
+      color,
+      headLength,
+      headWidth,
+    )
+
+    arrow.traverse((entry) => {
+      if (entry instanceof THREE.Line || entry instanceof THREE.Mesh) {
+        const material = Array.isArray(entry.material) ? entry.material : [entry.material]
+        material.forEach((item) => {
+          item.transparent = true
+          item.opacity = 0.95
+          item.depthWrite = false
+          item.depthTest = false
+        })
+      }
+    })
+
+    objects.push(arrow)
+    distanceSinceLastArrowByKind[move.kind] = 0
+  }
+
+  return objects
+}
+
 function buildToolpathOverlay(toolpath: ToolpathResult, emphasized: boolean): THREE.Object3D[] {
   const layers: Array<{
     kinds: ToolpathResult['moves'][number]['kind'][]
@@ -142,6 +307,11 @@ function buildToolpathOverlay(toolpath: ToolpathResult, emphasized: boolean): TH
     })
 
     objects.push(new THREE.LineSegments(geometry, material))
+  }
+
+  if (emphasized) {
+    objects.push(...buildToolpathDirectionMarkers(toolpath, emphasized))
+    objects.push(...buildToolpathEndpointMarkers(toolpath, emphasized))
   }
 
   return objects

--- a/src/engine/toolpaths/pocket.ts
+++ b/src/engine/toolpaths/pocket.ts
@@ -15,6 +15,7 @@ import {
   getOperationSafeZ,
   normalizeWinding,
   normalizeToolForProject,
+  resolveFeatureZSpan,
   toClipperPath,
 } from './geometry'
 import { resolvePocketRegions } from './resolver'
@@ -451,6 +452,149 @@ function distanceSquared(a: Point, b: Point): number {
   return dx * dx + dy * dy
 }
 
+function contourNearestVertexIndex(points: Point[], anchor: Point): { index: number; distance: number } {
+  let bestIndex = 0
+  let bestDistance = Number.POSITIVE_INFINITY
+
+  for (let index = 0; index < points.length; index += 1) {
+    const distance = distanceSquared(anchor, points[index])
+    if (distance < bestDistance) {
+      bestIndex = index
+      bestDistance = distance
+    }
+  }
+
+  return { index: bestIndex, distance: bestDistance }
+}
+
+function contourNearestVertexDistance(points: Point[], anchor: Point): number {
+  return contourNearestVertexIndex(points, anchor).distance
+}
+
+function rotateClosedContour(points: Point[], startIndex: number): Point[] {
+  if (points.length <= 1 || startIndex <= 0 || startIndex >= points.length) {
+    return points
+  }
+
+  return [...points.slice(startIndex), ...points.slice(0, startIndex)]
+}
+
+function contourEntryDistanceSquared(points: Point[], anchor: Point): number {
+  if (points.length === 0) {
+    return Number.POSITIVE_INFINITY
+  }
+
+  return contourNearestVertexDistance(points, anchor)
+}
+
+function rotateContourToNearestEntry(points: Point[], anchor: Point | null): Point[] {
+  if (points.length === 0 || anchor === null) {
+    return points
+  }
+
+  const { index } = contourNearestVertexIndex(points, anchor)
+  return rotateClosedContour(points, index)
+}
+
+function rotateContourToBestEntry(
+  points: Point[],
+  fromAnchor: Point | null,
+  nextAnchors: Point[],
+): Point[] {
+  if (points.length === 0) {
+    return points
+  }
+
+  let bestIndex = 0
+  let bestScore = Number.POSITIVE_INFINITY
+
+  for (let index = 0; index < points.length; index += 1) {
+    const candidate = points[index]
+    const fromDistance = fromAnchor ? distanceSquared(fromAnchor, candidate) : 0
+    const nextDistance = nextAnchors.length > 0
+      ? Math.min(...nextAnchors.map((anchor) => distanceSquared(anchor, candidate)))
+      : 0
+    const score = fromDistance + nextDistance
+
+    if (score < bestScore) {
+      bestIndex = index
+      bestScore = score
+    }
+  }
+
+  return rotateClosedContour(points, bestIndex)
+}
+
+function contourAnchorPoint(points: Point[]): Point | null {
+  const first = points[0]
+  return first ? { x: first.x, y: first.y } : null
+}
+
+function regionEntryDistanceSquared(region: ResolvedPocketRegion, anchor: Point): number {
+  return contourEntryDistanceSquared(region.outer, anchor)
+}
+
+function orderRegionsGreedy(regions: ResolvedPocketRegion[], start: Point | null): ResolvedPocketRegion[] {
+  if (regions.length <= 1 || start === null) {
+    return regions
+  }
+
+  const remaining = [...regions]
+  const ordered: ResolvedPocketRegion[] = []
+  let current = start
+
+  while (remaining.length > 0) {
+    let bestIndex = 0
+    let bestDistance = Number.POSITIVE_INFINITY
+
+    for (let index = 0; index < remaining.length; index += 1) {
+      const distance = regionEntryDistanceSquared(remaining[index], current)
+      if (distance < bestDistance) {
+        bestIndex = index
+        bestDistance = distance
+      }
+    }
+
+    const [nextRegion] = remaining.splice(bestIndex, 1)
+    ordered.push(nextRegion)
+    current = contourAnchorPoint(nextRegion.outer) ?? current
+  }
+
+  return ordered
+}
+
+function orderClosedContoursGreedy(contours: Point[][], start: Point | null): Point[][] {
+  if (contours.length <= 1 || start === null) {
+    return contours
+  }
+
+  const remaining = contours
+    .filter((contour) => contour.length >= 3)
+    .map((contour) => [...contour])
+  const ordered: Point[][] = []
+  let current = start
+
+  while (remaining.length > 0) {
+    let bestIndex = 0
+    let bestDistance = Number.POSITIVE_INFINITY
+
+    for (let index = 0; index < remaining.length; index += 1) {
+      const distance = contourEntryDistanceSquared(remaining[index], current)
+      if (distance < bestDistance) {
+        bestIndex = index
+        bestDistance = distance
+      }
+    }
+
+    const [nextContour] = remaining.splice(bestIndex, 1)
+    const rotated = rotateContourToNearestEntry(nextContour, current)
+    ordered.push(rotated)
+    current = contourAnchorPoint(rotated) ?? current
+  }
+
+  return ordered
+}
+
 function orderOpenSegmentsGreedy(segments: Point[][], start: Point | null): Point[][] {
   if (segments.length <= 1 || start === null) {
     return segments
@@ -540,6 +684,80 @@ export function buildPocketParallelSegments(
   })
 
   return segments
+}
+
+function cutClosedContours(
+  moves: ToolpathMove[],
+  contours: Point[][],
+  z: number,
+  safeZ: number,
+  maxLinkDistance: number,
+  currentPosition: ToolpathPoint | null,
+): ToolpathPoint | null {
+  const orderedContours = orderClosedContoursGreedy(
+    contours,
+    currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
+  )
+
+  let nextPosition = currentPosition
+  for (const contour of orderedContours) {
+    const entryPoint = contourStartPoint(contour, z)
+    nextPosition = transitionToCutEntry(moves, nextPosition, entryPoint, safeZ, maxLinkDistance)
+    const cutMoves = toClosedCutMoves(contour, z)
+    moves.push(...cutMoves)
+    nextPosition = cutMoves.at(-1)?.to ?? nextPosition
+  }
+
+  return nextPosition
+}
+
+function cutOffsetRegionRecursive(
+  moves: ToolpathMove[],
+  region: ResolvedPocketRegion,
+  z: number,
+  safeZ: number,
+  stepoverDistance: number,
+  maxLinkDistance: number,
+  currentPosition: ToolpathPoint | null,
+): ToolpathPoint | null {
+  const childRegions = buildInsetRegions(region, stepoverDistance)
+  const childAnchors = childRegions
+    .map((child) => child.outer)
+    .filter((contour) => contour.length > 0)
+    .map((contour) => contour[0])
+  const preparedContours = buildContourLoops([region]).map((contour) => rotateContourToBestEntry(
+    contour,
+    currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
+    childAnchors,
+  ))
+
+  let nextPosition = cutClosedContours(
+    moves,
+    preparedContours,
+    z,
+    safeZ,
+    maxLinkDistance,
+    currentPosition,
+  )
+
+  const orderedChildren = orderRegionsGreedy(
+    childRegions,
+    nextPosition ? { x: nextPosition.x, y: nextPosition.y } : null,
+  )
+
+  for (const childRegion of orderedChildren) {
+    nextPosition = cutOffsetRegionRecursive(
+      moves,
+      childRegion,
+      z,
+      safeZ,
+      stepoverDistance,
+      maxLinkDistance,
+      nextPosition,
+    )
+  }
+
+  return nextPosition
 }
 
 export function toOpenCutMoves(points: Point[], z: number): ToolpathMove[] {
@@ -635,23 +853,28 @@ function generateRoughBandMoves(
   }
 
   for (const z of stepLevels) {
-    let currentRegions = band.regions.flatMap((region) => buildInsetRegions(region, initialInset))
-    while (currentRegions.length > 0) {
-      const contours = buildContourLoops(currentRegions)
-      if (contours.length === 0) {
-        warnings.push(`No machinable offset contours for band ${band.topZ} -> ${band.bottomZ}`)
-        break
-      }
+    const currentRegions = band.regions.flatMap((region) => buildInsetRegions(region, initialInset))
+    if (currentRegions.length === 0) {
+      warnings.push(`No machinable offset contours for band ${band.topZ} -> ${band.bottomZ}`)
+      currentPosition = retractToSafe(moves, currentPosition, safeZ)
+      continue
+    }
 
-      for (const contour of contours) {
-        const entryPoint = contourStartPoint(contour, z)
-        currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
-        const cutMoves = toClosedCutMoves(contour, z)
-        moves.push(...cutMoves)
-        currentPosition = cutMoves.at(-1)?.to ?? currentPosition
-      }
+    const orderedRegions = orderRegionsGreedy(
+      currentRegions,
+      currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
+    )
 
-      currentRegions = currentRegions.flatMap((region) => buildInsetRegions(region, effectiveStepover))
+    for (const region of orderedRegions) {
+      currentPosition = cutOffsetRegionRecursive(
+        moves,
+        region,
+        z,
+        safeZ,
+        effectiveStepover,
+        maxLinkDistance,
+        currentPosition,
+      )
     }
 
     currentPosition = retractToSafe(moves, currentPosition, safeZ)
@@ -711,25 +934,13 @@ function generateFinishBandMoves(
   let currentPosition: ToolpathPoint | null = null
 
   for (const z of wallStepLevels) {
-    for (const contour of wallContours) {
-      const entryPoint = contourStartPoint(contour, z)
-      currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
-      const cutMoves = toClosedCutMoves(contour, z)
-      moves.push(...cutMoves)
-      currentPosition = cutMoves.at(-1)?.to ?? currentPosition
-    }
+    currentPosition = cutClosedContours(moves, wallContours, z, safeZ, maxLinkDistance, currentPosition)
 
     currentPosition = retractToSafe(moves, currentPosition, safeZ)
   }
 
   for (const z of floorStepLevels) {
-    for (const contour of floorContours) {
-      const entryPoint = contourStartPoint(contour, z)
-      currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
-      const cutMoves = toClosedCutMoves(contour, z)
-      moves.push(...cutMoves)
-      currentPosition = cutMoves.at(-1)?.to ?? currentPosition
-    }
+    currentPosition = cutClosedContours(moves, floorContours, z, safeZ, maxLinkDistance, currentPosition)
 
     const orderedFloorSegments = orderOpenSegmentsGreedy(
       floorSegments,
@@ -808,6 +1019,42 @@ export function generatePocketToolpath(project: Project, operation: Operation): 
   const warnings = [...resolved.warnings]
   const allStepLevels = new Set<number>()
 
+  const formatZ = (value: number) => Number(value.toFixed(6)).toString()
+  const formatFeatureSpan = (featureId: string) => {
+    const feature = project.features.find((entry) => entry.id === featureId)
+    if (!feature) {
+      return `${featureId} [missing]`
+    }
+
+    const span = resolveFeatureZSpan(project, feature)
+    return `${feature.name} (${feature.id}) [${formatZ(span.max)} -> ${formatZ(span.min)}]`
+  }
+
+  const formatIslandSpan = (id: string) => {
+    const feature = project.features.find((entry) => entry.id === id)
+    if (feature) {
+      const span = resolveFeatureZSpan(project, feature)
+      return `${feature.name} (${feature.id}) [${formatZ(span.max)} -> ${formatZ(span.min)}]`
+    }
+
+    const tab = project.tabs.find((entry) => entry.id === id)
+    if (tab) {
+      return `${tab.name} (${tab.id}) [${formatZ(Math.max(tab.z_top, tab.z_bottom))} -> ${formatZ(Math.min(tab.z_top, tab.z_bottom))}]`
+    }
+
+    return `${id} [missing]`
+  }
+
+  if (operation.debugToolpath) {
+    const resolvedBandSummary = resolved.bands
+      .map((band) => `${formatZ(band.topZ)} -> ${formatZ(band.bottomZ)}`)
+      .join(', ')
+
+    if (resolved.bands.length > 0) {
+      warnings.push(`Debug: resolved pocket bands = ${resolvedBandSummary}`)
+    }
+  }
+
   for (const band of resolved.bands) {
     const result = operation.pass === 'finish'
       ? generateFinishBandMoves(
@@ -832,6 +1079,23 @@ export function generatePocketToolpath(project: Project, operation: Operation): 
     moves.forEach((move) => allMoves.push(move))
     stepLevels.forEach((level) => allStepLevels.add(level))
     warnings.push(...bandWarnings)
+    if (operation.debugToolpath) {
+      warnings.push(
+        `Debug: band ${formatZ(band.topZ)} -> ${formatZ(band.bottomZ)} cut levels = ${
+          stepLevels.length > 0 ? stepLevels.map((level) => formatZ(level)).join(', ') : 'none'
+        }`,
+      )
+      warnings.push(
+        `Debug: band ${formatZ(band.topZ)} -> ${formatZ(band.bottomZ)} targets = ${
+          band.targetFeatureIds.length > 0 ? band.targetFeatureIds.map((id) => formatFeatureSpan(id)).join('; ') : 'none'
+        }`,
+      )
+      warnings.push(
+        `Debug: band ${formatZ(band.topZ)} -> ${formatZ(band.bottomZ)} islands = ${
+          band.islandFeatureIds.length > 0 ? band.islandFeatureIds.map((id) => formatIslandSpan(id)).join('; ') : 'none'
+        }`,
+      )
+    }
   }
 
   let bounds: ToolpathBounds | null = null

--- a/src/engine/toolpaths/resolver.ts
+++ b/src/engine/toolpaths/resolver.ts
@@ -140,6 +140,14 @@ function differencePaths(subjectPaths: ClipperPath[], clipPaths: ClipperPath[]):
   return executeClipPaths(subjectPaths, clipPaths, ClipperLib.ClipType.ctDifference)
 }
 
+function pathsIntersect(subjectPaths: ClipperPath[], clipPaths: ClipperPath[]): boolean {
+  if (subjectPaths.length === 0 || clipPaths.length === 0) {
+    return false
+  }
+
+  return executeClipPaths(subjectPaths, clipPaths, ClipperLib.ClipType.ctIntersection).length > 0
+}
+
 function polyTreeToRegions(
   node: PolyTreeNode,
   targetFeatureIds: string[],
@@ -235,21 +243,26 @@ export function resolvePocketRegions(project: Project, operation: Operation): Re
     }
   }
 
+  const targetUnionPaths = unionPaths(closedTargetFeatures.map(({ feature }) => flattenFeatureToClipperPath(feature)))
+
   const candidateIslands = project.features
     .flatMap((feature) => expandFeatureGeometry(feature))
     .filter((feature) => feature.operation === 'add' && featureHasClosedGeometry(feature))
+    .filter((feature) => pathsIntersect(targetUnionPaths, [flattenFeatureToClipperPath(feature)]))
     .map((feature) => ({
       feature,
       span: resolveFeatureZSpan(project, feature),
     }))
-  const candidateTabIslands: AdditiveObstacleWithSpan[] = project.tabs.map((tab) => ({
-    id: tab.id,
-    path: toClipperPath(normalizeWinding(flattenProfile(rectProfile(tab.x, tab.y, tab.w, tab.h)).points, false), DEFAULT_CLIPPER_SCALE),
-    span: {
-      min: Math.min(tab.z_bottom, tab.z_top),
-      max: Math.max(tab.z_bottom, tab.z_top),
-    },
-  }))
+  const candidateTabIslands: AdditiveObstacleWithSpan[] = project.tabs
+    .map((tab) => ({
+      id: tab.id,
+      path: toClipperPath(normalizeWinding(flattenProfile(rectProfile(tab.x, tab.y, tab.w, tab.h)).points, false), DEFAULT_CLIPPER_SCALE),
+      span: {
+        min: Math.min(tab.z_bottom, tab.z_top),
+        max: Math.max(tab.z_bottom, tab.z_top),
+      },
+    }))
+    .filter((tab) => pathsIntersect(targetUnionPaths, [tab.path]))
 
   const depths = uniqueSortedDepthsFromSpans([
     ...closedTargetFeatures.map(({ span }) => span),

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1433,6 +1433,7 @@ function defaultOperationForTarget(
     pass,
     enabled: true,
     showToolpath: true,
+    debugToolpath: false,
     target,
     toolRef,
     stepdown: tool.defaultStepdown,

--- a/src/types/clipper-lib.d.ts
+++ b/src/types/clipper-lib.d.ts
@@ -48,6 +48,7 @@ declare module 'clipper-lib' {
     }
     ClipType: {
       ctUnion: number
+      ctIntersection: number
       ctDifference: number
     }
     PolyFillType: {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -228,6 +228,7 @@ export interface Operation {
   pass: OperationPass
   enabled: boolean
   showToolpath: boolean
+  debugToolpath: boolean
   target: OperationTarget
   toolRef: string | null
   stepdown: number


### PR DESCRIPTION
## Summary
- switch offset pocket roughing from breadth-first contour traversal to recursive branch-first traversal
- filter pocket band islands and tabs to only those overlapping the selected target in XY, preventing unrelated geometry from creating extra depth bands
- add an optional per-operation  flag for pocket diagnostics
- add start/end markers and per-segment direction arrows to the selected toolpath in 3D view
- add matching direction arrows to the selected toolpath in sketch view

## Validation
- npm run build
- visually checked complex offset pockets with islands and split branches
- verified unrelated geometry no longer affects selected pocket depth banding
- verified selected-operation direction markers in both sketch and 3D views