### PR TITLE
Boot watchdog: static fallback when module bundle fails to parse

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,32 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      // Boot watchdog: if the ES module bundle fails to parse or execute on
+      // older browsers (e.g. iPad 4 / iOS 10), main.tsx never runs and the
+      // React error boundary never mounts — #root stays empty. This inline
+      // ES5 script detects that case and shows a static fallback card.
+      // Cleared by main.tsx once React renders successfully.
+      (function () {
+        var TIMEOUT_MS = 3000
+        window.__pcBootWatchdog = window.setTimeout(function () {
+          var root = document.getElementById('root')
+          if (!root || root.firstChild) return
+          root.innerHTML =
+            '<main style="min-height:100%;display:flex;align-items:center;justify-content:center;padding:1.5rem;background:#0a1016;color:#d8e4ef;font-family:\'Segoe UI\',sans-serif;">' +
+              '<div style="width:min(100%,32rem);padding:1.75rem;border:1px solid #2a3a49;border-radius:1rem;background:#101821;box-shadow:0 24px 60px rgba(0,0,0,0.35);">' +
+                '<div style="margin-bottom:0.85rem;color:#d48484;font-size:0.74rem;font-weight:800;letter-spacing:0.14em;text-transform:uppercase;">Unsupported Browser</div>' +
+                '<h1 style="margin:0 0 0.85rem;font-size:1.6rem;line-height:1.2;">Sorry &mdash; PureCut CNC could not start on this device.</h1>' +
+                '<p style="margin:0 0 1rem;color:#94aabc;font-size:1rem;line-height:1.6;">Your browser or operating system is too old to run this app. Try a current version of Chrome, Edge, or Firefox on a recent desktop or tablet, or use one of our desktop builds.</p>' +
+                '<div style="display:flex;flex-wrap:wrap;gap:0.6rem;margin-top:1rem;">' +
+                  '<a href="https://purecutcnc.github.io/downloads.html" style="display:inline-flex;align-items:center;justify-content:center;min-height:2.75rem;padding:0.7rem 1rem;border-radius:0.7rem;background:#5a8fcc;color:#071019;font-weight:700;text-decoration:none;">Desktop Downloads</a>' +
+                  '<a href="https://purecutcnc.github.io/" style="display:inline-flex;align-items:center;justify-content:center;min-height:2.75rem;padding:0.7rem 1rem;border-radius:0.7rem;background:transparent;color:#d8e4ef;border:1px solid #2a3a49;font-weight:700;text-decoration:none;">Project Website</a>' +
+                '</div>' +
+              '</div>' +
+            '</main>'
+        }, TIMEOUT_MS)
+      })()
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/planning/TABLET_UX_Implementation_Plan.md
+++ b/planning/TABLET_UX_Implementation_Plan.md
@@ -321,6 +321,27 @@ now capture the failure and show a friendly screen.
 - Unhandled promise rejection during startup → `unhandledrejection` listener.
 - Late runtime error after app is running → error boundary.
 
+### Phase 2G — Boot watchdog for module parse failures
+
+**Status:** `[x] done` — landed in `worktree-boot-watchdog`.
+
+Out-of-band follow-up to 2F: an old iPad (4th gen, iOS 10) still showed a blank page after
+PR #57 merged. Cause: iOS 10 Safari can parse `<script type="module">` but chokes on modern
+JS syntax Vite emits (optional chaining, nullish coalescing, BigInt, private class fields).
+When the module bundle fails to parse, `main.tsx` never runs, the `error` listener and the
+`reactMounted` flag never install, and `#root` stays empty.
+
+**Done:**
+- [index.html](index.html) — inline (non-module, ES5) watchdog script runs before the
+  module tag, sets a 3 s timeout. If `#root` is still empty when the timeout fires, it
+  injects a static fallback card with inline styles (external CSS may also fail to load).
+- [src/main.tsx](src/main.tsx) — clears `window.__pcBootWatchdog` after `createRoot().render()`
+  so the fallback never fires on healthy boots.
+
+This catches module parse errors, network errors, and any other failure where JS can't
+reach the `reactMounted = true` line. Only a browser that can't run *any* JavaScript at all
+would still see a blank page — at which point there's nothing more we can do.
+
 ### Suggested PR order
 
 1. Phase 2A — unblocks issue #56

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -96,3 +96,14 @@ function rootElement() {
 
 createRoot(document.getElementById('root')!).render(rootElement())
 reactMounted = true
+
+// Clear the index.html boot watchdog: React is alive, no fallback needed.
+declare global {
+  interface Window {
+    __pcBootWatchdog?: number
+  }
+}
+if (typeof window !== 'undefined' && window.__pcBootWatchdog !== undefined) {
+  window.clearTimeout(window.__pcBootWatchdog)
+  window.__pcBootWatchdog = undefined
+}


### PR DESCRIPTION
## Summary

Follow-up to #57. An old iPad (4th gen, iOS 10) still showed a blank page after #57 merged: iOS 10 Safari can parse \`<script type=\"module\">\` but chokes on modern JS syntax Vite emits (optional chaining, nullish coalescing, BigInt, private class fields). When the module bundle fails to parse, \`main.tsx\` never runs, the \`error\` listener never installs, \`reactMounted\` never flips, and \`#root\` stays empty — none of the #57 machinery can help.

This PR adds a last-resort watchdog that runs before any module code.

## What changed

- **`index.html`** — inline (non-module, ES5) script runs before the module tag, sets a 3 s timeout. If `#root` is still empty when it fires, it injects a static fallback card with **inline styles** (external CSS may also fail to load on the same browsers).
- **`src/main.tsx`** — clears `window.__pcBootWatchdog` immediately after `createRoot().render()`, so the fallback never fires on a healthy boot.

## Coverage matrix (this PR + #57)

| Failure mode | Caught by |
|---|---|
| WebGL context creation throws in viewport mount | #57 error boundary |
| Missing Web API during init (pre-mount) | #57 global `error` listener |
| Missing Web API during render (post-mount) | #57 error boundary |
| Unhandled promise rejection during startup | #57 `unhandledrejection` listener |
| Late runtime error after app is running | #57 error boundary |
| **Module bundle fails to parse (iOS 10 Safari, etc.)** | **This PR** |
| Network error fetching bundle | This PR |

The only remaining blank-page case is a browser that can't execute any JavaScript at all — at which point there's nothing more we can do.

## Tradeoffs

- **3 s delay** before the fallback shows on failing devices. User sees blank briefly. Dialable; 3 s gives slow devices time to actually boot.
- Inline CSS in the fallback HTML (duplication with `.app-error-*` styles, but required since the stylesheet may also fail).
- One more thing to maintain. Small.

## Test plan

- [ ] Healthy desktop boot: no flash of the fallback card; app renders normally within 3 s.
- [ ] Slow boot (throttle CPU in devtools to 6×): fallback still doesn't fire because `reactMounted` clears the timeout before 3 s.
- [ ] Simulate module parse failure: edit the built bundle to include invalid syntax, or block it via devtools → fallback card appears after ~3 s.
- [ ] Old iPad 4 / iOS 10: **the actual target case** — confirm card appears instead of blank screen.
- [ ] Links in the fallback card are clickable and work.