### PR TITLE
Fix desktop close and quit flow in worktrees

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,27 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[derive(Default)]
+struct ExitCoordinator {
+  exit_confirmed: AtomicBool,
+  exit_request_pending: AtomicBool,
+}
+
+#[tauri::command]
+fn request_app_exit(app: tauri::AppHandle, exit_coordinator: tauri::State<ExitCoordinator>) {
+  exit_coordinator.exit_request_pending.store(false, Ordering::SeqCst);
+  exit_coordinator.exit_confirmed.store(true, Ordering::SeqCst);
+  app.exit(0);
+}
+
+#[tauri::command]
+fn cancel_app_exit_request(exit_coordinator: tauri::State<ExitCoordinator>) {
+  exit_coordinator.exit_request_pending.store(false, Ordering::SeqCst);
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  tauri::Builder::default()
+  let app = tauri::Builder::default()
+    .manage(ExitCoordinator::default())
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(
@@ -22,6 +43,7 @@ pub fn run() {
       let export_i     = MenuItem::with_id(app, "export_gcode","Export G-code\u{2026}", true, Some("CmdOrCtrl+E"))?;
       let undo_i       = MenuItem::with_id(app, "undo",        "Undo",             true, Some("CmdOrCtrl+Z"))?;
       let redo_i       = MenuItem::with_id(app, "redo",        "Redo",             true, Some("CmdOrCtrl+Shift+Z"))?;
+      let quit_i       = MenuItem::with_id(app, "quit",        "Quit PureCutCNC",  true, Some("CmdOrCtrl+Q"))?;
 
       // macOS app menu — must be the FIRST submenu; macOS replaces its label
       // with the running app name automatically.
@@ -34,7 +56,7 @@ pub fn run() {
         &PredefinedMenuItem::hide_others(app, None)?,
         &PredefinedMenuItem::show_all(app, None)?,
         &PredefinedMenuItem::separator(app)?,
-        &PredefinedMenuItem::quit(app, None)?,
+        &quit_i,
       ])?;
 
       let file_menu = Submenu::with_id_and_items(app, "file", "File", true, &[
@@ -71,8 +93,34 @@ pub fn run() {
         let _ = window.emit("menu", event.id().0.as_str().to_string());
       }
     })
+    .invoke_handler(tauri::generate_handler![request_app_exit, cancel_app_exit_request])
     .plugin(tauri_plugin_dialog::init())
     .plugin(tauri_plugin_fs::init())
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    .build(tauri::generate_context!())
+    .expect("error while building tauri application");
+
+  app.run(|app_handle, event| {
+    if let tauri::RunEvent::ExitRequested { api, .. } = event {
+      use tauri::{Emitter, Manager};
+
+      let exit_coordinator = app_handle.state::<ExitCoordinator>();
+      if exit_coordinator.exit_confirmed.swap(false, Ordering::SeqCst) {
+        exit_coordinator.exit_request_pending.store(false, Ordering::SeqCst);
+        return;
+      }
+
+      let Some(window) = app_handle.get_webview_window("main") else {
+        exit_coordinator.exit_request_pending.store(false, Ordering::SeqCst);
+        return;
+      };
+
+      api.prevent_exit();
+
+      if exit_coordinator.exit_request_pending.swap(true, Ordering::SeqCst) {
+        return;
+      }
+
+      let _ = window.emit("app-exit-requested", ());
+    }
+  });
 }

--- a/src/platform/useDesktopIntegration.ts
+++ b/src/platform/useDesktopIntegration.ts
@@ -93,29 +93,58 @@ export function useDesktopIntegration({ onExportGcode }: DesktopIntegrationOptio
     const cleanups: (() => void)[] = []
 
     async function setup() {
-      const [{ getCurrentWindow }, { listen }, { readTextFile }] = await Promise.all([
+      const [{ getCurrentWindow }, { listen }, { readTextFile }, { invoke }] = await Promise.all([
         import('@tauri-apps/api/window'),
         import('@tauri-apps/api/event'),
         import('@tauri-apps/plugin-fs'),
+        import('@tauri-apps/api/core'),
       ])
       if (isCancelled) return
 
       const win = getCurrentWindow()
+      let exitFlowActive = false
+
+      async function handleAppExitRequest() {
+        if (exitFlowActive) {
+          return
+        }
+
+        exitFlowActive = true
+        try {
+          const { dirty: currentDirty } = useProjectStore.getState()
+          const ok = !currentDirty || await platform.confirmDiscardChanges()
+
+          if (!ok) {
+            await invoke('cancel_app_exit_request').catch(() => {})
+            return
+          }
+
+          await invoke('request_app_exit')
+        } catch (error) {
+          await invoke('cancel_app_exit_request').catch(() => {})
+          alert(error instanceof Error ? error.message : 'Failed to close the application.')
+        } finally {
+          exitFlowActive = false
+        }
+      }
 
       // -- Window close prompt -----------------------------------------------
-      // Always preventDefault so we control the close flow explicitly.
+      // Route window-close through the same app-exit path as Quit / Cmd+Q.
       const unlistenClose = await win.onCloseRequested(async (event) => {
         event.preventDefault()
-        const { dirty: currentDirty } = useProjectStore.getState()
-        if (currentDirty) {
-          const ok = await platform.confirmDiscardChanges()
-          if (ok) await win.destroy()
-        } else {
-          await win.destroy()
-        }
+        await handleAppExitRequest()
       })
       if (isCancelled) { unlistenClose(); return }
       cleanups.push(unlistenClose)
+
+      // -- App exit requests -------------------------------------------------
+      // Quit / Cmd+Q can bypass window-close semantics, so intercept the app
+      // exit request emitted by the Rust shell and re-use the same dirty check.
+      const unlistenAppExit = await listen('app-exit-requested', async () => {
+        await handleAppExitRequest()
+      })
+      if (isCancelled) { unlistenAppExit(); return }
+      cleanups.push(unlistenAppExit)
 
       // -- Native menu events ------------------------------------------------
       const unlistenMenu = await listen<string>('menu', async (event) => {
@@ -166,6 +195,9 @@ export function useDesktopIntegration({ onExportGcode }: DesktopIntegrationOptio
           }
           case 'export_gcode':
             onExportGcodeRef.current()
+            break
+          case 'quit':
+            await handleAppExitRequest()
             break
           case 'select_all': {
             const visibleIds = store.project.features

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { existsSync } from 'node:fs'
+import { existsSync, realpathSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineConfig, searchForWorkspaceRoot } from 'vite'
@@ -31,6 +31,11 @@ const sharedProjectRoot = candidateSharedRoots.find((candidate) => (
   existsSync(resolve(candidate, 'package.json')) && existsSync(resolve(candidate, 'node_modules'))
 )) ?? configDir
 
+const nodeModulesPath = resolve(configDir, 'node_modules')
+const resolvedNodeModulesRoot = existsSync(nodeModulesPath)
+  ? realpathSync(nodeModulesPath)
+  : null
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
@@ -42,6 +47,7 @@ export default defineConfig({
       allow: [
         searchForWorkspaceRoot(configDir),
         sharedProjectRoot,
+        ...(resolvedNodeModulesRoot ? [resolvedNodeModulesRoot] : []),
       ],
     },
   },


### PR DESCRIPTION
## Summary
- route desktop window close and app quit through a shared dirty-check exit flow
- keep app-level exit requests cancellable from the frontend so close and Quit/Cmd+Q behave consistently
- allow the real symlinked node_modules path in Vite dev server fs access so manifold.wasm loads from a worktree

## Testing
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml --target-dir /tmp/purecutcnc-close-fix-cargo-target
- curl -I http://127.0.0.1:1420/@fs/Users/frankp/Projects/purecutcnc/node_modules/manifold-3d/manifold.wasm
