### PR TITLE
fix: optimize layout for tablet screens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ type ToolbarOrientation = 'top' | 'left'
 
 const TOOLBAR_ORIENTATION_STORAGE_KEY = 'camcam.toolbarOrientation'
 const DEPTH_LEGEND_COLLAPSED_STORAGE_KEY = 'camcam.depthLegendCollapsed'
-const TOOLBAR_LEFT_BREAKPOINT = 1100
+const TOOLBAR_LEFT_BREAKPOINT = 920
 
 function App() {
   const [centerTab, setCenterTab] = useState<'sketch' | 'preview3d' | 'simulation'>('sketch')

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -235,8 +235,8 @@ export function AppShell({
                 <button
                   className={`toolbar-orientation-btn ${toolbarOrientation === 'left' ? 'toolbar-orientation-btn--active' : ''}`}
                   type="button"
-                  title={toolbarOrientationForced ? 'Left toolbar is disabled below 1100px wide' : 'Use left toolbar'}
-                  aria-label={toolbarOrientationForced ? 'Left toolbar is disabled below 1100px wide' : 'Use left toolbar'}
+                  title={toolbarOrientationForced ? 'Left toolbar is disabled below 920px wide' : 'Use left toolbar'}
+                  aria-label={toolbarOrientationForced ? 'Left toolbar is disabled below 920px wide' : 'Use left toolbar'}
                   onClick={() => onToolbarOrientationChange('left')}
                   disabled={toolbarOrientationForced}
                 >

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -337,38 +337,38 @@
 .app-body {
   min-height: 0;
   display: grid;
-  grid-template-columns: minmax(220px, 17%) minmax(540px, 1fr) minmax(290px, 22%);
+  grid-template-columns: minmax(200px, 17%) minmax(400px, 1fr) minmax(240px, 22%);
   gap: 10px;
   padding: 10px 6px;
 }
 
 .app-body--toolbar-left {
-  grid-template-columns: 32px minmax(220px, 17%) minmax(540px, 1fr) minmax(290px, 22%);
+  grid-template-columns: 32px minmax(200px, 17%) minmax(400px, 1fr) minmax(240px, 22%);
   gap: 4px;
 }
 
 .app-body--lc {
-  grid-template-columns: minmax(220px, 17%) minmax(540px, 1fr);
+  grid-template-columns: minmax(200px, 17%) minmax(400px, 1fr);
 }
 
 .app-body--toolbar-left.app-body--lc {
-  grid-template-columns: 32px minmax(220px, 17%) minmax(540px, 1fr);
+  grid-template-columns: 32px minmax(200px, 17%) minmax(400px, 1fr);
 }
 
 .app-body--c {
-  grid-template-columns: minmax(540px, 1fr);
+  grid-template-columns: minmax(400px, 1fr);
 }
 
 .app-body--toolbar-left.app-body--c {
-  grid-template-columns: 32px minmax(540px, 1fr);
+  grid-template-columns: 32px minmax(400px, 1fr);
 }
 
 .app-body--cr {
-  grid-template-columns: minmax(540px, 1fr) minmax(290px, 22%);
+  grid-template-columns: minmax(400px, 1fr) minmax(240px, 22%);
 }
 
 .app-body--toolbar-left.app-body--cr {
-  grid-template-columns: 32px minmax(540px, 1fr) minmax(290px, 22%);
+  grid-template-columns: 32px minmax(400px, 1fr) minmax(240px, 22%);
 }
 
 .app-left-rail {
@@ -2293,12 +2293,13 @@
   align-self: center;
 }
 
-@media (max-width: 1100px) {
+@media (max-width: 920px) {
   .app-body {
-    grid-template-columns: minmax(220px, 1fr) minmax(0, 1.8fr);
+    grid-template-columns: 220px 1fr;
     grid-template-areas:
       'left centre'
       'right right';
+    gap: 8px;
   }
 
   .panel-left {


### PR DESCRIPTION
This PR improves the application layout for tablet screens (specifically targeting 1024px landscape) by adjusting column constraints and breakpoints.

**Key Changes:**
- **Breakpoint Adjustment:** Lowered the TOOLBAR_LEFT_BREAKPOINT from 1100px to 920px in both CSS and TypeScript.
- **Column Sizing:** Reduced minmax values for the app-body columns to allow more flexibility before wrapping.
- **Tablet Proportions:** Fixed the left column width to 220px in the tablet media query to prevent it from becoming disproportionately wide.
- **UI Consistency:** Updated tooltips and ARIA labels to reflect the new 920px breakpoint.