### PR TITLE
Fix circle edit radius input

### DIFF
--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -1443,6 +1443,10 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       return computeEditDimSteps(profile, control.index)
     }
 
+    if (control.kind === 'circle_center') {
+      return computeEditDimSteps(profile, 0)
+    }
+
     if (control.kind === 'arc_handle') {
       return [{ kind: 'arc_radius', control, arcStartAnchorIndex: control.index }]
     }


### PR DESCRIPTION
## Summary
- route native circle center control into the existing radius edit flow
- restore the radius value input when resizing circles in sketch edit mode
- keep the existing arc radius edit behavior unchanged

## Testing
- npm run build