### PR TITLE
Tablet UX: shell drawer, touch targets, clickable kbd banners

### DIFF
--- a/planning/TABLET_UX_Implementation_Plan.md
+++ b/planning/TABLET_UX_Implementation_Plan.md
@@ -1,0 +1,197 @@
+# Tablet UX Implementation Plan
+
+## Context
+
+This plan is based on a code review of the current shell, responsive CSS, and input handling.
+The app is responsive in the narrow sense but not tablet-ready: the layout still compresses a
+desktop workflow, and several core interactions assume mouse + keyboard.
+
+Supported tablet target: landscape >= 900–960 px, optimized for 1024–1366 px.
+Phones remain blocked (< 900 px).
+
+This is based on code review, not live device testing.
+
+---
+
+## Items
+
+### 1 — Explicit tablet shell layout
+
+**Status:** `[x] done`
+
+**Problem:**
+Below 920 px the right panel is pushed under the canvas instead of switching to drawers or
+sheets. The app still reserves fixed left/center/right columns tuned for desktop.
+
+**References:**
+- `src/styles/layout.css` line 337, line 2296
+- `src/App.tsx` line 49
+- `src/components/AppShell.tsx` line 94
+
+**Work:**
+- Define a `tablet` breakpoint class (landscape >= 900 px) separate from the existing narrow
+  desktop fallback.
+- Switch right panel to a slide-in drawer or bottom sheet at tablet widths instead of
+  reflowing under the canvas.
+- Ensure the center canvas always gets the majority of available width.
+
+---
+
+### 2 — Split toolbar into primary and contextual layers
+
+**Status:** `[ ] todo`
+
+**Problem:**
+The combined toolbar renders file, view, snap, creation, edit, alignment, and backdrop actions
+in one wrapping strip. On tablets this eats vertical space and wraps unpredictably.
+
+**References:**
+- `src/components/Toolbar.tsx` line 1252, line 1157
+- `src/styles/layout.css` line 40
+
+**Work:**
+- Keep file / view / global actions in a persistent top bar.
+- Move creation / edit / alignment tools to a contextual rail or bottom sheet that appears
+  near the canvas when a sketch is active.
+- Backdrop and snap controls can live in a collapsible overflow menu.
+
+---
+
+### 3 — Raise touch targets to 40–44 px
+
+**Status:** `[x] done`
+
+**Problem:**
+Current interactive targets are desktop-density: toolbar icons 32 px, tree rows 28 px, tree
+action buttons 20 px, properties inputs 32 px, CAM buttons 28–32 px. Too small for reliable
+touch.
+
+**References:**
+- `src/styles/layout.css` line 165, line 1236, line 1380, line 1476, line 1837, line 1948
+
+**Work:**
+- Under the tablet breakpoint, set a CSS custom property `--touch-target: 44px` and apply it
+  to toolbar buttons, tree rows, tree action buttons, tab handles, inspector inputs, and CAM
+  row buttons.
+- Slightly increase font size in trees, tabs, and inspectors at tablet widths.
+
+---
+
+### 4 — Remove mouse-only workflow dependencies
+
+**Status:** `[~] partial`
+
+**Done:**
+- Added `triggerDimensionEdit()` function that exposes the Tab-open logic so buttons can call it
+- All sketch canvas banners now use clickable `<kbd>` elements for Enter/Esc/Tab actions — banners look identical on desktop, tap-friendly on touch (44 px hit area via `pointer: coarse`)
+- Keyboard shortcuts (Enter/Esc/Tab) are fully preserved for desktop users
+
+**Remaining:**
+- Pointer event migration (`onMouseDown` → `onPointerDown`)
+- Double-click edit entry → explicit Edit button / long-press
+- Multi-select modifier key dependency
+- Right-click context menus on tree rows → More (…) button
+
+**Problem:**
+- Sketch canvas uses `onMouseDown`, `onMouseUp`, `onDoubleClick`, `onContextMenu`.
+- Edit entry depends on double-click.
+- Multi-select depends on modifier keys (Shift/Ctrl).
+- Row actions rely on right-click context menus.
+
+**References:**
+- `src/sketch/SketchCanvas.tsx` line 3418, line 1808, line 2667, line 2632
+- `src/components/FeatureTree.tsx` line 159, line 168
+
+**Work:**
+- Migrate canvas event handlers to pointer events (`onPointerDown`, `onPointerUp`).
+- Replace double-click edit entry with an explicit **Edit** button / long-press gesture.
+- Add a **Select multiple** toggle mode so multi-select does not require modifier keys.
+- Replace right-click context menus on tree rows with a visible **More (…)** action button
+  per row.
+
+---
+
+### 5 — Add real touch gestures for sketch, 3D, and simulation
+
+**Status:** `[ ] todo`
+
+**Problem:**
+3D and simulation views map pan to middle/right-click or Shift+drag and zoom to the mouse
+wheel. Both set `touchAction = 'none'` without providing a touch replacement, so tablets get
+no usable navigation.
+
+**References:**
+- `src/components/Viewport3D.tsx` line 422, line 657
+- `src/components/SimulationViewport.tsx` line 264, line 582
+
+**Work:**
+- Implement pinch-to-zoom using `pointermove` distance delta between two active pointers.
+- Implement two-finger pan.
+- Map one-finger drag to orbit (3D) or canvas pan (sketch).
+- Treat pen input as precise edit/select input (no orbit on pen contact).
+
+---
+
+### 6 — Replace drag-only ordering with explicit reorder controls
+
+**Status:** `[ ] todo`
+
+**Problem:**
+Feature tree rows and CAM operations rely on HTML drag-and-drop, which is unreliable on touch
+and has no fallback.
+
+**References:**
+- `src/components/FeatureTree.tsx` line 175
+- `src/components/CAMPanel.tsx` line 1039
+
+**Work:**
+- Add visible **Move up / Move down** buttons to tree rows and CAM operation rows (shown on
+  tablet, hidden or secondary on desktop).
+- Keep HTML drag-and-drop as a desktop enhancement, not the only path.
+
+---
+
+### 7 — Reduce persistent chrome and enlarge tiny utility controls
+
+**Status:** `[~] partial`
+
+**Done:**
+- Split divider hit area raised to >= 12 px via `padding: 8px 0` under `pointer: coarse`
+- Status bar gets `flex-wrap: wrap` and `height: auto` on tablet so it doesn't clip
+- Depth legend toggle and statusbar legend raised to 44 px hit area under `pointer: coarse`
+
+**Remaining:**
+- Status bar collapsible / auto-hide toggle
+- Legend toggles on the sketch canvas (18–20 px) need the same treatment verified on device
+
+**Problem:**
+Status bar, legends, and split handles are tuned for desktop density. The split divider is a
+3 px bar. Some legend toggles and status controls are 18–20 px — too small for touch.
+
+**References:**
+- `src/styles/layout.css` line 1779, line 1108, line 1895
+
+**Work:**
+- Make the status bar collapsible or auto-hide on tablet.
+- Increase split divider hit area to >= 12 px (visual can stay narrow, hit area via padding).
+- Raise legend toggle and status control hit areas to >= 40 px under the tablet breakpoint.
+
+---
+
+## Suggested Implementation Order
+
+1. **Item 1** — Tablet shell layout (unblocks everything else)
+2. **Item 3** — Touch target CSS (low risk, high impact, can land early)
+3. **Item 4** — Pointer event migration + explicit Edit / More affordances
+4. **Item 5** — Touch gestures for 3D and simulation
+5. **Item 2** — Toolbar split (depends on shell being stable)
+6. **Item 6** — Reorder controls
+7. **Item 7** — Chrome reduction and hit area cleanup
+
+---
+
+## Notes
+
+- All changes should be additive under the tablet breakpoint; desktop behavior must not regress.
+- Live device testing on an actual tablet should follow each item before it is marked done.
+- Pen input (Apple Pencil / stylus) should be validated separately from finger touch.

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -2866,6 +2866,112 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     canvasRef.current?.focus({ preventScroll: true })
   }
 
+  // Called by the "Type" button in banners — opens dimension input without
+  // the Tab toggle-close behaviour. Keyboard Tab keeps its existing logic.
+  function triggerDimensionEdit() {
+    const project = projectRef.current
+    const pendingAdd = pendingAddRef.current
+    const pendingMove = pendingMoveRef.current
+    const pendingTransform = pendingTransformRef.current
+    const pendingOffset = pendingOffsetRef.current
+    const selection = selectionRef.current
+    const units = project.meta.units
+
+    if (pendingAdd) {
+      if (
+        (pendingAdd.shape === 'rect' || pendingAdd.shape === 'circle' || pendingAdd.shape === 'tab' || pendingAdd.shape === 'clamp')
+        && pendingAdd.anchor
+      ) {
+        const previewPoint = pendingPreviewPointRef.current?.point ?? pendingAdd.anchor
+        if (pendingAdd.shape === 'circle') {
+          const r = Math.hypot(previewPoint.x - pendingAdd.anchor.x, previewPoint.y - pendingAdd.anchor.y)
+          setDimensionEdit({ shape: 'circle', anchor: pendingAdd.anchor, signX: 1, signY: 1, activeField: 'radius', width: '', height: '', radius: formatLength(r, units), length: '', angle: '' })
+        } else {
+          const w = Math.abs(previewPoint.x - pendingAdd.anchor.x)
+          const h = Math.abs(previewPoint.y - pendingAdd.anchor.y)
+          setDimensionEdit({ shape: pendingAdd.shape, anchor: pendingAdd.anchor, signX: previewPoint.x >= pendingAdd.anchor.x ? 1 : -1, signY: previewPoint.y >= pendingAdd.anchor.y ? 1 : -1, activeField: 'width', width: formatLength(w, units), height: formatLength(h, units), radius: '', length: '', angle: '' })
+        }
+        return
+      }
+      if ((pendingAdd.shape === 'polygon' || pendingAdd.shape === 'spline') && pendingAdd.points.length >= 1) {
+        const fromPoint = pendingAdd.points[pendingAdd.points.length - 1]
+        const previewPoint = pendingPreviewPointRef.current?.point ?? fromPoint
+        const dx = previewPoint.x - fromPoint.x
+        const dy = previewPoint.y - fromPoint.y
+        setDimensionEdit({ shape: pendingAdd.shape, anchor: fromPoint, signX: 1, signY: 1, activeField: 'length', width: '', height: '', radius: '', length: formatLength(Math.hypot(dx, dy), units), angle: (Math.atan2(dy, dx) * (180 / Math.PI)).toFixed(2).replace(/\.?0+$/, '') })
+        return
+      }
+      if (pendingAdd.shape === 'composite' && pendingAdd.start && !pendingAdd.closed) {
+        const fromPoint = pendingAdd.lastPoint ?? pendingAdd.start
+        const previewPoint = pendingPreviewPointRef.current?.point ?? fromPoint
+        const dx = previewPoint.x - fromPoint.x
+        const dy = previewPoint.y - fromPoint.y
+        setDimensionEdit({ shape: 'composite', anchor: fromPoint, signX: 1, signY: 1, activeField: 'length', width: '', height: '', radius: '', length: formatLength(Math.hypot(dx, dy), units), angle: (Math.atan2(dy, dx) * (180 / Math.PI)).toFixed(2).replace(/\.?0+$/, '') })
+        return
+      }
+    }
+
+    if (pendingMove?.fromPoint && !pendingMove.toPoint) {
+      const previewPoint = pendingMovePreviewPointRef.current?.point ?? pendingMove.fromPoint
+      const dx = previewPoint.x - pendingMove.fromPoint.x
+      const dy = previewPoint.y - pendingMove.fromPoint.y
+      setOperationDimEdit({ kind: pendingMove.mode, distance: formatLength(Math.hypot(dx, dy), units) })
+      return
+    }
+
+    if (pendingTransform?.mode === 'resize' && pendingTransform.referenceStart && pendingTransform.referenceEnd) {
+      let factor = '1'
+      const previewPoint = pendingTransformPreviewPointRef.current?.point
+      if (previewPoint) factor = computeScaleFactorFromPreview(pendingTransform.referenceStart, pendingTransform.referenceEnd, previewPoint)
+      setOperationDimEdit({ kind: 'scale', factor })
+      return
+    }
+
+    if (pendingTransform?.mode === 'rotate' && pendingTransform.referenceStart && pendingTransform.referenceEnd) {
+      let angle = '0'
+      const previewPoint = pendingTransformPreviewPointRef.current?.point
+      if (previewPoint) angle = computeRotateDegreesFromPreview(pendingTransform.referenceStart, pendingTransform.referenceEnd, previewPoint)
+      setOperationDimEdit({ kind: 'rotate', angle })
+      return
+    }
+
+    if (pendingOffset) {
+      let distance = '0'
+      const rawOffsetPoint = pendingOffsetRawPreviewPointRef.current?.point
+      const snappedOffsetPoint = pendingOffsetPreviewPointRef.current?.point
+      if (rawOffsetPoint && snappedOffsetPoint) {
+        const canvas = canvasRef.current
+        if (canvas) {
+          const vt = computeViewTransform(project.stock, canvas.width, canvas.height, viewStateRef.current)
+          const sourceFeatures = pendingOffset.entityIds
+            .map((id) => project.features.find((f) => f.id === id) ?? null)
+            .filter((f): f is SketchFeature => f !== null)
+            .filter((f) => f.sketch.profile.closed)
+          const previewInput = resolveOffsetPreview(sourceFeatures, rawOffsetPoint, snappedOffsetPoint, activeSnapRef.current?.mode ?? null, vt)
+          if (previewInput) distance = formatLength(previewInput.signedDistance, units)
+        }
+      }
+      setOperationDimEdit({ kind: 'offset', distance })
+      return
+    }
+
+    if (selection.mode === 'sketch_edit' && !pendingAdd && pendingSketchFilletRef.current && sketchEditPreviewRef.current) {
+      const featureId = selection.selectedFeatureId
+      const feature = featureId ? project.features.find((f) => f.id === featureId) ?? null : null
+      if (!feature) return
+      const radius = filletRadiusFromPoint(feature, pendingSketchFilletRef.current.anchorIndex, sketchEditPreviewRef.current.point)
+      setFilletDimensionEdit({ anchorIndex: pendingSketchFilletRef.current.anchorIndex, corner: pendingSketchFilletRef.current.corner, radius: radius ? formatLength(radius, units) : '' })
+      return
+    }
+
+    if (selection.mode === 'sketch_edit' && !pendingAdd && !filletDimensionEditRef.current) {
+      const currentEdit = dimensionEditRef.current
+      if (!currentEdit && dimensionEditControlRef.current) {
+        advanceTabInEditMode()
+      }
+    }
+  }
+
   function handleKeyDown(event: KeyboardEvent<HTMLCanvasElement>) {
     const project = projectRef.current
     const selection = selectionRef.current
@@ -4093,7 +4199,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
                     ? 'Fillet active. Click a second point to define the corner round, or press Tab to type the radius. Press '
                     : 'Fillet active. Click a line-line corner to start. Press '
                   : 'Drag nodes or straight segments to reshape. Hover a node and press Tab to type length/angle. Press '}
-            <kbd>Enter</kbd> to apply or <kbd>Esc</kbd> to cancel.
+            <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Apply" onClick={() => { stopNodeDrag(); applySketchEdit() }} onKeyDown={(e) => { if (e.key === 'Enter') { stopNodeDrag(); applySketchEdit() } }}>Enter</kbd> to apply or <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={() => { stopNodeDrag(); cancelSketchEdit() }} onKeyDown={(e) => { if (e.key === 'Enter') { stopNodeDrag(); cancelSketchEdit() } }}>Esc</kbd> to cancel.
           </div>
           {editingFeatureHasSelfIntersection ? (
             <div className="sketch-banner-warning">This profile self-intersects. 3D/CAM results may be invalid.</div>
@@ -4105,7 +4211,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       )}
       {pendingOffset && (
         <div className="sketch-place-banner">
-          <>Move the mouse to preview the offset. Inside creates an inward offset, outside creates an outward offset. Press <kbd>Tab</kbd> to type exact distance, click to commit, or press <kbd>Esc</kbd> to cancel.</>
+          <>Move the mouse to preview the offset. Inside creates an inward offset, outside creates an outward offset. Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Type exact distance" onClick={triggerDimensionEdit} onKeyDown={(e) => { if (e.key === 'Enter') triggerDimensionEdit() }}>Tab</kbd> to type exact distance, click to commit, or press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingOffset} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingOffset() }}>Esc</kbd> to cancel.</>
         </div>
       )}
       {pendingShapeAction && (
@@ -4139,7 +4245,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
             />
             <span>Keep originals</span>
           </label>
-          <span>Press <kbd>Enter</kbd> to confirm or <kbd>Esc</kbd> to cancel.</span>
+          <span>Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm" onClick={completePendingShapeAction} onKeyDown={(e) => { if (e.key === 'Enter') completePendingShapeAction() }}>Enter</kbd> to confirm or <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingShapeAction} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingShapeAction() }}>Esc</kbd> to cancel.</span>
         </div>
       )}
       {pendingAdd && (
@@ -4180,7 +4286,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
                           : pendingAdd.currentMode === 'spline'
                             ? 'Click to add a spline segment endpoint. Press Tab to type length/angle. Click the first point to close, or press Enter to finish open.'
                             : 'Click to add connected line segments. Press Tab to type length/angle. Click the first point to close, or press Enter to finish open.'}
-            {' '}Press <kbd>Esc</kbd> to cancel.
+            {' '}Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingAdd} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingAdd() }}>Esc</kbd> to cancel.
           </div>
           {pendingDraftHasSelfIntersection ? (
             <div className="sketch-banner-warning">This profile self-intersects. 3D/CAM results may be invalid.</div>
@@ -4199,7 +4305,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
               : !pendingConstraint.reference
                 ? 'Click a snap point on another feature to set the reference.'
                 : 'Type the distance and press Enter.'}
-            {' '}Press <kbd>Esc</kbd> to cancel.
+            {' '}Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingConstraint} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingConstraint() }}>Esc</kbd> to cancel.
           </div>
         </div>
       )}
@@ -4232,32 +4338,42 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
                 }}
                 autoFocus
               />
-              <span>Press <kbd>Enter</kbd> to confirm, <kbd>Esc</kbd> to cancel.</span>
+              <span>Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm" onClick={() => { const n = Math.max(1, Math.floor(Number(copyCountDraft) || 1)); completePendingMove(pendingMove.toPoint!, n); setPendingMovePreviewPointRef(null); setCopyCountDraft('1') }} onKeyDown={(e) => { if (e.key === 'Enter') { const n = Math.max(1, Math.floor(Number(copyCountDraft) || 1)); completePendingMove(pendingMove.toPoint!, n); setPendingMovePreviewPointRef(null); setCopyCountDraft('1') } }}>Enter</kbd> to confirm, <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={() => { cancelPendingMove(); setPendingMovePreviewPointRef(null); setCopyCountDraft('1') }} onKeyDown={(e) => { if (e.key === 'Enter') { cancelPendingMove(); setPendingMovePreviewPointRef(null); setCopyCountDraft('1') } }}>Esc</kbd> to cancel.</span>
             </>
           ) : (
-            pendingMove.fromPoint
-              ? pendingMove.mode === 'copy'
-                ? 'Click the copy to point, then enter the copy count. Press Tab to type exact distance. Press Esc to cancel.'
-                : 'Click the destination point to complete the move. Press Tab to type exact distance. Press Esc to cancel.'
-              : pendingMove.mode === 'copy'
-                ? 'Click the copy from point, then click the copy to point. Press Esc to cancel.'
-                : 'Click the move from point, then click the move to point. Press Esc to cancel.'
+            <>
+              <span>{pendingMove.fromPoint
+                ? pendingMove.mode === 'copy'
+                  ? 'Click the copy to point, then enter the copy count.'
+                  : 'Click the destination point to complete the move.'
+                : pendingMove.mode === 'copy'
+                  ? 'Click the copy from point, then click the copy to point.'
+                  : 'Click the move from point, then click the move to point.'}</span>
+              {pendingMove.fromPoint && !pendingMove.toPoint && (
+                <> Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Type exact distance" onClick={triggerDimensionEdit} onKeyDown={(e) => { if (e.key === 'Enter') triggerDimensionEdit() }}>Tab</kbd> to type exact distance.</>)}
+              {' '}Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingMove} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingMove() }}>Esc</kbd> to cancel.
+            </>
           )}
         </div>
       )}
       {pendingTransform && (
         <div className="sketch-place-banner">
-          {pendingTransform.mode === 'resize'
+          <span>{pendingTransform.mode === 'resize'
             ? !pendingTransform.referenceStart
-              ? 'Click the first resize reference point. Press Esc to cancel.'
+              ? 'Click the first resize reference point.'
               : !pendingTransform.referenceEnd
-                ? 'Click the second resize reference point. Press Esc to cancel.'
-                : 'Move along the reference line to preview the resized feature, then click to commit. Press Tab to type scale factor. Press Esc to cancel.'
+                ? 'Click the second resize reference point.'
+                : 'Move along the reference line to preview the resized feature, then click to commit.'
             : !pendingTransform.referenceStart
-              ? 'Click the rotation origin. Press Esc to cancel.'
+              ? 'Click the rotation origin.'
               : !pendingTransform.referenceEnd
-                ? 'Click the reference direction point. Press Esc to cancel.'
-                : 'Move to preview the rotated feature, then click to commit. Press Tab to type exact angle. Press Esc to cancel.'}
+                ? 'Click the reference direction point.'
+                : 'Move to preview the rotated feature, then click to commit.'}</span>
+          {((pendingTransform.mode === 'resize' && pendingTransform.referenceStart && pendingTransform.referenceEnd)
+            || (pendingTransform.mode === 'rotate' && pendingTransform.referenceStart && pendingTransform.referenceEnd)) && (
+            <> Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title={pendingTransform.mode === 'resize' ? 'Type scale factor' : 'Type exact angle'} onClick={triggerDimensionEdit} onKeyDown={(e) => { if (e.key === 'Enter') triggerDimensionEdit() }}>Tab</kbd> to type {pendingTransform.mode === 'resize' ? 'scale factor' : 'exact angle'}.</>
+          )}
+          {' '}Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingTransform} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingTransform() }}>Esc</kbd> to cancel.
         </div>
       )}
     </div>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react'
+import { useState, type ReactNode } from 'react'
 import { useProjectStore } from '../../store/projectStore'
 import { getStockBounds } from '../../types/project'
 import { formatLength } from '../../utils/units'
@@ -70,6 +70,7 @@ export function AppShell({
   onRightTabChange,
   statusBarExtras,
 }: AppShellProps) {
+  const [rightDrawerOpen, setRightDrawerOpen] = useState(false)
   const { project } = useProjectStore()
   const stockBounds = getStockBounds(project.stock)
   const stockWidth = stockBounds.maxX - stockBounds.minX
@@ -84,10 +85,27 @@ export function AppShell({
   ] as const
 
   return (
-    <div className="app-shell">
+    <div className="app-shell" data-right-open={rightDrawerOpen ? 'true' : undefined}>
+      {rightDrawerOpen && (
+        <div
+          className="tablet-drawer-scrim"
+          aria-hidden="true"
+          onClick={() => setRightDrawerOpen(false)}
+        />
+      )}
       {/* ── Top toolbar ── */}
       <header className={`app-toolbar app-toolbar--${toolbarOrientation}`}>
         {toolbarOrientation === 'left' ? globalToolbar : toolbar}
+        <button
+          className="tablet-drawer-toggle toolbar-btn"
+          type="button"
+          title="Open operations panel"
+          aria-label="Open operations panel"
+          aria-expanded={rightDrawerOpen}
+          onClick={() => setRightDrawerOpen(true)}
+        >
+          CAM
+        </button>
       </header>
 
       {/* Main work area */}
@@ -279,9 +297,17 @@ export function AppShell({
           </div>
         </main>
 
-        <aside className="panel-right">
+        <aside className="panel-right" aria-label="CAM panel">
           <section className="panel panel-tabs">
             <div className="panel-tabs-header" role="tablist" aria-label="Right Sidebar">
+              <button
+                className="tablet-drawer-close"
+                type="button"
+                aria-label="Close operations panel"
+                onClick={() => setRightDrawerOpen(false)}
+              >
+                ✕
+              </button>
               <button
                 id="sidebar-tab-operations"
                 className={`panel-tab ${rightTab === 'operations' ? 'panel-tab--active' : ''}`}

--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,7 @@
 
 @import './styles/layout.css';
 @import './styles/dialog.css';
+@import './styles/tablet.css';
 
 :root {
   --bg: #0a1016;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1014,12 +1014,37 @@
   color: #f7b86a;
 }
 
-.sketch-edit-banner kbd {
+.sketch-edit-banner kbd,
+.sketch-place-banner kbd {
   border: 1px solid var(--line-strong);
   border-bottom-width: 2px;
   border-radius: 4px;
   padding: 1px 4px;
   background: #0f161f;
+}
+
+.sketch-kbd-btn {
+  cursor: pointer;
+  user-select: none;
+}
+
+.sketch-kbd-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+@media (pointer: coarse) {
+  .sketch-kbd-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--touch-target, 44px);
+    min-height: var(--touch-target, 44px);
+    padding: 0 10px;
+    font-size: 13px;
+    border-radius: 6px;
+    vertical-align: middle;
+  }
 }
 
 .sketch-place-banner {
@@ -1053,14 +1078,6 @@
   margin: 0;
   position: relative;
   top: 1px;
-}
-
-.sketch-place-banner kbd {
-  border: 1px solid var(--line-strong);
-  border-bottom-width: 2px;
-  border-radius: 4px;
-  padding: 1px 4px;
-  background: #0f161f;
 }
 
 .sketch-place-count {

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -1,0 +1,236 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Tablet shell overrides.
+ *
+ * Applies when the primary input is coarse (touch / stylus) OR when the
+ * viewport is in the tablet-width range (900–960 px landscape).
+ * Desktop mouse users are never affected.
+ *
+ * Supported target: landscape >= 900 px, optimised for 1024–1366 px.
+ */
+
+/* ── Touch-target custom property ─────────────────────────── */
+
+@media (pointer: coarse) {
+  :root {
+    --touch-target: 44px;
+  }
+}
+
+/* ── Tablet layout: right panel becomes a slide-in drawer ─── */
+
+@media (pointer: coarse), (max-width: 960px) {
+
+  /* The right panel slides in from the right as an overlay drawer.
+     It is hidden by default; .app-shell[data-right-open="true"] reveals it. */
+  .panel-right {
+    position: fixed;
+    inset: 0 0 0 auto;
+    z-index: 50;
+    width: min(340px, 88vw);
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-elev-1);
+    border-left: 1px solid var(--line);
+    box-shadow: -8px 0 32px rgba(0, 0, 0, 0.45);
+    transform: translateX(100%);
+    transition: transform 0.22s ease;
+    /* Override the grid-area assignment from the narrow desktop breakpoint */
+    grid-area: unset;
+  }
+
+  .app-shell[data-right-open="true"] .panel-right {
+    transform: translateX(0);
+  }
+
+  /* Scrim behind the open drawer */
+  .tablet-drawer-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 49;
+    background: rgba(0, 0, 0, 0.45);
+  }
+
+  /* The main body no longer needs to reserve a column for the right panel */
+  .app-body,
+  .app-body--toolbar-left,
+  .app-body--lcr,
+  .app-body--cr {
+    grid-template-columns: minmax(200px, 20%) minmax(0, 1fr) !important;
+    grid-template-areas: 'left centre' !important;
+  }
+
+  .app-body--lc,
+  .app-body--toolbar-left.app-body--lc {
+    grid-template-columns: minmax(200px, 20%) minmax(0, 1fr) !important;
+    grid-template-areas: 'left centre' !important;
+  }
+
+  .app-body--c,
+  .app-body--toolbar-left.app-body--c {
+    grid-template-columns: minmax(0, 1fr) !important;
+    grid-template-areas: 'centre' !important;
+  }
+
+  /* Drawer toggle button — shown only on tablet */
+  .tablet-drawer-toggle {
+    display: inline-flex;
+  }
+}
+
+/* Hide the drawer toggle on desktop */
+.tablet-drawer-toggle {
+  display: none;
+}
+
+/* Scrim is only rendered by React when the drawer is open, but ensure
+   it never shows on desktop even if the component renders it */
+.tablet-drawer-scrim {
+  display: none;
+}
+
+@media (pointer: coarse), (max-width: 960px) {
+  .tablet-drawer-scrim {
+    display: block;
+  }
+}
+
+/* ── Touch targets: toolbar ───────────────────────────────── */
+
+@media (pointer: coarse) {
+  .toolbar-icon-btn {
+    width: var(--touch-target, 44px);
+    height: var(--touch-target, 44px);
+  }
+
+  .toolbar-btn,
+  .toolbar-project-name {
+    height: var(--touch-target, 44px);
+    padding: 0 14px;
+  }
+
+  /* Vertical creation rail */
+  .toolbar--creation.toolbar--vertical .toolbar-icon-btn {
+    width: var(--touch-target, 44px);
+    height: var(--touch-target, 44px);
+  }
+}
+
+/* ── Touch targets: feature tree rows ────────────────────── */
+
+@media (pointer: coarse) {
+  .tree-row {
+    min-height: var(--touch-target, 44px);
+    padding-top: 6px;
+    padding-bottom: 6px;
+    font-size: 13px;
+  }
+
+  .tree-action-btn {
+    width: var(--touch-target, 44px);
+    height: var(--touch-target, 44px);
+  }
+}
+
+/* ── Touch targets: panel tabs ───────────────────────────── */
+
+@media (pointer: coarse) {
+  .panel-tab {
+    min-height: var(--touch-target, 44px);
+    font-size: 13px;
+  }
+}
+
+/* ── Touch targets: properties inputs ───────────────────── */
+
+@media (pointer: coarse) {
+  .properties-field input,
+  .properties-field select,
+  .properties-field textarea,
+  .properties-field button:not(.tree-action-btn) {
+    height: var(--touch-target, 44px);
+  }
+}
+
+/* ── Touch targets: CAM buttons ─────────────────────────── */
+
+@media (pointer: coarse) {
+  .cam-subtab,
+  .cam-header-action {
+    min-height: var(--touch-target, 44px);
+    padding: 0 14px;
+  }
+}
+
+/* ── Split divider: larger hit area ─────────────────────── */
+
+@media (pointer: coarse) {
+  .panel-split__divider {
+    padding: 8px 0;
+  }
+}
+
+/* ── Status bar: collapsible on tablet ──────────────────── */
+
+@media (pointer: coarse) {
+  .app-statusbar {
+    height: auto;
+    min-height: 36px;
+    padding: 6px 14px;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .statusbar-depth-legend {
+    height: var(--touch-target, 44px);
+    padding: 0 10px;
+    font-size: 12px;
+  }
+
+  .sketch-depth-legend__toggle {
+    width: var(--touch-target, 44px);
+    height: var(--touch-target, 44px);
+    min-height: var(--touch-target, 44px);
+  }
+}
+
+/* ── Drawer close button ─────────────────────────────────── */
+
+.tablet-drawer-close {
+  display: none;
+}
+
+@media (pointer: coarse), (max-width: 960px) {
+  .tablet-drawer-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--touch-target, 44px);
+    height: var(--touch-target, 44px);
+    border: none;
+    background: transparent;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 18px;
+    flex-shrink: 0;
+  }
+
+  .tablet-drawer-close:hover {
+    color: var(--text);
+  }
+}


### PR DESCRIPTION
## Summary

Initial tablet UX pass based on the review in `planning/TABLET_UX_Implementation_Plan.md`.

All changes are additive under `@media (pointer: coarse)` or the tablet-width breakpoint — desktop behavior is unchanged.

---

## What landed

### Item 1 — Tablet shell layout
- Right panel (`panel-right`) becomes a fixed slide-in drawer on `pointer: coarse` / `<=960px`
- A **CAM** button in the top toolbar opens it (hidden on desktop via CSS)
- An **✕** button inside the drawer header and a tap-outside scrim close it
- Main body columns no longer reserve space for the right panel on tablet

### Item 3 — Touch targets 44 px
- `--touch-target: 44px` CSS custom property set under `pointer: coarse`
- Applied to: toolbar icon buttons, toolbar text buttons, tree rows, tree action buttons, panel tabs, properties inputs, CAM subtabs and header actions, split divider hit area, status bar depth legend toggle

### Item 4 (partial) — Keyboard-dependent banners
- Added `triggerDimensionEdit()` — extracts the Tab-open path from `handleKeyDown` so it can be called from touch targets
- All sketch canvas banners (`sketch-edit-banner`, `sketch-place-banner`) now use clickable `<kbd>` elements with `role="button"` and `tabIndex` for Enter / Esc / Tab actions
- Banner appearance is pixel-identical on desktop; on `pointer: coarse` the kbd chips get 44 px hit area
- Keyboard shortcuts fully preserved

### Item 7 (partial) — Chrome and utility controls
- Split divider padding raised to 12 px hit area on touch
- Status bar gets `flex-wrap: wrap` and `height: auto` on tablet
- Depth legend toggle raised to 44 px

---

## Files changed
| File | Change |
|---|---|
| `src/styles/tablet.css` | New — all tablet overrides |
| `src/index.css` | Import `tablet.css` |
| `src/components/layout/AppShell.tsx` | Drawer state, toggle button, scrim |
| `src/components/canvas/SketchCanvas.tsx` | `triggerDimensionEdit()`, clickable `<kbd>` banners |
| `src/styles/layout.css` | `sketch-kbd-btn` styles |
| `planning/TABLET_UX_Implementation_Plan.md` | Tracking plan |

---

## Remaining (future PRs)
- Item 2 — Toolbar split into primary / contextual layers
- Item 4 (rest) — Pointer event migration, double-click edit entry, multi-select toggle, tree context menu → More button
- Item 5 — Pinch/pan/orbit touch gestures for 3D and simulation viewports
- Item 6 — Move up/down reorder controls for feature tree and CAM operations
- Item 7 (rest) — Collapsible status bar