### PR TITLE
Add feature alignment and distribution toolbar actions

### DIFF
--- a/public/icons.svg
+++ b/public/icons.svg
@@ -333,4 +333,81 @@
     <path d="M 7 10 L 12 15 L 17 10" />
     <path d="M 12 15 L 12 3" />
   </symbol>
+  <symbol id="align" viewBox="0 0 24 24">
+    <path d="M 12 3 L 12 21" />
+    <path d="M 6 7 L 18 7" />
+    <path d="M 8 12 L 16 12" />
+    <path d="M 5 17 L 19 17" />
+  </symbol>
+  <symbol id="align-left" viewBox="0 0 24 24">
+    <path d="M 3 3 L 3 21" />
+    <path d="M 3 6 L 17 6 L 17 10 L 3 10" />
+    <path d="M 3 14 L 21 14 L 21 18 L 3 18" />
+  </symbol>
+  <symbol id="align-center-horizontal" viewBox="0 0 24 24">
+    <path d="M 12 3 L 12 21" />
+    <path d="M 5 6 L 19 6 L 19 10 L 5 10 Z" />
+    <path d="M 7 14 L 17 14 L 17 18 L 7 18 Z" />
+  </symbol>
+  <symbol id="align-right" viewBox="0 0 24 24">
+    <path d="M 21 3 L 21 21" />
+    <path d="M 7 6 L 21 6 L 21 10 L 7 10" />
+    <path d="M 3 14 L 21 14 L 21 18 L 3 18" />
+  </symbol>
+  <symbol id="align-top" viewBox="0 0 24 24">
+    <path d="M 3 3 L 21 3" />
+    <path d="M 6 3 L 6 17 L 10 17 L 10 3" />
+    <path d="M 14 3 L 14 21 L 18 21 L 18 3" />
+  </symbol>
+  <symbol id="align-center-vertical" viewBox="0 0 24 24">
+    <path d="M 3 12 L 21 12" />
+    <path d="M 6 5 L 10 5 L 10 19 L 6 19 Z" />
+    <path d="M 14 7 L 18 7 L 18 17 L 14 17 Z" />
+  </symbol>
+  <symbol id="align-bottom" viewBox="0 0 24 24">
+    <path d="M 3 21 L 21 21" />
+    <path d="M 6 7 L 6 21 L 10 21 L 10 7" />
+    <path d="M 14 3 L 14 21 L 18 21 L 18 3" />
+  </symbol>
+  <symbol id="distribute" viewBox="0 0 24 24">
+    <path d="M 3 3 L 3 21" />
+    <path d="M 12 3 L 12 21" />
+    <path d="M 21 3 L 21 21" />
+    <path d="M 6 12 L 9 12" />
+    <path d="M 15 12 L 18 12" />
+  </symbol>
+  <symbol id="distribute-horizontal-gaps" viewBox="0 0 24 24">
+    <path d="M 3 5 L 7 5 L 7 19 L 3 19 Z" />
+    <path d="M 10 5 L 14 5 L 14 19 L 10 19 Z" />
+    <path d="M 17 5 L 21 5 L 21 19 L 17 19 Z" />
+    <path d="M 7 22 L 10 22" />
+    <path d="M 14 22 L 17 22" />
+  </symbol>
+  <symbol id="distribute-horizontal-centers" viewBox="0 0 24 24">
+    <path d="M 3 6 L 7 6 L 7 18 L 3 18 Z" />
+    <path d="M 10 4 L 14 4 L 14 20 L 10 20 Z" />
+    <path d="M 17 8 L 21 8 L 21 16 L 17 16 Z" />
+    <path d="M 5 22 L 12 22" />
+    <path d="M 12 22 L 19 22" />
+    <path d="M 5 21 L 5 23" />
+    <path d="M 12 21 L 12 23" />
+    <path d="M 19 21 L 19 23" />
+  </symbol>
+  <symbol id="distribute-vertical-gaps" viewBox="0 0 24 24">
+    <path d="M 5 3 L 19 3 L 19 7 L 5 7 Z" />
+    <path d="M 5 10 L 19 10 L 19 14 L 5 14 Z" />
+    <path d="M 5 17 L 19 17 L 19 21 L 5 21 Z" />
+    <path d="M 22 7 L 22 10" />
+    <path d="M 22 14 L 22 17" />
+  </symbol>
+  <symbol id="distribute-vertical-centers" viewBox="0 0 24 24">
+    <path d="M 6 3 L 18 3 L 18 7 L 6 7 Z" />
+    <path d="M 4 10 L 20 10 L 20 14 L 4 14 Z" />
+    <path d="M 8 17 L 16 17 L 16 21 L 8 21 Z" />
+    <path d="M 22 5 L 22 12" />
+    <path d="M 22 12 L 22 19" />
+    <path d="M 21 5 L 23 5" />
+    <path d="M 21 12 L 23 12" />
+    <path d="M 21 19 L 23 19" />
+  </symbol>
 </svg>

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Icon } from '../Icon'
 import { ImportGeometryDialog } from '../project/ImportGeometryDialog'
 import { NewProjectDialog } from '../project/NewProjectDialog'
 import { TextToolDialog } from '../project/TextToolDialog'
 import { featureHasClosedGeometry } from '../../text'
 import type { SnapMode, SnapSettings } from '../../sketch/snapping'
-import type { SketchEditTool } from '../../store/types'
+import type { FeatureAlignment, FeatureDistribution, SketchEditTool } from '../../store/types'
 import { useProjectStore } from '../../store/projectStore'
 import type { TextToolConfig } from '../../text'
 import { useFileActions } from '../../platform/useFileActions'
@@ -108,6 +108,8 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
     startJoinSelectedFeatures,
     startCutSelectedFeatures,
     startOffsetSelectedFeatures,
+    alignFeatures,
+    distributeFeatures,
     startMoveBackdrop,
     startResizeBackdrop,
     startRotateBackdrop,
@@ -187,6 +189,9 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
   const hasClosedSelectedFeatures = selectedFeatures.length > 0 && selectedFeatures.every((feature) => featureHasClosedGeometry(feature))
   const hasOffsetEligibleSelectedFeatures =
     hasClosedSelectedFeatures && selectedFeatures.every((feature) => feature.kind !== 'text')
+  const alignableFeatureCount = selectedFeatures.filter((feature) => !feature.locked).length
+  const canAlignSelectedFeatures = alignableFeatureCount >= 2
+  const canDistributeSelectedFeatures = alignableFeatureCount >= 3
   const featureSketchEditActive =
     selection.mode === 'sketch_edit'
     && selection.selectedNode?.type === 'feature'
@@ -320,6 +325,26 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
     startOffsetSelectedFeatures()
   }
 
+  function handleAlignSelectedFeatures(alignment: FeatureAlignment) {
+    const eligibleIds = selectedFeatures
+      .filter((feature) => !feature.locked)
+      .map((feature) => feature.id)
+    if (eligibleIds.length < 2) {
+      return
+    }
+    alignFeatures(eligibleIds, alignment)
+  }
+
+  function handleDistributeSelectedFeatures(distribution: FeatureDistribution) {
+    const eligibleIds = selectedFeatures
+      .filter((feature) => !feature.locked)
+      .map((feature) => feature.id)
+    if (eligibleIds.length < 3) {
+      return
+    }
+    distributeFeatures(eligibleIds, distribution)
+  }
+
   function toggleSketchEditTool(tool: SketchEditTool) {
     if (!featureSketchEditActive) {
       return
@@ -346,6 +371,8 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
     hasLockedSelectedFeatures,
     hasClosedSelectedFeatures,
     hasOffsetEligibleSelectedFeatures,
+    canAlignSelectedFeatures,
+    canDistributeSelectedFeatures,
     featureSketchEditActive,
     sketchEditTool: selection.sketchEditTool,
     setProjectName,
@@ -380,6 +407,8 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
     handleJoinSelectedFeatures,
     handleCutSelectedFeatures,
     handleOffsetSelectedFeatures,
+    handleAlignSelectedFeatures,
+    handleDistributeSelectedFeatures,
     handleSketchEditAddPoint: () => toggleSketchEditTool('add_point'),
     handleSketchEditDeletePoint: () => toggleSketchEditTool('delete_point'),
     handleSketchEditFillet: () => toggleSketchEditTool('fillet'),
@@ -640,6 +669,156 @@ function FeatureEditActions({
         />
       </div>
     </>
+  )
+}
+
+interface PopoverMenuOption<T extends string> {
+  value: T
+  icon: string
+  label: string
+}
+
+function ToolbarPopoverMenu<T extends string>({
+  triggerIcon,
+  triggerLabelOpen,
+  triggerLabelClosed,
+  enabled,
+  tooltipSide,
+  columns,
+  options,
+  onSelect,
+}: {
+  triggerIcon: string
+  triggerLabelOpen: string
+  triggerLabelClosed: string
+  enabled: boolean
+  tooltipSide?: 'bottom' | 'right'
+  columns: number
+  options: PopoverMenuOption<T>[]
+  onSelect: (value: T) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const effectiveOpen = open && enabled
+
+  useEffect(() => {
+    if (!effectiveOpen) {
+      return
+    }
+    function handlePointerDown(event: PointerEvent) {
+      if (!containerRef.current) {
+        return
+      }
+      if (!containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [effectiveOpen])
+
+  return (
+    <div className="toolbar-group toolbar-popover-host" ref={containerRef}>
+      <ToolbarActionButton
+        icon={triggerIcon}
+        label={effectiveOpen ? triggerLabelOpen : triggerLabelClosed}
+        active={effectiveOpen}
+        disabled={!enabled}
+        tooltipSide={tooltipSide}
+        onClick={() => setOpen((prev) => !prev)}
+      />
+      {effectiveOpen ? (
+        <div
+          className={`toolbar-popover toolbar-popover--${tooltipSide ?? 'bottom'}`}
+          style={{ gridTemplateColumns: `repeat(${columns}, auto)` }}
+          role="menu"
+        >
+          {options.map((option) => (
+            <ToolbarActionButton
+              key={option.value}
+              icon={option.icon}
+              label={option.label}
+              tooltipSide="bottom"
+              onClick={() => {
+                onSelect(option.value)
+                setOpen(false)
+              }}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+const ALIGNMENT_OPTIONS: PopoverMenuOption<FeatureAlignment>[] = [
+  { value: 'left', icon: 'align-left', label: 'Align left' },
+  { value: 'center_horizontal', icon: 'align-center-horizontal', label: 'Align center horizontally' },
+  { value: 'right', icon: 'align-right', label: 'Align right' },
+  { value: 'top', icon: 'align-top', label: 'Align top' },
+  { value: 'center_vertical', icon: 'align-center-vertical', label: 'Align center vertically' },
+  { value: 'bottom', icon: 'align-bottom', label: 'Align bottom' },
+]
+
+const DISTRIBUTION_OPTIONS: PopoverMenuOption<FeatureDistribution>[] = [
+  { value: 'horizontal_gaps', icon: 'distribute-horizontal-gaps', label: 'Distribute horizontally (equal gaps)' },
+  { value: 'horizontal_centers', icon: 'distribute-horizontal-centers', label: 'Distribute horizontally (equal centers)' },
+  { value: 'vertical_gaps', icon: 'distribute-vertical-gaps', label: 'Distribute vertically (equal gaps)' },
+  { value: 'vertical_centers', icon: 'distribute-vertical-centers', label: 'Distribute vertically (equal centers)' },
+]
+
+function AlignmentActions({
+  enabled,
+  tooltipSide,
+  onAlign,
+}: {
+  enabled: boolean
+  tooltipSide?: 'bottom' | 'right'
+  onAlign: (alignment: FeatureAlignment) => void
+}) {
+  return (
+    <ToolbarPopoverMenu
+      triggerIcon="align"
+      triggerLabelOpen="Close alignment menu"
+      triggerLabelClosed="Align selected features"
+      enabled={enabled}
+      tooltipSide={tooltipSide}
+      columns={3}
+      options={ALIGNMENT_OPTIONS}
+      onSelect={onAlign}
+    />
+  )
+}
+
+function DistributionActions({
+  enabled,
+  tooltipSide,
+  onDistribute,
+}: {
+  enabled: boolean
+  tooltipSide?: 'bottom' | 'right'
+  onDistribute: (distribution: FeatureDistribution) => void
+}) {
+  return (
+    <ToolbarPopoverMenu
+      triggerIcon="distribute"
+      triggerLabelOpen="Close distribute menu"
+      triggerLabelClosed="Distribute selected features"
+      enabled={enabled}
+      tooltipSide={tooltipSide}
+      columns={2}
+      options={DISTRIBUTION_OPTIONS}
+      onSelect={onDistribute}
+    />
   )
 }
 
@@ -979,6 +1158,16 @@ export function CreationToolbar({
           onRotate={toolbar.handleFeatureRotate}
           onOffset={toolbar.handleOffsetSelectedFeatures}
         />
+        <AlignmentActions
+          enabled={toolbar.canAlignSelectedFeatures}
+          tooltipSide={layout === 'vertical' ? 'right' : 'bottom'}
+          onAlign={toolbar.handleAlignSelectedFeatures}
+        />
+        <DistributionActions
+          enabled={toolbar.canDistributeSelectedFeatures}
+          tooltipSide={layout === 'vertical' ? 'right' : 'bottom'}
+          onDistribute={toolbar.handleDistributeSelectedFeatures}
+        />
         <SketchEditActions
           enabled={toolbar.featureSketchEditActive}
           activeTool={toolbar.sketchEditTool}
@@ -1085,6 +1274,14 @@ export function Toolbar({
           onResize={toolbar.handleFeatureResize}
           onRotate={toolbar.handleFeatureRotate}
           onOffset={toolbar.handleOffsetSelectedFeatures}
+        />
+        <AlignmentActions
+          enabled={toolbar.canAlignSelectedFeatures}
+          onAlign={toolbar.handleAlignSelectedFeatures}
+        />
+        <DistributionActions
+          enabled={toolbar.canDistributeSelectedFeatures}
+          onDistribute={toolbar.handleDistributeSelectedFeatures}
         />
         <SketchEditActions
           enabled={toolbar.featureSketchEditActive}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -3939,6 +3939,180 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
       }
     }),
 
+  alignFeatures: (ids, alignment) =>
+    set((s) => {
+      const idSet = new Set(ids)
+      const eligibleFeatures = s.project.features.filter((feature) => idSet.has(feature.id) && !feature.locked)
+      if (eligibleFeatures.length < 2) {
+        return {}
+      }
+
+      const featureBounds = new Map(
+        eligibleFeatures.map((feature) => [feature.id, getProfileBounds(feature.sketch.profile)] as const),
+      )
+
+      let refMinX = Infinity
+      let refMaxX = -Infinity
+      let refMinY = Infinity
+      let refMaxY = -Infinity
+      for (const bounds of featureBounds.values()) {
+        if (bounds.minX < refMinX) refMinX = bounds.minX
+        if (bounds.maxX > refMaxX) refMaxX = bounds.maxX
+        if (bounds.minY < refMinY) refMinY = bounds.minY
+        if (bounds.maxY > refMaxY) refMaxY = bounds.maxY
+      }
+      const refCenterX = (refMinX + refMaxX) / 2
+      const refCenterY = (refMinY + refMaxY) / 2
+
+      const nextFeatures = s.project.features.map((feature) => {
+        const bounds = featureBounds.get(feature.id)
+        if (!bounds) {
+          return feature
+        }
+        let dx = 0
+        let dy = 0
+        switch (alignment) {
+          case 'left':
+            dx = refMinX - bounds.minX
+            break
+          case 'right':
+            dx = refMaxX - bounds.maxX
+            break
+          case 'center_horizontal':
+            dx = refCenterX - (bounds.minX + bounds.maxX) / 2
+            break
+          case 'top':
+            dy = refMinY - bounds.minY
+            break
+          case 'bottom':
+            dy = refMaxY - bounds.maxY
+            break
+          case 'center_vertical':
+            dy = refCenterY - (bounds.minY + bounds.maxY) / 2
+            break
+        }
+        if (dx === 0 && dy === 0) {
+          return feature
+        }
+        return {
+          ...feature,
+          sketch: {
+            ...feature.sketch,
+            profile: translateProfile(feature.sketch.profile, dx, dy),
+          },
+        }
+      })
+
+      const nextProject = {
+        ...s.project,
+        features: nextFeatures,
+        meta: { ...s.project.meta, modified: new Date().toISOString() },
+      }
+      if (projectsEqual(nextProject, s.project)) {
+        return {}
+      }
+      return {
+        project: nextProject,
+        history: {
+          past: [...s.history.past, cloneProject(s.project)].slice(-100),
+          future: [],
+          transactionStart: null,
+        },
+      }
+    }),
+
+  distributeFeatures: (ids, distribution) =>
+    set((s) => {
+      const idSet = new Set(ids)
+      const eligibleFeatures = s.project.features.filter((feature) => idSet.has(feature.id) && !feature.locked)
+      if (eligibleFeatures.length < 3) {
+        return {}
+      }
+
+      const axis: 'x' | 'y' =
+        distribution === 'horizontal_gaps' || distribution === 'horizontal_centers' ? 'x' : 'y'
+      const mode: 'gaps' | 'centers' =
+        distribution === 'horizontal_gaps' || distribution === 'vertical_gaps' ? 'gaps' : 'centers'
+
+      const entries = eligibleFeatures.map((feature) => {
+        const bounds = getProfileBounds(feature.sketch.profile)
+        const min = axis === 'x' ? bounds.minX : bounds.minY
+        const max = axis === 'x' ? bounds.maxX : bounds.maxY
+        return { feature, bounds, min, max, center: (min + max) / 2, size: max - min }
+      })
+
+      entries.sort((a, b) => (mode === 'centers' ? a.center - b.center : a.min - b.min))
+
+      const offsets = new Map<string, number>()
+      if (mode === 'centers') {
+        const firstCenter = entries[0].center
+        const lastCenter = entries[entries.length - 1].center
+        const step = (lastCenter - firstCenter) / (entries.length - 1)
+        entries.forEach((entry, index) => {
+          if (index === 0 || index === entries.length - 1) {
+            return
+          }
+          const targetCenter = firstCenter + step * index
+          const delta = targetCenter - entry.center
+          if (delta !== 0) {
+            offsets.set(entry.feature.id, delta)
+          }
+        })
+      } else {
+        const spanStart = entries[0].min
+        const spanEnd = entries[entries.length - 1].max
+        const totalSize = entries.reduce((sum, entry) => sum + entry.size, 0)
+        const gap = (spanEnd - spanStart - totalSize) / (entries.length - 1)
+        let cursor = entries[0].max
+        for (let index = 1; index < entries.length - 1; index++) {
+          const entry = entries[index]
+          const targetMin = cursor + gap
+          const delta = targetMin - entry.min
+          if (delta !== 0) {
+            offsets.set(entry.feature.id, delta)
+          }
+          cursor = targetMin + entry.size
+        }
+      }
+
+      if (offsets.size === 0) {
+        return {}
+      }
+
+      const nextFeatures = s.project.features.map((feature) => {
+        const delta = offsets.get(feature.id)
+        if (delta === undefined) {
+          return feature
+        }
+        const dx = axis === 'x' ? delta : 0
+        const dy = axis === 'y' ? delta : 0
+        return {
+          ...feature,
+          sketch: {
+            ...feature.sketch,
+            profile: translateProfile(feature.sketch.profile, dx, dy),
+          },
+        }
+      })
+
+      const nextProject = {
+        ...s.project,
+        features: nextFeatures,
+        meta: { ...s.project.meta, modified: new Date().toISOString() },
+      }
+      if (projectsEqual(nextProject, s.project)) {
+        return {}
+      }
+      return {
+        project: nextProject,
+        history: {
+          past: [...s.history.past, cloneProject(s.project)].slice(-100),
+          future: [],
+          transactionStart: null,
+        },
+      }
+    }),
+
   addClamp: () => {
     const state = get()
     const bounds = getStockBounds(state.project.stock)

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -56,6 +56,20 @@ export interface SketchControlRef {
 
 export type SketchEditTool = 'add_point' | 'delete_point' | 'fillet'
 
+export type FeatureAlignment =
+  | 'left'
+  | 'center_horizontal'
+  | 'right'
+  | 'top'
+  | 'center_vertical'
+  | 'bottom'
+
+export type FeatureDistribution =
+  | 'horizontal_gaps'
+  | 'horizontal_centers'
+  | 'vertical_gaps'
+  | 'vertical_centers'
+
 export type SketchInsertTarget =
   | { kind: 'segment'; segmentIndex: number; point: Point; t: number }
   | { kind: 'extend_start'; point: Point }
@@ -222,6 +236,8 @@ export interface ProjectStore {
   cutSelectedFeatures: (keepOriginals?: boolean) => string[]
   offsetSelectedFeatures: (distance: number) => string[]
   reorderFeatures: (ids: string[]) => void
+  alignFeatures: (ids: string[], alignment: FeatureAlignment) => void
+  distributeFeatures: (ids: string[], distribution: FeatureDistribution) => void
 
   addClamp: () => string
   updateClamp: (id: string, patch: Partial<Clamp>) => void

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -108,6 +108,38 @@
   display: inline-flex;
 }
 
+.toolbar-popover-host {
+  position: relative;
+}
+
+.toolbar-popover {
+  position: absolute;
+  z-index: 30;
+  display: grid;
+  gap: 4px;
+  padding: 6px;
+  border-radius: 8px;
+  border: 1px solid rgba(104, 129, 151, 0.6);
+  background: linear-gradient(180deg, #1e2c3b, #111923);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.42);
+}
+
+.toolbar-popover--bottom {
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.toolbar-popover--right {
+  left: calc(100% + 6px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.toolbar-popover .toolbar-icon-btn {
+  border-radius: 6px;
+}
+
 .icon-sprite {
   display: block;
 }


### PR DESCRIPTION
## Summary
- New **Align** popover (2+ unlocked features selected): left / center-h / right, top / center-v / bottom.
- New **Distribute** popover (3+ unlocked features selected): horizontal & vertical, in equal-gap or equal-center modes.
- Both collapse into a single toolbar trigger icon; triggers stay mounted and use disabled state so the toolbar doesn't jitter as the selection changes.
- Reusable `ToolbarPopoverMenu<T>` component drives both popovers; click-outside and Escape close it. Both actions push to history and integrate with undo/redo.

## Test plan
- [x] Select 2 features → align button enables; try each of the 6 alignment modes.
- [x] Select 3+ mixed-size features → distribute button enables; try gaps vs. centers, both axes.
- [x] Select 1 feature → both triggers are disabled (toolbar layout unchanged).
- [x] Undo/redo restores prior positions.
- [x] Locked features are skipped (don't move, don't count toward the 2/3 threshold).
- [x] Click outside the popover or press Escape to close.