### PR TITLE
Add multi-feature property editing and folder tree fixes

### DIFF
--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -264,7 +264,7 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
           onDragOver={(event) => handleDragOver(event, { kind: 'features' })}
           onDrop={handleDrop}
         />
-        {featuresCollapsed ? null : project.features.length === 0 ? (
+        {featuresCollapsed ? null : rootEntries.length === 0 ? (
           <div className="feature-tree-empty">No feature nodes yet.</div>
         ) : (
           <div className="tree-children">

--- a/src/components/feature-tree/PropertiesPanel.tsx
+++ b/src/components/feature-tree/PropertiesPanel.tsx
@@ -71,11 +71,12 @@ function DraftTextInput({ value, disabled = false, onCommit }: DraftTextInputPro
 }
 
 interface DraftNumberInputProps {
-  value: number
+  value: number | null
   units: 'mm' | 'inch'
   min?: number
   max?: number
   disabled?: boolean
+  placeholder?: string
   onCommit: (value: number) => void
   validate?: (value: number) => boolean
 }
@@ -86,11 +87,12 @@ function DraftNumberInput({
   min,
   max,
   disabled = false,
+  placeholder,
   onCommit,
   validate,
 }: DraftNumberInputProps) {
   function reset(element: HTMLInputElement) {
-    element.value = formatLength(value, units)
+    element.value = value === null ? '' : formatLength(value, units)
   }
 
   function isValid(next: number) {
@@ -102,13 +104,18 @@ function DraftNumberInput({
   }
 
   function commit(element: HTMLInputElement) {
+    if (element.value.trim() === '') {
+      reset(element)
+      return
+    }
+
     const next = parseLengthInput(element.value, units)
     if (next === null || !isValid(next)) {
       reset(element)
       return
     }
 
-    if (next !== value) {
+    if (value === null || next !== value) {
       onCommit(next)
     } else {
       reset(element)
@@ -119,7 +126,8 @@ function DraftNumberInput({
     <input
       type="text"
       inputMode="decimal"
-      defaultValue={formatLength(value, units)}
+      defaultValue={value === null ? '' : formatLength(value, units)}
+      placeholder={placeholder}
       disabled={disabled}
       spellCheck={false}
       data-numeric-entry="true"
@@ -174,6 +182,7 @@ export function PropertiesPanel() {
     updateClamp,
     updateFeatureFolder,
     updateFeature,
+    updateFeatures,
     deleteFeature,
     deleteFeatures,
     enterSketchEdit,
@@ -211,6 +220,37 @@ export function PropertiesPanel() {
     allSelectedFeatures.every((feature) => feature.folderId === allSelectedFeatures[0]?.folderId)
       ? allSelectedFeatures[0]?.folderId ?? null
       : '__mixed__'
+  const commonSelectedOperation =
+    allSelectedFeatures.length > 0 &&
+    allSelectedFeatures.every((feature) => feature.operation === allSelectedFeatures[0]?.operation)
+      ? allSelectedFeatures[0]?.operation ?? null
+      : '__mixed__'
+  const commonSelectedZTop =
+    allSelectedFeatures.length > 0 &&
+    typeof allSelectedFeatures[0]?.z_top === 'number' &&
+    allSelectedFeatures.every((feature) => feature.z_top === allSelectedFeatures[0]?.z_top)
+      ? allSelectedFeatures[0]?.z_top ?? null
+      : null
+  const commonSelectedZBottom =
+    allSelectedFeatures.length > 0 &&
+    typeof allSelectedFeatures[0]?.z_bottom === 'number' &&
+    allSelectedFeatures.every((feature) => feature.z_bottom === allSelectedFeatures[0]?.z_bottom)
+      ? allSelectedFeatures[0]?.z_bottom ?? null
+      : null
+  const selectedNumericZBottoms = allSelectedFeatures
+    .map((feature) => feature.z_bottom)
+    .filter((value): value is number => typeof value === 'number')
+  const selectedNumericZTops = allSelectedFeatures
+    .map((feature) => feature.z_top)
+    .filter((value): value is number => typeof value === 'number')
+  const multiEditMinZTop =
+    selectedNumericZBottoms.length === allSelectedFeatures.length
+      ? Math.max(...selectedNumericZBottoms)
+      : null
+  const multiEditMaxZBottom =
+    selectedNumericZTops.length === allSelectedFeatures.length
+      ? Math.min(...selectedNumericZTops)
+      : null
   const selectedMachine = project.meta.selectedMachineId
       ? project.meta.machineDefinitions.find((definition) => definition.id === project.meta.selectedMachineId) ?? null
       : null
@@ -276,12 +316,16 @@ export function PropertiesPanel() {
     }
   }
 
-  function renderFolderSelect(value: string | null, onChange: (folderId: string | null) => void) {
+  function renderFolderSelect(value: string | '__mixed__' | null, onChange: (folderId: string | null) => void) {
     return (
       <select
         value={value ?? ''}
-        onChange={(event) => onChange(event.target.value === '' ? null : event.target.value)}
+        onChange={(event) =>
+          onChange(event.target.value === '' || event.target.value === '__mixed__' ? null : event.target.value)}
       >
+        {value === '__mixed__' ? (
+          <option value="__mixed__">Mixed folders</option>
+        ) : null}
         <option value="">Root</option>
         {project.featureFolders.map((folder) => (
           <option key={folder.id} value={folder.id}>
@@ -979,25 +1023,49 @@ export function PropertiesPanel() {
             </label>
             <label className="properties-field">
               <span>Folder</span>
+              {renderFolderSelect(commonSelectedFolderId, (folderId) =>
+                assignFeaturesToFolder(selectedFeatureIds, folderId),
+              )}
+            </label>
+            <label className="properties-field">
+              <span>Operation</span>
               <select
-                value={commonSelectedFolderId ?? ''}
+                value={commonSelectedOperation ?? ''}
                 onChange={(event) =>
-                  assignFeaturesToFolder(
-                    selectedFeatureIds,
-                    event.target.value === '' || event.target.value === '__mixed__' ? null : event.target.value,
-                  )
-                }
+                  updateFeatures(selectedFeatureIds, {
+                    operation: event.target.value as 'add' | 'subtract',
+                  })}
               >
-                {commonSelectedFolderId === '__mixed__' ? (
-                  <option value="__mixed__">Mixed folders</option>
+                {commonSelectedOperation === '__mixed__' ? (
+                  <option value="__mixed__">Mixed operations</option>
                 ) : null}
-                <option value="">Root</option>
-                {project.featureFolders.map((folder) => (
-                  <option key={folder.id} value={folder.id}>
-                    {folder.name}
-                  </option>
-                ))}
+                <option value="subtract">Subtract</option>
+                <option value="add">Add</option>
               </select>
+            </label>
+            <label className="properties-field">
+              <span>Z Top</span>
+              <DraftNumberInput
+                key={`multi-feature-ztop-${selectedFeatureIds.join(',')}-${commonSelectedZTop ?? 'mixed'}-${commonSelectedZBottom ?? 'mixed'}`}
+                value={commonSelectedZTop}
+                units={units}
+                min={0}
+                placeholder="Mixed values"
+                validate={(next) => multiEditMinZTop === null || next >= multiEditMinZTop}
+                onCommit={(next) => updateFeatures(selectedFeatureIds, { z_top: next })}
+              />
+            </label>
+            <label className="properties-field">
+              <span>Z Bottom</span>
+              <DraftNumberInput
+                key={`multi-feature-zbottom-${selectedFeatureIds.join(',')}-${commonSelectedZTop ?? 'mixed'}-${commonSelectedZBottom ?? 'mixed'}`}
+                value={commonSelectedZBottom}
+                units={units}
+                min={0}
+                placeholder="Mixed values"
+                validate={(next) => multiEditMaxZBottom === null || next <= multiEditMaxZBottom}
+                onCommit={(next) => updateFeatures(selectedFeatureIds, { z_bottom: next })}
+              />
             </label>
           </div>
           <div className="properties-actions">

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -3455,7 +3455,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
       // First feature must always be 'add' — it is the base solid of the part model.
       const isFirst = s.project.features.length === 0
       // Determine folder context and insertion point from current selection.
-      const selectedNode = !isFirst ? s.selection.selectedNode : null
+      const selectedNode = s.selection.selectedNode
       let effectiveFolderId: string | null = feature.folderId ?? null
       let insertAfterFeatureId: string | null = null
       if (selectedNode?.type === 'folder') {
@@ -3466,7 +3466,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         insertAfterFeatureId = selectedNode.featureId
       }
       const safeFeature: SketchFeature = isFirst
-        ? normalizeFeatureZRange({ ...feature, id: safeId, folderId: null, operation: 'add' })
+        ? normalizeFeatureZRange({ ...feature, id: safeId, folderId: effectiveFolderId, operation: 'add' })
         : normalizeFeatureZRange({ ...feature, id: safeId, folderId: effectiveFolderId })
       // Build features and featureTree arrays with correct insertion position.
       let nextFeatures: SketchFeature[]
@@ -3631,6 +3631,46 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         features: features.map((f) =>
           f.id === id ? normalizeFeatureZRange({ ...f, ...safePatch }) : f
         ),
+        meta: { ...s.project.meta, modified: new Date().toISOString() },
+      }
+      if (projectsEqual(nextProject, s.project)) {
+        return {}
+      }
+      if (s.history.transactionStart) {
+        return { project: nextProject }
+      }
+      return {
+        project: nextProject,
+        history: {
+          past: [...s.history.past, cloneProject(s.project)].slice(-100),
+          future: [],
+          transactionStart: null,
+        },
+      }
+    }),
+
+  updateFeatures: (ids, patch) =>
+    set((s) => {
+      if (ids.length === 0) {
+        return {}
+      }
+
+      const selectedIds = new Set(ids)
+      const features = s.project.features
+      const nextProject = {
+        ...s.project,
+        features: features.map((feature, index) => {
+          if (!selectedIds.has(feature.id)) {
+            return feature
+          }
+
+          const safePatch: Partial<SketchFeature> =
+            index === 0 && patch.operation !== undefined && patch.operation !== 'add'
+              ? { ...patch, operation: 'add' }
+              : patch
+
+          return normalizeFeatureZRange({ ...feature, ...safePatch })
+        }),
         meta: { ...s.project.meta, modified: new Date().toISOString() },
       }
       if (projectsEqual(nextProject, s.project)) {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -215,6 +215,7 @@ export interface ProjectStore {
   addFeature: (feature: SketchFeature) => void
   importShapes: (input: { fileName: string; sourceType: ImportSourceType; shapes: ImportedShape[] }) => string[]
   updateFeature: (id: string, patch: Partial<SketchFeature>) => void
+  updateFeatures: (ids: string[], patch: Partial<SketchFeature>) => void
   deleteFeature: (id: string) => void
   deleteFeatures: (ids: string[]) => void
   mergeSelectedFeatures: (keepOriginals?: boolean) => string[]


### PR DESCRIPTION
## Summary
- add multi-feature property editing for folder, operation, z top, and z bottom
- show empty folders in the feature tree even before any features exist
- place the first created feature into the selected folder instead of always forcing it to root

## Verification
- npm run build