### PR TITLE
ci: add PR build check workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,25 @@
+name: PR Build Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs on every PR (opened, updated, reopened)
- Installs dependencies and runs `npm run build`
- Fails the check if the build fails, blocking merges with broken builds

## Test plan
- [x] Open a PR and verify the `PR Build Check` job runs and passes
- [ ] Optionally: break the build in a branch and confirm the check fails