### PR TITLE
Add tool playback simulation for the selected operation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,8 @@ import { SketchCanvas, type SketchCanvasHandle } from './components/canvas/Sketc
 import { applyClampWarnings, applyTabsToEdgeRoute, applyTabWarnings, generateEdgeRouteToolpath, generateFollowLineToolpath, generatePocketToolpath, generateSurfaceCleanToolpath, generateVCarveToolpath, generateVCarveRecursiveToolpath } from './engine/toolpaths'
 import { normalizeToolForProject } from './engine/toolpaths/geometry'
 import type { ToolpathResult } from './engine/toolpaths'
-import { createSimulationGrid, simulateOperationHeightfield, simulateReplayItemsHeightfield } from './engine/simulation'
+import { createSimulationGrid, simulateOperationHeightfield, simulateReplayItemsHeightfield, type SimulationReplayItem } from './engine/simulation'
+import type { SimulationPlaybackInput } from './components/simulation/SimulationViewport'
 import { FeatureTree } from './components/feature-tree/FeatureTree'
 import { PropertiesPanel } from './components/feature-tree/PropertiesPanel'
 import { AppShell } from './components/layout/AppShell'
@@ -282,6 +283,94 @@ function App() {
 
     return project.operations.filter((operation) => operation.enabled && operation.showToolpath).length
   }, [project.operations, selectedOperation, selectedToolpath, simulationMode])
+
+  const simulationPlaybackInput = useMemo<SimulationPlaybackInput | null>(() => {
+    if (centerTab !== 'simulation' || simulationMode !== 'selected') {
+      return null
+    }
+    if (!selectedOperation || !selectedToolpath) {
+      return null
+    }
+    const toolRecord = selectedOperation.toolRef
+      ? project.tools.find((tool) => tool.id === selectedOperation.toolRef) ?? null
+      : null
+    if (!toolRecord || toolRecord.type === 'drill') {
+      return null
+    }
+
+    const normalizedSelectedTool = normalizeToolForProject(toolRecord, project)
+
+    // Pre-apply only operations that come BEFORE the selected one in the feature
+    // tree order — operations listed after the selection haven't run yet at this
+    // point in the cycle, so their cuts shouldn't appear in the starting state.
+    const selectedIndex = project.operations.findIndex((operation) => operation.id === selectedOperation.id)
+    const priorOperations = selectedIndex >= 0 ? project.operations.slice(0, selectedIndex) : []
+
+    const priorItems: SimulationReplayItem[] = priorOperations
+      .filter((operation) =>
+        operation.enabled
+        && operation.showToolpath
+        && operation.toolRef,
+      )
+      .map((operation): SimulationReplayItem | null => {
+        const toolpath = generateToolpathForOperation(operation)
+        const operationTool = operation.toolRef
+          ? project.tools.find((tool) => tool.id === operation.toolRef) ?? null
+          : null
+        if (!toolpath || !operationTool) {
+          return null
+        }
+        const normalizedTool = normalizeToolForProject(operationTool, project)
+        return {
+          operationId: operation.id,
+          operationName: operation.name,
+          toolRef: operationTool.id,
+          toolType: operationTool.type,
+          toolRadius: normalizedTool.radius,
+          vBitAngle: normalizedTool.vBitAngle,
+          toolpath,
+        }
+      })
+      .filter((item): item is SimulationReplayItem => item !== null)
+
+    const baseResult = simulateReplayItemsHeightfield(project, priorItems, {
+      targetLongAxisCells: simulationDetailCells,
+    })
+
+    const diameter = normalizedSelectedTool.radius * 2
+    // Both maxCutDepth and diameter come from `normalizeToolForProject`, so they're
+    // already in project units — mm or inch, whichever the project uses. All the
+    // derived dimensions below stay unit-agnostic by staying diameter-relative.
+    const toolCutLength = normalizedSelectedTool.maxCutDepth > 0
+      ? normalizedSelectedTool.maxCutDepth
+      : diameter * 3
+    const toolShankLength = diameter * 2
+    // Split source moves longer than ~0.4× tool radius so long straights don't
+    // apply a single giant cut in one shot. The playback controller also throttles
+    // by distance-per-frame now, so this is belt-and-suspenders for partial-cut
+    // granularity on very long segments.
+    const maxSegmentLength = normalizedSelectedTool.radius * 0.4
+
+    // Operation feed is stored in project-units-per-minute. The viewport works in
+    // units-per-second, so divide by 60. This becomes the "1×" playback speed so
+    // users can intuitively speed up or slow down relative to the real feed rate.
+    const feedPerSecond = selectedOperation.feed > 0 ? selectedOperation.feed / 60 : undefined
+    // `project.meta.units` uses 'inch'; the playback UI shows the short label 'in'.
+    const units: 'mm' | 'in' = project.meta.units === 'inch' ? 'in' : 'mm'
+
+    return {
+      baseGrid: baseResult.grid,
+      moves: selectedToolpath.moves,
+      toolType: toolRecord.type,
+      toolRadius: normalizedSelectedTool.radius,
+      vBitAngle: normalizedSelectedTool.vBitAngle,
+      toolCutLength,
+      toolShankLength,
+      maxSegmentLength,
+      units,
+      feedPerSecond,
+    }
+  }, [centerTab, generateToolpathForOperation, project, selectedOperation, selectedToolpath, simulationDetailCells, simulationMode])
 
   const visibleToolpaths = useMemo<ToolpathResult[]>(() => {
     return project.operations
@@ -663,6 +752,7 @@ function App() {
             stockColor={project.stock.color}
             zoomWindowActive={zoomWindowActive && centerTab === 'simulation'}
             onZoomWindowComplete={() => setZoomWindowActive(false)}
+            playbackInput={simulationPlaybackInput}
           />
         }
         featureTree={<FeatureTree onFeatureContextMenu={openFeatureContextMenu} onTabContextMenu={openTabContextMenu} onClampContextMenu={openClampContextMenu} />}

--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -19,8 +19,11 @@ import * as THREE from 'three'
 import { Icon } from '../Icon'
 import { buildClampMesh, buildOriginTriad } from '../../engine/csg'
 import { buildSimulationGeometry } from '../../engine/simulation/mesh'
-import type { SimulationResult } from '../../engine/simulation'
-import type { Clamp, MachineOrigin, Operation } from '../../types/project'
+import { PlaybackController } from '../../engine/simulation/playback'
+import { buildToolMesh, disposeToolMesh } from '../../engine/simulation/toolMesh'
+import type { SimulationGrid, SimulationResult } from '../../engine/simulation'
+import type { ToolpathMove } from '../../engine/toolpaths/types'
+import type { Clamp, MachineOrigin, Operation, ToolType } from '../../types/project'
 
 const DEFAULT_CAMERA_SPHERICAL = {
   theta: Math.PI / 4,
@@ -71,6 +74,29 @@ const VIEW_PRESETS: Record<ViewPreset, { theta: number; phi: number; up: THREE.V
   },
 }
 
+export interface SimulationPlaybackInput {
+  baseGrid: SimulationGrid
+  moves: ToolpathMove[]
+  toolType: ToolType
+  toolRadius: number
+  vBitAngle: number | null
+  /** Flute / cutting portion length in project units. */
+  toolCutLength?: number
+  /** Shank length above the flutes in project units. */
+  toolShankLength?: number
+  /** Max length of any single internal sub-move. Long sources get split. */
+  maxSegmentLength?: number
+  /** Project units for UI labels ('mm' or 'in'). */
+  units?: 'mm' | 'in'
+  /**
+   * Operation feed rate converted to project-units-per-second. When provided, this
+   * becomes the "1×" baseline for the playback speed multiplier so the user can
+   * scrub faster/slower relative to the real cutting feed. Omit (or pass 0) to
+   * fall back to the generic per-unit default.
+   */
+  feedPerSecond?: number
+}
+
 interface SimulationViewportProps {
   operation: Operation | null
   simulation: SimulationResult | null
@@ -86,6 +112,7 @@ interface SimulationViewportProps {
   stockColor?: string
   zoomWindowActive?: boolean
   onZoomWindowComplete?: () => void
+  playbackInput: SimulationPlaybackInput | null
 }
 
 export interface SimulationViewportHandle {
@@ -95,6 +122,69 @@ export interface SimulationViewportHandle {
 const SIMULATION_DETAIL_MIN = 240
 const SIMULATION_DETAIL_MAX = 720
 const SIMULATION_DETAIL_STEP = 40
+
+/**
+ * Playback speed is a multiplier of the operation's feed rate ("1×" means "play at
+ * the real cutting feed"). The UI renders a log-scaled slider so the low end (where
+ * small changes matter visually) gets as much travel as the high end. When the op
+ * doesn't expose a feed rate we fall back to a generic per-unit default.
+ */
+const PLAYBACK_MULTIPLIER_MIN = 1
+// Above ~30× the per-frame Step cap and the browser's RAF cadence both saturate,
+// so further increases stop translating into faster playback. Cap at 32× to keep
+// the slider's range meaningful end-to-end.
+const PLAYBACK_MULTIPLIER_MAX = 32
+const PLAYBACK_DEFAULT_MULTIPLIER = 2
+const PLAYBACK_SLIDER_STEPS = 100
+const PLAYBACK_FALLBACK_FEED_MM = 50
+const PLAYBACK_FALLBACK_FEED_IN = 2
+
+/**
+ * Map a linear slider position (0..STEPS) to a multiplier using a log scale so the
+ * low end feels precise even when the top end reaches into the hundreds.
+ */
+function sliderPositionToMultiplier(position: number): number {
+  const t = Math.max(0, Math.min(1, position / PLAYBACK_SLIDER_STEPS))
+  const log = Math.log(PLAYBACK_MULTIPLIER_MIN) + t * (Math.log(PLAYBACK_MULTIPLIER_MAX) - Math.log(PLAYBACK_MULTIPLIER_MIN))
+  return Math.exp(log)
+}
+
+function multiplierToSliderPosition(multiplier: number): number {
+  const clamped = Math.max(PLAYBACK_MULTIPLIER_MIN, Math.min(PLAYBACK_MULTIPLIER_MAX, multiplier))
+  const t = (Math.log(clamped) - Math.log(PLAYBACK_MULTIPLIER_MIN))
+    / (Math.log(PLAYBACK_MULTIPLIER_MAX) - Math.log(PLAYBACK_MULTIPLIER_MIN))
+  return Math.round(t * PLAYBACK_SLIDER_STEPS)
+}
+
+function formatMultiplierLabel(multiplier: number): string {
+  if (multiplier >= 10) {
+    return `${Math.round(multiplier)}×`
+  }
+  return `${Number(multiplier.toFixed(1))}×`
+}
+
+/**
+ * Max distance the tool can advance in a single animation frame, expressed in project
+ * units. Chunks are applied via partial-move cuts, so one step can span many small moves
+ * or just a slice of a larger one — per your request, we throttle by distance, not count.
+ */
+const PLAYBACK_STEP_SIZES_MM = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+const PLAYBACK_STEP_SIZES_IN = [0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5]
+// 0.1 in ≈ 2.5 mm — same visual cadence in either unit system.
+const PLAYBACK_DEFAULT_STEP_MM = 2.5
+const PLAYBACK_DEFAULT_STEP_IN = 0.1
+const PLAYBACK_REBUILD_INTERVAL_MS = 0
+
+function formatSpeedLabel(perSecond: number, units: 'mm' | 'in'): string {
+  // Internally the sim advances by distance-per-second (it's what RAF multiplies
+  // by dt), but CNC operators think in feed-per-minute — so display units/min to
+  // match how the operation's feed was authored. Multiply back up by 60.
+  const perMinute = perSecond * 60
+  // Inches read nicer with a couple of decimals, mm can stay whole for normal feeds.
+  const digits = units === 'in' ? 1 : 0
+  const rounded = Number(perMinute.toFixed(digits))
+  return `${rounded} ${units}/min`
+}
 
 function createOrbitControls(
   camera: THREE.PerspectiveCamera,
@@ -351,7 +441,49 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   stockColor,
   zoomWindowActive = false,
   onZoomWindowComplete,
+  playbackInput,
 }, ref) {
+  const playbackUnits = playbackInput?.units ?? 'mm'
+  const fallbackFeed = playbackUnits === 'in' ? PLAYBACK_FALLBACK_FEED_IN : PLAYBACK_FALLBACK_FEED_MM
+  // Anchor the playback speed multiplier to the operation's feed (units/sec). If the
+  // operation has no feed defined, anchor to a sensible per-unit fallback so the UI
+  // still behaves like "1× = a reasonable starting pace".
+  const baseSpeed = playbackInput?.feedPerSecond && playbackInput.feedPerSecond > 0
+    ? playbackInput.feedPerSecond
+    : fallbackFeed
+  const stepSizes = playbackUnits === 'in' ? PLAYBACK_STEP_SIZES_IN : PLAYBACK_STEP_SIZES_MM
+  const defaultStep = playbackUnits === 'in' ? PLAYBACK_DEFAULT_STEP_IN : PLAYBACK_DEFAULT_STEP_MM
+
+  const [playbackEnabled, setPlaybackEnabled] = useState(false)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [playbackMultiplier, setPlaybackMultiplier] = useState<number>(PLAYBACK_DEFAULT_MULTIPLIER)
+  const [playbackMaxStep, setPlaybackMaxStep] = useState(defaultStep)
+  const [playbackProgress, setPlaybackProgress] = useState(0)
+  const playbackControllerRef = useRef<PlaybackController | null>(null)
+  const toolMeshRef = useRef<THREE.Group | null>(null)
+  const playbackMaterialMeshRef = useRef<THREE.Mesh | null>(null)
+  const playbackFrameRef = useRef<number>(0)
+  const playbackLastTimeRef = useRef<number>(0)
+  const playbackLastRebuildRef = useRef<number>(0)
+  const isPlayingRef = useRef(false)
+  const playbackSpeedRef = useRef(baseSpeed * PLAYBACK_DEFAULT_MULTIPLIER)
+  const playbackMaxStepRef = useRef(playbackMaxStep)
+  useEffect(() => {
+    isPlayingRef.current = isPlaying
+  }, [isPlaying])
+  useEffect(() => {
+    // The RAF tick reads speed from a ref so it stays current without restarting
+    // the loop. Recompute on every baseSpeed or multiplier change.
+    playbackSpeedRef.current = baseSpeed * playbackMultiplier
+  }, [baseSpeed, playbackMultiplier])
+  useEffect(() => {
+    playbackMaxStepRef.current = playbackMaxStep
+  }, [playbackMaxStep])
+  // Reset the step default if the project units change under us — but leave the
+  // multiplier alone so the user's chosen pace is preserved across operations.
+  useEffect(() => {
+    setPlaybackMaxStep(defaultStep)
+  }, [defaultStep])
   const [zoomWindowBox, setZoomWindowBox] = useState<{ startX: number; startY: number; currentX: number; currentY: number } | null>(null)
   const zoomWindowBoxRef = useRef<{ startX: number; startY: number; currentX: number; currentY: number } | null>(null)
   const mountRef = useRef<HTMLDivElement>(null)
@@ -502,6 +634,11 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
       return
     }
 
+    if (playbackEnabled) {
+      disposeCurrentMesh(scene)
+      return
+    }
+
     disposeCurrentMesh(scene)
 
     if (!simulation) {
@@ -527,7 +664,226 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
         hasAutoFramedRef.current = true
       }
     }
-  }, [disposeCurrentMesh, simulation])
+  }, [disposeCurrentMesh, playbackEnabled, simulation, stockColor])
+
+  const rebuildPlaybackGeometry = useCallback(() => {
+    const mesh = playbackMaterialMeshRef.current
+    const controller = playbackControllerRef.current
+    if (!mesh || !controller) {
+      return
+    }
+    const nextGeometry = buildSimulationGeometry(controller.liveGrid)
+    mesh.geometry.dispose()
+    mesh.geometry = nextGeometry
+  }, [])
+
+  const updateToolMeshPose = useCallback(() => {
+    const controller = playbackControllerRef.current
+    const tool = toolMeshRef.current
+    if (!controller || !tool) {
+      return
+    }
+    const pose = controller.getPose()
+    // Toolpath (x, y, z) → world (x, z, y): the viewport treats world Y as vertical.
+    tool.position.set(pose.x, pose.z, pose.y)
+  }, [])
+
+  useEffect(() => {
+    const scene = sceneRef.current
+    if (!scene) {
+      return
+    }
+
+    if (!playbackEnabled || !playbackInput) {
+      if (playbackMaterialMeshRef.current) {
+        scene.remove(playbackMaterialMeshRef.current)
+        playbackMaterialMeshRef.current.geometry.dispose()
+        const material = playbackMaterialMeshRef.current.material
+        if (Array.isArray(material)) {
+          material.forEach((entry) => entry.dispose())
+        } else {
+          material.dispose()
+        }
+        playbackMaterialMeshRef.current = null
+      }
+      if (toolMeshRef.current) {
+        scene.remove(toolMeshRef.current)
+        disposeToolMesh(toolMeshRef.current)
+        toolMeshRef.current = null
+      }
+      playbackControllerRef.current = null
+      setIsPlaying(false)
+      setPlaybackProgress(0)
+      return
+    }
+
+    const controller = new PlaybackController(
+      playbackInput.baseGrid,
+      playbackInput.moves,
+      {
+        toolType: playbackInput.toolType,
+        toolRadius: playbackInput.toolRadius,
+        vBitAngle: playbackInput.vBitAngle,
+      },
+      { maxSegmentLength: playbackInput.maxSegmentLength },
+    )
+    playbackControllerRef.current = controller
+
+    const geometry = buildSimulationGeometry(controller.liveGrid)
+    const material = new THREE.MeshStandardMaterial({
+      color: stockColor ? new THREE.Color(stockColor) : 0xb5beca,
+      roughness: 0.86,
+      metalness: 0.05,
+      flatShading: true,
+      side: THREE.DoubleSide,
+    })
+    const mesh = new THREE.Mesh(geometry, material)
+    scene.add(mesh)
+    playbackMaterialMeshRef.current = mesh
+
+    const tool = buildToolMesh({
+      toolType: playbackInput.toolType,
+      toolRadius: playbackInput.toolRadius,
+      vBitAngle: playbackInput.vBitAngle,
+      cutLength: playbackInput.toolCutLength,
+      shankLength: playbackInput.toolShankLength,
+    })
+    scene.add(tool)
+    toolMeshRef.current = tool
+
+    setPlaybackProgress(0)
+    updateToolMeshPose()
+
+    return () => {
+      if (playbackMaterialMeshRef.current) {
+        scene.remove(playbackMaterialMeshRef.current)
+        playbackMaterialMeshRef.current.geometry.dispose()
+        const material = playbackMaterialMeshRef.current.material
+        if (Array.isArray(material)) {
+          material.forEach((entry) => entry.dispose())
+        } else {
+          material.dispose()
+        }
+        playbackMaterialMeshRef.current = null
+      }
+      if (toolMeshRef.current) {
+        scene.remove(toolMeshRef.current)
+        disposeToolMesh(toolMeshRef.current)
+        toolMeshRef.current = null
+      }
+      playbackControllerRef.current = null
+    }
+  }, [playbackEnabled, playbackInput, stockColor, updateToolMeshPose])
+
+  useEffect(() => {
+    if (!playbackEnabled || !isPlaying) {
+      cancelAnimationFrame(playbackFrameRef.current)
+      playbackFrameRef.current = 0
+      return
+    }
+
+    const controller = playbackControllerRef.current
+    if (!controller) {
+      return
+    }
+
+    playbackLastTimeRef.current = performance.now()
+    playbackLastRebuildRef.current = performance.now()
+
+    const tick = () => {
+      const controllerInner = playbackControllerRef.current
+      if (!controllerInner || !isPlayingRef.current) {
+        playbackFrameRef.current = 0
+        return
+      }
+
+      const now = performance.now()
+      const dt = Math.min((now - playbackLastTimeRef.current) / 1000, 0.1)
+      playbackLastTimeRef.current = now
+
+      // Advance by speed × dt, but never more than the user-selected "step per frame"
+      // distance. This is what makes geometry-heavy operations (long straights) pace
+      // the same as move-heavy ones (tight arcs) — we step by distance, not by move.
+      const requested = playbackSpeedRef.current * dt
+      const step = playbackMaxStepRef.current > 0
+        ? Math.min(requested, playbackMaxStepRef.current)
+        : requested
+      const gridChanged = controllerInner.advance(step)
+      updateToolMeshPose()
+
+      if (gridChanged && now - playbackLastRebuildRef.current >= PLAYBACK_REBUILD_INTERVAL_MS) {
+        rebuildPlaybackGeometry()
+        playbackLastRebuildRef.current = now
+      }
+
+      setPlaybackProgress(controllerInner.totalPathLength > 0
+        ? controllerInner.getDistanceTraveled() / controllerInner.totalPathLength
+        : 1)
+
+      if (controllerInner.isFinished()) {
+        rebuildPlaybackGeometry()
+        setIsPlaying(false)
+        playbackFrameRef.current = 0
+        return
+      }
+
+      playbackFrameRef.current = requestAnimationFrame(tick)
+    }
+
+    playbackFrameRef.current = requestAnimationFrame(tick)
+
+    return () => {
+      cancelAnimationFrame(playbackFrameRef.current)
+      playbackFrameRef.current = 0
+    }
+  }, [isPlaying, playbackEnabled, rebuildPlaybackGeometry, updateToolMeshPose])
+
+  useEffect(() => {
+    if (playbackEnabled && (mode !== 'selected' || !playbackInput)) {
+      setPlaybackEnabled(false)
+    }
+  }, [mode, playbackEnabled, playbackInput])
+
+  const handlePlaybackToggle = useCallback(() => {
+    setPlaybackEnabled((current) => !current)
+  }, [])
+
+  const handlePlayPause = useCallback(() => {
+    const controller = playbackControllerRef.current
+    if (!controller) {
+      return
+    }
+    if (controller.isFinished()) {
+      controller.reset()
+      rebuildPlaybackGeometry()
+      setPlaybackProgress(0)
+      updateToolMeshPose()
+    }
+    setIsPlaying((current) => !current)
+  }, [rebuildPlaybackGeometry, updateToolMeshPose])
+
+  const handleStop = useCallback(() => {
+    const controller = playbackControllerRef.current
+    if (!controller) {
+      return
+    }
+    setIsPlaying(false)
+    controller.reset()
+    rebuildPlaybackGeometry()
+    updateToolMeshPose()
+    setPlaybackProgress(0)
+  }, [rebuildPlaybackGeometry, updateToolMeshPose])
+
+  const handleSeek = useCallback((fraction: number) => {
+    const controller = playbackControllerRef.current
+    if (!controller) {
+      return
+    }
+    controller.seekToFraction(fraction)
+    rebuildPlaybackGeometry()
+    updateToolMeshPose()
+    setPlaybackProgress(fraction)
+  }, [rebuildPlaybackGeometry, updateToolMeshPose])
 
   useEffect(() => {
     const scene = sceneRef.current
@@ -688,6 +1044,19 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
             />
             <span className="simulation-detail-control__value">{detailCells}</span>
           </label>
+          <button
+            className={`simulation-mode-toggle__btn simulation-playback-toggle ${playbackEnabled ? 'simulation-mode-toggle__btn--active' : ''}`}
+            type="button"
+            onClick={handlePlaybackToggle}
+            disabled={mode !== 'selected' || !playbackInput}
+            title={mode !== 'selected'
+              ? 'Switch to Selected mode to use Tool playback'
+              : !playbackInput
+                ? 'Select an operation with a valid toolpath to play'
+                : 'Toggle tool playback'}
+          >
+            Play Tool
+          </button>
         </div>
         <div className="viewport-presets__group viewport-presets__group--views">
           <div className="preset-btn-panel">
@@ -701,6 +1070,75 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
           </div>
         </div>
       </div>
+      {playbackEnabled && playbackInput && (
+        <div className="simulation-playback-bar">
+          <div className="simulation-playback-bar__controls">
+            <button
+              type="button"
+              className="simulation-playback-bar__btn simulation-playback-bar__btn--primary"
+              onClick={handlePlayPause}
+              title={isPlaying ? 'Pause' : 'Play'}
+            >
+              {isPlaying ? '❚❚' : '▶'}
+            </button>
+            <button
+              type="button"
+              className="simulation-playback-bar__btn"
+              onClick={handleStop}
+              title="Stop & reset"
+            >
+              ■
+            </button>
+          </div>
+          <div className="simulation-playback-bar__progress">
+            <span className="simulation-playback-bar__readout">
+              {Math.round(playbackProgress * 100)}%
+            </span>
+            <input
+              type="range"
+              min={0}
+              max={1000}
+              step={1}
+              value={Math.round(playbackProgress * 1000)}
+              onChange={(event) => handleSeek(Number(event.target.value) / 1000)}
+              aria-label="Playback progress"
+            />
+          </div>
+          <label
+            className="simulation-playback-bar__speed simulation-playback-bar__speed--slider"
+            title={
+              playbackInput.feedPerSecond && playbackInput.feedPerSecond > 0
+                ? `Speed multiplier of operation feed (${formatSpeedLabel(baseSpeed, playbackUnits)} = 1×). Current: ${formatMultiplierLabel(playbackMultiplier)}`
+                : `Speed multiplier of fallback feed (${formatSpeedLabel(baseSpeed, playbackUnits)} = 1×). Current: ${formatMultiplierLabel(playbackMultiplier)}`
+            }
+          >
+            <span>Speed</span>
+            <input
+              type="range"
+              min={0}
+              max={PLAYBACK_SLIDER_STEPS}
+              step={1}
+              value={multiplierToSliderPosition(playbackMultiplier)}
+              onChange={(event) => setPlaybackMultiplier(sliderPositionToMultiplier(Number(event.target.value)))}
+              aria-label="Playback speed multiplier"
+            />
+          </label>
+          <label
+            className="simulation-playback-bar__speed"
+            title="Maximum distance the tool advances per frame. Smaller = smoother motion, larger = faster playback."
+          >
+            <span>Step</span>
+            <select
+              value={playbackMaxStep}
+              onChange={(event) => setPlaybackMaxStep(Number(event.target.value))}
+            >
+              {stepSizes.map((value) => (
+                <option key={value} value={value}>{value} {playbackUnits}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+      )}
     </div>
   )
 })

--- a/src/engine/simulation/index.ts
+++ b/src/engine/simulation/index.ts
@@ -20,3 +20,7 @@ export * from './tools'
 export * from './replay'
 
 export * from './mesh'
+
+export * from './playback'
+
+export * from './toolMesh'

--- a/src/engine/simulation/playback.ts
+++ b/src/engine/simulation/playback.ts
@@ -1,0 +1,282 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ToolType } from '../../types/project'
+import type { ToolpathMove } from '../toolpaths/types'
+import { applyMoveToGrid } from './replay'
+import type { SimulationGrid } from './types'
+
+export interface PlaybackToolInfo {
+  toolType: ToolType
+  toolRadius: number
+  vBitAngle: number | null
+}
+
+export interface PlaybackOptions {
+  /**
+   * Upper bound on the length of any single move used during playback. Longer moves
+   * are split into equal sub-segments before replay, which keeps the moves-per-frame
+   * throttle meaningful regardless of how coarse the source toolpath is.
+   * Pass 0 or a negative value to disable subdivision.
+   */
+  maxSegmentLength?: number
+}
+
+export interface PlaybackPose {
+  x: number
+  y: number
+  z: number
+  moveKind: ToolpathMove['kind'] | null
+}
+
+export function cloneSimulationGrid(source: SimulationGrid): SimulationGrid {
+  return { ...source, topZ: new Float32Array(source.topZ) }
+}
+
+function moveLength(move: ToolpathMove): number {
+  const dx = move.to.x - move.from.x
+  const dy = move.to.y - move.from.y
+  const dz = move.to.z - move.from.z
+  return Math.hypot(dx, dy, dz)
+}
+
+function interpolatePoint(move: ToolpathMove, fraction: number): { x: number; y: number; z: number } {
+  return {
+    x: move.from.x + (move.to.x - move.from.x) * fraction,
+    y: move.from.y + (move.to.y - move.from.y) * fraction,
+    z: move.from.z + (move.to.z - move.from.z) * fraction,
+  }
+}
+
+function isCuttingMove(move: ToolpathMove): boolean {
+  return move.kind === 'cut' || move.kind === 'plunge' || move.kind === 'lead_in' || move.kind === 'lead_out'
+}
+
+/**
+ * Split any move longer than `maxSegmentLength` into equal-length sub-segments.
+ * Splitting is semantically safe because `applyMoveToGrid` removes material based on
+ * distance-to-segment, and the sub-segments' swept volumes union to the original.
+ */
+export function subdivideMoves(moves: ToolpathMove[], maxSegmentLength: number): ToolpathMove[] {
+  if (!(maxSegmentLength > 0) || moves.length === 0) {
+    return moves.slice()
+  }
+
+  const out: ToolpathMove[] = []
+  for (const move of moves) {
+    const length = moveLength(move)
+    if (length <= maxSegmentLength + 1e-9) {
+      out.push(move)
+      continue
+    }
+    const subdivisions = Math.ceil(length / maxSegmentLength)
+    for (let i = 0; i < subdivisions; i += 1) {
+      const t0 = i / subdivisions
+      const t1 = (i + 1) / subdivisions
+      out.push({
+        kind: move.kind,
+        from: interpolatePoint(move, t0),
+        to: interpolatePoint(move, t1),
+      })
+    }
+  }
+  return out
+}
+
+export class PlaybackController {
+  readonly baseGrid: SimulationGrid
+  readonly liveGrid: SimulationGrid
+  readonly moves: ToolpathMove[]
+  readonly tool: PlaybackToolInfo
+  readonly totalPathLength: number
+
+  private moveIndex = 0
+  private moveFraction = 0
+  private distanceTraveled = 0
+  private finished = false
+  private lastMoveApplied = -1
+
+  constructor(
+    baseGrid: SimulationGrid,
+    moves: ToolpathMove[],
+    tool: PlaybackToolInfo,
+    options: PlaybackOptions = {},
+  ) {
+    this.baseGrid = baseGrid
+    this.liveGrid = cloneSimulationGrid(baseGrid)
+    const maxSegmentLength = options.maxSegmentLength ?? Math.max(tool.toolRadius * 1.5, 0.5)
+    this.moves = subdivideMoves(moves, maxSegmentLength)
+    this.tool = tool
+    this.totalPathLength = this.moves.reduce((sum, move) => sum + moveLength(move), 0)
+
+    if (this.moves.length === 0) {
+      this.finished = true
+    }
+  }
+
+  reset(): void {
+    this.liveGrid.topZ.set(this.baseGrid.topZ)
+    this.moveIndex = 0
+    this.moveFraction = 0
+    this.distanceTraveled = 0
+    this.finished = this.moves.length === 0
+    this.lastMoveApplied = -1
+  }
+
+  isFinished(): boolean {
+    return this.finished
+  }
+
+  getDistanceTraveled(): number {
+    return this.distanceTraveled
+  }
+
+  getMoveIndex(): number {
+    return this.moveIndex
+  }
+
+  getMoveCount(): number {
+    return this.moves.length
+  }
+
+  getPose(): PlaybackPose {
+    if (this.moves.length === 0) {
+      return { x: 0, y: 0, z: 0, moveKind: null }
+    }
+
+    if (this.finished) {
+      const last = this.moves[this.moves.length - 1]
+      return { x: last.to.x, y: last.to.y, z: last.to.z, moveKind: last.kind }
+    }
+
+    const move = this.moves[this.moveIndex]
+    const p = interpolatePoint(move, this.moveFraction)
+    return { x: p.x, y: p.y, z: p.z, moveKind: move.kind }
+  }
+
+  /**
+   * Advance the tool by `distance` along the path, applying cuts as we go.
+   * `distance` is interpreted in project units — the caller is responsible for
+   * throttling it (e.g., `min(speed * dt, maxStepPerFrame)`) before each call.
+   * Whether that distance spans one long move partially or many short moves
+   * fully is opaque to the caller; either way the cumulative cut is correct.
+   */
+  advance(distance: number): boolean {
+    if (this.finished || distance <= 0) {
+      return false
+    }
+
+    let remaining = distance
+    let gridChanged = false
+
+    while (remaining > 0 && !this.finished) {
+      const move = this.moves[this.moveIndex]
+      const length = moveLength(move)
+
+      if (length <= 1e-9) {
+        if (isCuttingMove(move) && this.lastMoveApplied !== this.moveIndex) {
+          const changed = applyMoveToGrid(
+            this.liveGrid,
+            move,
+            this.tool.toolRadius,
+            this.tool.toolType,
+            this.tool.vBitAngle,
+          )
+          if (changed > 0) {
+            gridChanged = true
+          }
+          this.lastMoveApplied = this.moveIndex
+        }
+        this.advanceToNextMove()
+        continue
+      }
+
+      const traveled = length * this.moveFraction
+      const available = length - traveled
+
+      if (remaining >= available) {
+        if (isCuttingMove(move) && this.lastMoveApplied !== this.moveIndex) {
+          const changed = applyMoveToGrid(
+            this.liveGrid,
+            move,
+            this.tool.toolRadius,
+            this.tool.toolType,
+            this.tool.vBitAngle,
+          )
+          if (changed > 0) {
+            gridChanged = true
+          }
+          this.lastMoveApplied = this.moveIndex
+        }
+        this.distanceTraveled += available
+        remaining -= available
+        this.advanceToNextMove()
+      } else {
+        const prevFraction = this.moveFraction
+        const nextFraction = prevFraction + remaining / length
+
+        if (isCuttingMove(move)) {
+          const prevPoint = interpolatePoint(move, prevFraction)
+          const nextPoint = interpolatePoint(move, nextFraction)
+          const partial: ToolpathMove = {
+            kind: move.kind,
+            from: prevPoint,
+            to: nextPoint,
+          }
+          const changed = applyMoveToGrid(
+            this.liveGrid,
+            partial,
+            this.tool.toolRadius,
+            this.tool.toolType,
+            this.tool.vBitAngle,
+          )
+          if (changed > 0) {
+            gridChanged = true
+          }
+        }
+
+        this.moveFraction = nextFraction
+        this.distanceTraveled += remaining
+        remaining = 0
+      }
+    }
+
+    return gridChanged
+  }
+
+  seekToDistance(target: number): boolean {
+    const clampedTarget = Math.max(0, Math.min(this.totalPathLength, target))
+    this.reset()
+    if (clampedTarget <= 0) {
+      return false
+    }
+    return this.advance(clampedTarget)
+  }
+
+  seekToFraction(fraction: number): boolean {
+    return this.seekToDistance(fraction * this.totalPathLength)
+  }
+
+  private advanceToNextMove(): void {
+    this.moveIndex += 1
+    this.moveFraction = 0
+    if (this.moveIndex >= this.moves.length) {
+      this.moveIndex = this.moves.length - 1
+      this.moveFraction = 1
+      this.finished = true
+    }
+  }
+}

--- a/src/engine/simulation/replay.ts
+++ b/src/engine/simulation/replay.ts
@@ -59,11 +59,11 @@ function pointSegmentDistanceAndT(
   return { distance: Math.hypot(px - cx, py - cy), t }
 }
 
-function moveIsMaterialRemoving(move: ToolpathMove): boolean {
+export function moveIsMaterialRemoving(move: ToolpathMove): boolean {
   return move.kind === 'cut' || move.kind === 'plunge' || move.kind === 'lead_in' || move.kind === 'lead_out'
 }
 
-function applyMoveToGrid(
+export function applyMoveToGrid(
   grid: SimulationGrid,
   move: ToolpathMove,
   toolRadius: number,

--- a/src/engine/simulation/toolMesh.ts
+++ b/src/engine/simulation/toolMesh.ts
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as THREE from 'three'
+import type { ToolType } from '../../types/project'
+
+const TOOL_COLOR = 0xd9dde3
+const TOOL_EMISSIVE = 0x2a3443
+const SHANK_COLOR = 0x7d8591
+
+export interface ToolMeshInfo {
+  toolType: ToolType
+  toolRadius: number
+  vBitAngle: number | null
+  /** Length of the flute / cutting portion. Falls back to ~3× diameter when omitted. */
+  cutLength?: number
+  /** Length of the shank above the flutes. Falls back to ~4× diameter, clamped. */
+  shankLength?: number
+}
+
+function resolveCutLength(radius: number, explicit: number | undefined): number {
+  if (typeof explicit === 'number' && explicit > 0) {
+    return explicit
+  }
+  // Fall back to ~3× diameter when the caller didn't specify. Expressed purely in
+  // diameters so the result is unit-agnostic (works for both mm and inch projects).
+  return radius * 6
+}
+
+function resolveShankLength(diameter: number, explicit: number | undefined): number {
+  if (typeof explicit === 'number' && explicit > 0) {
+    return explicit
+  }
+  // A short stub above the flutes — diameter-relative, unit-agnostic.
+  return diameter * 2
+}
+
+/**
+ * Build a simple representation of the cutting tool. The tool is centered at origin with
+ * the tip at y=0 and the shank extending upward (+Y). Caller translates it so the tip sits
+ * at the current (toolCenterZ) position.
+ */
+export function buildToolMesh(info: ToolMeshInfo): THREE.Group {
+  const radius = Math.max(info.toolRadius, 0.05)
+  const diameter = radius * 2
+  const cutLength = resolveCutLength(radius, info.cutLength)
+  const shankLength = resolveShankLength(diameter, info.shankLength)
+  const group = new THREE.Group()
+  group.name = 'toolMesh'
+
+  const cutterMaterial = new THREE.MeshStandardMaterial({
+    color: TOOL_COLOR,
+    emissive: TOOL_EMISSIVE,
+    emissiveIntensity: 0.35,
+    roughness: 0.3,
+    metalness: 0.85,
+  })
+
+  const shankMaterial = new THREE.MeshStandardMaterial({
+    color: SHANK_COLOR,
+    roughness: 0.45,
+    metalness: 0.7,
+  })
+
+  let cutterMesh: THREE.Mesh
+  let cutterTopY = 0
+
+  switch (info.toolType) {
+    case 'ball_endmill': {
+      const cylinderLength = Math.max(cutLength - radius, 0.5)
+      const cylinderGeom = new THREE.CylinderGeometry(radius, radius, cylinderLength, 24, 1, false)
+      const cylinder = new THREE.Mesh(cylinderGeom, cutterMaterial)
+      cylinder.position.y = radius + cylinderLength / 2
+      group.add(cylinder)
+
+      const sphereGeom = new THREE.SphereGeometry(radius, 24, 16, 0, Math.PI * 2, 0, Math.PI / 2)
+      const sphereBottom = new THREE.Mesh(sphereGeom, cutterMaterial)
+      sphereBottom.rotation.x = Math.PI
+      sphereBottom.position.y = radius
+      group.add(sphereBottom)
+
+      cutterTopY = radius + cylinderLength
+      cutterMesh = cylinder
+      break
+    }
+    case 'v_bit': {
+      const angle = Math.max(1, Math.min(179, info.vBitAngle ?? 60))
+      const halfAngleRad = (angle * Math.PI) / 360
+      const tipLength = Math.max(radius / Math.tan(halfAngleRad), 0.2)
+      // ConeGeometry's apex points +Y by default; flip so the sharp tip is at y=0
+      // (the cutting point) and the wide base meets the shank above.
+      const coneGeom = new THREE.ConeGeometry(radius, tipLength, 24, 1, false)
+      const cone = new THREE.Mesh(coneGeom, cutterMaterial)
+      cone.rotation.x = Math.PI
+      cone.position.y = tipLength / 2
+      group.add(cone)
+
+      const shaftLength = Math.max(cutLength - tipLength, 2)
+      const shaftGeom = new THREE.CylinderGeometry(radius, radius, shaftLength, 24, 1, false)
+      const shaft = new THREE.Mesh(shaftGeom, cutterMaterial)
+      shaft.position.y = tipLength + shaftLength / 2
+      group.add(shaft)
+
+      cutterTopY = tipLength + shaftLength
+      cutterMesh = cone
+      break
+    }
+    case 'drill':
+    case 'flat_endmill':
+    default: {
+      const cylinderGeom = new THREE.CylinderGeometry(radius, radius, cutLength, 24, 1, false)
+      const cylinder = new THREE.Mesh(cylinderGeom, cutterMaterial)
+      cylinder.position.y = cutLength / 2
+      group.add(cylinder)
+      cutterTopY = cutLength
+      cutterMesh = cylinder
+      break
+    }
+  }
+  void cutterMesh
+
+  // Keep the shank visually distinct but thin — just a touch wider than the flute
+  // so the silhouette reads right without dwarfing the cutter. Purely
+  // diameter-relative, so it stays proportional in both mm and inch projects.
+  const shankRadius = radius * 1.05
+  const shankGeom = new THREE.CylinderGeometry(shankRadius, shankRadius, shankLength, 24, 1, false)
+  const shank = new THREE.Mesh(shankGeom, shankMaterial)
+  shank.position.y = cutterTopY + shankLength / 2
+  group.add(shank)
+
+  return group
+}
+
+export function disposeToolMesh(group: THREE.Group): void {
+  group.traverse((object) => {
+    if (object instanceof THREE.Mesh) {
+      object.geometry.dispose()
+      if (Array.isArray(object.material)) {
+        object.material.forEach((material) => material.dispose())
+      } else {
+        object.material.dispose()
+      }
+    }
+  })
+}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -582,6 +582,120 @@
   color: var(--text);
 }
 
+.simulation-playback-toggle {
+  margin-left: 4px;
+  height: 30px;
+  padding: 0 12px;
+  border: 1px solid var(--line-strong);
+  border-radius: 7px;
+  background: rgba(10, 18, 27, 0.85);
+  color: var(--text-dim);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.simulation-playback-toggle:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.simulation-playback-bar {
+  position: absolute;
+  left: 50%;
+  bottom: 16px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  background: rgba(10, 18, 27, 0.92);
+  color: var(--text);
+  font-size: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  min-width: 460px;
+  pointer-events: auto;
+}
+
+.simulation-playback-bar__controls {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.simulation-playback-bar__btn {
+  width: 32px;
+  height: 28px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.simulation-playback-bar__btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.simulation-playback-bar__btn--primary {
+  background: var(--accent, #3b82f6);
+  border-color: var(--accent, #3b82f6);
+  color: #fff;
+}
+
+.simulation-playback-bar__btn--primary:hover {
+  filter: brightness(1.08);
+}
+
+.simulation-playback-bar__progress {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex: 1;
+  gap: 8px;
+}
+
+.simulation-playback-bar__progress input[type='range'] {
+  flex: 1;
+  accent-color: var(--accent);
+}
+
+.simulation-playback-bar__readout {
+  /* Fixed width keeps the slider edge stable as the percentage ticks 0 → 100. */
+  min-width: 36px;
+  text-align: right;
+  color: var(--text-dim);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.simulation-playback-bar__speed {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.simulation-playback-bar__speed--slider input[type='range'] {
+  width: 130px;
+  accent-color: var(--accent);
+}
+
+.simulation-playback-bar__speed select {
+  height: 26px;
+  padding: 0 6px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  font-size: 11px;
+}
+
 .panel-right {
   min-height: 0;
 }


### PR DESCRIPTION
## Summary
- Animate the actual cutting tool (flat / ball / v-bit) along the selected operation's toolpath with play/pause/stop/scrub controls, updating the heightfield in real time as material is removed.
- Starting state pre-applies every enabled & visible operation that appears **before** the selected one in the feature tree; the selected operation is what plays.
- Speed slider is keyed to the operation's feed rate (1× = programmed feed, log-scaled up to 32× where per-frame Step and RAF cadence saturate). Step size and unit labels follow \`project.meta.units\` (mm / in).
- Playback throttle is distance-based, so long straights and dense arcs pace the same way. Source moves are optionally subdivided for sim-only granularity — the exported toolpath is untouched.
- Tool mesh dimensions are diameter-relative, so the tool stays correctly sized in both mm and inch projects.

## Test plan
- [x] Select an operation → Simulation tab → click **Play Tool**
- [x] Verify the tool mesh matches the operation's tool type (flat endmill, ball endmill, v-bit) and that v-bits point down
- [x] Play / pause / stop works; scrubbing the progress bar jumps the cut and repositions the tool
- [x] Speed slider reads \`1×\` at the operation's programmed feed (hover tooltip shows units/min)
- [x] Step dropdown shows \`mm\` for mm projects and \`in\` for inch projects; default is 2.5 mm / 0.1 in
- [x] Confirm operations **after** the selected one are NOT visible in the starting grid, and operations **before** it are pre-applied
- [x] Toggle tool playback off and the classic simulation view comes back unchanged