### PR TITLE
fix: remove unused props from SimulationViewport after overlay removal

### DIFF
--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -323,13 +323,11 @@ function createOrbitControls(
 }
 
 export const SimulationViewport = forwardRef<SimulationViewportHandle, SimulationViewportProps>(function SimulationViewport({
-  operation,
   simulation,
   detailCells,
   onDetailCellsChange,
   mode,
   onModeChange,
-  operationCount,
   clamps,
   selectedClampId,
   collidingClampIds,


### PR DESCRIPTION
## Summary
- Removes `operation` and `operationCount` from the `SimulationViewport` destructuring — these were only consumed by the debug overlay removed in #25, causing a TypeScript build error.
- The props remain in the interface since `App.tsx` still passes them.

## Test plan
- [x] `npm run build` completes without TypeScript errors