### PR TITLE
fix: correct conventional/climb direction for outside edge route

### DIFF
--- a/src/engine/toolpaths/edge.ts
+++ b/src/engine/toolpaths/edge.ts
@@ -221,8 +221,8 @@ function updateBounds(bounds: ToolpathBounds | null, point: ToolpathPoint): Tool
 
 function flattenFeatureToClipperPath(feature: SketchFeature): ClipperPath {
   const flattened = flattenProfile(feature.sketch.profile)
-  // Normalize to CCW on screen (isClockwise=true) so Clipper treats it as an outer polygon.
-  // Offsetting outward then preserves CCW orientation → conventional cut by default (CW in machine after Y-flip).
+  // Clipper normalises closed paths to CCW in Y-up (its outer-polygon convention) regardless
+  // of the winding supplied here, so the input orientation does not affect offset output.
   return toClipperPath(normalizeWinding(flattened.points, true), DEFAULT_CLIPPER_SCALE)
 }
 
@@ -367,6 +367,12 @@ export function generateEdgeRouteToolpath(project: Project, operation: Operation
   let currentPosition: ToolpathPoint | null = null
   const maxLinkDistance = tool.diameter
   const direction = operation.cutDirection ?? 'conventional'
+  // Clipper's ClipperOffset always normalises closed-polygon paths to CCW in machine
+  // Y-up coords (isClockwise=false) before applying the delta, so the output is always
+  // CCW regardless of input winding.  CCW in Y-up = conventional for INSIDE cuts but
+  // = climb for OUTSIDE cuts (where conventional requires CW in Y-up, isClockwise=true).
+  // Invert the requested direction for outside so applyContourDirection maps correctly.
+  const outsideDirection = (direction === 'conventional' ? 'climb' : 'conventional') as typeof direction
 
   if (operation.kind === 'edge_route_inside') {
     const resolved = resolveInsideEdgeRegions(project, operation)
@@ -458,7 +464,7 @@ export function generateEdgeRouteToolpath(project: Project, operation: Operation
       if (rawContours.length === 0) {
         warnings.push('No valid combined outer contour could be generated for the selected outside edge targets')
       } else {
-        const contours = applyContourDirection(rawContours, direction)
+        const contours = applyContourDirection(rawContours, outsideDirection)
         const levels =
           operation.pass === 'finish'
             ? [referenceTarget.bottomZ]
@@ -481,7 +487,7 @@ export function generateEdgeRouteToolpath(project: Project, operation: Operation
         continue
       }
 
-      const contours = applyContourDirection(rawContours, direction)
+      const contours = applyContourDirection(rawContours, outsideDirection)
       const levels =
         operation.pass === 'finish'
           ? [target.bottomZ]

--- a/src/engine/toolpaths/geometry.ts
+++ b/src/engine/toolpaths/geometry.ts
@@ -140,9 +140,10 @@ export function normalizeWinding(points: Point[], wantClockwise: boolean): Point
 }
 
 export function applyContourDirection(contours: Point[][], direction: 'conventional' | 'climb' = 'conventional'): Point[][] {
-  // Conventional = no-op: the natural Clipper output is already conventional for every
-  // operation (both inside cuts like pocket and outside cuts like edge_route_outside after
-  // the flattenFeatureToClipperPath fix). Climb simply reverses each contour.
+  // Conventional = no-op: Clipper's natural output is CCW in machine Y-up (isClockwise=false),
+  // which equals conventional direction for inside/pocket cuts.  For outside edge cuts the
+  // caller must invert the direction before calling here (CCW = climb for outside cuts).
+  // Climb simply reverses each contour.
   if (direction === 'conventional') {
     return contours
   }


### PR DESCRIPTION
## Summary

- Outside edge route cuts were generating **climb when conventional was selected** and vice versa
- Root cause: `ClipperLib.ClipperOffset` always normalises closed paths to CCW in machine Y-up internally, making the output `isClockwise=false` regardless of input. CCW in Y-up = conventional for **inside** cuts, but = **climb** for outside cuts (cutter is on the opposite side of the material)
- PR #24's winding change in `flattenFeatureToClipperPath` had no effect on Clipper's output, so the bug was never actually fixed
- Fix: invert the direction string (`conventional`↔`climb`) for outside paths before calling `applyContourDirection`, so the reversal lands on the correct side
- Also corrects the misleading comments in `edge.ts` and `geometry.ts` that claimed the natural Clipper output was already conventional for outside cuts

## Test plan

- [x] Set an edge route outside operation to **Conventional** — arrows should show CW in machine (down on right wall, left on bottom, up on left wall, right on top)
- [x] Set same operation to **Climb** — arrows should reverse
- [x] Verify edge route **inside** still works correctly in both directions (should be unaffected)