### PR TITLE
Tablet UX Phase 2A + graceful error screen (issue #56)

### DIFF
--- a/planning/TABLET_UX_Implementation_Plan.md
+++ b/planning/TABLET_UX_Implementation_Plan.md
@@ -210,34 +210,34 @@ Phase 2 sub-items below use current paths.
 
 ### Phase 2A — Editing reachability *(addresses #56 directly)*
 
-**Status:** `[ ] todo`
+**Status:** `[~] partial` — landed in `distracted-panini-131628`, awaiting on-device tablet test.
 
 **Goal:** Every edit entry point that today depends on Tab, double-click, or right-click has
 a visible, tappable equivalent.
 
-**Work:**
-- Sketch dimension labels: make the rendered dimension text tappable; tap calls
-  `triggerDimensionEdit()` with that dimension as context. Same code path the banner kbd
-  chips already use.
-  - [SketchCanvas.tsx:2871](src/components/canvas/SketchCanvas.tsx:2871) — existing `triggerDimensionEdit()`
-  - Dimension label rendering in the same file (drawn inside the main canvas render path;
-    currently no `onClick` / `pointerdown` on the text shapes)
-- Transform gizmo readouts (distance / angle / scale during move/rotate/resize): same
-  tap-to-edit treatment.
-- Feature tree row: explicit **Edit** button (pencil icon) on each row under
-  `pointer: coarse`, replacing the double-click entry into `FEATURE_EDIT`.
-  - [FeatureTree.tsx](src/components/feature-tree/FeatureTree.tsx) — add button alongside
-    existing visible/operation toggles
-- Feature tree row: **More (…)** button that opens the same menu today's `onContextMenu`
-  triggers, so right-click-only actions become tap-reachable.
-  - [FeatureTree.tsx:168](src/components/feature-tree/FeatureTree.tsx:168) — existing
-    `onContextMenu` handler; wire the same `onFeatureContextMenu` callback to a button.
+**Done:**
+- `pendingAdd` banner gained a clickable **Tab** kbd chip (shown when
+  `triggerDimensionEdit()` has something to act on: rect/circle/tab/clamp with anchor,
+  polygon/spline with ≥1 point, composite with start set).
+- Feature / tab / clamp tree rows gained a pencil **Edit** button that routes through the
+  existing `handleEditSketch` / `handleEditTab` / `handleEditClamp` handlers, matching the
+  "Edit Sketch" context-menu item.
+- Feature / tab / clamp tree rows gained a **⋯ More** button that opens the same context
+  menu right-click opens, anchored at the button's bottom-left rect.
+
+**Remaining (follow-up):**
+- Sketch-edit mode says "Hover a node and press Tab to type length/angle." — hover has no
+  touch equivalent. Needs a tap-a-node-to-arm design so the banner can then show a clickable
+  Tab chip for the armed node.
+- Sketch dimension labels drawn on the canvas (as opposed to banner chips) still aren't
+  tap-targets; the banner path is sufficient for pending operations but dimension-label
+  taps would be a nicer future improvement.
 
 **Acceptance:**
 - On tablet, a user can enter a distance value for any pending add/move/transform without a
-  keyboard.
+  keyboard. ✓ (pending device test)
 - On tablet, every feature-tree row action available via right-click on desktop is reachable
-  via tap.
+  via tap. ✓ (pending device test)
 
 ### Phase 2B — Pointer events in sketch canvas
 
@@ -292,10 +292,40 @@ a visible, tappable equivalent.
 - Status bar collapsible or auto-hide on tablet.
 - Verify sketch-canvas legend toggles hit 44 px on device.
 
+### Phase 2F — Graceful failure on unsupported devices
+
+**Status:** `[x] done` — landed in `distracted-panini-131628`.
+
+Out-of-band item: the tablet discussion surfaced that older desktops and tablets were
+hitting a blank screen instead of an error (typically when WebGL context creation fails in
+`Viewport3D` / `SimulationViewport` on mount). Rather than commit to a support baseline, we
+now capture the failure and show a friendly screen.
+
+**Done:**
+- [src/components/errorFormat.ts](src/components/errorFormat.ts) — shared `formatError` +
+  `renderErrorHTML` helpers (error message, first 3 stack frames, `navigator.userAgent`,
+  timestamp).
+- [src/components/ErrorScreen.tsx](src/components/ErrorScreen.tsx) — React component:
+  apology, collapsible technical details, Reload / Downloads / Website actions.
+- [src/components/AppErrorBoundary.tsx](src/components/AppErrorBoundary.tsx) — classic error
+  boundary wrapping `<App />`, catches anything thrown during render / mount.
+- [src/main.tsx](src/main.tsx) — `window.error` + `unhandledrejection` listeners installed
+  before React mounts. A `reactMounted` flag gates them so they only inject static HTML into
+  `#root` when React isn't alive yet; once mounted, the error boundary takes over.
+- [src/index.css](src/index.css) — `.app-error-*` styles (red-tinted eyebrow, collapsible
+  `<pre>` for tech details, wrap-friendly action row).
+
+**Coverage:**
+- WebGL context creation failure in viewport mount → error boundary.
+- Missing Web API at init → global listener (pre-mount) or error boundary (post-mount).
+- Unhandled promise rejection during startup → `unhandledrejection` listener.
+- Late runtime error after app is running → error boundary.
+
 ### Suggested PR order
 
 1. Phase 2A — unblocks issue #56
-2. Phase 2B — prerequisite for reliable gestures in 2C
-3. Phase 2C
-4. Phase 2D
-5. Phase 2E
+2. Phase 2F — bundled with 2A (one PR)
+3. Phase 2B — prerequisite for reliable gestures in 2C
+4. Phase 2C
+5. Phase 2D
+6. Phase 2E

--- a/planning/TABLET_UX_Implementation_Plan.md
+++ b/planning/TABLET_UX_Implementation_Plan.md
@@ -195,3 +195,107 @@ Status bar, legends, and split handles are tuned for desktop density. The split 
 - All changes should be additive under the tablet breakpoint; desktop behavior must not regress.
 - Live device testing on an actual tablet should follow each item before it is marked done.
 - Pen input (Apple Pencil / stylus) should be validated separately from finger touch.
+
+---
+
+## Phase 2 Prioritization (tracks issue #56)
+
+Phase 1 (PR #53) landed Items 1, 3, and the banner-kbd subset of Item 4. Issue #56 reports
+that core interactions — particularly tab-into-distance-editing — are still unreachable on
+tablet. Remaining work is re-ordered by user impact and split into five PRs. Each PR is
+tablet-tested on device before the next begins.
+
+Note: paths in Items 2–7 predate the feature-tree / canvas / viewport folder refactor. The
+Phase 2 sub-items below use current paths.
+
+### Phase 2A — Editing reachability *(addresses #56 directly)*
+
+**Status:** `[ ] todo`
+
+**Goal:** Every edit entry point that today depends on Tab, double-click, or right-click has
+a visible, tappable equivalent.
+
+**Work:**
+- Sketch dimension labels: make the rendered dimension text tappable; tap calls
+  `triggerDimensionEdit()` with that dimension as context. Same code path the banner kbd
+  chips already use.
+  - [SketchCanvas.tsx:2871](src/components/canvas/SketchCanvas.tsx:2871) — existing `triggerDimensionEdit()`
+  - Dimension label rendering in the same file (drawn inside the main canvas render path;
+    currently no `onClick` / `pointerdown` on the text shapes)
+- Transform gizmo readouts (distance / angle / scale during move/rotate/resize): same
+  tap-to-edit treatment.
+- Feature tree row: explicit **Edit** button (pencil icon) on each row under
+  `pointer: coarse`, replacing the double-click entry into `FEATURE_EDIT`.
+  - [FeatureTree.tsx](src/components/feature-tree/FeatureTree.tsx) — add button alongside
+    existing visible/operation toggles
+- Feature tree row: **More (…)** button that opens the same menu today's `onContextMenu`
+  triggers, so right-click-only actions become tap-reachable.
+  - [FeatureTree.tsx:168](src/components/feature-tree/FeatureTree.tsx:168) — existing
+    `onContextMenu` handler; wire the same `onFeatureContextMenu` callback to a button.
+
+**Acceptance:**
+- On tablet, a user can enter a distance value for any pending add/move/transform without a
+  keyboard.
+- On tablet, every feature-tree row action available via right-click on desktop is reachable
+  via tap.
+
+### Phase 2B — Pointer events in sketch canvas
+
+**Status:** `[ ] todo`
+
+**Work:**
+- Migrate `onMouseDown` / `onMouseUp` / `onDoubleClick` / `onContextMenu` on the sketch
+  canvas to pointer events; keep mouse-button semantics (button 0 = select, button 2 =
+  context) inside the handler.
+- Long-press (configurable duration, ~500 ms) as the touch equivalent of right-click for any
+  context-menu surface that remains after 2A.
+- **Select multiple** mode toggle in the sketch toolbar so multi-select does not require
+  Shift/Ctrl. Toggle is sticky until explicitly turned off.
+
+**References:** [SketchCanvas.tsx](src/components/canvas/SketchCanvas.tsx) (look for all
+`onMouse*` / `onContextMenu` / `onDoubleClick` props on the root canvas element)
+
+### Phase 2C — 3D and simulation touch gestures
+
+**Status:** `[ ] todo`
+
+**Work:**
+- Pinch-to-zoom, two-finger pan, one-finger orbit in
+  [Viewport3D.tsx](src/components/viewport3d/Viewport3D.tsx) and
+  [SimulationViewport.tsx](src/components/simulation/SimulationViewport.tsx), using
+  `pointermove` with active-pointer tracking.
+- Pen input (pointerType === 'pen') is treated as a precise pointer — no orbit on contact,
+  same semantics as mouse hover + click.
+- Remove the unconditional `touchAction = 'none'` once real touch handlers exist; keep it
+  only on the gesture region.
+
+### Phase 2D — Reorder controls
+
+**Status:** `[ ] todo`
+
+**Work:**
+- Move up / Move down buttons on feature-tree rows and CAM operation rows, visible under
+  `pointer: coarse`, secondary on desktop.
+- Keep existing HTML drag-and-drop as a desktop enhancement.
+- References: [FeatureTree.tsx](src/components/feature-tree/FeatureTree.tsx),
+  [CAMPanel.tsx](src/components/CAMPanel.tsx)
+
+### Phase 2E — Toolbar split + chrome cleanup
+
+**Status:** `[ ] todo`
+
+**Work:**
+- Split [Toolbar.tsx](src/components/Toolbar.tsx) into a persistent top bar (file / view /
+  global) and a contextual rail / bottom sheet (creation / edit / alignment) that appears
+  when a sketch is active.
+- Backdrop and snap controls move into a collapsible overflow menu.
+- Status bar collapsible or auto-hide on tablet.
+- Verify sketch-canvas legend toggles hit 44 px on device.
+
+### Suggested PR order
+
+1. Phase 2A — unblocks issue #56
+2. Phase 2B — prerequisite for reliable gestures in 2C
+3. Phase 2C
+4. Phase 2D
+5. Phase 2E

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -803,7 +803,7 @@ function App() {
             playbackInput={simulationPlaybackInput}
           />
         }
-        featureTree={<FeatureTree onFeatureContextMenu={openFeatureContextMenu} onTabContextMenu={openTabContextMenu} onClampContextMenu={openClampContextMenu} />}
+        featureTree={<FeatureTree onFeatureContextMenu={openFeatureContextMenu} onTabContextMenu={openTabContextMenu} onClampContextMenu={openClampContextMenu} onEditFeature={handleEditSketch} onEditTab={handleEditTab} onEditClamp={handleEditClamp} />}
         propertiesPanel={<PropertiesPanel />}
         camPanel={
           <CAMPanel

--- a/src/components/AppErrorBoundary.tsx
+++ b/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
+import { ErrorScreen } from './ErrorScreen'
+
+interface State {
+  error: unknown
+  info: string | null
+}
+
+interface Props {
+  children: ReactNode
+}
+
+export class AppErrorBoundary extends Component<Props, State> {
+  state: State = { error: null, info: null }
+
+  static getDerivedStateFromError(error: unknown): State {
+    return { error, info: null }
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo) {
+    this.setState({ error, info: info.componentStack ?? null })
+    console.error('App crashed:', error, info)
+  }
+
+  render() {
+    if (this.state.error) {
+      return <ErrorScreen error={this.state.error} info={this.state.info ?? undefined} />
+    }
+    return this.props.children
+  }
+}

--- a/src/components/ErrorScreen.tsx
+++ b/src/components/ErrorScreen.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { formatError } from './errorFormat'
+
+interface ErrorScreenProps {
+  error: unknown
+  info?: string
+}
+
+export function ErrorScreen({ error, info }: ErrorScreenProps) {
+  const details = formatError(error, info)
+  return (
+    <main className="app-error-shell">
+      <div className="app-error-card">
+        <div className="app-error-eyebrow">Something went wrong</div>
+        <h1>Sorry &mdash; PureCut CNC couldn't start on this device.</h1>
+        <p>
+          This usually means your browser or operating system doesn't support
+          the 3D graphics features the app needs. Try a current version of
+          Chrome, Edge, or Firefox on a reasonably recent desktop or tablet, or
+          use one of our desktop builds.
+        </p>
+        <details className="app-error-details">
+          <summary>Show technical details</summary>
+          <pre>{details}</pre>
+        </details>
+        <div className="app-error-actions">
+          <button type="button" onClick={() => window.location.reload()}>
+            Reload
+          </button>
+          <a href="https://purecutcnc.github.io/downloads.html">Desktop Downloads</a>
+          <a href="https://purecutcnc.github.io/">Project Website</a>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -4286,6 +4286,15 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
                           : pendingAdd.currentMode === 'spline'
                             ? 'Click to add a spline segment endpoint. Press Tab to type length/angle. Click the first point to close, or press Enter to finish open.'
                             : 'Click to add connected line segments. Press Tab to type length/angle. Click the first point to close, or press Enter to finish open.'}
+            {(() => {
+              const canType =
+                ((pendingAdd.shape === 'rect' || pendingAdd.shape === 'circle' || pendingAdd.shape === 'tab' || pendingAdd.shape === 'clamp') && !!pendingAdd.anchor)
+                || ((pendingAdd.shape === 'polygon' || pendingAdd.shape === 'spline') && pendingAdd.points.length >= 1)
+                || (pendingAdd.shape === 'composite' && !!pendingAdd.start && !pendingAdd.closed)
+              return canType ? (
+                <> Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Type exact value" onClick={triggerDimensionEdit} onKeyDown={(e) => { if (e.key === 'Enter') triggerDimensionEdit() }}>Tab</kbd> to type exact value.</>
+              ) : null
+            })()}
             {' '}Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingAdd} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingAdd() }}>Esc</kbd> to cancel.
           </div>
           {pendingDraftHasSelfIntersection ? (

--- a/src/components/errorFormat.ts
+++ b/src/components/errorFormat.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function formatError(error: unknown, info?: string): string {
+  const parts: string[] = []
+  if (error instanceof Error) {
+    parts.push(`${error.name}: ${error.message}`)
+    if (error.stack) {
+      const frames = error.stack.split('\n').slice(0, 4).join('\n')
+      parts.push(frames)
+    }
+  } else if (typeof error === 'string') {
+    parts.push(error)
+  } else if (error) {
+    try {
+      parts.push(JSON.stringify(error))
+    } catch {
+      parts.push(String(error))
+    }
+  }
+  if (info) parts.push(info)
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown'
+  parts.push(`User agent: ${ua}`)
+  parts.push(`Timestamp: ${new Date().toISOString()}`)
+  return parts.join('\n\n')
+}
+
+export function renderErrorHTML(error: unknown, info?: string): string {
+  const details = formatError(error, info)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+  return `
+    <main class="app-error-shell">
+      <div class="app-error-card">
+        <div class="app-error-eyebrow">Something went wrong</div>
+        <h1>Sorry &mdash; PureCut CNC couldn't start on this device.</h1>
+        <p>
+          This usually means your browser or operating system doesn't support
+          the 3D graphics features the app needs. Try a current version of
+          Chrome, Edge, or Firefox on a reasonably recent desktop or tablet, or
+          use one of our desktop builds.
+        </p>
+        <details class="app-error-details">
+          <summary>Show technical details</summary>
+          <pre>${details}</pre>
+        </details>
+        <div class="app-error-actions">
+          <button type="button" onclick="window.location.reload()">Reload</button>
+          <a href="https://purecutcnc.github.io/downloads.html">Desktop Downloads</a>
+          <a href="https://purecutcnc.github.io/">Project Website</a>
+        </div>
+      </div>
+    </main>
+  `
+}

--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -22,9 +22,12 @@ interface FeatureTreeProps {
   onFeatureContextMenu?: (featureId: string, x: number, y: number) => void
   onTabContextMenu?: (tabId: string, x: number, y: number) => void
   onClampContextMenu?: (clampId: string, x: number, y: number) => void
+  onEditFeature?: (featureId: string) => void
+  onEditTab?: (tabId: string) => void
+  onEditClamp?: (clampId: string) => void
 }
 
-export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampContextMenu }: FeatureTreeProps) {
+export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampContextMenu, onEditFeature, onEditTab, onEditClamp }: FeatureTreeProps) {
   const {
     project,
     selection,
@@ -172,6 +175,13 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
           }
           onFeatureContextMenu?.(feature.id, event.clientX, event.clientY)
         }}
+        onEditEntry={onEditFeature ? () => onEditFeature(feature.id) : undefined}
+        onMoreMenu={onFeatureContextMenu ? (x, y) => {
+          if (!selection.selectedFeatureIds.includes(feature.id)) {
+            selectFeature(feature.id)
+          }
+          onFeatureContextMenu(feature.id, x, y)
+        } : undefined}
         draggable
         onDragStart={() => handleFeatureDragStart(feature.id)}
         onDragEnd={() => setDragItem(null)}
@@ -358,6 +368,11 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                   selectTab(tab.id)
                   onTabContextMenu?.(tab.id, event.clientX, event.clientY)
                 }}
+                onEditEntry={onEditTab ? () => onEditTab(tab.id) : undefined}
+                onMoreMenu={onTabContextMenu ? (x, y) => {
+                  selectTab(tab.id)
+                  onTabContextMenu(tab.id, x, y)
+                } : undefined}
               />
             ))}
           </div>
@@ -399,6 +414,11 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                   selectClamp(clamp.id)
                   onClampContextMenu?.(clamp.id, event.clientX, event.clientY)
                 }}
+                onEditEntry={onEditClamp ? () => onEditClamp(clamp.id) : undefined}
+                onMoreMenu={onClampContextMenu ? (x, y) => {
+                  selectClamp(clamp.id)
+                  onClampContextMenu(clamp.id, x, y)
+                } : undefined}
               />
             ))}
           </div>
@@ -431,6 +451,8 @@ interface TreeRowProps {
   onShowAll?: () => void
   onHideAll?: () => void
   onContextMenu?: (event: ReactMouseEvent<HTMLDivElement>) => void
+  onEditEntry?: () => void
+  onMoreMenu?: (x: number, y: number) => void
   draggable?: boolean
   onDragStart?: () => void
   onDragEnd?: () => void
@@ -461,6 +483,8 @@ function TreeRow({
   onShowAll,
   onHideAll,
   onContextMenu,
+  onEditEntry,
+  onMoreMenu,
   draggable,
   onDragStart,
   onDragEnd,
@@ -654,6 +678,37 @@ function TreeRow({
             <svg viewBox="0 0 14 14" width="12" height="12" focusable="false" aria-hidden="true" style={{ display: 'block' }}>
               <rect x="1.5" y="1.5" width="11" height="11" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.5" strokeDasharray="2.5 1.5" />
             </svg>
+          </button>
+        ) : null}
+        {onEditEntry ? (
+          <button
+            type="button"
+            className="tree-action-btn tree-action-btn--edit"
+            onClick={(event) => {
+              event.stopPropagation()
+              onEditEntry()
+            }}
+            title="Edit sketch"
+            aria-label="Edit sketch"
+          >
+            <svg viewBox="0 0 14 14" width="12" height="12" focusable="false" aria-hidden="true" style={{ display: 'block' }}>
+              <path fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" d="M1.5 12.5h2.5l7-7-2.5-2.5-7 7v2.5Zm7.5-9.5 2-2 2.5 2.5-2 2" />
+            </svg>
+          </button>
+        ) : null}
+        {onMoreMenu ? (
+          <button
+            type="button"
+            className="tree-action-btn tree-action-btn--more"
+            onClick={(event) => {
+              event.stopPropagation()
+              const rect = event.currentTarget.getBoundingClientRect()
+              onMoreMenu(rect.left, rect.bottom)
+            }}
+            title="More actions"
+            aria-label="More actions"
+          >
+            ⋯
           </button>
         ) : null}
         {onToggleVisible ? (

--- a/src/index.css
+++ b/src/index.css
@@ -128,3 +128,106 @@ input {
   color: var(--text);
   border: 1px solid var(--line);
 }
+
+.app-error-shell {
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background:
+    radial-gradient(circle at top, rgba(204, 90, 90, 0.16), transparent 36%),
+    linear-gradient(180deg, #091018 0%, #0a1016 100%);
+}
+
+.app-error-card {
+  width: min(100%, 40rem);
+  padding: 1.75rem;
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  background: rgba(16, 24, 33, 0.94);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+}
+
+.app-error-eyebrow {
+  margin-bottom: 0.85rem;
+  color: #d48484;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.app-error-card h1 {
+  margin: 0 0 0.85rem;
+  font-size: clamp(1.5rem, 5vw, 2rem);
+  line-height: 1.1;
+}
+
+.app-error-card p {
+  margin: 0 0 1rem;
+  color: var(--text-dim);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.app-error-details {
+  margin: 0.5rem 0 1rem;
+  color: var(--text-dim);
+  font-size: 0.85rem;
+}
+
+.app-error-details summary {
+  cursor: pointer;
+  user-select: none;
+  padding: 0.35rem 0;
+  color: var(--text);
+}
+
+.app-error-details pre {
+  margin: 0.5rem 0 0;
+  padding: 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 0.6rem;
+  background: rgba(9, 14, 20, 0.7);
+  color: var(--text-dim);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 18rem;
+  overflow: auto;
+}
+
+.app-error-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.app-error-actions button,
+.app-error-actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.7rem 1rem;
+  border-radius: 0.7rem;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.app-error-actions button {
+  background: var(--cut);
+  color: #071019;
+  border: none;
+}
+
+.app-error-actions a {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--line);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,10 +17,31 @@
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { AppErrorBoundary } from './components/AppErrorBoundary'
+import { renderErrorHTML } from './components/errorFormat'
 import { IconGalleryRoute } from './components/IconGallery'
 import { isDesktop } from './platform'
 import { installAnalytics } from './utils/analytics'
 import { applyVersionToTitle } from './utils/version'
+
+// Swap #root for a static error card if something throws before React mounts.
+// Once React is alive, AppErrorBoundary takes over — this flag prevents the
+// global listeners from clobbering a React-rendered tree.
+let reactMounted = false
+
+function showFatalErrorHTML(error: unknown, info?: string) {
+  if (reactMounted) return
+  const root = document.getElementById('root')
+  if (!root) return
+  root.innerHTML = renderErrorHTML(error, info)
+}
+
+window.addEventListener('error', (event) => {
+  showFatalErrorHTML(event.error ?? event.message, 'window error')
+})
+window.addEventListener('unhandledrejection', (event) => {
+  showFatalErrorHTML(event.reason, 'unhandled promise rejection')
+})
 
 // In the desktop app, the window title is managed by useDesktopIntegration
 // (showing filename + dirty flag). Only apply the version title in browser.
@@ -66,7 +87,12 @@ const isIconGalleryRoute =
 function rootElement() {
   if (isPhoneSizedTouchDevice()) return <UnsupportedMobileScreen />
   if (isIconGalleryRoute) return <IconGalleryRoute />
-  return <App />
+  return (
+    <AppErrorBoundary>
+      <App />
+    </AppErrorBoundary>
+  )
 }
 
 createRoot(document.getElementById('root')!).render(rootElement())
+reactMounted = true


### PR DESCRIPTION
## Summary

- **Phase 2A** of the tablet UX plan — makes editing reachable without mouse/keyboard, closing the core gap in [#56](https://github.com/PureCutCNC/purecutcnc/issues/56).
- **Phase 2F** (bundled out-of-band) — replaces the blank-page failure mode on older devices with a friendly error card.

Closes #56 once on-device testing passes.

## Phase 2A — Editing reachability

- `pendingAdd` banner now renders a clickable **Tab** kbd chip when `triggerDimensionEdit()` has something to act on (rect/circle/tab/clamp with anchor, polygon/spline with ≥1 point, composite with start set). Matches the existing pattern on `pendingMove`, `pendingTransform`, `pendingOffset` banners.
- Feature / tab / clamp tree rows gained:
  - ✏️ **Edit** button → routes through the existing `handleEditSketch` / `handleEditTab` / `handleEditClamp` handlers (same handler the context menu's "Edit Sketch" item uses).
  - **⋯ More** button → opens the same context menu right-click opens, anchored at the button's bottom-left rect, with the row auto-selected first.
- Both buttons reuse the existing `tree-action-btn` class so they inherit the 44 px touch target from Phase 1.

### Known gap (follow-up)

Sketch-edit mode still says "Hover a node and press Tab to type length/angle." — hover has no touch equivalent. Needs a tap-a-node-to-arm design in a separate PR.

## Phase 2F — Graceful error screen

Older desktops and tablets were showing blank pages when startup failed (most commonly WebGL context creation throwing inside `Viewport3D` / `SimulationViewport` on mount). We don't pick a support baseline; we just catch the failure.

- `src/components/errorFormat.ts` — shared `formatError` + `renderErrorHTML` helpers (error message, first 3 stack frames, `navigator.userAgent`, timestamp).
- `src/components/ErrorScreen.tsx` — React component: apology, collapsible technical details, Reload / Downloads / Website actions.
- `src/components/AppErrorBoundary.tsx` — classic error boundary wrapping `<App />`.
- `src/main.tsx` — `window.error` + `unhandledrejection` listeners installed before React mounts. A `reactMounted` flag gates them so they only inject static HTML into `#root` if React isn't alive yet; once mounted, the boundary takes over.
- `src/index.css` — `.app-error-*` styles.

### Coverage

| Failure mode | Caught by |
|---|---|
| WebGL context creation throws in viewport mount | Error boundary |
| Missing Web API during init (pre-mount) | Global `error` listener |
| Missing Web API during render (post-mount) | Error boundary |
| Unhandled promise rejection during startup | `unhandledrejection` listener |
| Late runtime error after app is running | Error boundary |

The one thing we still can't catch is browsers so old they can't parse the ES module bundle at all — that needs a `<script nomodule>` fallback, deferred unless we see the case in the wild.

## Test plan

- [x] On a recent desktop browser: app boots normally; feature tree rows show Edit + More buttons; existing right-click, visibility, operation toggles still work; dev Fast Refresh still works.
- [x] On tablet: create rect/circle/tab/clamp → "Tab" chip appears in banner → tap it → dimension input opens without a keyboard.
- [x] On tablet: tap Edit on a feature row → enters sketch edit mode.
- [x] On tablet: tap More on a feature row → context menu opens at the button; all actions work.
- [x] On tablet: tap More on a tab and clamp row → their context menus open correctly.
- [x] Simulate WebGL failure (devtools: disable WebGL, or throw from `Viewport3D` on mount) → error card appears with details, Reload button works.
- [x] Simulate pre-mount failure (throw from `installAnalytics` or similar early init) → error card appears via global listener.
- [x] Desktop regressions: right-click on tree rows still works; double-click on canvas still enters sketch edit; keyboard Tab still opens dimension input.