### PR TITLE
Add browser-only GoatCounter analytics

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,12 +17,15 @@
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { isDesktop } from './platform'
+import { installAnalytics } from './utils/analytics'
 import { applyVersionToTitle } from './utils/version'
 
 // In the desktop app, the window title is managed by useDesktopIntegration
 // (showing filename + dirty flag). Only apply the version title in browser.
-if (!('__TAURI_INTERNALS__' in window)) {
+if (!isDesktop) {
   applyVersionToTitle()
+  installAnalytics()
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -24,7 +24,7 @@ export type { PlatformApi, OpenProjectResult, PickGeometryResult } from './api'
  * True when the app is running inside Tauri.
  * Tauri v2 injects __TAURI_INTERNALS__ into the window object.
  */
-const isDesktop =
+export const isDesktop =
   typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
 
 export const platform: PlatformApi = isDesktop ? desktopPlatform : browserPlatform

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isDesktop } from '../platform'
+
+const GOATCOUNTER_SCRIPT_ID = 'goatcounter-count'
+const GOATCOUNTER_ENDPOINT = 'https://purecutcnc.goatcounter.com/count'
+const GOATCOUNTER_SRC = 'https://gc.zgo.at/count.js'
+
+export function installAnalytics(): void {
+  if (typeof document === 'undefined' || isDesktop) {
+    return
+  }
+
+  if (document.getElementById(GOATCOUNTER_SCRIPT_ID)) {
+    return
+  }
+
+  const script = document.createElement('script')
+  script.id = GOATCOUNTER_SCRIPT_ID
+  script.async = true
+  script.src = GOATCOUNTER_SRC
+  script.dataset.goatcounter = GOATCOUNTER_ENDPOINT
+  document.head.append(script)
+}


### PR DESCRIPTION
## Summary
- add a small analytics loader for GoatCounter
- load analytics only in the browser startup path
- keep the native Tauri wrapper free of the GoatCounter script

## Testing
- npm run build