### PR TITLE
fix: use BASE_URL for tool-library.json fetch

### DIFF
--- a/src/toolLibrary.ts
+++ b/src/toolLibrary.ts
@@ -108,7 +108,7 @@ function parseToolLibraryFile(value: unknown): ToolLibraryFile {
 
 export async function loadBundledToolLibrary(): Promise<ToolLibraryFile> {
   if (!bundledToolLibraryPromise) {
-    bundledToolLibraryPromise = fetch('/tool-library.json')
+    bundledToolLibraryPromise = fetch(`${import.meta.env.BASE_URL}tool-library.json`)
       .then(async (response) => {
         if (!response.ok) {
           throw new Error(`Failed to load tool library (${response.status}).`)


### PR DESCRIPTION
## Summary
- Fixes 404 error for `tool-library.json` when running from `/app` and `/app-rc` subpaths on GitHub Pages
- Replaces absolute path `/tool-library.json` with `import.meta.env.BASE_URL + 'tool-library.json'` so it resolves relative to the deployment subpath