### PR TITLE
feat: add conventional/climb cut direction to CAM operations

### DIFF
--- a/planning/CUT_DIRECTION_Implementation_Plan.md
+++ b/planning/CUT_DIRECTION_Implementation_Plan.md
@@ -1,0 +1,118 @@
+# Cut Direction (Conventional / Climb) Implementation Plan
+
+## Status: IN PROGRESS
+
+## Background
+
+CNC milling has two fundamental cut directions:
+
+- **Conventional cut** (CW in machine coordinates): The cutter tooth enters the material gradually. Generates more heat but is safer for worn machines and climb-cutting-unfriendly materials.
+- **Climb cut** (CCW in machine coordinates): The cutter tooth bites in aggressively, producing a cleaner surface finish. Preferred on modern rigid machines.
+
+## Coordinate System
+
+The app uses screen coordinates (+Y down). The G-code postprocessor inverts Y
+(`dy = origin.y - point.y`) to produce machine coordinates (+Y up / forward).
+
+Shoelace signed area in screen coordinates (+Y down):
+- CW on screen → positive signed area → `isClockwise()` returns **false**
+- CCW on screen → negative signed area → `isClockwise()` returns **true**
+
+After Y-flip in G-code export:
+- CCW on screen → CW in machine → **conventional cut**
+- CW on screen → CCW in machine → **climb cut**
+
+`normalizeWinding(contour, true)` = `isClockwise` = true = CCW on screen = **conventional**
+`normalizeWinding(contour, false)` = `isClockwise` = false = CW on screen = **climb**
+
+## Root Cause of Wrong Edge-Outside Direction
+
+`flattenFeatureToClipperPath` in `edge.ts` uses `normalizeWinding(points, false)` = CW on screen. Clipper treats this as a hole polygon. Offsetting a hole polygon outward with a positive delta keeps it CW on screen. After Y-flip: CCW in machine = **climb** (wrong).
+
+**Fix**: change to `normalizeWinding(points, true)` so Clipper sees it as an outer polygon. Offset expands it outward keeping CCW on screen → **conventional** by default.
+
+## What Needs to Change
+
+### 1. Data Model (`src/types/project.ts`)
+```ts
+export type CutDirection = 'conventional' | 'climb'
+
+// In Operation interface (optional for backward compat):
+cutDirection?: CutDirection
+```
+
+Applies to: `pocket`, `edge_route_inside`, `edge_route_outside`, `v_carve`, `surface_clean`.
+Does NOT apply to: `follow_line` (open path), `v_carve_recursive` (diagonal skeleton cuts).
+
+### 2. Store Default (`src/store/projectStore.ts`)
+Add `cutDirection: 'conventional'` in `defaultOperationForTarget`.
+
+### 3. Geometry Helper (`src/engine/toolpaths/geometry.ts`)
+```ts
+export function applyContourDirection(contours: Point[][], direction: CutDirection = 'conventional'): Point[][] {
+  // conventional = CCW on screen = normalizeWinding(c, true)
+  // climb       = CW on screen  = normalizeWinding(c, false)
+  const wantClockwise = direction === 'conventional'
+  return contours.map(c => normalizeWinding(c, wantClockwise))
+}
+```
+
+### 4. Edge Toolpath (`src/engine/toolpaths/edge.ts`)
+- **Fix winding input**: `flattenFeatureToClipperPath` → `normalizeWinding(points, true)` (was `false`)
+- **edge_route_outside**: normalize `resolveContourPaths` result with `applyContourDirection` before passing to `appendContoursAtLevels`
+- **edge_route_inside**: pass `operation.cutDirection` to `cutClosedContours`
+
+### 5. Pocket Toolpath (`src/engine/toolpaths/pocket.ts`)
+- **`cutClosedContours`**: add `direction?: CutDirection = 'conventional'` parameter, normalize contours inside
+- **`cutOffsetRegionRecursive`**: add `direction` parameter, pass to `cutClosedContours`
+- **`generateRoughBandMoves`**: add `direction` parameter; for parallel pattern, normalize `boundaryContours` before looping; for offset pattern, pass to `cutOffsetRegionRecursive`
+- **`generateFinishBandMoves`**: add `direction` parameter; pass to `cutClosedContours` for walls and floor
+- **`generatePocketToolpath`**: extract `operation.cutDirection ?? 'conventional'` and thread to both band generators
+
+### 6. V-Carve Offset (`src/engine/toolpaths/vcarve.ts`)
+Before `toClosedCutMoves(contour, z)`, normalize: `normalizeWinding(contour, (op.cutDirection ?? 'conventional') === 'conventional')`.
+
+### 7. Surface Cleanup (`src/engine/toolpaths/surface.ts`)
+- The internal `generateRoughBandMoves` and finish pass call `cutOffsetRegionRecursive` and `cutClosedContours`. Pass `direction` parameter through.
+- `generateSurfaceCleanToolpath`: extract direction and thread through.
+
+### 8. UI (`src/components/cam/CAMPanel.tsx`)
+Add a `<select>` for cut direction, visible for `pocket | edge_route_inside | edge_route_outside | v_carve | surface_clean`:
+
+```tsx
+{['pocket', 'edge_route_inside', 'edge_route_outside', 'v_carve', 'surface_clean'].includes(operation.kind) && (
+  <label className="properties-field">
+    <span>Cut Direction</span>
+    <select
+      value={selectedOperation.cutDirection ?? 'conventional'}
+      onChange={(e) => updateOperation(selectedOperation.id, { cutDirection: e.target.value as CutDirection })}
+    >
+      <option value="conventional">Conventional</option>
+      <option value="climb">Climb</option>
+    </select>
+  </label>
+)}
+```
+
+## Testing Checklist
+
+- [ ] Edge route outside (rough + finish) cuts CW on machine (conventional) by default
+- [ ] Edge route outside switches to CCW (climb) when set
+- [ ] Pocket offset pattern: same conventional/climb toggle works
+- [ ] Pocket parallel pattern: boundary contours follow direction
+- [ ] V-carve offset contours follow direction
+- [ ] Surface clean contours follow direction
+- [ ] Edge route inside follows direction
+- [ ] Existing projects without `cutDirection` field default to conventional
+- [ ] `npm run build` passes with no TypeScript errors
+
+## Files Changed
+
+1. `src/types/project.ts`
+2. `src/store/projectStore.ts`
+3. `src/engine/toolpaths/geometry.ts`
+4. `src/engine/toolpaths/edge.ts`
+5. `src/engine/toolpaths/pocket.ts`
+6. `src/engine/toolpaths/vcarve.ts`
+7. `src/engine/toolpaths/surface.ts`
+8. `src/components/cam/CAMPanel.tsx`

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -4,6 +4,7 @@ import type { SelectionState } from '../../store/types'
 import { useProjectStore } from '../../store/projectStore'
 import { loadBundledToolLibrary, type ToolLibraryEntry } from '../../toolLibrary'
 import type {
+  CutDirection,
   OperationKind,
   OperationPass,
   PocketPattern,
@@ -1064,6 +1065,18 @@ export function CAMPanel({
                         value={selectedOperation.pocketAngle}
                         onCommit={(value) => updateOperation(selectedOperation.id, { pocketAngle: value })}
                       />
+                    </label>
+                  ) : null}
+                  {(selectedOperation.kind === 'pocket' || selectedOperation.kind === 'edge_route_inside' || selectedOperation.kind === 'edge_route_outside' || selectedOperation.kind === 'v_carve' || selectedOperation.kind === 'surface_clean') ? (
+                    <label className="properties-field">
+                      <span>Cut Direction</span>
+                      <select
+                        value={selectedOperation.cutDirection ?? 'conventional'}
+                        onChange={(event) => updateOperation(selectedOperation.id, { cutDirection: event.target.value as CutDirection })}
+                      >
+                        <option value="conventional">Conventional</option>
+                        <option value="climb">Climb</option>
+                      </select>
                     </label>
                   ) : null}
                   {selectedOperation.kind === 'follow_line' ? (

--- a/src/engine/toolpaths/edge.ts
+++ b/src/engine/toolpaths/edge.ts
@@ -4,6 +4,7 @@ import { expandFeatureGeometry, featureHasClosedGeometry } from '../../text'
 import type { ClipperPath, ToolpathBounds, ToolpathMove, ToolpathPoint, ToolpathResult } from './types'
 import {
   DEFAULT_CLIPPER_SCALE,
+  applyContourDirection,
   flattenProfile,
   fromClipperPath,
   getOperationSafeZ,
@@ -204,7 +205,9 @@ function updateBounds(bounds: ToolpathBounds | null, point: ToolpathPoint): Tool
 
 function flattenFeatureToClipperPath(feature: SketchFeature): ClipperPath {
   const flattened = flattenProfile(feature.sketch.profile)
-  return toClipperPath(normalizeWinding(flattened.points, false), DEFAULT_CLIPPER_SCALE)
+  // Normalize to CCW on screen (isClockwise=true) so Clipper treats it as an outer polygon.
+  // Offsetting outward then preserves CCW orientation → conventional cut by default (CW in machine after Y-flip).
+  return toClipperPath(normalizeWinding(flattened.points, true), DEFAULT_CLIPPER_SCALE)
 }
 
 function resolveContourPaths(paths: ClipperPath[], offsetDistance: number): Point[][] {
@@ -347,6 +350,7 @@ export function generateEdgeRouteToolpath(project: Project, operation: Operation
   const moves: ToolpathMove[] = []
   let currentPosition: ToolpathPoint | null = null
   const maxLinkDistance = tool.diameter
+  const direction = operation.cutDirection ?? 'conventional'
 
   if (operation.kind === 'edge_route_inside') {
     const resolved = resolveInsideEdgeRegions(project, operation)
@@ -361,12 +365,13 @@ export function generateEdgeRouteToolpath(project: Project, operation: Operation
       }
 
       const insetRegions = band.regions.flatMap((region) => buildInsetRegions(region, insideInset))
-      const contours = buildOuterContours(insetRegions)
-      if (contours.length === 0) {
+      const rawContours = buildOuterContours(insetRegions)
+      if (rawContours.length === 0) {
         warnings.push(`No valid inside contour could be generated for band ${band.topZ} -> ${band.bottomZ}`)
         continue
       }
 
+      const contours = applyContourDirection(rawContours, direction)
       const levels =
         operation.pass === 'finish'
           ? [effectiveBottom]
@@ -429,14 +434,15 @@ export function generateEdgeRouteToolpath(project: Project, operation: Operation
     ))
 
     if (canCombineOutsideTargets) {
-      const contours = resolveContourPaths(
+      const rawContours = resolveContourPaths(
         unionPaths(routableTargets.map((target) => target.contourPath)),
         offsetDistance,
       )
 
-      if (contours.length === 0) {
+      if (rawContours.length === 0) {
         warnings.push('No valid combined outer contour could be generated for the selected outside edge targets')
       } else {
+        const contours = applyContourDirection(rawContours, direction)
         const levels =
           operation.pass === 'finish'
             ? [referenceTarget.bottomZ]
@@ -453,12 +459,13 @@ export function generateEdgeRouteToolpath(project: Project, operation: Operation
 
   if (moves.length === 0) {
     for (const target of routableTargets) {
-      const contours = resolveContourPaths([target.contourPath], offsetDistance)
-      if (contours.length === 0) {
+      const rawContours = resolveContourPaths([target.contourPath], offsetDistance)
+      if (rawContours.length === 0) {
         warnings.push(`No valid contour could be generated for ${target.feature.name}`)
         continue
       }
 
+      const contours = applyContourDirection(rawContours, direction)
       const levels =
         operation.pass === 'finish'
           ? [target.bottomZ]

--- a/src/engine/toolpaths/geometry.ts
+++ b/src/engine/toolpaths/geometry.ts
@@ -27,12 +27,10 @@ export function resolveDimensionRef(project: Project, value: DimensionRef): numb
   if (typeof value === 'number') {
     return value
   }
-
   const named = project.dimensions[value]
   if (!named) {
     throw new Error(`Unknown dimension reference: ${value}`)
   }
-
   return named.value
 }
 
@@ -41,7 +39,6 @@ export function resolveFeatureZSpan(project: Project, feature: SketchFeature): R
   const bottom = resolveDimensionRef(project, feature.z_bottom)
   const min = Math.min(top, bottom)
   const max = Math.max(top, bottom)
-
   return {
     top,
     bottom,
@@ -52,10 +49,7 @@ export function resolveFeatureZSpan(project: Project, feature: SketchFeature): R
 }
 
 export function normalizeToolForProject(tool: Tool, project: Project): NormalizedTool {
-  const normalizedTool = tool.units === project.meta.units
-    ? tool
-    : convertToolUnits(tool, project.meta.units)
-
+  const normalizedTool = tool.units === project.meta.units ? tool : convertToolUnits(tool, project.meta.units)
   return {
     id: tool.id,
     name: tool.name,
@@ -76,10 +70,7 @@ export function normalizeToolForProject(tool: Tool, project: Project): Normalize
 }
 
 export function resolveOperationTool(project: Project, operation: Operation): ResolvedToolpathOperation {
-  const tool = operation.toolRef
-    ? project.tools.find((candidate) => candidate.id === operation.toolRef) ?? null
-    : null
-
+  const tool = operation.toolRef ? project.tools.find((c) => c.id === operation.toolRef) ?? null : null
   return {
     operation,
     tool: tool ? normalizeToolForProject(tool, project) : null,
@@ -89,7 +80,6 @@ export function resolveOperationTool(project: Project, operation: Operation): Re
 
 export function flattenProfile(profile: SketchProfile, curveSamples = 24, arcStepRadians = Math.PI / 36): FlattenedPath {
   const sampled = sampleProfilePoints(profile, curveSamples, arcStepRadians)
-
   return {
     points: sampled.map(clonePoint),
     closed: profile.closed,
@@ -97,32 +87,22 @@ export function flattenProfile(profile: SketchProfile, curveSamples = 24, arcSte
 }
 
 export function ensureClosedPath(points: Point[]): Point[] {
-  if (points.length === 0) {
-    return []
-  }
-
+  if (points.length === 0) return []
   const first = points[0]
   const last = points[points.length - 1]
-  if (first.x === last.x && first.y === last.y) {
-    return points.map(clonePoint)
-  }
-
+  if (first.x === last.x && first.y === last.y) return points.map(clonePoint)
   return [...points.map(clonePoint), clonePoint(first)]
 }
 
 export function signedArea(points: Point[]): number {
-  if (points.length < 3) {
-    return 0
-  }
-
+  if (points.length < 3) return 0
   let area = 0
   const closed = ensureClosedPath(points)
-  for (let index = 0; index < closed.length - 1; index += 1) {
-    const a = closed[index]
-    const b = closed[index + 1]
+  for (let i = 0; i < closed.length - 1; i++) {
+    const a = closed[i]
+    const b = closed[i + 1]
     area += a.x * b.y - b.x * a.y
   }
-
   return area / 2
 }
 
@@ -130,28 +110,35 @@ export function isClockwise(points: Point[]): boolean {
   return signedArea(points) < 0
 }
 
-export function normalizeWinding(points: Point[], clockwise: boolean): Point[] {
+export function normalizeWinding(points: Point[], wantClockwise: boolean): Point[] {
   const closed = ensureClosedPath(points)
-  const currentlyClockwise = isClockwise(closed)
-  if (currentlyClockwise === clockwise) {
-    return closed
+  const alreadyClockwise = isClockwise(closed)
+  if (alreadyClockwise === wantClockwise) return closed
+  const reversed = [...closed].reverse()
+  const first = reversed[0]
+  const last = reversed[reversed.length - 1]
+  if (first.x !== last.x || first.y !== last.y) {
+    reversed.push({ x: first.x, y: first.y })
   }
+  return reversed
+}
 
-  return [...closed].reverse()
+export function applyContourDirection(contours: Point[][], direction: 'conventional' | 'climb' = 'conventional'): Point[][] {
+  // Conventional = no-op: the natural Clipper output is already conventional for every
+  // operation (both inside cuts like pocket and outside cuts like edge_route_outside after
+  // the flattenFeatureToClipperPath fix). Climb simply reverses each contour.
+  if (direction === 'conventional') {
+    return contours
+  }
+  return contours.map((c) => normalizeWinding(c, !isClockwise(c)))
 }
 
 export function toClipperPath(points: Point[], scale = DEFAULT_CLIPPER_SCALE): ClipperPath {
-  return ensureClosedPath(points).map((point) => ({
-    X: Math.round(point.x * scale),
-    Y: Math.round(point.y * scale),
-  }))
+  return ensureClosedPath(points).map((p) => ({ X: Math.round(p.x * scale), Y: Math.round(p.y * scale) }))
 }
 
 export function fromClipperPath(path: ClipperPath, scale = DEFAULT_CLIPPER_SCALE): Point[] {
-  return path.map((point) => ({
-    x: point.X / scale,
-    y: point.Y / scale,
-  }))
+  return path.map((p) => ({ x: p.X / scale, y: p.Y / scale }))
 }
 
 export function getOperationClearance(project: Project): number {
@@ -159,7 +146,7 @@ export function getOperationClearance(project: Project): number {
 }
 
 export function getOperationSafeZ(project: Project, featureSpans: ResolvedFeatureZSpan[] = []): number {
-  const highestFeatureZ = featureSpans.reduce((highest, span) => Math.max(highest, span.max), 0)
+  const highestFeatureZ = featureSpans.reduce((h, span) => Math.max(h, span.max), 0)
   const stockTop = project.stock.thickness
   return Math.max(stockTop, highestFeatureZ) + getOperationClearance(project)
 }

--- a/src/engine/toolpaths/pocket.ts
+++ b/src/engine/toolpaths/pocket.ts
@@ -1,5 +1,5 @@
 import ClipperLib from 'clipper-lib'
-import type { Operation, Point, Project } from '../../types/project'
+import type { CutDirection, Operation, Point, Project } from '../../types/project'
 import type {
   ClipperPath,
   PocketToolpathResult,
@@ -11,6 +11,7 @@ import type {
 } from './types'
 import {
   DEFAULT_CLIPPER_SCALE,
+  applyContourDirection,
   fromClipperPath,
   getOperationSafeZ,
   normalizeWinding,
@@ -725,11 +726,13 @@ export function cutClosedContours(
   maxLinkDistance: number,
   currentPosition: ToolpathPoint | null,
   preserveContourRotation = false,
+  direction: CutDirection = 'conventional',
 ): ToolpathPoint | null {
+  const directedContours = applyContourDirection(contours, direction)
   const start = currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null
   const orderedContours = preserveContourRotation
-    ? orderClosedContoursGreedyPreservingRotation(contours, start)
-    : orderClosedContoursGreedy(contours, start)
+    ? orderClosedContoursGreedyPreservingRotation(directedContours, start)
+    : orderClosedContoursGreedy(directedContours, start)
 
   let nextPosition = currentPosition
   for (const contour of orderedContours) {
@@ -751,6 +754,7 @@ export function cutOffsetRegionRecursive(
   stepoverDistance: number,
   maxLinkDistance: number,
   currentPosition: ToolpathPoint | null,
+  direction: CutDirection = 'conventional',
 ): ToolpathPoint | null {
   const childRegions = buildInsetRegions(region, stepoverDistance)
   const childAnchors = childRegions
@@ -771,6 +775,7 @@ export function cutOffsetRegionRecursive(
     maxLinkDistance,
     currentPosition,
     true,
+    direction,
   )
 
   const orderedChildren = orderRegionsGreedy(
@@ -787,6 +792,7 @@ export function cutOffsetRegionRecursive(
       stepoverDistance,
       maxLinkDistance,
       nextPosition,
+      direction,
     )
   }
 
@@ -818,6 +824,7 @@ function generateRoughBandMoves(
   toolRadius: number,
   stepoverDistance: number,
   maxLinkDistance: number,
+  direction: CutDirection = 'conventional',
 ): { moves: ToolpathMove[]; stepLevels: number[]; warnings: string[] } {
   const moves: ToolpathMove[] = []
   const warnings: string[] = []
@@ -847,7 +854,7 @@ function generateRoughBandMoves(
       }
     }
 
-    const boundaryContours = buildContourLoops(roughRegions)
+    const boundaryContours = applyContourDirection(buildContourLoops(roughRegions), direction)
     const segments = buildPocketParallelSegments(roughRegions, effectiveStepover, operation.pocketAngle)
     if (segments.length === 0) {
       return {
@@ -907,6 +914,7 @@ function generateRoughBandMoves(
         effectiveStepover,
         maxLinkDistance,
         currentPosition,
+        direction,
       )
     }
 
@@ -924,6 +932,7 @@ function generateFinishBandMoves(
   toolRadius: number,
   stepoverDistance: number,
   maxLinkDistance: number,
+  direction: CutDirection = 'conventional',
 ): { moves: ToolpathMove[]; stepLevels: number[]; warnings: string[] } {
   const moves: ToolpathMove[] = []
   const warnings: string[] = []
@@ -967,13 +976,13 @@ function generateFinishBandMoves(
   let currentPosition: ToolpathPoint | null = null
 
   for (const z of wallStepLevels) {
-    currentPosition = cutClosedContours(moves, wallContours, z, safeZ, maxLinkDistance, currentPosition)
+    currentPosition = cutClosedContours(moves, wallContours, z, safeZ, maxLinkDistance, currentPosition, false, direction)
 
     currentPosition = retractToSafe(moves, currentPosition, safeZ)
   }
 
   for (const z of floorStepLevels) {
-    currentPosition = cutClosedContours(moves, floorContours, z, safeZ, maxLinkDistance, currentPosition)
+    currentPosition = cutClosedContours(moves, floorContours, z, safeZ, maxLinkDistance, currentPosition, false, direction)
 
     const orderedFloorSegments = orderOpenSegmentsGreedy(
       floorSegments,
@@ -1048,6 +1057,7 @@ export function generatePocketToolpath(project: Project, operation: Operation): 
   const safeZ = getOperationSafeZ(project)
   const stepoverDistance = tool.diameter * operation.stepover
   const maxLinkDistance = tool.diameter
+  const direction = operation.cutDirection ?? 'conventional'
   const allMoves: ToolpathMove[] = []
   const warnings = [...resolved.warnings]
   const allStepLevels = new Set<number>()
@@ -1098,6 +1108,7 @@ export function generatePocketToolpath(project: Project, operation: Operation): 
         tool.radius,
         stepoverDistance,
         maxLinkDistance,
+        direction,
       )
       : generateRoughBandMoves(
         band,
@@ -1107,6 +1118,7 @@ export function generatePocketToolpath(project: Project, operation: Operation): 
         tool.radius,
         stepoverDistance,
         maxLinkDistance,
+        direction,
       )
     const { moves, stepLevels, warnings: bandWarnings } = result
     moves.forEach((move) => allMoves.push(move))

--- a/src/engine/toolpaths/surface.ts
+++ b/src/engine/toolpaths/surface.ts
@@ -1,5 +1,5 @@
 import ClipperLib from 'clipper-lib'
-import type { Operation, Project, SketchFeature } from '../../types/project'
+import type { CutDirection, Operation, Project, SketchFeature } from '../../types/project'
 import type {
   ClipperPath,
   PocketToolpathResult,
@@ -12,6 +12,7 @@ import type {
 } from './types'
 import {
   DEFAULT_CLIPPER_SCALE,
+  applyContourDirection,
   flattenProfile,
   getOperationSafeZ,
   normalizeToolForProject,
@@ -253,6 +254,7 @@ function generateRoughBandMoves(
   toolRadius: number,
   stepoverDistance: number,
   maxLinkDistance: number,
+  direction: CutDirection = 'conventional',
 ): { moves: ToolpathMove[]; stepLevels: number[]; warnings: string[] } {
   const moves: ToolpathMove[] = []
   const warnings: string[] = []
@@ -283,7 +285,7 @@ function generateRoughBandMoves(
       }
     }
 
-    const boundaryContours = buildContourLoops(roughRegions)
+    const boundaryContours = applyContourDirection(buildContourLoops(roughRegions), direction)
     const segments = buildPocketParallelSegments(roughRegions, effectiveStepover, operation.pocketAngle)
     if (segments.length === 0) {
       return {
@@ -348,6 +350,7 @@ function generateRoughBandMoves(
         effectiveStepover,
         maxLinkDistance,
         currentPosition,
+        direction,
       )
     }
 
@@ -365,6 +368,7 @@ function generateFinishBandMoves(
   toolRadius: number,
   stepoverDistance: number,
   maxLinkDistance: number,
+  direction: CutDirection = 'conventional',
 ): { moves: ToolpathMove[]; stepLevels: number[]; warnings: string[] } {
   const moves: ToolpathMove[] = []
   const warnings: string[] = []
@@ -389,9 +393,9 @@ function generateFinishBandMoves(
   const coverageRegions = buildSurfaceCoverageRegions(band.subjectPaths, band.protectedPaths, band.regions, toolRadius)
   const finishDelta = radialLeave
   const finishRegions = coverageRegions.flatMap((region) => buildInsetRegions(region, finishDelta))
-  const wallContours = operation.finishWalls ? buildContourLoops(finishRegions) : []
+  const wallContours = operation.finishWalls ? applyContourDirection(buildContourLoops(finishRegions), direction) : []
   const floorContours = operation.finishFloor && operation.pocketPattern === 'offset'
-    ? buildPocketFloorContours(finishRegions, 0, stepoverDistance)
+    ? applyContourDirection(buildPocketFloorContours(finishRegions, 0, stepoverDistance), direction)
     : []
   const floorSegments = operation.finishFloor && operation.pocketPattern === 'parallel'
     ? buildPocketParallelSegments(finishRegions, stepoverDistance, operation.pocketAngle)
@@ -502,6 +506,7 @@ export function generateSurfaceCleanToolpath(project: Project, operation: Operat
   const safeZ = getOperationSafeZ(project)
   const stepoverDistance = tool.diameter * operation.stepover
   const maxLinkDistance = tool.diameter
+  const direction = operation.cutDirection ?? 'conventional'
   const allMoves: ToolpathMove[] = []
   const warnings = [...resolved.warnings]
   const allStepLevels = new Set<number>()
@@ -516,6 +521,7 @@ export function generateSurfaceCleanToolpath(project: Project, operation: Operat
         tool.radius,
         stepoverDistance,
         maxLinkDistance,
+        direction,
       )
       : generateRoughBandMoves(
         band,
@@ -525,6 +531,7 @@ export function generateSurfaceCleanToolpath(project: Project, operation: Operat
         tool.radius,
         stepoverDistance,
         maxLinkDistance,
+        direction,
       )
 
     const { moves, stepLevels, warnings: bandWarnings } = result

--- a/src/engine/toolpaths/vcarve.ts
+++ b/src/engine/toolpaths/vcarve.ts
@@ -1,7 +1,7 @@
 import ClipperLib from 'clipper-lib'
 import type { Operation, Project } from '../../types/project'
 import type { ToolpathBounds, ToolpathMove, ToolpathPoint, ToolpathResult } from './types'
-import { getOperationSafeZ, normalizeToolForProject } from './geometry'
+import { applyContourDirection, getOperationSafeZ, normalizeToolForProject } from './geometry'
 import { buildContourLoops, buildInsetRegions, contourStartPoint, pushRapidAndPlunge, retractToSafe, toClosedCutMoves, updateBounds } from './pocket'
 import { resolvePocketRegions } from './resolver'
 
@@ -89,6 +89,7 @@ export function generateVCarveToolpath(project: Project, operation: Operation): 
   const safeZ = getOperationSafeZ(project)
   // stepover is the absolute contour spacing distance in project units.
   const stepoverDistance = operation.stepover
+  const direction = operation.cutDirection ?? 'conventional'
   const moves: ToolpathMove[] = []
   const warnings = [...resolved.warnings]
   let currentPosition: ToolpathPoint | null = null
@@ -105,11 +106,12 @@ export function generateVCarveToolpath(project: Project, operation: Operation): 
     let currentRegions = band.regions.flatMap((region) => buildInsetRegions(region, currentDepth * slope, vcarveJoinType))
 
     while (currentRegions.length > 0 && currentDepth <= maxBandDepth + 1e-9) {
-      const contours = buildContourLoops(currentRegions)
-      if (contours.length === 0) {
+      const rawContours = buildContourLoops(currentRegions)
+      if (rawContours.length === 0) {
         break
       }
 
+      const contours = applyContourDirection(rawContours, direction)
       const z = band.topZ - currentDepth
       for (const contour of contours) {
         const entryPoint = contourStartPoint(contour, z)

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1449,6 +1449,7 @@ function defaultOperationForTarget(
     finishFloor: true,
     carveDepth: convertLength(1, 'mm', project.meta.units),
     maxCarveDepth: convertLength(1, 'mm', project.meta.units),
+    cutDirection: 'conventional',
   }
 }
 

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -235,6 +235,7 @@ export type OperationKind =
 
 export type OperationPass = 'rough' | 'finish'
 export type PocketPattern = 'offset' | 'parallel'
+export type CutDirection = 'conventional' | 'climb'
 
 export type OperationTarget =
   | { source: 'features'; featureIds: string[] }
@@ -263,6 +264,7 @@ export interface Operation {
   finishFloor: boolean
   carveDepth: number
   maxCarveDepth: number
+  cutDirection?: CutDirection
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

- Adds a **Cut Direction** dropdown (Conventional / Climb) to pocket, edge route inside/outside, v-carve offset, and surface clean operations
- Defaults to **Conventional** for all new and existing operations (backward compatible via optional field)
- Fixes **edge_route_outside** which was unconditionally generating climb cuts due to incorrect polygon winding being fed to Clipper before the offset step

## How it works

The app uses screen coordinates (+Y down). The G-code postprocessor inverts Y, so:
- CCW on screen → CW in machine = **conventional**
- CW on screen → CCW in machine = **climb**

`applyContourDirection` is a no-op for conventional (Clipper's natural output is already conventional for all operation types) and reverses point order for climb.

The `flattenFeatureToClipperPath` fix in `edge.ts` feeds CCW-normalised polygons to Clipper so the outward offset preserves the conventional orientation.

## Test plan

- [x] Edge route outside (rough + finish) cuts conventional by default, switches correctly to climb
- [x] Edge route inside responds to direction change
- [x] Pocket offset pattern follows direction
- [x] Pocket parallel pattern boundary contours follow direction
- [ ] V-carve offset contours follow direction
- [x] Surface clean contours follow direction
- [x] Existing saved projects without `cutDirection` field default to conventional