### PR TITLE
feat: view preset icon panel

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,7 +35,19 @@ Defined in `src/types/project.ts`:
 - `src/import/`: DXF and SVG parsers that normalize external geometry into the `.camj` format.
 - `src/text/`: Logic for converting text and fonts into machinable geometry.
 
-## 5. Coding Standards & Conventions
+## 5. Icon System
+
+Icons are managed as a custom build pipeline using the `.camj` project format.
+
+- **Source of truth:** `src/assets/icons.camj` — a standard `.camj` project file where each icon is a named folder of sketch features on a 24×24 unit canvas. This file can be opened and edited in the application itself.
+- **Build output:** `public/icons.svg` — an SVG sprite sheet generated from `icons.camj`. This file is **generated; do not edit it directly**.
+- **Build command:** `npm run sync-icons` (also runs as part of the full `npm run build`).
+- **Conversion script:** `scripts/convert-camj-to-icons.js` reads `icons.camj`, converts each feature's sketch profile to an SVG `<path>`, and writes `<symbol>` elements to `public/icons.svg`. Features with empty segment arrays are skipped.
+- **Icon naming:** The folder `name` in `icons.camj` becomes the symbol `id` in the SVG (e.g. folder name `"view-top"` → `<symbol id="view-top">`).
+- **Usage in components:** Import `Icon` from `src/components/Icon.tsx` and pass the folder name as the `id` prop: `<Icon id="view-top" size={18} />`. The component renders a `<use href="icons.svg#id" />` reference, so the icon inherits `stroke="currentColor"` and `fill="none"` from the SVG wrapper.
+- **Adding new icons:** Add feature folders and features to `icons.camj`, then run `npm run sync-icons`. Each icon group needs a `featureFolders` entry and a `featureTree` entry in addition to the `features` entries.
+
+## 6. Coding Standards & Conventions
 - **Strict TypeScript:** No `any`. Use interfaces and types defined in `src/types/project.ts`.
 - **State Mutation:** All modifications to the project must go through the `projectStore` actions to ensure consistency and history tracking.
 - **UI:** React for component structure + Vanilla CSS for styling. Avoid heavy UI libraries.

--- a/public/icons.svg
+++ b/public/icons.svg
@@ -305,6 +305,30 @@
     <path d="M 12 2 L 12 22" />
     <path d="M 2 12 L 22 12" />
   </symbol>
+  <symbol id="view-bottom" viewBox="0 0 24 24">
+    <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
+    <path d="M 12 7 L 12 16" />
+    <path d="M 9 13 L 12 17 L 15 13" />
+  </symbol>
+  <symbol id="view-front" viewBox="0 0 24 24">
+    <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
+    <path d="M 12 7 L 17 12 L 12 17 L 7 12 L 12 7 Z" />
+  </symbol>
+  <symbol id="view-back" viewBox="0 0 24 24">
+    <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
+    <path d="M 8 8 L 16 16" />
+    <path d="M 16 8 L 8 16" />
+  </symbol>
+  <symbol id="view-right" viewBox="0 0 24 24">
+    <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
+    <path d="M 7 12 L 16 12" />
+    <path d="M 13 9 L 17 12 L 13 15" />
+  </symbol>
+  <symbol id="view-left" viewBox="0 0 24 24">
+    <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
+    <path d="M 17 12 L 8 12" />
+    <path d="M 11 9 L 7 12 L 11 15" />
+  </symbol>
   <symbol id="play" viewBox="0 0 24 24">
     <path d="M 5 3 L 19 12 L 5 21 L 5 3 Z" />
   </symbol>

--- a/src/assets/icons.camj
+++ b/src/assets/icons.camj
@@ -17000,6 +17000,363 @@
       "z_bottom": -1,
       "visible": false,
       "locked": false
+    },
+    {
+      "id": "icon_view-bottom_1",
+      "name": "view-bottom_shape_1",
+      "kind": "composite",
+      "folderId": "folder_view-bottom",
+      "sketch": {
+        "profile": {
+          "start": { "x": 4, "y": 4 },
+          "segments": [
+            { "type": "line", "to": { "x": 20, "y": 4 } },
+            { "type": "line", "to": { "x": 20, "y": 20 } },
+            { "type": "line", "to": { "x": 4, "y": 20 } },
+            { "type": "line", "to": { "x": 4, "y": 4 } }
+          ],
+          "closed": true
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-bottom_2",
+      "name": "view-bottom_shape_2",
+      "kind": "composite",
+      "folderId": "folder_view-bottom",
+      "sketch": {
+        "profile": {
+          "start": { "x": 12, "y": 7 },
+          "segments": [
+            { "type": "line", "to": { "x": 12, "y": 16 } }
+          ],
+          "closed": false
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-bottom_3",
+      "name": "view-bottom_shape_3",
+      "kind": "composite",
+      "folderId": "folder_view-bottom",
+      "sketch": {
+        "profile": {
+          "start": { "x": 9, "y": 13 },
+          "segments": [
+            { "type": "line", "to": { "x": 12, "y": 17 } },
+            { "type": "line", "to": { "x": 15, "y": 13 } }
+          ],
+          "closed": false
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-front_1",
+      "name": "view-front_shape_1",
+      "kind": "composite",
+      "folderId": "folder_view-front",
+      "sketch": {
+        "profile": {
+          "start": { "x": 4, "y": 4 },
+          "segments": [
+            { "type": "line", "to": { "x": 20, "y": 4 } },
+            { "type": "line", "to": { "x": 20, "y": 20 } },
+            { "type": "line", "to": { "x": 4, "y": 20 } },
+            { "type": "line", "to": { "x": 4, "y": 4 } }
+          ],
+          "closed": true
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-front_2",
+      "name": "view-front_shape_2",
+      "kind": "composite",
+      "folderId": "folder_view-front",
+      "sketch": {
+        "profile": {
+          "start": { "x": 12, "y": 7 },
+          "segments": [
+            { "type": "line", "to": { "x": 17, "y": 12 } },
+            { "type": "line", "to": { "x": 12, "y": 17 } },
+            { "type": "line", "to": { "x": 7, "y": 12 } },
+            { "type": "line", "to": { "x": 12, "y": 7 } }
+          ],
+          "closed": true
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-back_1",
+      "name": "view-back_shape_1",
+      "kind": "composite",
+      "folderId": "folder_view-back",
+      "sketch": {
+        "profile": {
+          "start": { "x": 4, "y": 4 },
+          "segments": [
+            { "type": "line", "to": { "x": 20, "y": 4 } },
+            { "type": "line", "to": { "x": 20, "y": 20 } },
+            { "type": "line", "to": { "x": 4, "y": 20 } },
+            { "type": "line", "to": { "x": 4, "y": 4 } }
+          ],
+          "closed": true
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-back_2",
+      "name": "view-back_shape_2",
+      "kind": "composite",
+      "folderId": "folder_view-back",
+      "sketch": {
+        "profile": {
+          "start": { "x": 8, "y": 8 },
+          "segments": [
+            { "type": "line", "to": { "x": 16, "y": 16 } }
+          ],
+          "closed": false
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-back_3",
+      "name": "view-back_shape_3",
+      "kind": "composite",
+      "folderId": "folder_view-back",
+      "sketch": {
+        "profile": {
+          "start": { "x": 16, "y": 8 },
+          "segments": [
+            { "type": "line", "to": { "x": 8, "y": 16 } }
+          ],
+          "closed": false
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-right_1",
+      "name": "view-right_shape_1",
+      "kind": "composite",
+      "folderId": "folder_view-right",
+      "sketch": {
+        "profile": {
+          "start": { "x": 4, "y": 4 },
+          "segments": [
+            { "type": "line", "to": { "x": 20, "y": 4 } },
+            { "type": "line", "to": { "x": 20, "y": 20 } },
+            { "type": "line", "to": { "x": 4, "y": 20 } },
+            { "type": "line", "to": { "x": 4, "y": 4 } }
+          ],
+          "closed": true
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-right_2",
+      "name": "view-right_shape_2",
+      "kind": "composite",
+      "folderId": "folder_view-right",
+      "sketch": {
+        "profile": {
+          "start": { "x": 7, "y": 12 },
+          "segments": [
+            { "type": "line", "to": { "x": 16, "y": 12 } }
+          ],
+          "closed": false
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-right_3",
+      "name": "view-right_shape_3",
+      "kind": "composite",
+      "folderId": "folder_view-right",
+      "sketch": {
+        "profile": {
+          "start": { "x": 13, "y": 9 },
+          "segments": [
+            { "type": "line", "to": { "x": 17, "y": 12 } },
+            { "type": "line", "to": { "x": 13, "y": 15 } }
+          ],
+          "closed": false
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-left_1",
+      "name": "view-left_shape_1",
+      "kind": "composite",
+      "folderId": "folder_view-left",
+      "sketch": {
+        "profile": {
+          "start": { "x": 4, "y": 4 },
+          "segments": [
+            { "type": "line", "to": { "x": 20, "y": 4 } },
+            { "type": "line", "to": { "x": 20, "y": 20 } },
+            { "type": "line", "to": { "x": 4, "y": 20 } },
+            { "type": "line", "to": { "x": 4, "y": 4 } }
+          ],
+          "closed": true
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-left_2",
+      "name": "view-left_shape_2",
+      "kind": "composite",
+      "folderId": "folder_view-left",
+      "sketch": {
+        "profile": {
+          "start": { "x": 17, "y": 12 },
+          "segments": [
+            { "type": "line", "to": { "x": 8, "y": 12 } }
+          ],
+          "closed": false
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
+    },
+    {
+      "id": "icon_view-left_3",
+      "name": "view-left_shape_3",
+      "kind": "composite",
+      "folderId": "folder_view-left",
+      "sketch": {
+        "profile": {
+          "start": { "x": 11, "y": 9 },
+          "segments": [
+            { "type": "line", "to": { "x": 7, "y": 12 } },
+            { "type": "line", "to": { "x": 11, "y": 15 } }
+          ],
+          "closed": false
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false
     }
   ],
   "featureFolders": [
@@ -17289,6 +17646,31 @@
       "collapsed": true
     },
     {
+      "id": "folder_view-bottom",
+      "name": "view-bottom",
+      "collapsed": true
+    },
+    {
+      "id": "folder_view-front",
+      "name": "view-front",
+      "collapsed": true
+    },
+    {
+      "id": "folder_view-back",
+      "name": "view-back",
+      "collapsed": true
+    },
+    {
+      "id": "folder_view-right",
+      "name": "view-right",
+      "collapsed": true
+    },
+    {
+      "id": "folder_view-left",
+      "name": "view-left",
+      "collapsed": true
+    },
+    {
       "id": "folder_play",
       "name": "play",
       "collapsed": true
@@ -17532,6 +17914,26 @@
     {
       "type": "folder",
       "folderId": "folder_view-top"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_view-bottom"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_view-front"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_view-back"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_view-right"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_view-left"
     },
     {
       "type": "folder",

--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import * as THREE from 'three'
+import { Icon } from '../Icon'
 import { buildClampMesh, buildOriginTriad } from '../../engine/csg'
 import { buildSimulationGeometry } from '../../engine/simulation/mesh'
 import type { SimulationResult } from '../../engine/simulation'
@@ -337,7 +338,6 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   zoomWindowActive = false,
   onZoomWindowComplete,
 }, ref) {
-  const [showOverlay, setShowOverlay] = useState(false)
   const [zoomWindowBox, setZoomWindowBox] = useState<{ startX: number; startY: number; currentX: number; currentY: number } | null>(null)
   const zoomWindowBoxRef = useRef<{ startX: number; startY: number; currentX: number; currentY: number } | null>(null)
   const mountRef = useRef<HTMLDivElement>(null)
@@ -645,14 +645,6 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
       )}
       <div className="viewport-presets">
         <div className="viewport-presets__group viewport-presets__group--status">
-          <button
-            className={`preset-btn ${showOverlay ? 'preset-btn--active' : ''}`}
-            onClick={() => setShowOverlay((current) => !current)}
-            title="Show simulation stats"
-            type="button"
-          >
-            Info
-          </button>
           <div className="simulation-mode-toggle" role="tablist" aria-label="Simulation mode">
             <button
               className={`simulation-mode-toggle__btn ${mode === 'selected' ? 'simulation-mode-toggle__btn--active' : ''}`}
@@ -684,76 +676,17 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
           </label>
         </div>
         <div className="viewport-presets__group viewport-presets__group--views">
-          <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('top')} title="Top view" type="button">Top</button>
-          <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('bottom')} title="Bottom view" type="button">Bottom</button>
-          <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('front')} title="Front view" type="button">Front</button>
-          <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('back')} title="Back view" type="button">Back</button>
-          <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('right')} title="Right view" type="button">Right</button>
-          <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('left')} title="Left view" type="button">Left</button>
-          <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('iso')} title="Isometric view" type="button">Iso</button>
+          <div className="preset-btn-panel">
+            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('top')} title="Top view" type="button"><Icon id="view-top" size={16} /></button>
+            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('bottom')} title="Bottom view" type="button"><Icon id="view-bottom" size={16} /></button>
+            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('front')} title="Front view" type="button"><Icon id="view-front" size={16} /></button>
+            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('back')} title="Back view" type="button"><Icon id="view-back" size={16} /></button>
+            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('right')} title="Right view" type="button"><Icon id="view-right" size={16} /></button>
+            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('left')} title="Left view" type="button"><Icon id="view-left" size={16} /></button>
+            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('iso')} title="Isometric view" type="button"><Icon id="view-iso" size={16} /></button>
+          </div>
         </div>
       </div>
-      {showOverlay ? (
-        <div className="simulation-viewport__overlay">
-          <div className="simulation-viewport__overlay-header">
-            <div className="simulation-viewport__title">Simulation</div>
-            <button
-              className="simulation-viewport__close"
-              onClick={() => setShowOverlay(false)}
-              title="Hide simulation stats"
-              type="button"
-            >
-              Close
-            </button>
-          </div>
-          {mode === 'visible' || operation ? (
-            <>
-              <div className="simulation-viewport__line">
-                Mode: <strong>{mode === 'selected' ? 'Selected' : 'Visible'}</strong>
-              </div>
-              {mode === 'selected' ? (
-                <div className="simulation-viewport__line">
-                  Operation: <strong>{operation?.name ?? 'Selected operation'}</strong>
-                </div>
-              ) : (
-                <div className="simulation-viewport__line">
-                  Operations: <strong>{operationCount}</strong>
-                </div>
-              )}
-              {simulation ? (
-                <>
-                  <div className="simulation-viewport__line">
-                    Grid: <strong>{simulation.grid.cols} × {simulation.grid.rows}</strong>
-                  </div>
-                  <div className="simulation-viewport__line">
-                    Cell size: <strong>{simulation.grid.cellSize.toFixed(4)}</strong>
-                  </div>
-                  <div className="simulation-viewport__line">
-                    Moves: <strong>{simulation.stats.processedMoveCount}</strong>
-                  </div>
-                  <div className="simulation-viewport__line">
-                    Removed cells: <strong>{simulation.stats.removedCellCount}</strong>
-                  </div>
-                  <div className="simulation-viewport__line">
-                    Min top Z: <strong>{simulation.stats.minTopZ.toFixed(4)}</strong>
-                  </div>
-                </>
-              ) : null}
-              {simulation && simulation.warnings.length > 0 ? (
-                <div className="simulation-viewport__warnings">
-                  {simulation.warnings.map((warning, index) => (
-                    <div key={`${operation?.id ?? mode}-simulation-warning-${index}`} className="simulation-viewport__warning">
-                      {warning}
-                    </div>
-                  ))}
-                </div>
-              ) : null}
-            </>
-          ) : (
-            <div className="simulation-viewport__note">Select an operation to simulate.</div>
-          )}
-        </div>
-      ) : null}
     </div>
   )
 })

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import * as THREE from 'three'
+import { Icon } from '../Icon'
 import type { ToolpathResult } from '../../engine/toolpaths/types'
 import { useProjectStore } from '../../store/projectStore'
 import { buildOriginTriad, buildScene } from '../../engine/csg'
@@ -1026,27 +1027,29 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
         </div>
       )}
       <div className="viewport-presets">
-        <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('top')} title="Top view" type="button">
-          Top
-        </button>
-        <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('bottom')} title="Bottom view" type="button">
-          Bottom
-        </button>
-        <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('front')} title="Front view" type="button">
-          Front
-        </button>
-        <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('back')} title="Back view" type="button">
-          Back
-        </button>
-        <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('right')} title="Right view" type="button">
-          Right
-        </button>
-        <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('left')} title="Left view" type="button">
-          Left
-        </button>
-        <button className="preset-btn" onClick={() => controlsRef.current?.setPreset('iso')} title="Isometric view" type="button">
-          Iso
-        </button>
+        <div className="preset-btn-panel">
+          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('top')} title="Top view" type="button">
+            <Icon id="view-top" size={16} />
+          </button>
+          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('bottom')} title="Bottom view" type="button">
+            <Icon id="view-bottom" size={16} />
+          </button>
+          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('front')} title="Front view" type="button">
+            <Icon id="view-front" size={16} />
+          </button>
+          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('back')} title="Back view" type="button">
+            <Icon id="view-back" size={16} />
+          </button>
+          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('right')} title="Right view" type="button">
+            <Icon id="view-right" size={16} />
+          </button>
+          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('left')} title="Left view" type="button">
+            <Icon id="view-left" size={16} />
+          </button>
+          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('iso')} title="Isometric view" type="button">
+            <Icon id="view-iso" size={16} />
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1394,6 +1394,36 @@
 .preset-btn--icon {
   width: 30px;
   padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.preset-btn-panel {
+  display: inline-flex;
+}
+
+.preset-btn-panel .preset-btn {
+  border-radius: 0;
+}
+
+.preset-btn-panel .preset-btn:first-child {
+  border-top-left-radius: 7px;
+  border-bottom-left-radius: 7px;
+}
+
+.preset-btn-panel .preset-btn:last-child {
+  border-top-right-radius: 7px;
+  border-bottom-right-radius: 7px;
+}
+
+.preset-btn-panel .preset-btn + .preset-btn {
+  margin-left: -1px;
+}
+
+.preset-btn-panel .preset-btn:hover {
+  position: relative;
+  z-index: 1;
 }
 
 .feature-context-menu {


### PR DESCRIPTION
## Summary
- Groups view direction buttons (Top/Bottom/Front/Back/Right/Left/Iso) into a connected panel strip in both the 3D View and Simulation viewports
- Replaces text labels with icons; adds 5 new view icons to `icons.camj` (`view-bottom`, `view-front`, `view-back`, `view-right`, `view-left`) and regenerates `icons.svg`
- Removes the debug Info button and its overlay from SimulationViewport
- Adds icon system documentation to `ARCHITECTURE.md`

## Test plan
- [x] 3D View: all 7 view preset buttons render as icons in a connected strip and set the correct camera angle
- [x] Simulation: same strip appears alongside the Selected/Visible toggle and Detail slider
- [x] Hovering each button shows the correct title tooltip
- [x] `npm run sync-icons` regenerates `public/icons.svg` cleanly from `src/assets/icons.camj`