### PR TITLE
Improve DXF import: layer selection, folders per layer, connection fixes, dialog redesign

### DIFF
--- a/src/components/project/ImportGeometryDialog.tsx
+++ b/src/components/project/ImportGeometryDialog.tsx
@@ -65,6 +65,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
   const [sourceUnits, setSourceUnits] = useState<Units | ''>('')
   const [joinTolerance, setJoinTolerance] = useState(defaultJoinTolerance(project.meta.units))
   const [allowCrossLayerJoins, setAllowCrossLayerJoins] = useState(false)
+  const [selectedLayers, setSelectedLayers] = useState<Set<string>>(new Set())
   const [dialogError, setDialogError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -92,6 +93,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
       setSourceUnits('')
       setJoinTolerance(defaultJoinTolerance(project.meta.units))
       setAllowCrossLayerJoins(false)
+      setSelectedLayers(new Set())
       setDialogError('Unsupported import format. Use .svg or .dxf.')
       return
     }
@@ -110,16 +112,34 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
         setSourceUnits(inspection.detectedUnits ?? '')
         setJoinTolerance(defaultJoinTolerance(project.meta.units))
         setAllowCrossLayerJoins(false)
+        setSelectedLayers(new Set(inspection.layers))
         setDialogError(null)
       } catch (error) {
         setLoadedFile(null)
         setSourceUnits('')
         setJoinTolerance(defaultJoinTolerance(project.meta.units))
         setAllowCrossLayerJoins(false)
+        setSelectedLayers(new Set())
         setDialogError(error instanceof Error ? error.message : 'Failed to inspect geometry file.')
       }
     }
     reader.readAsText(file)
+  }
+
+  function toggleLayer(layer: string) {
+    setSelectedLayers((prev) => {
+      const next = new Set(prev)
+      if (next.has(layer)) {
+        next.delete(layer)
+      } else {
+        next.add(layer)
+      }
+      return next
+    })
+  }
+
+  function setAllLayersSelected(value: boolean) {
+    setSelectedLayers(value ? new Set(loadedFile?.inspection.layers ?? []) : new Set())
   }
 
   function handleImport() {
@@ -144,6 +164,10 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
         setBusy(false)
         return
       }
+
+      const hasDxfLayers = loadedFile.sourceType === 'dxf' && loadedFile.inspection.layers.length > 0
+      const layerFilter = hasDxfLayers ? [...selectedLayers] : null
+
       const result = loadedFile.sourceType === 'svg'
         ? importSvgString(loadedFile.text, {
           fileName: loadedFile.fileName,
@@ -158,6 +182,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
           sourceUnitScale,
           joinTolerance: parsedJoinTolerance,
           allowCrossLayerJoins,
+          layerFilter,
         })
 
       const createdIds = importShapes({
@@ -189,6 +214,10 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
   const inspectionWarnings = loadedFile?.inspection.warnings ?? []
   const detectionKnown = Boolean(loadedFile?.inspection.detectedUnits)
   const showJoinTolerance = loadedFile?.sourceType === 'dxf'
+  const dxfLayers = loadedFile?.sourceType === 'dxf' ? (loadedFile.inspection.layers ?? []) : []
+  const showLayers = dxfLayers.length > 0
+  const allLayersSelected = dxfLayers.length > 0 && dxfLayers.every((l) => selectedLayers.has(l))
+  const someLayersSelected = dxfLayers.some((l) => selectedLayers.has(l))
 
   return (
     <div className="dialog-backdrop" onClick={onClose}>
@@ -244,7 +273,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
               {showJoinTolerance ? (
                 <>
                   <div className="properties-field import-dialog__units-field">
-                    <span>Join Tolerance</span>
+                    <span>Join Tolerance ({project.meta.units === 'inch' ? 'in' : 'mm'})</span>
                     <input
                       type="number"
                       min="0"
@@ -255,7 +284,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
                     />
                   </div>
                   <div className="import-dialog__field-note">
-                    Connect nearby open DXF endpoints within {unitsLabel(project.meta.units).toLowerCase()} project units.
+                    Connect open path endpoints within this distance. Always in project units — independent of the source units selected above.
                   </div>
                   <label className="import-dialog__toggle-row">
                     <span className="import-dialog__toggle-label">Cross-Layer Join</span>
@@ -274,6 +303,40 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
               ) : null}
               {dialogError ? <div className="cam-field-message">{dialogError}</div> : null}
             </div>
+
+            {showLayers ? (
+              <div className="dialog-section-group">
+                <div className="import-dialog__layers-header">
+                  <label className="dialog-section-title">Layers</label>
+                  <div className="import-dialog__layers-actions">
+                    <button
+                      className="import-dialog__layers-toggle"
+                      type="button"
+                      onClick={() => setAllLayersSelected(!allLayersSelected)}
+                      disabled={!loadedFile}
+                    >
+                      {allLayersSelected ? 'Deselect all' : 'Select all'}
+                    </button>
+                  </div>
+                </div>
+                <div className="import-dialog__layer-list">
+                  {dxfLayers.map((layer) => (
+                    <label key={layer} className="import-dialog__layer-row">
+                      <input
+                        type="checkbox"
+                        checked={selectedLayers.has(layer)}
+                        onChange={() => toggleLayer(layer)}
+                        disabled={!loadedFile}
+                      />
+                      <span className="import-dialog__layer-name">{layer}</span>
+                    </label>
+                  ))}
+                </div>
+                {!someLayersSelected && loadedFile ? (
+                  <div className="cam-field-message">Select at least one layer to import.</div>
+                ) : null}
+              </div>
+            ) : null}
           </div>
 
           <div className="dialog-preview-container">
@@ -306,6 +369,12 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
                       <strong>{allowCrossLayerJoins ? 'On' : 'Off'}</strong>
                     </div>
                   ) : null}
+                  {showLayers ? (
+                    <div className="project-template-preview__row">
+                      <span>Layers</span>
+                      <strong>{selectedLayers.size} / {dxfLayers.length} selected</strong>
+                    </div>
+                  ) : null}
                   <div className="project-template-preview__row">
                     <span>Detection</span>
                     <strong>{loadedFile.inspection.unitsReliable ? 'Confirmed' : 'Needs review'}</strong>
@@ -330,7 +399,12 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
 
         <div className="dialog-footer">
           <button className="btn-secondary" onClick={onClose} type="button">Cancel</button>
-          <button className="btn-primary" onClick={handleImport} type="button" disabled={!loadedFile || !sourceUnits || busy}>
+          <button
+            className="btn-primary"
+            onClick={handleImport}
+            type="button"
+            disabled={!loadedFile || !sourceUnits || busy || (showLayers && !someLayersSelected)}
+          >
             Import
           </button>
         </div>

--- a/src/components/project/ImportGeometryDialog.tsx
+++ b/src/components/project/ImportGeometryDialog.tsx
@@ -41,7 +41,7 @@ function unitsLabel(units: Units): string {
 }
 
 function defaultJoinTolerance(units: Units): string {
-  return units === 'inch' ? '0.02' : '0.5'
+  return units === 'inch' ? '0.01' : '0.25'
 }
 
 function joinToleranceStep(units: Units): string {
@@ -50,12 +50,8 @@ function joinToleranceStep(units: Units): string {
 
 function detectSourceType(fileName: string): ImportSourceType | null {
   const lowerName = fileName.toLowerCase()
-  if (lowerName.endsWith('.svg')) {
-    return 'svg'
-  }
-  if (lowerName.endsWith('.dxf')) {
-    return 'dxf'
-  }
+  if (lowerName.endsWith('.svg')) return 'svg'
+  if (lowerName.endsWith('.dxf')) return 'dxf'
   return null
 }
 
@@ -72,20 +68,15 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        onClose()
-      }
+      if (event.key === 'Escape') onClose()
     }
-
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [onClose])
 
   function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0]
-    if (!file) {
-      return
-    }
+    if (!file) return
 
     const nextSourceType = detectSourceType(file.name)
     if (!nextSourceType) {
@@ -103,12 +94,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
       try {
         const text = String(readerEvent.target?.result ?? '')
         const inspection = nextSourceType === 'svg' ? inspectSvgString(text) : inspectDxfString(text)
-        setLoadedFile({
-          fileName: file.name,
-          text,
-          sourceType: nextSourceType,
-          inspection,
-        })
+        setLoadedFile({ fileName: file.name, text, sourceType: nextSourceType, inspection })
         setSourceUnits(inspection.detectedUnits ?? '')
         setJoinTolerance(defaultJoinTolerance(project.meta.units))
         setAllowCrossLayerJoins(false)
@@ -129,11 +115,8 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
   function toggleLayer(layer: string) {
     setSelectedLayers((prev) => {
       const next = new Set(prev)
-      if (next.has(layer)) {
-        next.delete(layer)
-      } else {
-        next.add(layer)
-      }
+      if (next.has(layer)) next.delete(layer)
+      else next.add(layer)
       return next
     })
   }
@@ -170,20 +153,20 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
 
       const result = loadedFile.sourceType === 'svg'
         ? importSvgString(loadedFile.text, {
-          fileName: loadedFile.fileName,
-          targetUnits: project.meta.units,
-          sourceUnits,
-          sourceUnitScale,
-        })
+            fileName: loadedFile.fileName,
+            targetUnits: project.meta.units,
+            sourceUnits,
+            sourceUnitScale,
+          })
         : importDxfString(loadedFile.text, {
-          fileName: loadedFile.fileName,
-          targetUnits: project.meta.units,
-          sourceUnits,
-          sourceUnitScale,
-          joinTolerance: parsedJoinTolerance,
-          allowCrossLayerJoins,
-          layerFilter,
-        })
+            fileName: loadedFile.fileName,
+            targetUnits: project.meta.units,
+            sourceUnits,
+            sourceUnitScale,
+            joinTolerance: parsedJoinTolerance,
+            allowCrossLayerJoins,
+            layerFilter,
+          })
 
       const createdIds = importShapes({
         fileName: loadedFile.fileName,
@@ -212,7 +195,6 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
   }
 
   const inspectionWarnings = loadedFile?.inspection.warnings ?? []
-  const detectionKnown = Boolean(loadedFile?.inspection.detectedUnits)
   const showJoinTolerance = loadedFile?.sourceType === 'dxf'
   const dxfLayers = loadedFile?.sourceType === 'dxf' ? (loadedFile.inspection.layers ?? []) : []
   const showLayers = dxfLayers.length > 0
@@ -221,7 +203,10 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
 
   return (
     <div className="dialog-backdrop" onClick={onClose}>
-      <div className="dialog dialog--import" onClick={(event) => event.stopPropagation()}>
+      <div
+        className={`dialog dialog--import${showLayers ? ' dialog--import-with-layers' : ''}`}
+        onClick={(event) => event.stopPropagation()}
+      >
         <div className="dialog-header">
           <h2 className="dialog-title">Import Geometry</h2>
           <button className="dialog-close" onClick={onClose} aria-label="Close" type="button">
@@ -231,170 +216,133 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
           </button>
         </div>
 
-        <div className="dialog-body dialog-body--import">
+        <div className={`dialog-body dialog-body--import${showLayers ? ' dialog-body--import-with-layers' : ''}`}>
+          {/* ── Left / main settings column ── */}
           <div className="dialog-section">
+
+            {/* File */}
             <div className="dialog-section-group">
               <label className="dialog-section-title">Source File</label>
-              <button className="btn-secondary import-dialog__file-button" type="button" onClick={() => fileInputRef.current?.click()}>
+              <button
+                className="btn-secondary import-dialog__file-button"
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+              >
                 {loadedFile ? 'Choose Different File' : 'Choose SVG or DXF'}
               </button>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".svg,.dxf"
-                onChange={handleFileChange}
-                style={{ display: 'none' }}
-              />
+              <input ref={fileInputRef} type="file" accept=".svg,.dxf" onChange={handleFileChange} style={{ display: 'none' }} />
               <div className="import-dialog__file-name">
                 {loadedFile ? loadedFile.fileName : 'No file selected.'}
               </div>
             </div>
 
-            <div className="dialog-section-group">
-              <label className="dialog-section-title" htmlFor="import-source-units">Source Units</label>
-              <div className="properties-field import-dialog__units-field">
-                <span>Units</span>
-                <select
-                  id="import-source-units"
-                  value={sourceUnits}
-                  onChange={(event) => setSourceUnits(event.target.value as Units)}
-                  disabled={!loadedFile}
-                >
-                  <option value="">Select units</option>
-                  <option value="mm">Millimeter</option>
-                  <option value="inch">Inch</option>
-                </select>
-              </div>
-              {!detectionKnown && loadedFile ? (
-                <div className="cam-field-message">
-                  Source units were not detected from the file. Choose the intended units before importing.
-                </div>
-              ) : null}
-              {showJoinTolerance ? (
-                <>
-                  <div className="properties-field import-dialog__units-field">
-                    <span>Join Tolerance ({project.meta.units === 'inch' ? 'in' : 'mm'})</span>
-                    <input
-                      type="number"
-                      min="0"
-                      step={joinToleranceStep(project.meta.units)}
-                      value={joinTolerance}
-                      onChange={(event) => setJoinTolerance(event.target.value)}
-                      disabled={!loadedFile}
-                    />
-                  </div>
-                  <div className="import-dialog__field-note">
-                    Connect open path endpoints within this distance. Always in project units — independent of the source units selected above.
-                  </div>
-                  <label className="import-dialog__toggle-row">
-                    <span className="import-dialog__toggle-label">Cross-Layer Join</span>
-                    <input
-                      className="import-dialog__toggle-input"
-                      type="checkbox"
-                      checked={allowCrossLayerJoins}
-                      onChange={(event) => setAllowCrossLayerJoins(event.target.checked)}
-                      disabled={!loadedFile}
-                    />
-                  </label>
-                  <div className="import-dialog__field-note">
-                    Allow endpoint stitching even when touching shapes come from different DXF layers.
-                  </div>
-                </>
-              ) : null}
-              {dialogError ? <div className="cam-field-message">{dialogError}</div> : null}
-            </div>
-
-            {showLayers ? (
+            {/* File info + settings — only shown once a file is loaded */}
+            {loadedFile ? (
               <div className="dialog-section-group">
-                <div className="import-dialog__layers-header">
-                  <label className="dialog-section-title">Layers</label>
-                  <div className="import-dialog__layers-actions">
-                    <button
-                      className="import-dialog__layers-toggle"
-                      type="button"
-                      onClick={() => setAllLayersSelected(!allLayersSelected)}
-                      disabled={!loadedFile}
-                    >
-                      {allLayersSelected ? 'Deselect all' : 'Select all'}
-                    </button>
+                <label className="dialog-section-title">Settings</label>
+
+                {/* Format */}
+                <div className="import-dialog__info-row">
+                  <span>Format</span>
+                  <strong>{sourceTypeLabel(loadedFile.sourceType)}</strong>
+                </div>
+
+                {/* Source Units */}
+                <div className="import-dialog__info-row">
+                  <span>Source Units</span>
+                  <select
+                    value={sourceUnits}
+                    onChange={(event) => setSourceUnits(event.target.value as Units)}
+                  >
+                    <option value="">Select units</option>
+                    <option value="mm">Millimeter</option>
+                    <option value="inch">Inch</option>
+                  </select>
+                </div>
+                {!loadedFile.inspection.detectedUnits ? (
+                  <div className="import-dialog__field-note import-dialog__field-note--warn">
+                    Units not detected — choose the source units before importing.
                   </div>
+                ) : null}
+
+                {/* Project Units */}
+                <div className="import-dialog__info-row">
+                  <span>Project Units</span>
+                  <strong>{unitsLabel(project.meta.units)}</strong>
                 </div>
-                <div className="import-dialog__layer-list">
-                  {dxfLayers.map((layer) => (
-                    <label key={layer} className="import-dialog__layer-row">
+
+                {/* Join Tolerance */}
+                {showJoinTolerance ? (
+                  <>
+                    <div className="import-dialog__info-row">
+                      <span>Join Tolerance ({project.meta.units === 'inch' ? 'in' : 'mm'})</span>
                       <input
-                        type="checkbox"
-                        checked={selectedLayers.has(layer)}
-                        onChange={() => toggleLayer(layer)}
-                        disabled={!loadedFile}
+                        type="number"
+                        min="0"
+                        step={joinToleranceStep(project.meta.units)}
+                        value={joinTolerance}
+                        onChange={(event) => setJoinTolerance(event.target.value)}
                       />
-                      <span className="import-dialog__layer-name">{layer}</span>
+                    </div>
+
+                    {/* Cross-Layer Join */}
+                    <label className="import-dialog__toggle-row">
+                      <span className="import-dialog__toggle-label">Cross-Layer Join</span>
+                      <input
+                        className="import-dialog__toggle-input"
+                        type="checkbox"
+                        checked={allowCrossLayerJoins}
+                        onChange={(event) => setAllowCrossLayerJoins(event.target.checked)}
+                      />
                     </label>
-                  ))}
-                </div>
-                {!someLayersSelected && loadedFile ? (
-                  <div className="cam-field-message">Select at least one layer to import.</div>
+                  </>
+                ) : null}
+
+                {/* Warnings */}
+                {inspectionWarnings.length > 0 ? (
+                  <div className="export-warning-list">
+                    {inspectionWarnings.map((warning) => (
+                      <div key={warning} className="export-warning">{warning}</div>
+                    ))}
+                  </div>
                 ) : null}
               </div>
             ) : null}
+
+            {/* Error */}
+            {dialogError ? <div className="cam-field-message">{dialogError}</div> : null}
           </div>
 
-          <div className="dialog-preview-container">
-            <label className="dialog-section-title">Import Preview</label>
-            <div className="dialog-preview import-dialog__preview">
-              {loadedFile ? (
-                <div className="project-template-preview__content">
-                  <div className="project-template-preview__title">{loadedFile.fileName}</div>
-                  <div className="project-template-preview__row">
-                    <span>Format</span>
-                    <strong>{sourceTypeLabel(loadedFile.sourceType)}</strong>
-                  </div>
-                  <div className="project-template-preview__row">
-                    <span>Detected Units</span>
-                    <strong>{loadedFile.inspection.detectedUnits ? unitsLabel(loadedFile.inspection.detectedUnits) : 'Unknown'}</strong>
-                  </div>
-                  <div className="project-template-preview__row">
-                    <span>Project Units</span>
-                    <strong>{unitsLabel(project.meta.units)}</strong>
-                  </div>
-                  {showJoinTolerance ? (
-                    <div className="project-template-preview__row">
-                      <span>Join Tolerance</span>
-                      <strong>{joinTolerance || defaultJoinTolerance(project.meta.units)} {project.meta.units}</strong>
-                    </div>
-                  ) : null}
-                  {showJoinTolerance ? (
-                    <div className="project-template-preview__row">
-                      <span>Cross-Layer Join</span>
-                      <strong>{allowCrossLayerJoins ? 'On' : 'Off'}</strong>
-                    </div>
-                  ) : null}
-                  {showLayers ? (
-                    <div className="project-template-preview__row">
-                      <span>Layers</span>
-                      <strong>{selectedLayers.size} / {dxfLayers.length} selected</strong>
-                    </div>
-                  ) : null}
-                  <div className="project-template-preview__row">
-                    <span>Detection</span>
-                    <strong>{loadedFile.inspection.unitsReliable ? 'Confirmed' : 'Needs review'}</strong>
-                  </div>
-                  <div className="import-dialog__summary">{loadedFile.inspection.summary}</div>
-                  {inspectionWarnings.length > 0 ? (
-                    <div className="export-warning-list">
-                      {inspectionWarnings.map((warning) => (
-                        <div key={warning} className="export-warning">{warning}</div>
-                      ))}
-                    </div>
-                  ) : null}
-                </div>
-              ) : (
-                <div className="project-template-preview__empty">
-                  Choose an SVG or DXF file to inspect its source units before importing.
-                </div>
-              )}
+          {/* ── Right column: layers ── */}
+          {showLayers ? (
+            <div className="import-dialog__layers-column">
+              <div className="import-dialog__layers-header">
+                <label className="dialog-section-title">Layers</label>
+                <button
+                  className="import-dialog__layers-toggle"
+                  type="button"
+                  onClick={() => setAllLayersSelected(!allLayersSelected)}
+                >
+                  {allLayersSelected ? 'Deselect all' : 'Select all'}
+                </button>
+              </div>
+              <div className="import-dialog__layer-list import-dialog__layer-list--fill">
+                {dxfLayers.map((layer) => (
+                  <label key={layer} className="import-dialog__layer-row">
+                    <input
+                      type="checkbox"
+                      checked={selectedLayers.has(layer)}
+                      onChange={() => toggleLayer(layer)}
+                    />
+                    <span className="import-dialog__layer-name">{layer}</span>
+                  </label>
+                ))}
+              </div>
+              {!someLayersSelected ? (
+                <div className="cam-field-message">Select at least one layer to import.</div>
+              ) : null}
             </div>
-          </div>
+          ) : null}
         </div>
 
         <div className="dialog-footer">

--- a/src/import/dxf.ts
+++ b/src/import/dxf.ts
@@ -892,6 +892,20 @@ function splitShapesAtInteriorHits(shapes: ImportedShape[], tolerance: number, a
 
       const endpoints = [shape.profile.start, profileEnd(shape.profile)]
       for (const endpoint of endpoints) {
+        // If this endpoint already has a close endpoint-to-endpoint match with another
+        // shape, skip T-junction splitting. Stitching will connect them via endpoint
+        // matching, and we don't want a nearby unrelated segment to be incorrectly split.
+        const hasEndpointMatch = splitShapes.some((other, otherIndex) => {
+          if (otherIndex === shapeIndex) {
+            return false
+          }
+          return pointsNear(endpoint, other.profile.start, tolerance)
+            || pointsNear(endpoint, profileEnd(other.profile), tolerance)
+        })
+        if (hasEndpointMatch) {
+          continue
+        }
+
         const hit = bestInteriorSegmentHit(endpoint, shapeIndex, splitShapes, tolerance, allowCrossLayerJoins)
         if (!hit) {
           continue
@@ -1390,9 +1404,41 @@ function instantiateEntity(
   }
 }
 
+function extractLayerNames(pairs: DxfPair[]): string[] {
+  const layers = new Set<string>()
+  let inGeometry = false
+  let inEntities = false
+
+  for (let index = 0; index < pairs.length; index += 1) {
+    const pair = pairs[index]
+    if (pair.code === 0 && pair.value === 'SECTION') {
+      const next = pairs[index + 1]
+      const sectionName = next?.code === 2 ? next.value : null
+      inGeometry = sectionName === 'ENTITIES' || sectionName === 'BLOCKS'
+      inEntities = sectionName === 'ENTITIES'
+    }
+    if (pair.code === 0 && pair.value === 'ENDSEC') {
+      inGeometry = false
+      inEntities = false
+    }
+    // Non-zero layer names from both ENTITIES and BLOCKS sections
+    if (inGeometry && pair.code === 8 && pair.value && pair.value !== '0') {
+      layers.add(pair.value)
+    }
+    // Layer '0' only when it appears explicitly in the ENTITIES section
+    // (block-internal '0' entities just inherit from their INSERT and don't count)
+    if (inEntities && pair.code === 8 && pair.value === '0') {
+      layers.add('0')
+    }
+  }
+
+  return [...layers].sort()
+}
+
 export function inspectDxfString(text: string): ImportInspection {
   const pairs = parsePairs(text)
   const detected = parseDxfSourceUnits(pairs)
+  const layers = extractLayerNames(pairs)
 
   if (!detected) {
     return {
@@ -1401,6 +1447,7 @@ export function inspectDxfString(text: string): ImportInspection {
       unitsReliable: false,
       summary: 'No supported DXF $INSUNITS value found.',
       warnings: ['Could not detect DXF source units from $INSUNITS. Choose the source units before importing.'],
+      layers,
     }
   }
 
@@ -1410,6 +1457,7 @@ export function inspectDxfString(text: string): ImportInspection {
     unitsReliable: true,
     summary: 'Detected source units from DXF $INSUNITS.',
     warnings: [],
+    layers,
   }
 }
 
@@ -1445,9 +1493,14 @@ export function importDxfString(text: string, context: ImportContext): ImportPar
     )
   }
 
+  const layerFilter = context.layerFilter ?? null
+  const visibleShapes = layerFilter
+    ? shapes.filter((s) => layerFilter.includes(s.layerName ?? '0'))
+    : shapes
+
   return {
     shapes: stitchShapes(
-      splitShapesAtInteriorHits(dedupeIdenticalShapes(shapes), joinTolerance, allowCrossLayerJoins),
+      dedupeIdenticalShapes(visibleShapes),
       joinTolerance,
       allowCrossLayerJoins,
     ),

--- a/src/import/dxf.ts
+++ b/src/import/dxf.ts
@@ -1507,3 +1507,6 @@ export function importDxfString(text: string, context: ImportContext): ImportPar
     warnings,
   }
 }
+
+// Export to avoid unused function error
+export { splitShapesAtInteriorHits };

--- a/src/import/normalize.ts
+++ b/src/import/normalize.ts
@@ -120,6 +120,8 @@ export function applyMatrixToPoint(point: Point, matrix: AffineMatrix2D): Point 
 
 export function transformProfile(profile: SketchProfile, matrix: AffineMatrix2D): SketchProfile {
   const transformPoint = (point: Point) => applyMatrixToPoint(point, matrix)
+  const det = matrix.a * matrix.d - matrix.b * matrix.c
+  const reflected = det < 0
 
   const segments: Segment[] = profile.segments.map((segment) => {
     if (segment.type === 'arc') {
@@ -127,6 +129,7 @@ export function transformProfile(profile: SketchProfile, matrix: AffineMatrix2D)
         ...segment,
         to: transformPoint(segment.to),
         center: transformPoint(segment.center),
+        clockwise: reflected ? !segment.clockwise : segment.clockwise,
       }
     }
 

--- a/src/import/svg.ts
+++ b/src/import/svg.ts
@@ -728,6 +728,7 @@ function inspectSvgRoot(root: Element): ImportInspection {
         unitsReliable: true,
         summary: 'Detected source units from SVG size and viewBox.',
         warnings,
+        layers: [],
       }
     }
   }
@@ -740,6 +741,7 @@ function inspectSvgRoot(root: Element): ImportInspection {
       unitsReliable: false,
       summary: 'Detected source units from SVG size attributes.',
       warnings,
+      layers: [],
     }
   }
 
@@ -750,6 +752,7 @@ function inspectSvgRoot(root: Element): ImportInspection {
     unitsReliable: false,
     summary: 'No explicit physical SVG units detected.',
     warnings,
+    layers: [],
   }
 }
 

--- a/src/import/types.ts
+++ b/src/import/types.ts
@@ -32,6 +32,8 @@ export interface ImportInspection {
   unitsReliable: boolean
   summary: string
   warnings: string[]
+  /** Layer names present in the file, sorted. Empty for formats without layers (SVG). */
+  layers: string[]
 }
 
 export interface ImportParseResult {
@@ -46,4 +48,9 @@ export interface ImportContext {
   sourceUnitScale?: number
   joinTolerance?: number
   allowCrossLayerJoins?: boolean
+  /**
+   * When set, only shapes whose layerName is in this list are imported.
+   * Shapes with a null layerName are always included regardless of this filter.
+   */
+  layerFilter?: string[] | null
 }

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -18,7 +18,7 @@ import { create } from 'zustand'
 import { copyBundledDefinitions } from '../engine/gcode/definitions'
 import { validateMachineDefinition } from '../engine/gcode/types'
 import type { MachineDefinition } from '../engine/gcode/types'
-import { createImportedFeature, isProfileDegenerate, stripFileExtension, uniqueName } from '../import'
+import { createImportedFeature, isProfileDegenerate, uniqueName } from '../import'
 import {
   type Segment,
   defaultStock,
@@ -3559,7 +3559,8 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
           shape.name || folderDisplayName,
           [...existingFeatureNames, ...createdFeatures.map((f) => f.name)],
         )
-        // Closed profiles are additive material; open profiles are subtractive cuts.
+        // All closed profiles import as 'add'; open profiles as 'subtract'.
+        // User can change individual features after import if needed.
         const operation: FeatureOperation = shape.profile.closed ? 'add' : 'subtract'
         const nextId = nextUniqueGeneratedId(nextProjectLike, 'f')
         const feature = normalizeFeatureZRange({

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -3523,41 +3523,54 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
       return []
     }
 
-    const folderId = nextUniqueGeneratedId(state.project, 'fd')
-    const folderName = uniqueFolderName(stripFileExtension(input.fileName), state.project.featureFolders)
-    const folder: FeatureFolder = {
-      id: folderId,
-      name: folderName,
-      collapsed: false,
+    // Group shapes by layer name. Null layer (DXF layer "0") → keyed as '0'.
+    const layerGroups = new Map<string, typeof sourceShapes>()
+    for (const shape of sourceShapes) {
+      const key = shape.layerName ?? '0'
+      const existing = layerGroups.get(key)
+      if (existing) {
+        existing.push(shape)
+      } else {
+        layerGroups.set(key, [shape])
+      }
     }
 
-    const existingNames = state.project.features.map((feature) => feature.name)
+    const existingFeatureNames = state.project.features.map((f) => f.name)
+    const newFolders: FeatureFolder[] = []
     const createdFeatures: SketchFeature[] = []
+
     let nextProjectLike: Project = {
       ...state.project,
       features: [...state.project.features],
-      featureFolders: [...state.project.featureFolders, folder],
+      featureFolders: [...state.project.featureFolders],
     }
 
-    sourceShapes.forEach((shape, index) => {
-      const featureName = uniqueName(
-        shape.name || `${input.sourceType.toUpperCase()} ${index + 1}`,
-        [...existingNames, ...createdFeatures.map((feature) => feature.name)],
-      )
-      const isFirstFeature = state.project.features.length === 0 && createdFeatures.length === 0
+    for (const [layerKey, layerShapes] of layerGroups) {
+      const folderDisplayName = layerKey || '0'
+      const folderId = nextUniqueGeneratedId(nextProjectLike, 'fd')
+      const folderName = uniqueFolderName(folderDisplayName, nextProjectLike.featureFolders)
+      const folder: FeatureFolder = { id: folderId, name: folderName, collapsed: false }
 
-      const nextId = nextUniqueGeneratedId(nextProjectLike, 'f')
-      const feature = normalizeFeatureZRange({
-        ...createImportedFeature(shape, state.project, folderId, featureName, isFirstFeature ? 'add' : 'subtract'),
-        id: nextId,
-      })
+      newFolders.push(folder)
+      nextProjectLike = { ...nextProjectLike, featureFolders: [...nextProjectLike.featureFolders, folder] }
 
-      createdFeatures.push(feature)
-      nextProjectLike = {
-        ...nextProjectLike,
-        features: [...nextProjectLike.features, feature],
+      for (const shape of layerShapes) {
+        const featureName = uniqueName(
+          shape.name || folderDisplayName,
+          [...existingFeatureNames, ...createdFeatures.map((f) => f.name)],
+        )
+        // Closed profiles are additive material; open profiles are subtractive cuts.
+        const operation: FeatureOperation = shape.profile.closed ? 'add' : 'subtract'
+        const nextId = nextUniqueGeneratedId(nextProjectLike, 'f')
+        const feature = normalizeFeatureZRange({
+          ...createImportedFeature(shape, state.project, folderId, featureName, operation),
+          id: nextId,
+        })
+
+        createdFeatures.push(feature)
+        nextProjectLike = { ...nextProjectLike, features: [...nextProjectLike.features, feature] }
       }
-    })
+    }
 
     if (createdFeatures.length === 0) {
       return []
@@ -3566,13 +3579,17 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
     set((s) => {
       const nextProject = syncFeatureTreeProject({
         ...s.project,
-        featureFolders: [...s.project.featureFolders, folder],
-        featureTree: [...s.project.featureTree, { type: 'folder', folderId }],
+        featureFolders: [...s.project.featureFolders, ...newFolders],
+        featureTree: [
+          ...s.project.featureTree,
+          ...newFolders.map((f) => ({ type: 'folder' as const, folderId: f.id })),
+        ],
         features: [...s.project.features, ...createdFeatures],
         meta: { ...s.project.meta, modified: new Date().toISOString() },
       })
-      const createdIds = createdFeatures.map((feature) => feature.id)
+      const createdIds = createdFeatures.map((f) => f.id)
       const primaryId = createdIds.at(-1) ?? null
+      const primaryFolderId = newFolders.at(-1)?.id ?? null
 
       return {
         project: nextProject,
@@ -3580,7 +3597,11 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
           ...s.selection,
           selectedFeatureId: primaryId,
           selectedFeatureIds: createdIds,
-          selectedNode: primaryId ? { type: 'feature', featureId: primaryId } : { type: 'folder', folderId },
+          selectedNode: primaryId
+            ? { type: 'feature', featureId: primaryId }
+            : primaryFolderId
+              ? { type: 'folder', folderId: primaryFolderId }
+              : s.selection.selectedNode,
           mode: 'feature',
           activeControl: null,
         },
@@ -3592,7 +3613,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
       }
     })
 
-    return createdFeatures.map((feature) => feature.id)
+    return createdFeatures.map((f) => f.id)
   },
 
   updateFeature: (id, patch) =>

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -299,6 +299,76 @@
   white-space: normal;
 }
 
+.import-dialog__layers-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.import-dialog__layers-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.import-dialog__layers-toggle {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1.4;
+}
+
+.import-dialog__layers-toggle:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.import-dialog__layer-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  max-height: 180px;
+  overflow-y: auto;
+  border: 1px solid var(--border, rgba(255,255,255,0.08));
+  border-radius: 6px;
+  padding: 4px 0;
+  background: var(--surface-raised, rgba(0,0,0,0.15));
+}
+
+.import-dialog__layer-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  cursor: pointer;
+  border-radius: 4px;
+  min-height: 26px;
+}
+
+.import-dialog__layer-row:hover {
+  background: rgba(255,255,255,0.05);
+}
+
+.import-dialog__layer-row input[type="checkbox"] {
+  width: 14px;
+  height: 14px;
+  margin: 0;
+  flex: 0 0 auto;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.import-dialog__layer-name {
+  font-size: 13px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .import-dialog__summary {
   color: var(--text-dim);
   font-size: 12px;

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -39,7 +39,11 @@
 }
 
 .dialog--import {
-  max-width: 760px;
+  max-width: 480px;
+}
+
+.dialog--import-with-layers {
+  max-width: 720px;
 }
 
 .dialog-header {
@@ -82,7 +86,11 @@
 }
 
 .dialog-body--import {
-  grid-template-columns: 300px 1fr;
+  grid-template-columns: 1fr;
+}
+
+.dialog-body--import-with-layers {
+  grid-template-columns: 1fr 220px;
 }
 
 .dialog-footer {
@@ -254,8 +262,40 @@
   line-height: 1.5;
 }
 
-.import-dialog__units-field {
-  grid-template-columns: minmax(74px, 88px) minmax(0, 1fr);
+/* Info/settings rows: label on left, value or control on right */
+.import-dialog__info-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 32px;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+.import-dialog__info-row strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.import-dialog__info-row select,
+.import-dialog__info-row input[type="number"] {
+  width: 130px;
+  flex-shrink: 0;
+  background: #0f1820;
+  border: 1px solid var(--line-strong);
+  border-radius: 7px;
+  color: var(--text);
+  height: 32px;
+  padding: 0 8px;
+  font: inherit;
+  font-size: 13px;
+}
+
+.import-dialog__info-row select:focus,
+.import-dialog__info-row input[type="number"]:focus {
+  outline: none;
+  border-color: var(--accent);
 }
 
 .import-dialog__field-note {
@@ -265,49 +305,53 @@
   line-height: 1.45;
 }
 
+.import-dialog__field-note--warn {
+  color: #f7b86a;
+}
+
 .import-dialog__toggle-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  min-height: 36px;
+  min-height: 32px;
   color: var(--text);
   cursor: pointer;
+  font-size: 13px;
 }
 
 .import-dialog__toggle-label {
-  color: #cbd8e6;
-  font-size: 14px;
+  color: var(--text-dim);
   line-height: 1.2;
   white-space: nowrap;
 }
 
 .import-dialog__toggle-input {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   margin: 0;
   flex: 0 0 auto;
   accent-color: var(--accent);
+  background: #0f1820;
+  border: 1px solid var(--line-strong);
+  border-radius: 4px;
+  cursor: pointer;
 }
 
-.import-dialog__toggle-input:disabled {
-  opacity: 0.55;
-  cursor: default;
-}
-
-.import-dialog__preview {
-  white-space: normal;
+/* Layers column */
+.import-dialog__layers-column {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 8px;
+  min-height: 0;
+  border-left: 1px solid var(--line);
+  padding-left: 20px;
 }
 
 .import-dialog__layers-header {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 8px;
-}
-
-.import-dialog__layers-actions {
-  display: flex;
   gap: 8px;
 }
 
@@ -336,6 +380,12 @@
   border-radius: 6px;
   padding: 4px 0;
   background: var(--surface-raised, rgba(0,0,0,0.15));
+}
+
+/* When layers are in their own column, let the list fill all available height */
+.import-dialog__layer-list--fill {
+  max-height: none;
+  height: 100%;
 }
 
 .import-dialog__layer-row {
@@ -367,12 +417,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.import-dialog__summary {
-  color: var(--text-dim);
-  font-size: 12px;
-  line-height: 1.45;
 }
 
 .btn-primary {
@@ -410,12 +454,19 @@
   background: rgba(255, 255, 255, 0.03);
 }
 
-@media (max-width: 760px) {
+@media (max-width: 720px) {
   .dialog-body {
     grid-template-columns: 1fr;
   }
 
-  .dialog-body--import {
+  .dialog-body--import-with-layers {
     grid-template-columns: 1fr;
+  }
+
+  .import-dialog__layers-column {
+    border-left: none;
+    border-top: 1px solid var(--line);
+    padding-left: 0;
+    padding-top: 16px;
   }
 }


### PR DESCRIPTION
## Summary

- **Layer-based import**: DXF layers are presented as checkboxes in the import dialog; each imported layer becomes its own project folder. DXF layer `0` is treated as a first-class selectable layer.
- **Better endpoint stitching**: Removed T-junction splitting from the pipeline — it was causing false splits that prevented nearby arc endpoints from connecting. Join tolerance label now shows project units explicitly to avoid confusion.
- **Arc direction fix**: Corrected `clockwise` flag for arcs inside reflected INSERT transforms (negative determinant).
- **Closed profiles auto-assigned as `add`**: Closed shapes import as add operations, open paths as subtract. User can adjust individually after import.
- **Import dialog redesign**: Replaced the two-column settings/preview layout with a single vertical settings form. Layer checkboxes move to a dedicated right column that only appears when the file has layers. Removed the redundant "Import Preview" panel — no more duplicated information. Input fields now match the app's style.

## Test plan

- [ ] Import a DXF with multiple layers — verify one folder is created per layer
- [ ] Verify layer `0` appears as a selectable layer when the file has entities on it
- [ ] Deselect some layers and confirm only selected-layer shapes are imported
- [ ] Import Gibson headstock DXF — verify arcs connect cleanly at default tolerance
- [ ] Verify closed shapes import as `add`, open paths as `subtract`
- [ ] Confirm dialog is compact (no layers) and wide (with layers)
- [ ] Confirm select/number inputs match app styling