### PR TITLE
Fix surface clean cutting into taller targets in multi-feature ops (#54)

### DIFF
--- a/src/engine/toolpaths/surface.ts
+++ b/src/engine/toolpaths/surface.ts
@@ -211,7 +211,6 @@ function resolveSurfaceCleanRegions(project: Project, operation: Operation): Sur
   const depthLevels = [...new Set([project.stock.thickness, ...closedTargetFeatures.map(({ top }) => top)])]
     .sort((a, b) => b - a)
   const bands: SurfaceCleanBand[] = []
-  const targetIdSet = new Set(closedTargetFeatures.map(({ feature }) => feature.id))
 
   for (let index = 0; index < depthLevels.length - 1; index += 1) {
     const topZ = depthLevels[index]
@@ -226,7 +225,11 @@ function resolveSurfaceCleanRegions(project: Project, operation: Operation): Sur
     }
 
     const subjectPaths = activeTargets.map(({ feature }) => flattenProfileToClipperPath(feature.sketch.profile))
-    const protectedFeatures = allAddFeatures.filter(({ top, feature }) => top > bottomZ && !targetIdSet.has(feature.id))
+    // Protect any add feature whose top is above this band's floor — including
+    // target features at higher levels that haven't been reached yet. Otherwise
+    // the expanded subject of a lower target can sweep through a taller target.
+    const activeTargetIdSet = new Set(activeTargets.map(({ feature }) => feature.id))
+    const protectedFeatures = allAddFeatures.filter(({ top, feature }) => top > bottomZ && !activeTargetIdSet.has(feature.id))
     const protectedPaths = protectedFeatures.map(({ feature }) => flattenProfileToClipperPath(feature.sketch.profile))
     const polyTree = executeClip(subjectPaths, protectedPaths, ClipperLib.ClipType.ctDifference)
     const regions = polyTreeToRegions(

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -8,12 +8,13 @@
  */
 
 import type { Operation, Project, SketchFeature, Tool } from '../../types/project'
-import { defaultTool, newProject, rectProfile } from '../../types/project'
+import { circleProfile, defaultTool, newProject, rectProfile } from '../../types/project'
 import type { ToolpathBounds, ToolpathMove, ToolpathResult } from './types'
 import { mergePocketToolpathResults, mergeToolpathResults, perFeatureOperations } from './multiFeature'
 import { generatePocketToolpath } from './pocket'
 import { generateEdgeRouteToolpath } from './edge'
 import { generateVCarveToolpath } from './vcarve'
+import { generateSurfaceCleanToolpath } from './surface'
 
 function assert(condition: boolean, message: string) {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
@@ -416,6 +417,88 @@ function testVCarveFeatureFirstProducesSameMoveCount() {
 }
 
 // ---------------------------------------------------------------------------
+// Surface clean: multi-target with stepped heights protects taller targets
+// ---------------------------------------------------------------------------
+
+function makeCircleBoss(id: string, cx: number, cy: number, r: number, zTop: number, zBottom: number): SketchFeature {
+  return {
+    id,
+    name: id,
+    kind: 'circle',
+    folderId: null,
+    sketch: {
+      profile: circleProfile(cx, cy, r),
+      origin: { x: 0, y: 0 },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+    operation: 'add',
+    z_top: zTop,
+    z_bottom: zBottom,
+    visible: true,
+    locked: false,
+  }
+}
+
+function testSurfaceCleanMultiTargetProtectsTallerTarget() {
+  console.log('Testing surface_clean multi-target protects taller target (issue #54)...')
+
+  // Repro distilled from issue #54: two adjacent boss circles cleaned in one op
+  // at stepped heights. Without the fix, the deeper band's expanded subject
+  // sweeps over the still-tall neighbour because the neighbour is filtered out
+  // of the protected set just for being a target.
+  const baseTool = defaultTool('inch', 1)
+  const tool: Tool = {
+    ...baseTool,
+    id: 't1',
+    name: '1/4 endmill',
+    diameter: 0.25,
+    defaultStepdown: 0.125,
+    defaultStepover: 0.32,
+  }
+
+  const circA = makeCircleBoss('a', 0, 0, 0.5, 0.5, 0)
+  const circB = makeCircleBoss('b', 1, 0, 0.5, 0.4, 0)
+
+  const project: Project = {
+    ...newProject('surface-test', 'inch'),
+    tools: [tool],
+    features: [circA, circB],
+  }
+  project.stock = { ...project.stock, thickness: 0.75 }
+
+  const op = makePocketOp({
+    kind: 'surface_clean',
+    target: { source: 'features', featureIds: ['a', 'b'] },
+    toolRef: 't1',
+    stepdown: 0.05,
+    stepover: 0.1,
+  })
+
+  const result = generateSurfaceCleanToolpath(project, op)
+  assert(result.moves.length > 0, 'moves generated')
+
+  // Any cut move below z=0.5 (i.e., in the deeper band) whose XY lies inside
+  // circA's footprint means the tool is plowing through the taller boss.
+  const tallerRadius = 0.5
+  const violations = cutMoves(result.moves).filter((m) => {
+    if (m.to.z >= 0.5 - 1e-6) return false
+    const dx = m.to.x
+    const dy = m.to.y
+    return Math.hypot(dx, dy) < tallerRadius - 1e-3
+  })
+
+  assert(
+    violations.length === 0,
+    `expected no cut moves below z=0.5 inside the taller boss; got ${violations.length}`
+      + (violations[0] ? ` (e.g. ${JSON.stringify(violations[0])})` : ''),
+  )
+
+  console.log('surface_clean multi-target protects taller target: PASSED')
+}
+
+// ---------------------------------------------------------------------------
 // Driver
 // ---------------------------------------------------------------------------
 
@@ -427,6 +510,7 @@ try {
   testPocketSingleFeatureParity()
   testEdgeInsideLevelFirstVsFeatureFirst()
   testVCarveFeatureFirstProducesSameMoveCount()
+  testSurfaceCleanMultiTargetProtectsTallerTarget()
   console.log('\nAll toolpath tests PASSED.')
 } catch (e) {
   console.error(e)


### PR DESCRIPTION
## Summary
- Fixes [#54](https://github.com/PureCutCNC/purecutcnc/issues/54): surface-cleaning multiple features at once produced an invalid path that cut into the model.
- In `resolveSurfaceCleanRegions`, deeper bands previously excluded *every* target from the protected set. A target whose top still stood above the band's floor was no longer treated as material to avoid, and the expanded subject of a lower target could sweep through a taller neighbour. The fix filters on the *active* targets for the current band instead.

## Repro (from issue)
- Two adjacent boss circles ([f0010](https://github.com/PureCutCNC/purecutcnc/issues/54), top z=0.6 / [f0011](https://github.com/PureCutCNC/purecutcnc/issues/54), top z=0.5), 1/4" endmill.
- depthLevels = [0.75, 0.6, 0.5]; the 0.6→0.5 band cleans only f0011, but f0010 was unprotected because it was a target — so the expanded f0011 (radius 0.625") plowed through f0010 at z=0.5.
- Cleaning each circle individually has only one band, so the bug never manifests.

## Test plan
- [x] Added [`testSurfaceCleanMultiTargetProtectsTallerTarget`](src/engine/toolpaths/toolpaths.test.ts) reproducing the scenario; without the fix it reports 66 cut moves below z=0.5 inside the taller boss, with the fix zero.
- [x] `npx tsx src/engine/toolpaths/toolpaths.test.ts` — all toolpath tests pass.
- [x] `tsc -b` and `eslint` clean on touched files.
- [x] Re-load the issue's `surface-test.camj` in the app and visually verify op0016 no longer cuts into the model.