### PR TITLE
Add drilling operation for circle features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CAMPanel } from './components/cam/CAMPanel'
 import { SketchCanvas, type SketchCanvasHandle } from './components/canvas/SketchCanvas'
-import { applyClampWarnings, applyTabsToEdgeRoute, applyTabWarnings, generateEdgeRouteToolpath, generateFollowLineToolpath, generatePocketToolpath, generateSurfaceCleanToolpath, generateVCarveToolpath, generateVCarveRecursiveToolpath } from './engine/toolpaths'
+import { applyClampWarnings, applyTabsToEdgeRoute, applyTabWarnings, generateDrillingToolpath, generateEdgeRouteToolpath, generateFollowLineToolpath, generatePocketToolpath, generateSurfaceCleanToolpath, generateVCarveToolpath, generateVCarveRecursiveToolpath } from './engine/toolpaths'
 import { normalizeToolForProject } from './engine/toolpaths/geometry'
 import type { ToolpathResult } from './engine/toolpaths'
 import { createSimulationGrid, simulateOperationHeightfield, simulateReplayItemsHeightfield, type SimulationReplayItem } from './engine/simulation'
@@ -203,6 +203,10 @@ function App() {
 
       if (operation.kind === 'follow_line') {
         return applyClampWarnings(project, generateFollowLineToolpath(project, operation), operation)
+      }
+
+      if (operation.kind === 'drilling') {
+        return applyClampWarnings(project, generateDrillingToolpath(project, operation), operation)
       }
 
       return null

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -21,6 +21,7 @@ import { useProjectStore } from '../../store/projectStore'
 import { loadBundledToolLibrary, type ToolLibraryEntry } from '../../toolLibrary'
 import type {
   CutDirection,
+  DrillType,
   OperationKind,
   OperationPass,
   PocketPattern,
@@ -243,6 +244,8 @@ function operationKindLabel(kind: OperationKind): string {
       return 'Surface clean'
     case 'follow_line':
       return 'Engrave'
+    case 'drilling':
+      return 'Drill'
   }
 }
 
@@ -262,11 +265,26 @@ function operationAddButtonLabel(kind: OperationKind): string {
       return 'Surface'
     case 'follow_line':
       return 'Engrave'
+    case 'drilling':
+      return 'Drill'
   }
 }
 
 function operationSupportsPassSelection(kind: OperationKind): boolean {
-  return kind !== 'follow_line' && kind !== 'v_carve' && kind !== 'v_carve_recursive'
+  return kind !== 'follow_line' && kind !== 'v_carve' && kind !== 'v_carve_recursive' && kind !== 'drilling'
+}
+
+function drillTypeLabel(type: DrillType): string {
+  switch (type) {
+    case 'simple':
+      return 'Simple (G81)'
+    case 'peck':
+      return 'Peck (G83)'
+    case 'dwell':
+      return 'Dwell (G82)'
+    case 'chip_breaking':
+      return 'Chip breaking (G73)'
+  }
 }
 
 function operationTargetSummary(project: Project, target: OperationTarget): string {
@@ -295,6 +313,24 @@ function operationRequiresClosedProfiles(kind: OperationKind): boolean {
 }
 
 function getValidOperationTarget(project: Project, selection: SelectionState, kind: OperationKind): OperationTarget | null {
+  if (kind === 'drilling') {
+    if (selection.selectedFeatureIds.length === 0) {
+      return null
+    }
+
+    const features = selection.selectedFeatureIds
+      .map((featureId) => project.features.find((feature) => feature.id === featureId) ?? null)
+      .filter((feature): feature is Project['features'][number] => feature !== null)
+
+    if (features.length !== selection.selectedFeatureIds.length) {
+      return null
+    }
+
+    return features.every((feature) => feature.kind === 'circle')
+      ? { source: 'features', featureIds: features.map((feature) => feature.id) }
+      : null
+  }
+
   if (kind === 'follow_line') {
     if (selection.selectedFeatureIds.length === 0) {
       return null
@@ -371,6 +407,20 @@ function getValidOperationTarget(project: Project, selection: SelectionState, ki
 }
 
 function getOperationAddHint(project: Project, selection: SelectionState, kind: OperationKind): string | null {
+  if (kind === 'drilling') {
+    if (selection.selectedFeatureIds.length === 0) {
+      return 'Select one or more circle features first'
+    }
+
+    const features = selection.selectedFeatureIds
+      .map((featureId) => project.features.find((feature) => feature.id === featureId) ?? null)
+      .filter((feature): feature is Project['features'][number] => feature !== null)
+
+    return features.every((feature) => feature.kind === 'circle')
+      ? null
+      : 'Drilling only accepts circle features'
+  }
+
   if (kind === 'follow_line') {
     if (selection.selectedFeatureIds.length === 0) {
       return 'Select one or more open or closed features first'
@@ -595,6 +645,11 @@ export function CAMPanel({
         label: operationAddButtonLabel('follow_line'),
         hint: getOperationAddHint(project, selection, 'follow_line') ?? undefined,
       },
+      {
+        kind: 'drilling',
+        label: operationAddButtonLabel('drilling'),
+        hint: getOperationAddHint(project, selection, 'drilling') ?? undefined,
+      },
     ]),
     [project, selection]
   )
@@ -704,7 +759,7 @@ export function CAMPanel({
       return
     }
 
-    if ((kind === 'follow_line' || kind === 'v_carve' || kind === 'v_carve_recursive') && mode === 'pair') {
+    if ((kind === 'follow_line' || kind === 'v_carve' || kind === 'v_carve_recursive' || kind === 'drilling') && mode === 'pair') {
       const operationId = addOperation(kind, 'rough', target)
       if (operationId) {
         onSelectedOperationIdChange(operationId)
@@ -1056,7 +1111,7 @@ export function CAMPanel({
                     <span>Kind</span>
                     <input type="text" value={operationKindLabel(selectedOperation.kind)} readOnly />
                   </label>
-                  {selectedOperation.kind !== 'v_carve' && selectedOperation.kind !== 'v_carve_recursive' ? (
+                  {selectedOperation.kind !== 'v_carve' && selectedOperation.kind !== 'v_carve_recursive' && selectedOperation.kind !== 'drilling' ? (
                     <label className="properties-field">
                       <span>Pass</span>
                       <select
@@ -1122,6 +1177,52 @@ export function CAMPanel({
                         onCommit={(value) => updateOperation(selectedOperation.id, { carveDepth: value })}
                       />
                     </label>
+                  ) : null}
+                  {selectedOperation.kind === 'drilling' ? (
+                    <>
+                      <label className="properties-field">
+                        <span>Drill Type</span>
+                        <select
+                          value={selectedOperation.drillType ?? 'simple'}
+                          onChange={(event) => updateOperation(selectedOperation.id, { drillType: event.target.value as DrillType })}
+                        >
+                          <option value="simple">{drillTypeLabel('simple')}</option>
+                          <option value="peck">{drillTypeLabel('peck')}</option>
+                          <option value="dwell">{drillTypeLabel('dwell')}</option>
+                          <option value="chip_breaking">{drillTypeLabel('chip_breaking')}</option>
+                        </select>
+                      </label>
+                      {(selectedOperation.drillType === 'peck' || selectedOperation.drillType === 'chip_breaking') ? (
+                        <label className="properties-field">
+                          <span>Peck Depth</span>
+                          <DraftLengthInput
+                            value={selectedOperation.peckDepth ?? 0}
+                            units={project.meta.units}
+                            min={0}
+                            onCommit={(value) => updateOperation(selectedOperation.id, { peckDepth: value })}
+                          />
+                        </label>
+                      ) : null}
+                      {selectedOperation.drillType === 'dwell' ? (
+                        <label className="properties-field">
+                          <span>Dwell Time (s)</span>
+                          <DraftNumberInput
+                            value={selectedOperation.dwellTime ?? 0}
+                            min={0}
+                            onCommit={(value) => updateOperation(selectedOperation.id, { dwellTime: value })}
+                          />
+                        </label>
+                      ) : null}
+                      <label className="properties-field">
+                        <span>Retract Height</span>
+                        <DraftLengthInput
+                          value={selectedOperation.retractHeight ?? (project.stock.thickness + 1)}
+                          units={project.meta.units}
+                          min={0}
+                          onCommit={(value) => updateOperation(selectedOperation.id, { retractHeight: value })}
+                        />
+                      </label>
+                    </>
                   ) : null}
                   {(selectedOperation.kind === 'pocket' || selectedOperation.kind === 'surface_clean') && selectedOperation.pass === 'finish' ? (
                     <>
@@ -1236,7 +1337,7 @@ export function CAMPanel({
                     />
                     <span>Enabled</span>
                   </label>
-                  {selectedOperation.kind !== 'v_carve' && selectedOperation.kind !== 'v_carve_recursive' ? (
+                  {selectedOperation.kind !== 'v_carve' && selectedOperation.kind !== 'v_carve_recursive' && selectedOperation.kind !== 'drilling' ? (
                     <label className="properties-field">
                       <span>Stepdown</span>
                       <DraftLengthInput
@@ -1247,7 +1348,7 @@ export function CAMPanel({
                       />
                     </label>
                   ) : null}
-                  {selectedOperation.kind !== 'follow_line' ? (
+                  {selectedOperation.kind !== 'follow_line' && selectedOperation.kind !== 'drilling' ? (
                     <label className="properties-field">
                       <span>
                         {selectedOperation.kind === 'v_carve_recursive'
@@ -1291,7 +1392,8 @@ export function CAMPanel({
                   </label>
                   {selectedOperation.kind !== 'follow_line'
                     && selectedOperation.kind !== 'v_carve'
-                    && selectedOperation.kind !== 'v_carve_recursive' ? (
+                    && selectedOperation.kind !== 'v_carve_recursive'
+                    && selectedOperation.kind !== 'drilling' ? (
                     <>
                       <label className="properties-field">
                         <span>Stock To Leave Radial</span>

--- a/src/engine/simulation/replay.ts
+++ b/src/engine/simulation/replay.ts
@@ -79,12 +79,20 @@ export function applyMoveToGrid(
   const [rowStart, rowEnd] = pointToCellRange(minY, maxY, grid.originY, grid.cellSize, grid.rows)
   let changed = 0
 
+  const xyDx = move.to.x - move.from.x
+  const xyDy = move.to.y - move.from.y
+  const xyStationary = (xyDx * xyDx + xyDy * xyDy) <= 1e-12
+
   for (let row = rowStart; row <= rowEnd; row += 1) {
     const y = grid.originY + (row + 0.5) * grid.cellSize
     for (let col = colStart; col <= colEnd; col += 1) {
       const x = grid.originX + (col + 0.5) * grid.cellSize
       const { distance, t } = pointSegmentDistanceAndT(x, y, move.from.x, move.from.y, move.to.x, move.to.y)
-      const toolCenterZ = move.from.z + (move.to.z - move.from.z) * t
+      // For stationary-XY moves (plunges), the cutter sweeps every Z between
+      // from.z and to.z at this cell — record the deepest reach.
+      const toolCenterZ = xyStationary
+        ? Math.min(move.from.z, move.to.z)
+        : move.from.z + (move.to.z - move.from.z) * t
       const cutZ = cutterSurfaceZ(
         toolType,
         toolRadius,
@@ -131,11 +139,6 @@ function computeStats(grid: SimulationGrid, processedMoveCount: number): Simulat
 
 function replayItemIntoGrid(grid: SimulationGrid, item: SimulationReplayItem): { processedMoveCount: number; warnings: string[] } {
   const warnings: string[] = []
-  if (item.toolType === 'drill') {
-    warnings.push(`Operation "${item.operationName}" uses unsupported tool type "${item.toolType}" for simulation.`)
-    return { processedMoveCount: 0, warnings }
-  }
-
   let processedMoveCount = 0
   for (const move of item.toolpath.moves) {
     if (!moveIsMaterialRemoving(move)) {

--- a/src/engine/toolpaths/drilling.ts
+++ b/src/engine/toolpaths/drilling.ts
@@ -1,0 +1,263 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DrillType, Operation, Point, Project, SketchFeature, SketchProfile } from '../../types/project'
+import type { ToolpathBounds, ToolpathMove, ToolpathPoint, ToolpathResult } from './types'
+import {
+  checkMaxCutDepthWarning,
+  getOperationSafeZ,
+  normalizeToolForProject,
+  resolveFeatureZSpan,
+} from './geometry'
+
+const CHIP_BREAK_CLEARANCE = 0.5    // tiny retract between pecks in chip-breaking mode (project units)
+
+function updateBounds(bounds: ToolpathBounds | null, point: ToolpathPoint): ToolpathBounds {
+  if (!bounds) {
+    return {
+      minX: point.x, minY: point.y, minZ: point.z,
+      maxX: point.x, maxY: point.y, maxZ: point.z,
+    }
+  }
+  return {
+    minX: Math.min(bounds.minX, point.x),
+    minY: Math.min(bounds.minY, point.y),
+    minZ: Math.min(bounds.minZ, point.z),
+    maxX: Math.max(bounds.maxX, point.x),
+    maxY: Math.max(bounds.maxY, point.y),
+    maxZ: Math.max(bounds.maxZ, point.z),
+  }
+}
+
+function computeBounds(moves: ToolpathMove[]): ToolpathBounds | null {
+  let bounds: ToolpathBounds | null = null
+  for (const move of moves) {
+    bounds = updateBounds(bounds, move.from)
+    bounds = updateBounds(bounds, move.to)
+  }
+  return bounds
+}
+
+function getCircleCenter(profile: SketchProfile): Point | null {
+  if (profile.segments.length === 1 && profile.segments[0].type === 'circle') {
+    return profile.segments[0].center
+  }
+
+  if (profile.segments.length === 4 && profile.segments.every((s) => s.type === 'arc')) {
+    const first = profile.segments[0]
+    if (first.type === 'arc') {
+      return first.center
+    }
+  }
+
+  return null
+}
+
+function emitDrillCycle(
+  moves: ToolpathMove[],
+  current: ToolpathPoint | null,
+  center: Point,
+  topZ: number,
+  bottomZ: number,
+  safeZ: number,
+  retractZ: number,
+  drillType: DrillType,
+  peckDepth: number,
+): ToolpathPoint {
+  // Rapid above the hole at safeZ — skip if we're already there (first hole, no prior position)
+  const aboveSafe: ToolpathPoint = { x: center.x, y: center.y, z: safeZ }
+  if (current && (current.x !== aboveSafe.x || current.y !== aboveSafe.y || current.z !== aboveSafe.z)) {
+    moves.push({ kind: 'rapid', from: current, to: aboveSafe })
+  }
+
+  // Rapid down to retract height (just above the material)
+  const rapidStart: ToolpathPoint = { x: center.x, y: center.y, z: retractZ }
+  if (retractZ < safeZ) {
+    moves.push({ kind: 'rapid', from: aboveSafe, to: rapidStart })
+  }
+
+  if (drillType === 'simple' || drillType === 'dwell') {
+    const bottom: ToolpathPoint = { x: center.x, y: center.y, z: bottomZ }
+    moves.push({ kind: 'plunge', from: rapidStart, to: bottom })
+    const retract: ToolpathPoint = { x: center.x, y: center.y, z: safeZ }
+    moves.push({ kind: 'rapid', from: bottom, to: retract })
+    return retract
+  }
+
+  // Peck or chip-breaking: iteratively drill down peckDepth at a time.
+  const effectivePeck = peckDepth > 0 ? peckDepth : Math.max(topZ - bottomZ, 1e-6)
+  let currentZ = Math.min(topZ, retractZ)
+  let prev = rapidStart
+
+  while (currentZ > bottomZ) {
+    const nextZ = Math.max(bottomZ, currentZ - effectivePeck)
+    const plungeTo: ToolpathPoint = { x: center.x, y: center.y, z: nextZ }
+    moves.push({ kind: 'plunge', from: prev, to: plungeTo })
+
+    if (nextZ <= bottomZ) {
+      prev = plungeTo
+      break
+    }
+
+    if (drillType === 'peck') {
+      // G83 — full retract to safe Z to clear chips, then rapid back to just above last cut
+      const retract: ToolpathPoint = { x: center.x, y: center.y, z: safeZ }
+      moves.push({ kind: 'rapid', from: plungeTo, to: retract })
+      const reEntry: ToolpathPoint = { x: center.x, y: center.y, z: nextZ + CHIP_BREAK_CLEARANCE }
+      moves.push({ kind: 'rapid', from: retract, to: reEntry })
+      prev = reEntry
+    } else {
+      // G73 chip breaking — small retract to break the chip
+      const chipBreak: ToolpathPoint = { x: center.x, y: center.y, z: nextZ + CHIP_BREAK_CLEARANCE }
+      moves.push({ kind: 'rapid', from: plungeTo, to: chipBreak })
+      prev = chipBreak
+    }
+
+    currentZ = nextZ
+  }
+
+  const finalRetract: ToolpathPoint = { x: center.x, y: center.y, z: safeZ }
+  moves.push({ kind: 'rapid', from: prev, to: finalRetract })
+  return finalRetract
+}
+
+export function generateDrillingToolpath(project: Project, operation: Operation): ToolpathResult {
+  if (operation.kind !== 'drilling') {
+    return {
+      operationId: operation.id,
+      moves: [],
+      warnings: ['Only drilling operations can be resolved by the drilling generator'],
+      bounds: null,
+    }
+  }
+
+  if (operation.target.source !== 'features' || operation.target.featureIds.length === 0) {
+    return {
+      operationId: operation.id,
+      moves: [],
+      warnings: ['Drilling operation has no feature targets'],
+      bounds: null,
+    }
+  }
+
+  const toolRecord = operation.toolRef
+    ? project.tools.find((tool) => tool.id === operation.toolRef) ?? null
+    : null
+
+  if (!toolRecord) {
+    return {
+      operationId: operation.id,
+      moves: [],
+      warnings: ['No tool assigned to this operation'],
+      bounds: null,
+    }
+  }
+
+  const tool = normalizeToolForProject(toolRecord, project)
+  if (!(tool.diameter > 0)) {
+    return {
+      operationId: operation.id,
+      moves: [],
+      warnings: ['Tool diameter must be greater than zero'],
+      bounds: null,
+    }
+  }
+
+  const targetFeatures = operation.target.featureIds
+    .map((featureId) => project.features.find((feature) => feature.id === featureId) ?? null)
+    .filter((feature): feature is SketchFeature => feature !== null)
+    .filter((feature) => feature.kind === 'circle')
+
+  const warnings: string[] = []
+
+  if (tool.type !== 'drill') {
+    warnings.push('Selected tool is not a drill bit — drilling cycles typically require a drill tool')
+  }
+
+  if (targetFeatures.length !== operation.target.featureIds.length) {
+    warnings.push('Some selected target features are not circles and were skipped')
+  }
+
+  if (targetFeatures.length === 0) {
+    return {
+      operationId: operation.id,
+      moves: [],
+      warnings: [...warnings, 'No valid circle features were found for this drilling operation'],
+      bounds: null,
+    }
+  }
+
+  const drillType: DrillType = operation.drillType ?? 'simple'
+  const peckDepth = operation.peckDepth ?? 0
+
+  if ((drillType === 'peck' || drillType === 'chip_breaking') && !(peckDepth > 0)) {
+    warnings.push('Peck depth must be greater than zero for peck / chip-breaking drilling; falling back to a single plunge')
+  }
+
+  const featureSpans = targetFeatures.map((feature) => resolveFeatureZSpan(project, feature))
+  const safeZ = getOperationSafeZ(project, featureSpans)
+
+  // Default retract height is just above the highest feature top, below safe Z.
+  const defaultRetractOffset = 1 // small offset in project units
+  const highestTop = featureSpans.reduce((max, span) => Math.max(max, span.top), 0)
+  const retractZ = operation.retractHeight !== undefined
+    ? Math.min(safeZ, operation.retractHeight)
+    : Math.min(safeZ, highestTop + defaultRetractOffset)
+
+  const moves: ToolpathMove[] = []
+  let currentPosition: ToolpathPoint | null = null
+
+  for (const feature of targetFeatures) {
+    const center = getCircleCenter(feature.sketch.profile)
+    if (!center) {
+      warnings.push(`${feature.name} is marked as a circle but has no resolvable center`)
+      continue
+    }
+
+    const span = resolveFeatureZSpan(project, feature)
+    const topZ = span.top
+    const bottomZ = span.bottom
+
+    if (bottomZ >= topZ) {
+      warnings.push(`${feature.name} bottom Z is not below top Z; skipping`)
+      continue
+    }
+
+    const depthWarning = checkMaxCutDepthWarning(tool, topZ - bottomZ)
+    if (depthWarning) {
+      warnings.push(`${feature.name}: ${depthWarning}`)
+    }
+
+    currentPosition = emitDrillCycle(
+      moves,
+      currentPosition,
+      center,
+      topZ,
+      bottomZ,
+      safeZ,
+      retractZ,
+      drillType,
+      peckDepth,
+    )
+  }
+
+  return {
+    operationId: operation.id,
+    moves,
+    warnings,
+    bounds: computeBounds(moves),
+  }
+}

--- a/src/engine/toolpaths/index.ts
+++ b/src/engine/toolpaths/index.ts
@@ -16,6 +16,7 @@
 
 export * from './clamps'
 export * from './carving'
+export * from './drilling'
 export * from './edge'
 export * from './geometry'
 export * from './pocket'

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1349,6 +1349,8 @@ function operationKindLabel(kind: OperationKind): string {
       return 'Surface clean'
     case 'follow_line':
       return 'Engrave'
+    case 'drilling':
+      return 'Drill'
   }
 }
 
@@ -1366,6 +1368,22 @@ function duplicateOperationName(name: string, operations: Operation[]): string {
 }
 
 function isOperationTargetValid(project: Project, kind: OperationKind, target: OperationTarget): boolean {
+  if (kind === 'drilling') {
+    if (target.source !== 'features' || target.featureIds.length === 0) {
+      return false
+    }
+
+    const features = target.featureIds
+      .map((featureId) => project.features.find((feature) => feature.id === featureId) ?? null)
+      .filter((feature): feature is SketchFeature => feature !== null)
+
+    if (features.length !== target.featureIds.length) {
+      return false
+    }
+
+    return features.every((feature) => feature.kind === 'circle')
+  }
+
   if (kind === 'follow_line') {
     if (target.source !== 'features' || target.featureIds.length === 0) {
       return false
@@ -1430,7 +1448,7 @@ function isOperationTargetValid(project: Project, kind: OperationKind, target: O
 }
 
 function defaultOperationName(kind: OperationKind, pass: OperationPass, operations: Operation[]): string {
-  const baseName = kind === 'follow_line' || kind === 'v_carve' || kind === 'v_carve_recursive'
+  const baseName = kind === 'follow_line' || kind === 'v_carve' || kind === 'v_carve_recursive' || kind === 'drilling'
     ? operationKindLabel(kind)
     : `${operationKindLabel(kind)} ${pass === 'rough' ? 'Rough' : 'Finish'}`
   if (!operations.some((operation) => operation.name === baseName)) {
@@ -1478,10 +1496,23 @@ function defaultOperationForTarget(
     carveDepth: convertLength(1, 'mm', project.meta.units),
     maxCarveDepth: convertLength(1, 'mm', project.meta.units),
     cutDirection: 'conventional',
+    ...(kind === 'drilling' ? {
+      drillType: 'simple' as const,
+      peckDepth: convertLength(2, 'mm', project.meta.units),
+      dwellTime: 0.5,
+      retractHeight: project.stock.thickness + convertLength(1, 'mm', project.meta.units),
+    } : {}),
   }
 }
 
 function fallbackOperationTarget(project: Project, kind: OperationKind): OperationTarget {
+  if (kind === 'drilling') {
+    const firstCircle = project.features.find((feature) => feature.kind === 'circle')
+    return firstCircle
+      ? { source: 'features', featureIds: [firstCircle.id] }
+      : { source: 'stock' }
+  }
+
   if (kind === 'follow_line') {
     const firstFeature = project.features[0]
     return firstFeature

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -256,10 +256,12 @@ export type OperationKind =
   | 'edge_route_outside'
   | 'surface_clean'
   | 'follow_line'
+  | 'drilling'
 
 export type OperationPass = 'rough' | 'finish'
 export type PocketPattern = 'offset' | 'parallel'
 export type CutDirection = 'conventional' | 'climb'
+export type DrillType = 'simple' | 'peck' | 'dwell' | 'chip_breaking'
 
 export type OperationTarget =
   | { source: 'features'; featureIds: string[] }
@@ -289,6 +291,10 @@ export interface Operation {
   carveDepth: number
   maxCarveDepth: number
   cutDirection?: CutDirection
+  drillType?: DrillType
+  peckDepth?: number
+  dwellTime?: number
+  retractHeight?: number
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

- New `drilling` operation kind that targets circle features only. The drill uses the circle's centre and `z_bottom`; diameter is ignored.
- Supports four typical drill cycles: simple (G81), peck (G83), dwell (G82), and chip breaking (G73), with peck depth, dwell time, and retract height parameters.
- Fixes a latent bug in the heightfield simulation: stationary-XY moves (pure plunges) previously kept `toolCenterZ` pinned to `from.z`, so the deepest reach of a plunge was never recorded. This was masked for every other op type because their plunges are followed by lateral cuts — drilling exposed it because the plunge *is* the cut.

## What changed

- `src/types/project.ts` — added `'drilling'` to `OperationKind`, new `DrillType`, and optional fields (`drillType`, `peckDepth`, `dwellTime`, `retractHeight`) on `Operation`.
- `src/engine/toolpaths/drilling.ts` — new toolpath generator. Filters targets to `kind === 'circle'`, extracts the centre from either single-circle or 4-arc profiles, and emits rapid/plunge sequences per drill cycle variant. Warns when the selected tool is not a drill.
- `src/App.tsx` — dispatch drilling to the new generator.
- `src/components/cam/CAMPanel.tsx` — labels, "Drill" add button, circle-only target validation, and a properties form with drill-type selector + conditional peck-depth / dwell-time / retract-height fields. Stepdown, stepover, stock-to-leave, and pass selector are hidden for drilling.
- `src/store/projectStore.ts` — operation name defaults (no rough/finish suffix for drilling), validation requires circle features, `fallbackOperationTarget` picks the first circle.
- `src/engine/simulation/replay.ts` — removed the hard skip for drill tool type; added stationary-XY handling in `applyMoveToGrid` so plunges carve to `min(from.z, to.z)` at every cell in the tool footprint.

## Test plan

- [x] `tsc --noEmit` and `eslint` clean
- [x] Manually added a drilling op on a circle, verified toolpath renders without stray travel from the origin
- [x] Verified simulation heightfield shows the drilled hole for single and multiple holes
- [x] Exercise each drill-type variant (simple / peck / dwell / chip breaking) in the G-code export and confirm plunge/retract sequences look right