### PR TITLE
Improve sketch edit controls and legend behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ interface TreeContextMenuState {
 type ToolbarOrientation = 'top' | 'left'
 
 const TOOLBAR_ORIENTATION_STORAGE_KEY = 'camcam.toolbarOrientation'
+const DEPTH_LEGEND_COLLAPSED_STORAGE_KEY = 'camcam.depthLegendCollapsed'
 const TOOLBAR_LEFT_BREAKPOINT = 1100
 
 function App() {
@@ -51,6 +52,13 @@ function App() {
   const [showExportDialog, setShowExportDialog] = useState(false)
   const [zoomWindowActive, setZoomWindowActive] = useState(false)
   const [activeSnapMode, setActiveSnapMode] = useState<SnapMode | null>(null)
+  const [depthLegendCollapsed, setDepthLegendCollapsed] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false
+    }
+
+    return window.localStorage.getItem(DEPTH_LEGEND_COLLAPSED_STORAGE_KEY) === 'true'
+  })
   const [snapSettings, setSnapSettings] = useState<SnapSettings>(() => {
     if (typeof window === 'undefined') {
       return DEFAULT_SNAP_SETTINGS
@@ -297,6 +305,10 @@ function App() {
   }, [toolbarOrientationPreference])
 
   useEffect(() => {
+    window.localStorage.setItem(DEPTH_LEGEND_COLLAPSED_STORAGE_KEY, String(depthLegendCollapsed))
+  }, [depthLegendCollapsed])
+
+  useEffect(() => {
     window.localStorage.setItem(SNAP_SETTINGS_STORAGE_KEY, JSON.stringify(snapSettings))
   }, [snapSettings])
 
@@ -519,6 +531,24 @@ function App() {
       project.features.some((feature) => feature.id === featureId && feature.locked)
     ) ?? false)
 
+  const collapsedDepthLegend = centerTab === 'sketch' && depthLegendCollapsed ? (
+    <button
+      className="statusbar-depth-legend"
+      type="button"
+      onClick={() => setDepthLegendCollapsed(false)}
+      title="Expand feature color legend"
+      aria-label="Expand feature color legend"
+    >
+      <span className="statusbar-depth-legend__label">Feature Colors</span>
+      <span className="statusbar-depth-legend__swatches" aria-hidden="true">
+        <span className="sketch-depth-legend__swatch sketch-depth-legend__swatch--subtract-shallow" />
+        <span className="sketch-depth-legend__swatch sketch-depth-legend__swatch--subtract-deep" />
+        <span className="sketch-depth-legend__swatch sketch-depth-legend__swatch--add" />
+        <span className="sketch-depth-legend__swatch sketch-depth-legend__swatch--selected" />
+      </span>
+    </button>
+  ) : null
+
   return (
     <>
       <AppShell
@@ -566,6 +596,8 @@ function App() {
             zoomWindowActive={zoomWindowActive && centerTab === 'sketch'}
             onZoomWindowComplete={() => setZoomWindowActive(false)}
             onActiveSnapModeChange={setActiveSnapMode}
+            depthLegendCollapsed={depthLegendCollapsed}
+            onToggleDepthLegend={() => setDepthLegendCollapsed((value) => !value)}
           />
         }
         viewport3d={
@@ -618,6 +650,7 @@ function App() {
         onToolbarOrientationChange={setToolbarOrientationPreference}
         rightTab={rightTab}
         onRightTabChange={setRightTab}
+        statusBarExtras={collapsedDepthLegend}
       />
       
       {showExportDialog && (

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -38,7 +38,6 @@ import type { DimensionEditState, OperationDimEdit } from './manualEntry'
 import { resolveSketchSnap } from './snappingHelpers'
 import type { ResolvedSnap } from './snappingHelpers'
 import {
-  drawDepthLegend,
   drawFeature,
   drawMoveGuide,
   drawPendingPathLoop,
@@ -124,6 +123,8 @@ interface SketchCanvasProps {
   zoomWindowActive?: boolean
   onZoomWindowComplete?: () => void
   onActiveSnapModeChange?: (mode: SnapMode | null) => void
+  depthLegendCollapsed?: boolean
+  onToggleDepthLegend?: () => void
 }
 
 export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(function SketchCanvas(
@@ -138,6 +139,8 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     zoomWindowActive = false,
     onZoomWindowComplete,
     onActiveSnapModeChange,
+    depthLegendCollapsed = false,
+    onToggleDepthLegend,
   },
   ref
 ) {
@@ -170,6 +173,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const [backdropImage, setBackdropImage] = useState<HTMLImageElement | null>(null)
   const [dimensionEdit, setDimensionEdit] = useState<DimensionEditState | null>(null)
   const copyCountInputRef = useRef<HTMLInputElement>(null)
+  const hoveredEditControlRef = useRef<SketchControlRef | null>(null)
   const dimensionEditRef = useRef<DimensionEditState | null>(null)
   const dimensionEditControlRef = useRef<SketchControlRef | null>(null)
   const dimensionEditFeatureIdRef = useRef<string | null>(null)
@@ -303,6 +307,18 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     scheduleDraw()
   }
 
+  function sameControl(a: SketchControlRef | null, b: SketchControlRef | null): boolean {
+    return a?.kind === b?.kind && a?.index === b?.index && a?.t === b?.t
+  }
+
+  function setHoveredEditControl(nextControl: SketchControlRef | null) {
+    if (sameControl(hoveredEditControlRef.current, nextControl)) {
+      return
+    }
+    hoveredEditControlRef.current = nextControl
+    scheduleDraw()
+  }
+
   function isActiveSnapPoint(point: Point | null | undefined): boolean {
     return !!point && !!activeSnapRef.current?.mode && pointsEqual(point, activeSnapRef.current.point, 1e-6)
   }
@@ -415,6 +431,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
   useEffect(() => {
     if (selection.mode !== 'sketch_edit') {
+      hoveredEditControlRef.current = null
       dimensionEditControlRef.current = null
       dimensionEditFeatureIdRef.current = null
       editDimStepsRef.current = []
@@ -422,6 +439,16 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       setDimensionEdit(null)
     }
   }, [selection.mode])
+
+  useEffect(() => {
+    if (
+      selection.mode !== 'sketch_edit'
+      || selection.selectedNode?.type !== 'feature'
+      || !!selection.sketchEditTool
+    ) {
+      setHoveredEditControl(null)
+    }
+  }, [selection.mode, selection.selectedFeatureId, selection.selectedNode, selection.sketchEditTool])
 
   useEffect(() => {
     pendingOffsetPreviewPointRef.current = null
@@ -596,9 +623,16 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       drawFeature(ctx, feature, vt, project.meta.units, project.meta.showFeatureInfo, selected, hovered, editing)
 
       if (editing) {
-        const editControl = isDraggingNodeRef.current ? selection.activeControl : (dimensionEditControlRef.current ?? selection.activeControl)
+        const hoveredEditControl =
+          !isDraggingNodeRef.current && !dimensionEditControlRef.current
+            ? hoveredEditControlRef.current
+            : null
+        const editControl =
+          isDraggingNodeRef.current
+            ? selection.activeControl
+            : (dimensionEditControlRef.current ?? selection.activeControl ?? hoveredEditControl)
         drawSketchControls(ctx, feature.sketch.profile, vt, editControl)
-        if (isDraggingNodeRef.current || dimensionEditControlRef.current) {
+        if (editControl && (isDraggingNodeRef.current || dimensionEditControlRef.current || hoveredEditControl)) {
           drawActiveEditMeasurements(ctx, feature.sketch.profile, vt, project.meta.units, editControl)
         }
       }
@@ -970,7 +1004,6 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           drawPendingPoint(ctx, currentTransformPreviewPoint, vt, isActiveSnapPoint(currentTransformPreviewPoint))
         }
 
-        drawDepthLegend(ctx, width, height)
         return
       }
 
@@ -1102,7 +1135,6 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     }
 
     drawSnapIndicator(ctx, activeSnapRef.current, vt)
-    drawDepthLegend(ctx, width, height)
   }
 
   function scheduleDraw() {
@@ -1386,7 +1418,49 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     return project.tabs.find((tab) => tab.id === selectedNode.tabId) ?? null
   }
 
-  function hitEditableControl(point: CanvasPoint): SketchControlRef | null {
+  function computeEditStepsForControl(profile: SketchFeature['sketch']['profile'], control: SketchControlRef | null): EditDimStep[] {
+    if (!control) {
+      return []
+    }
+
+    if (control.kind === 'anchor') {
+      return computeEditDimSteps(profile, control.index)
+    }
+
+    if (control.kind === 'arc_handle') {
+      return [{ kind: 'arc_radius', control, arcStartAnchorIndex: control.index }]
+    }
+
+    return []
+  }
+
+  function projectPointToSegment(point: Point, start: Point, end: Point): { point: Point; t: number; distance: number } {
+    const dx = end.x - start.x
+    const dy = end.y - start.y
+    const lengthSq = dx * dx + dy * dy
+    if (lengthSq <= 1e-12) {
+      return {
+        point: start,
+        t: 0,
+        distance: Math.hypot(point.x - start.x, point.y - start.y),
+      }
+    }
+
+    const rawT = ((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSq
+    const t = Math.max(0, Math.min(1, rawT))
+    const projectedPoint = {
+      x: start.x + dx * t,
+      y: start.y + dy * t,
+    }
+
+    return {
+      point: projectedPoint,
+      t,
+      distance: Math.hypot(point.x - projectedPoint.x, point.y - projectedPoint.y),
+    }
+  }
+
+  function hitEditableControl(point: CanvasPoint, options?: { includeSegments?: boolean }): SketchControlRef | null {
     const feature = editableFeature()
     const clamp = editableClamp()
     const tab = editableTab()
@@ -1404,6 +1478,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     if (!profile || (feature && feature.locked)) return null
 
     const vt = computeViewTransform(projectRef.current.stock, canvas.width, canvas.height, viewStateRef.current)
+    const worldPoint = canvasToWorld(point.cx, point.cy, vt)
     const vertices = profileVertices(profile)
     let bestControl: SketchControlRef | null = null
     let bestDistanceSq = NODE_HIT_RADIUS * NODE_HIT_RADIUS
@@ -1459,6 +1534,25 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       }
     }
 
+    if (feature && options?.includeSegments !== false && !bestControl) {
+      const segmentHitRadiusSq = NODE_HIT_RADIUS * NODE_HIT_RADIUS
+      for (let index = 0; index < profile.segments.length; index += 1) {
+        const segment = profile.segments[index]
+        if (segment.type !== 'line') {
+          continue
+        }
+
+        const start = anchorPointForIndex(profile, index)
+        const projected = projectPointToSegment(worldPoint, start, segment.to)
+        const projectedCanvas = worldToCanvas(projected.point, vt)
+        const d2 = distance2(point, projectedCanvas)
+        if (d2 <= Math.min(bestDistanceSq, segmentHitRadiusSq)) {
+          bestDistanceSq = d2
+          bestControl = { kind: 'segment', index, t: projected.t }
+        }
+      }
+    }
+
     return bestControl
   }
 
@@ -1473,6 +1567,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     if (zoomWindowActive && event.button === 0) {
       zoomWindowStartRef.current = point
       zoomWindowCurrentRef.current = point
+      setHoveredEditControl(null)
       hoverFeature(null)
       updateActiveSnap(null)
       scheduleDraw()
@@ -1484,6 +1579,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       isPanningRef.current = true
       didPanRef.current = false
       lastPanPointRef.current = point
+      setHoveredEditControl(null)
       return
     }
 
@@ -1509,6 +1605,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     if (!control && !hitClampId && !hitTabId && !hitFeatureId) {
       marqueeStartRef.current = point
       marqueeCurrentRef.current = point
+      setHoveredEditControl(null)
       scheduleDraw()
       return
     }
@@ -1517,9 +1614,33 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       return
     }
 
+    let nextControl = control
+    if (control.kind === 'segment' && selection.selectedFeatureId) {
+      const resolvedSnap = resolveCurrentSketchSnap(world, vt)
+      const targetPoint = resolvedSnap.mode ? resolvedSnap.point : world
+      const feature = editableFeature()
+      const segment = feature?.sketch.profile.segments[control.index]
+      if (feature && segment?.type === 'line') {
+        const segmentStart = anchorPointForIndex(feature.sketch.profile, control.index)
+        const projected = projectPointToSegment(targetPoint, segmentStart, segment.to)
+        nextControl = {
+          kind: 'segment',
+          index: control.index,
+          t: projected.t,
+        }
+      }
+    }
+
     beginHistoryTransaction()
-    setActiveControl(control)
+    setActiveControl(nextControl)
     isDraggingNodeRef.current = true
+
+    if (nextControl.kind === 'segment' && selection.selectedFeatureId) {
+      const resolvedSnap = resolveCurrentSketchSnap(world, vt)
+      const targetPoint = resolvedSnap.mode ? resolvedSnap.point : world
+      moveFeatureControl(selection.selectedFeatureId, nextControl, targetPoint)
+      updateActiveSnap(resolvedSnap.mode ? resolvedSnap : null)
+    }
   }
 
   function handleCanvasPointerMove(point: CanvasPoint) {
@@ -1542,6 +1663,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       sketchEditPreviewRef.current = null
       pendingSketchExtensionRef.current = null
       pendingSketchFilletRef.current = null
+      setHoveredEditControl(null)
       updateActiveSnap(null)
       const dx = point.cx - lastPanPointRef.current.cx
       const dy = point.cy - lastPanPointRef.current.cy
@@ -1594,9 +1716,12 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         })
       : { rawPoint: world, point: world, mode: null as null }
     const snapped = resolvedSnap.point
+    const activeEditControl = selection.activeControl
     const constrainedPoint =
       requiresResolvedSnapForPointPick() && !resolvedSnap.mode
-        ? null
+        ? activeEditControl?.kind === 'segment'
+          ? world
+          : null
         : snapped
     updateActiveSnap(shouldPreviewSnap ? resolvedSnap : null)
 
@@ -1604,6 +1729,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       sketchEditPreviewRef.current = null
       pendingSketchExtensionRef.current = null
       pendingSketchFilletRef.current = null
+      setHoveredEditControl(null)
       hoverFeature(null)
       if (pendingAdd.shape === 'origin') {
         originPreviewPointRef.current = { point: snapped, session: pendingAdd.session }
@@ -1618,6 +1744,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       sketchEditPreviewRef.current = null
       pendingSketchExtensionRef.current = null
       pendingSketchFilletRef.current = null
+      setHoveredEditControl(null)
       hoverFeature(null)
       const moveEdit = operationDimEditRef.current
       if ((moveEdit?.kind === 'move' || moveEdit?.kind === 'copy') && pendingMove.fromPoint) {
@@ -1642,6 +1769,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       sketchEditPreviewRef.current = null
       pendingSketchExtensionRef.current = null
       pendingSketchFilletRef.current = null
+      setHoveredEditControl(null)
       hoverFeature(null)
       const constrainedPoint =
         pendingTransform.mode === 'resize' && pendingTransform.referenceStart && pendingTransform.referenceEnd
@@ -1655,6 +1783,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       sketchEditPreviewRef.current = null
       pendingSketchExtensionRef.current = null
       pendingSketchFilletRef.current = null
+      setHoveredEditControl(null)
       hoverFeature(null)
       setPendingOffsetRawPreviewPointRef({ point: world, session: pendingOffset.session })
       setPendingOffsetPreviewPointRef({ point: snapped, session: pendingOffset.session })
@@ -1665,6 +1794,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       sketchEditPreviewRef.current = null
       pendingSketchExtensionRef.current = null
       pendingSketchFilletRef.current = null
+      setHoveredEditControl(null)
       if (!constrainedPoint) {
         scheduleDraw()
         return
@@ -1677,6 +1807,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       sketchEditPreviewRef.current = null
       pendingSketchExtensionRef.current = null
       pendingSketchFilletRef.current = null
+      setHoveredEditControl(null)
       if (!constrainedPoint) {
         scheduleDraw()
         return
@@ -1689,6 +1820,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       sketchEditPreviewRef.current = null
       pendingSketchExtensionRef.current = null
       pendingSketchFilletRef.current = null
+      setHoveredEditControl(null)
       if (!constrainedPoint) {
         scheduleDraw()
         return
@@ -1716,6 +1848,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           }
         }
         scheduleDraw()
+        setHoveredEditControl(null)
         hoverFeature(null)
         return
       }
@@ -1723,12 +1856,13 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       if (feature && sketchEditTool === 'delete_point') {
         pendingSketchExtensionRef.current = null
         pendingSketchFilletRef.current = null
-        const control = hitEditableControl(point)
-        sketchEditPreviewRef.current =
-          control?.kind === 'anchor'
-            ? { point: anchorPointForIndex(feature.sketch.profile, control.index), mode: 'delete_point' }
-            : null
+          const control = hitEditableControl(point, { includeSegments: false })
+          sketchEditPreviewRef.current =
+            control?.kind === 'anchor'
+              ? { point: anchorPointForIndex(feature.sketch.profile, control.index), mode: 'delete_point' }
+              : null
         scheduleDraw()
+        setHoveredEditControl(null)
         hoverFeature(null)
         return
       }
@@ -1738,7 +1872,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         if (pendingSketchFilletRef.current) {
           sketchEditPreviewRef.current = { point: snapped, mode: 'add_point' }
         } else {
-          const control = hitEditableControl(point)
+          const control = hitEditableControl(point, { includeSegments: false })
           if (control?.kind === 'anchor') {
             const corner = anchorPointForIndex(feature.sketch.profile, control.index)
             sketchEditPreviewRef.current = { point: corner, mode: 'add_point' }
@@ -1747,14 +1881,25 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           }
         }
         scheduleDraw()
+        setHoveredEditControl(null)
         hoverFeature(null)
         return
       }
     }
 
+    if (selection.mode === 'sketch_edit' && selection.selectedNode?.type === 'feature' && selection.selectedFeatureId) {
+      const feature = editableFeature()
+      const hoveredControl = feature ? hitEditableControl(point, { includeSegments: false }) : null
+      const steps = feature ? computeEditStepsForControl(feature.sketch.profile, hoveredControl) : []
+      setHoveredEditControl(steps.length > 0 ? hoveredControl : null)
+      hoverFeature(null)
+      return
+    }
+
     sketchEditPreviewRef.current = null
     pendingSketchExtensionRef.current = null
     pendingSketchFilletRef.current = null
+    setHoveredEditControl(null)
 
     const hitTabId = findHitTabId(world, project.tabs)
     if (hitTabId) {
@@ -1859,6 +2004,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     sketchEditPreviewRef.current = null
     pendingSketchFilletRef.current = null
     pendingSketchExtensionRef.current = null
+    setHoveredEditControl(null)
     setPendingOffsetPreviewPointRef(null)
     setPendingOffsetRawPreviewPointRef(null)
     hoverFeature(null)
@@ -1963,7 +2109,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         }
 
         if (feature && selection.sketchEditTool === 'delete_point') {
-          const control = hitEditableControl(point)
+          const control = hitEditableControl(point, { includeSegments: false })
           if (control?.kind === 'anchor') {
             deleteFeaturePoint(selection.selectedFeatureId, control.index)
           }
@@ -1985,7 +2131,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
             return
           }
 
-          const control = hitEditableControl(point)
+          const control = hitEditableControl(point, { includeSegments: false })
           if (control?.kind === 'anchor') {
             pendingSketchFilletRef.current = {
               anchorIndex: control.index,
@@ -2654,14 +2800,8 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       if (!feature) return
 
       const profile = feature.sketch.profile
-      const activeControl = selection.activeControl
-
-      let steps: EditDimStep[] = []
-      if (activeControl?.kind === 'anchor') {
-        steps = computeEditDimSteps(profile, activeControl.index)
-      } else if (activeControl?.kind === 'arc_handle') {
-        steps = [{ kind: 'arc_radius', control: activeControl, arcStartAnchorIndex: activeControl.index }]
-      }
+      const control = selection.activeControl ?? hoveredEditControlRef.current
+      const steps = computeEditStepsForControl(profile, control)
 
       if (steps.length === 0) return
 
@@ -2850,6 +2990,40 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         onContextMenu={handleContextMenu}
         tabIndex={0}
       />
+      {!depthLegendCollapsed ? (
+        <div className="sketch-depth-legend">
+          <div className="sketch-depth-legend__header">
+            <span>Feature Colors</span>
+            <button
+              className="sketch-depth-legend__toggle tree-action-btn"
+              type="button"
+              onClick={onToggleDepthLegend}
+              aria-label="Collapse feature color legend"
+              title="Collapse legend"
+            >
+              ▾
+            </button>
+          </div>
+          <div className="sketch-depth-legend__items">
+            <div className="sketch-depth-legend__item">
+              <span className="sketch-depth-legend__swatch sketch-depth-legend__swatch--subtract-shallow" />
+              <span>Subtract shallow</span>
+            </div>
+            <div className="sketch-depth-legend__item">
+              <span className="sketch-depth-legend__swatch sketch-depth-legend__swatch--subtract-deep" />
+              <span>Subtract deep</span>
+            </div>
+            <div className="sketch-depth-legend__item">
+              <span className="sketch-depth-legend__swatch sketch-depth-legend__swatch--add" />
+              <span>Add feature</span>
+            </div>
+            <div className="sketch-depth-legend__item">
+              <span className="sketch-depth-legend__swatch sketch-depth-legend__swatch--selected" />
+              <span>Selected</span>
+            </div>
+          </div>
+        </div>
+      ) : null}
       {dimensionEdit && pendingAdd && (() => {
         const canvas = canvasRef.current
         if (!canvas) return null
@@ -3364,10 +3538,10 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
               : selection.sketchEditTool === 'delete_point'
                 ? 'Delete Point active. Click anchors to remove them. Press '
                 : selection.sketchEditTool === 'fillet'
-                  ? pendingSketchFilletRef.current
+                ? pendingSketchFilletRef.current
                     ? 'Fillet active. Click a second point to define the corner round. Press '
                     : 'Fillet active. Click a line-line corner to start. Press '
-                  : 'Drag nodes to reshape. Hover a node and press Tab to type length/angle. Press '}
+                  : 'Drag nodes or straight segments to reshape. Hover a node and press Tab to type length/angle. Press '}
             <kbd>Enter</kbd> to apply or <kbd>Esc</kbd> to cancel.
           </div>
           {editingFeatureHasSelfIntersection ? (

--- a/src/components/canvas/measurements.ts
+++ b/src/components/canvas/measurements.ts
@@ -199,14 +199,23 @@ export function drawActiveEditMeasurements(
   }
 
   if (activeControl.kind === 'anchor') {
-    const indices: number[] = []
+    const indices = new Set<number>()
     if (profile.closed || activeControl.index > 0) {
-      indices.push((activeControl.index - 1 + profile.segments.length) % profile.segments.length)
+      indices.add((activeControl.index - 1 + profile.segments.length) % profile.segments.length)
     }
     if (activeControl.index < profile.segments.length) {
-      indices.push(activeControl.index)
+      indices.add(activeControl.index)
     }
-    drawProfileLineMeasurements(ctx, profile, vt, units, { segmentIndices: indices })
+
+    for (const index of indices) {
+      const segment = profile.segments[index]
+      const start = anchorPointForIndex(profile, index)
+      if (segment?.type === 'line' || segment?.type === 'bezier') {
+        drawLineLengthMeasurement(ctx, start, segment.to, vt, units)
+      } else if (segment?.type === 'arc') {
+        drawArcRadiusMeasurement(ctx, start, segment, vt, units)
+      }
+    }
     return
   }
 
@@ -214,6 +223,14 @@ export function drawActiveEditMeasurements(
     const segment = profile.segments[activeControl.index]
     if (segment?.type === 'arc') {
       drawArcRadiusMeasurement(ctx, anchorPointForIndex(profile, activeControl.index), segment, vt, units)
+    }
+    return
+  }
+
+  if (activeControl.kind === 'segment') {
+    const segment = profile.segments[activeControl.index]
+    if (segment?.type === 'line') {
+      drawLineLengthMeasurement(ctx, anchorPointForIndex(profile, activeControl.index), segment.to, vt, units)
     }
   }
 }

--- a/src/components/canvas/previewPrimitives.ts
+++ b/src/components/canvas/previewPrimitives.ts
@@ -374,33 +374,6 @@ export function drawPendingSplineLoop(
   }
 }
 
-export function drawDepthLegend(ctx: CanvasRenderingContext2D, canvasW: number, canvasH: number): void {
-  const x = canvasW - 160
-  const y = canvasH - 88
-  const labels = [
-    { color: '#5da5d8', text: 'Subtract shallow' },
-    { color: '#3f76b4', text: 'Subtract deep' },
-    { color: '#63b176', text: 'Add feature' },
-  ]
-
-  ctx.save()
-  ctx.fillStyle = 'rgba(16, 22, 30, 0.65)'
-  ctx.fillRect(x - 10, y - 10, 150, 68)
-
-  ctx.font = '10px "IBM Plex Mono", "SFMono-Regular", Consolas, monospace'
-  ctx.textAlign = 'left'
-  ctx.textBaseline = 'middle'
-  for (let index = 0; index < labels.length; index += 1) {
-    const item = labels[index]
-    const rowY = y + index * 18
-    ctx.fillStyle = item.color
-    ctx.fillRect(x, rowY, 12, 12)
-    ctx.fillStyle = 'rgba(206, 220, 231, 0.95)'
-    ctx.fillText(item.text, x + 18, rowY + 6)
-  }
-  ctx.restore()
-}
-
 export function drawToolpath(
   ctx: CanvasRenderingContext2D,
   toolpath: ToolpathResult,

--- a/src/components/canvas/scenePrimitives.ts
+++ b/src/components/canvas/scenePrimitives.ts
@@ -30,6 +30,29 @@ export function drawSketchControls(
 ): void {
   const vertices = profileVertices(profile)
 
+  if (activeControl?.kind === 'segment') {
+    const segment = profile.segments[activeControl.index]
+    if (segment?.type === 'line') {
+      const start = worldToCanvas(anchorPointForIndex(profile, activeControl.index), vt)
+      const end = worldToCanvas(segment.to, vt)
+      ctx.beginPath()
+      ctx.moveTo(start.cx, start.cy)
+      ctx.lineTo(end.cx, end.cy)
+      ctx.strokeStyle = '#f7d394'
+      ctx.lineWidth = 5
+      ctx.lineCap = 'round'
+      ctx.stroke()
+
+      ctx.beginPath()
+      ctx.moveTo(start.cx, start.cy)
+      ctx.lineTo(end.cx, end.cy)
+      ctx.strokeStyle = '#f2b95c'
+      ctx.lineWidth = 3
+      ctx.lineCap = 'round'
+      ctx.stroke()
+    }
+  }
+
   for (let index = 0; index < profile.segments.length; index += 1) {
     const anchor = worldToCanvas(anchorPointForIndex(profile, index), vt)
     const outgoingSegment = profile.segments[index]

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -24,6 +24,7 @@ interface AppShellProps {
   onToolbarOrientationChange: (orientation: 'top' | 'left') => void
   rightTab: 'operations' | 'tools' | 'ai'
   onRightTabChange: (tab: 'operations' | 'tools' | 'ai') => void
+  statusBarExtras?: ReactNode
 }
 
 function nextTab<T extends string>(tabs: readonly T[], current: T, direction: 1 | -1): T {
@@ -52,6 +53,7 @@ export function AppShell({
   onToolbarOrientationChange,
   rightTab,
   onRightTabChange,
+  statusBarExtras,
 }: AppShellProps) {
   const { project } = useProjectStore()
   const stockBounds = getStockBounds(project.stock)
@@ -380,6 +382,7 @@ export function AppShell({
         </span>
         <span>{project.grid.visible ? 'Grid Visible' : 'Grid Hidden'}</span>
         <span>{project.stock.visible ? 'Stock Visible' : 'Stock Hidden'}</span>
+        {statusBarExtras}
       </footer>
     </div>
   )

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -3922,19 +3922,14 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
             return feature
           }
 
-          if (control.kind === 'anchor') {
-            const currentAnchor = anchorPointForIndex(nextProfile, control.index)
-
-            if (!currentAnchor) {
-              return feature
-            }
-
+          function moveAnchor(anchorIndex: number, nextPoint: Point): void {
+            const currentAnchor = anchorPointForIndex(nextProfile, anchorIndex)
             const incomingIndex = nextProfile.closed
-              ? (control.index - 1 + segmentCount) % segmentCount
-              : control.index > 0
-                ? control.index - 1
+              ? (anchorIndex - 1 + segmentCount) % segmentCount
+              : anchorIndex > 0
+                ? anchorIndex - 1
                 : null
-            const outgoingIndex = control.index < segmentCount ? control.index : null
+            const outgoingIndex = anchorIndex < segmentCount ? anchorIndex : null
             const originalIncoming = incomingIndex !== null ? nextProfile.segments[incomingIndex] : null
             const originalOutgoing = outgoingIndex !== null ? nextProfile.segments[outgoingIndex] : null
             const originalIncomingStart =
@@ -3943,37 +3938,36 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
                 : incomingIndex === 0
                   ? nextProfile.start
                   : nextProfile.segments[incomingIndex - 1]?.to
-            const originalOutgoingStart = currentAnchor
             const incomingArcThrough =
               originalIncoming?.type === 'arc' && originalIncomingStart
                 ? arcControlPoint(originalIncomingStart, originalIncoming)
                 : null
             const outgoingArcThrough =
-              originalOutgoing?.type === 'arc' && originalOutgoingStart
-                ? arcControlPoint(originalOutgoingStart, originalOutgoing)
+              originalOutgoing?.type === 'arc'
+                ? arcControlPoint(currentAnchor, originalOutgoing)
                 : null
 
-            const dx = point.x - currentAnchor.x
-            const dy = point.y - currentAnchor.y
+            const dx = nextPoint.x - currentAnchor.x
+            const dy = nextPoint.y - currentAnchor.y
 
-            if (control.index === 0) {
-              nextProfile.start = point
+            if (anchorIndex === 0) {
+              nextProfile.start = nextPoint
               const closingSegment = nextProfile.closed ? nextProfile.segments[segmentCount - 1] : null
               if (closingSegment) {
-                closingSegment.to = point
+                closingSegment.to = nextPoint
                 if (closingSegment.type === 'bezier') {
                   closingSegment.control2 = translatePoint(closingSegment.control2, dx, dy)
                 }
               }
-            } else if (control.index === anchorCount - 1 && !nextProfile.closed) {
-              nextProfile.segments[segmentCount - 1].to = point
+            } else if (anchorIndex === anchorCount - 1 && !nextProfile.closed) {
+              nextProfile.segments[segmentCount - 1].to = nextPoint
               const incomingSegment = nextProfile.segments[segmentCount - 1]
               if (incomingSegment.type === 'bezier') {
                 incomingSegment.control2 = translatePoint(incomingSegment.control2, dx, dy)
               }
-            } else if (control.index > 0) {
-              nextProfile.segments[control.index - 1].to = point
-              const incomingSegment = nextProfile.segments[control.index - 1]
+            } else if (anchorIndex > 0) {
+              nextProfile.segments[anchorIndex - 1].to = nextPoint
+              const incomingSegment = nextProfile.segments[anchorIndex - 1]
               if (incomingSegment.type === 'bezier') {
                 incomingSegment.control2 = translatePoint(incomingSegment.control2, dx, dy)
               }
@@ -3982,7 +3976,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
             const incomingSegment = incomingIndex !== null ? nextProfile.segments[incomingIndex] : null
             if (incomingSegment?.type === 'arc' && incomingArcThrough) {
               const incomingStart =
-                incomingIndex === 0
+                incomingIndex !== null && incomingIndex === 0
                   ? nextProfile.start
                   : incomingIndex !== null
                     ? nextProfile.segments[incomingIndex - 1]?.to
@@ -3997,8 +3991,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
 
             const outgoingSegment = outgoingIndex !== null ? nextProfile.segments[outgoingIndex] : null
             if (outgoingSegment?.type === 'arc' && outgoingArcThrough) {
-              const outgoingStart =
-                control.index === 0 ? nextProfile.start : nextProfile.segments[control.index - 1]?.to
+              const outgoingStart = anchorIndex === 0 ? nextProfile.start : nextProfile.segments[anchorIndex - 1]?.to
               if (outgoingStart) {
                 const rebuiltOutgoing = buildArcSegmentFromThreePoints(outgoingStart, outgoingSegment.to, outgoingArcThrough)
                 if (rebuiltOutgoing && outgoingIndex !== null) {
@@ -4010,6 +4003,24 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
             if (outgoingSegment?.type === 'bezier') {
               outgoingSegment.control1 = translatePoint(outgoingSegment.control1, dx, dy)
             }
+          }
+
+          if (control.kind === 'anchor') {
+            moveAnchor(control.index, point)
+          } else if (control.kind === 'segment') {
+            const segment = nextProfile.segments[control.index]
+            if (segment?.type !== 'line') {
+              return feature
+            }
+
+            const segmentStartIndex = control.index
+            const segmentEndIndex = nextProfile.closed ? (control.index + 1) % anchorCount : control.index + 1
+            const segmentStart = anchorPointForIndex(nextProfile, segmentStartIndex)
+            const hitPoint = lerpPoint(segmentStart, segment.to, Math.max(0, Math.min(1, control.t ?? 0.5)))
+            const dx = point.x - hitPoint.x
+            const dy = point.y - hitPoint.y
+            moveAnchor(segmentStartIndex, translatePoint(segmentStart, dx, dy))
+            moveAnchor(segmentEndIndex, translatePoint(segment.to, dx, dy))
           } else if (control.kind === 'out_handle') {
             const outgoingSegment = nextProfile.segments[control.index]
             if (outgoingSegment?.type === 'bezier') {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -33,8 +33,9 @@ export interface SelectionState {
 }
 
 export interface SketchControlRef {
-  kind: 'anchor' | 'in_handle' | 'out_handle' | 'arc_handle'
+  kind: 'anchor' | 'in_handle' | 'out_handle' | 'arc_handle' | 'segment'
   index: number
+  t?: number
 }
 
 export type SketchEditTool = 'add_point' | 'delete_point' | 'fillet'

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -919,6 +919,94 @@
   border-color: var(--accent);
 }
 
+.sketch-depth-legend {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  z-index: 4;
+  min-width: 158px;
+  padding: 10px 10px 9px;
+  border: 1px solid rgba(91, 117, 138, 0.78);
+  border-radius: 10px;
+  background: rgba(16, 22, 30, 0.92);
+  box-shadow:
+    0 10px 24px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.sketch-depth-legend__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+  color: rgba(230, 238, 245, 0.94);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.sketch-depth-legend__toggle,
+.statusbar-depth-legend {
+  border: 1px solid var(--line-strong);
+  border-radius: 7px;
+  background: rgba(13, 19, 27, 0.88);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: border-color 0.18s ease, color 0.18s ease, background 0.18s ease;
+}
+
+.sketch-depth-legend__toggle {
+  width: 20px;
+  height: 20px;
+  min-height: 20px;
+  padding: 0;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.sketch-depth-legend__toggle:hover,
+.statusbar-depth-legend:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.sketch-depth-legend__items {
+  display: grid;
+  gap: 7px;
+}
+
+.sketch-depth-legend__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: rgba(206, 220, 231, 0.95);
+  font-size: 11px;
+}
+
+.sketch-depth-legend__swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex: 0 0 12px;
+}
+
+.sketch-depth-legend__swatch--subtract-shallow {
+  background: #5da5d8;
+}
+
+.sketch-depth-legend__swatch--subtract-deep {
+  background: #3f76b4;
+}
+
+.sketch-depth-legend__swatch--add {
+  background: #63b176;
+}
+
+.sketch-depth-legend__swatch--selected {
+  background: #efbc7a;
+}
+
 .sketch-dim-input {
   position: absolute;
   z-index: 5;
@@ -1479,10 +1567,46 @@
   color: var(--text-dim);
   font-size: 12px;
   display: flex;
+  flex-wrap: nowrap;
   gap: 18px;
   align-items: center;
+  height: 35px;
   padding: 8px 14px;
   background: rgba(16, 24, 33, 0.9);
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  box-sizing: border-box;
+}
+
+.statusbar-depth-legend {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  height: 18px;
+  padding: 0 6px;
+  font-size: 10px;
+  line-height: 1;
+  margin-left: auto;
+  box-sizing: border-box;
+}
+
+.statusbar-depth-legend__label {
+  color: inherit;
+}
+
+.statusbar-depth-legend__swatches {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.statusbar-depth-legend .sketch-depth-legend__swatch {
+  width: 10px;
+  height: 10px;
+  flex-basis: 10px;
 }
 
 .cam-panel {
@@ -1888,11 +2012,6 @@
   .toolbar-group {
     border-right: none;
     padding-right: 0;
-  }
-
-  .app-statusbar {
-    flex-wrap: wrap;
-    row-gap: 6px;
   }
 
   .cam-tools-layout {


### PR DESCRIPTION
## Summary
- show hover dimensions in sketch edit mode and allow Tab entry from hovered nodes
- support straight-segment dragging in sketch edit mode with anchor-first hit priority and improved snap behavior
- replace the canvas depth legend with a collapsible UI that can dock into the status bar, including selected color

## Verification
- npm run build