### PR TITLE
feat: add keep-originals copy support to rotate

### DIFF
--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -256,6 +256,9 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const drawFrameRef = useRef<number | null>(null)
   const drawRef = useRef<() => void>(() => {})
   const [copyCountDraft, setCopyCountDraft] = useState('1')
+  const [rotateCopyCountDraft, setRotateCopyCountDraft] = useState('1')
+  const [pendingRotateCopyPoint, setPendingRotateCopyPoint] = useState<Point | null>(null)
+  const rotateCopyCountInputRef = useRef<HTMLInputElement>(null)
   const [viewState, setViewState] = useState<SketchViewState>({ zoom: 1, panX: 0, panY: 0 })
   const [backdropImage, setBackdropImage] = useState<HTMLImageElement | null>(null)
   const [stlImageRevision, setStlImageRevision] = useState(0)
@@ -338,6 +341,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     setPendingTransformReferenceEnd,
     completePendingTransform,
     cancelPendingTransform,
+    setPendingTransformKeepOriginals,
     completePendingOffset,
     cancelPendingOffset,
     completePendingShapeAction,
@@ -352,6 +356,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     updateConstraintValue,
   } = useProjectStore()
   const copyCountPromptActive = pendingMove?.mode === 'copy' && !!pendingMove.fromPoint && !!pendingMove.toPoint
+  const rotateCopyCountPromptActive = !!pendingRotateCopyPoint
   const projectRef = useRef(project)
   const selectionRef = useRef(selection)
   const pendingAddRef = useRef(pendingAdd)
@@ -1495,6 +1500,19 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   }, [copyCountPromptActive])
 
   useEffect(() => {
+    if (!rotateCopyCountPromptActive) {
+      return
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      rotateCopyCountInputRef.current?.focus({ preventScroll: true })
+      rotateCopyCountInputRef.current?.select()
+    })
+
+    return () => window.cancelAnimationFrame(frame)
+  }, [rotateCopyCountPromptActive])
+
+  useEffect(() => {
     if (!dimensionEdit) return
     const inputRef =
       dimensionEdit.activeField === 'width' ? widthInputRef
@@ -1676,7 +1694,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   }, [])
 
   useEffect(() => {
-    if (copyCountPromptActive) {
+    if (copyCountPromptActive || rotateCopyCountPromptActive) {
       return
     }
 
@@ -1693,7 +1711,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     })
 
     return () => window.cancelAnimationFrame(frame)
-  }, [copyCountPromptActive, operationDimEdit, pendingMove, pendingTransform, pendingOffset, pendingShapeAction, selection.mode, selection.selectedFeatureId, selection.selectedFeatureIds.length])
+  }, [copyCountPromptActive, rotateCopyCountPromptActive, operationDimEdit, pendingMove, pendingTransform, pendingOffset, pendingShapeAction, selection.mode, selection.selectedFeatureId, selection.selectedFeatureIds.length])
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -1711,7 +1729,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     return () => {
       canvas.removeEventListener('pointermove', handleNativePointerMove)
     }
-  }, [copyCountPromptActive, pendingMove, pendingTransform, selection.mode, selection.selectedFeatureId, selection.selectedFeatureIds.length, zoomWindowActive])
+  }, [copyCountPromptActive, rotateCopyCountPromptActive, pendingMove, pendingTransform, selection.mode, selection.selectedFeatureId, selection.selectedFeatureIds.length, zoomWindowActive])
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -2674,6 +2692,8 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       } else if (!pendingTransform.referenceEnd) {
         setPendingTransformReferenceEnd(snapped)
         setPendingTransformPreviewPointRef({ point: snapped, session: pendingTransform.session })
+      } else if (pendingTransform.mode === 'rotate' && pendingTransform.keepOriginals) {
+        setPendingRotateCopyPoint(constrainedPoint)
       } else {
         completePendingTransform(constrainedPoint)
         setPendingTransformPreviewPointRef(null)
@@ -3478,6 +3498,8 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     if (event.key === 'Escape' && pendingTransform) {
       cancelPendingTransform()
       setPendingTransformPreviewPointRef(null)
+      setPendingRotateCopyPoint(null)
+      setRotateCopyCountDraft('1')
       setOperationDimEdit(null)
       return
     }
@@ -4220,8 +4242,12 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
                     pt.referenceEnd,
                     angleDegrees,
                   )
-                  completePendingTransform(previewPoint)
-                  setPendingTransformPreviewPointRef(null)
+                  if (pt.keepOriginals) {
+                    setPendingRotateCopyPoint(previewPoint)
+                  } else {
+                    completePendingTransform(previewPoint)
+                    setPendingTransformPreviewPointRef(null)
+                  }
                   setOperationDimEdit(null)
                 } else if (e.key === 'Escape') {
                   e.preventDefault()
@@ -4488,7 +4514,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           )}
         </div>
       )}
-      {pendingTransform && (
+      {pendingTransform && !rotateCopyCountPromptActive && (
         <div className="sketch-place-banner">
           <span>{pendingTransform.mode === 'resize'
             ? !pendingTransform.referenceStart
@@ -4500,12 +4526,63 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
               ? 'Click the rotation origin.'
               : !pendingTransform.referenceEnd
                 ? 'Click the reference direction point.'
-                : 'Move to preview the rotated feature, then click to commit.'}</span>
+                : pendingTransform.keepOriginals
+                  ? 'Move to preview the rotated copy, then click to set angle.'
+                  : 'Move to preview the rotated feature, then click to commit.'}</span>
+          {pendingTransform.mode === 'rotate' && pendingTransform.referenceStart && pendingTransform.referenceEnd && (
+            <label className="sketch-place-toggle">
+              <input
+                type="checkbox"
+                checked={pendingTransform.keepOriginals}
+                onChange={(event) => setPendingTransformKeepOriginals(event.target.checked)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Escape') {
+                    event.preventDefault()
+                    cancelPendingTransform()
+                    setPendingTransformPreviewPointRef(null)
+                  }
+                }}
+              />
+              <span>Keep originals</span>
+            </label>
+          )}
           {((pendingTransform.mode === 'resize' && pendingTransform.referenceStart && pendingTransform.referenceEnd)
             || (pendingTransform.mode === 'rotate' && pendingTransform.referenceStart && pendingTransform.referenceEnd)) && (
             <> Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title={pendingTransform.mode === 'resize' ? 'Type scale factor' : 'Type exact angle'} onClick={triggerDimensionEdit} onKeyDown={(e) => { if (e.key === 'Enter') triggerDimensionEdit() }}>Tab</kbd> to type {pendingTransform.mode === 'resize' ? 'scale factor' : 'exact angle'}.</>
           )}
-          {' '}Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingTransform} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingTransform() }}>Esc</kbd> to cancel.
+          {' '}Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={() => { cancelPendingTransform(); setPendingTransformPreviewPointRef(null) }} onKeyDown={(e) => { if (e.key === 'Enter') { cancelPendingTransform(); setPendingTransformPreviewPointRef(null) } }}>Esc</kbd> to cancel.
+        </div>
+      )}
+      {rotateCopyCountPromptActive && pendingTransform && (
+        <div className="sketch-place-banner">
+          <span>Copies</span>
+          <input
+            ref={rotateCopyCountInputRef}
+            className="sketch-place-count"
+            type="text"
+            inputMode="numeric"
+            value={rotateCopyCountDraft}
+            onChange={(event) => setRotateCopyCountDraft(event.target.value.replace(/[^\d]/g, ''))}
+            onFocus={(event) => event.currentTarget.select()}
+            onKeyDown={(event) => {
+              event.stopPropagation()
+              if (event.key === 'Enter') {
+                const n = Math.max(1, Math.floor(Number(rotateCopyCountDraft) || 1))
+                completePendingTransform(pendingRotateCopyPoint!, n)
+                setPendingTransformPreviewPointRef(null)
+                setPendingRotateCopyPoint(null)
+                setRotateCopyCountDraft('1')
+              } else if (event.key === 'Escape') {
+                event.preventDefault()
+                cancelPendingTransform()
+                setPendingTransformPreviewPointRef(null)
+                setPendingRotateCopyPoint(null)
+                setRotateCopyCountDraft('1')
+              }
+            }}
+            autoFocus
+          />
+          <span>Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm" onClick={() => { const n = Math.max(1, Math.floor(Number(rotateCopyCountDraft) || 1)); completePendingTransform(pendingRotateCopyPoint!, n); setPendingTransformPreviewPointRef(null); setPendingRotateCopyPoint(null); setRotateCopyCountDraft('1') }} onKeyDown={(e) => { if (e.key === 'Enter') { const n = Math.max(1, Math.floor(Number(rotateCopyCountDraft) || 1)); completePendingTransform(pendingRotateCopyPoint!, n); setPendingTransformPreviewPointRef(null); setPendingRotateCopyPoint(null); setRotateCopyCountDraft('1') } }}>Enter</kbd> to confirm, <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={() => { cancelPendingTransform(); setPendingTransformPreviewPointRef(null); setPendingRotateCopyPoint(null); setRotateCopyCountDraft('1') }} onKeyDown={(e) => { if (e.key === 'Enter') { cancelPendingTransform(); setPendingTransformPreviewPointRef(null); setPendingRotateCopyPoint(null); setRotateCopyCountDraft('1') } }}>Esc</kbd> to cancel.</span>
         </div>
       )}
     </div>

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1814,6 +1814,47 @@ function fallbackOperationTarget(project: Project, kind: OperationKind): Operati
     : { source: 'stock' }
 }
 
+function buildRotatedCopies(
+  sourceFeatures: SketchFeature[],
+  existingFeatures: SketchFeature[],
+  pivot: Point,
+  angle: number,
+  count: number,
+): SketchFeature[] {
+  const created: SketchFeature[] = []
+  const projectLike: Project = { ...newProject(), features: existingFeatures, tools: [], operations: [] }
+
+  for (let step = 1; step <= count; step += 1) {
+    const stepAngle = angle * step
+    const rotatePoint = (point: Point) => rotatePointAround(point, pivot, stepAngle)
+    for (const sourceFeature of sourceFeatures) {
+      const nextId = nextUniqueGeneratedId(
+        { ...projectLike, features: [...existingFeatures, ...created] },
+        'f',
+      )
+      const profile = transformProfile(sourceFeature.sketch.profile, rotatePoint)
+      created.push({
+        ...sourceFeature,
+        id: nextId,
+        name: duplicateFeatureName(sourceFeature.name, [...existingFeatures, ...created], count, step),
+        folderId: sourceFeature.folderId,
+        stl: transformStlFeatureData(sourceFeature.stl, rotatePoint),
+        sketch: {
+          ...sourceFeature.sketch,
+          origin: rotatePoint(sourceFeature.sketch.origin),
+          orientationAngle: normalizeAngleDegrees(
+            (sourceFeature.sketch.orientationAngle ?? inferProfileOrientationAngle(sourceFeature.sketch.profile)) + stepAngle * (180 / Math.PI),
+          ),
+          profile,
+        },
+        locked: false,
+      })
+    }
+  }
+
+  return created
+}
+
 function buildCopiedFeatures(
   sourceFeatures: SketchFeature[],
   existingFeatures: SketchFeature[],
@@ -2502,6 +2543,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
     buildCopiedFeatures,
     buildCopiedClamps,
     buildCopiedTabs,
+    buildRotatedCopies,
     resizeBackdropFromReference,
     rotateBackdropFromReference,
     resizeFeatureFromReference,

--- a/src/store/slices/pendingActionsSlice.ts
+++ b/src/store/slices/pendingActionsSlice.ts
@@ -44,6 +44,7 @@ export type PendingActionsSlice = Pick<
   | 'cancelPendingTransform'
   | 'cancelPendingShapeAction'
   | 'setPendingShapeActionKeepOriginals'
+  | 'setPendingTransformKeepOriginals'
   | 'cancelPendingOffset'
   | 'setPendingMoveFrom'
   | 'setPendingMoveTo'
@@ -150,7 +151,7 @@ export function createPendingActionsSlice(
         return {
           pendingAdd: null,
           pendingMove: null,
-          pendingTransform: { mode: 'resize', entityType: 'feature', entityIds: featureIds, referenceStart: null, referenceEnd: null, session: nextPlacementSession() },
+          pendingTransform: { mode: 'resize', entityType: 'feature', entityIds: featureIds, referenceStart: null, referenceEnd: null, keepOriginals: false, session: nextPlacementSession() },
           pendingOffset: null,
           pendingShapeAction: null,
           sketchEditSession: null,
@@ -181,7 +182,7 @@ export function createPendingActionsSlice(
         return {
           pendingAdd: null,
           pendingMove: null,
-          pendingTransform: { mode: 'rotate', entityType: 'feature', entityIds: featureIds, referenceStart: null, referenceEnd: null, session: nextPlacementSession() },
+          pendingTransform: { mode: 'rotate', entityType: 'feature', entityIds: featureIds, referenceStart: null, referenceEnd: null, keepOriginals: false, session: nextPlacementSession() },
           pendingOffset: null,
           pendingShapeAction: null,
           sketchEditSession: null,
@@ -231,7 +232,7 @@ export function createPendingActionsSlice(
         return {
           pendingAdd: null,
           pendingMove: null,
-          pendingTransform: { mode: 'resize', entityType: 'backdrop', entityIds: [], referenceStart: null, referenceEnd: null, session: nextPlacementSession() },
+          pendingTransform: { mode: 'resize', entityType: 'backdrop', entityIds: [], referenceStart: null, referenceEnd: null, keepOriginals: false, session: nextPlacementSession() },
           pendingOffset: null,
           pendingShapeAction: null,
           sketchEditSession: null,
@@ -256,7 +257,7 @@ export function createPendingActionsSlice(
         return {
           pendingAdd: null,
           pendingMove: null,
-          pendingTransform: { mode: 'rotate', entityType: 'backdrop', entityIds: [], referenceStart: null, referenceEnd: null, session: nextPlacementSession() },
+          pendingTransform: { mode: 'rotate', entityType: 'backdrop', entityIds: [], referenceStart: null, referenceEnd: null, keepOriginals: false, session: nextPlacementSession() },
           pendingOffset: null,
           pendingShapeAction: null,
           sketchEditSession: null,
@@ -440,6 +441,11 @@ export function createPendingActionsSlice(
     cancelPendingMove: () => set({ pendingMove: null }),
 
     cancelPendingTransform: () => set({ pendingTransform: null }),
+
+    setPendingTransformKeepOriginals: (keepOriginals) =>
+      set((s) => ({
+        pendingTransform: s.pendingTransform ? { ...s.pendingTransform, keepOriginals } : null,
+      })),
 
     cancelPendingShapeAction: () => set({ pendingShapeAction: null }),
 

--- a/src/store/slices/pendingCompletionSlice.ts
+++ b/src/store/slices/pendingCompletionSlice.ts
@@ -81,6 +81,13 @@ export interface PendingCompletionSliceDependencies {
     referenceEnd: Point,
     previewPoint: Point,
   ) => SketchFeature | null
+  buildRotatedCopies: (
+    sourceFeatures: SketchFeature[],
+    existingFeatures: SketchFeature[],
+    pivot: Point,
+    angle: number,
+    copyCount: number,
+  ) => SketchFeature[]
   previewOffsetFeatures: (project: Project, featureIds: string[], distance: number) => SketchFeature[]
   syncFeatureTreeProject: (project: Project) => Project
   createDerivedFeature: (
@@ -342,7 +349,7 @@ export function createPendingCompletionSlice(
         }
       }),
 
-    completePendingTransform: (previewPoint) =>
+    completePendingTransform: (previewPoint, copyCount = 1) =>
       set((s) => {
         const pendingTransform = s.pendingTransform
         if (!pendingTransform?.referenceStart || !pendingTransform.referenceEnd) {
@@ -389,6 +396,61 @@ export function createPendingCompletionSlice(
           .filter((feature): feature is SketchFeature => feature !== null)
         if (sourceFeatures.length !== pendingTransform.entityIds.length) {
           return { pendingTransform: null }
+        }
+
+        // Rotate+copy: keep originals and add rotated copies
+        if (pendingTransform.mode === 'rotate' && pendingTransform.keepOriginals) {
+          const startVector = {
+            x: pendingTransform.referenceEnd.x - pendingTransform.referenceStart.x,
+            y: pendingTransform.referenceEnd.y - pendingTransform.referenceStart.y,
+          }
+          const endVector = {
+            x: previewPoint.x - pendingTransform.referenceStart.x,
+            y: previewPoint.y - pendingTransform.referenceStart.y,
+          }
+          const cross = startVector.x * endVector.y - startVector.y * endVector.x
+          const dot = startVector.x * endVector.x + startVector.y * endVector.y
+          const angle = Math.atan2(cross, dot)
+          if (!Number.isFinite(angle) || Math.abs(angle) < 1e-9) {
+            return { pendingTransform: null }
+          }
+          const normalizedCopyCount = Math.max(1, Math.floor(copyCount))
+          const createdFeatures = deps.buildRotatedCopies(
+            sourceFeatures,
+            s.project.features,
+            pendingTransform.referenceStart,
+            angle,
+            normalizedCopyCount,
+          )
+          if (createdFeatures.length === 0) {
+            return { pendingTransform: null }
+          }
+          const nextProject = {
+            ...s.project,
+            features: [...s.project.features, ...createdFeatures],
+            featureTree: [
+              ...s.project.featureTree,
+              ...createdFeatures.map((feature) => ({ type: 'feature' as const, featureId: feature.id })),
+            ],
+            meta: { ...s.project.meta, modified: new Date().toISOString() },
+          }
+          return {
+            project: nextProject,
+            pendingTransform: null,
+            selection: {
+              ...s.selection,
+              selectedFeatureId: createdFeatures.at(-1)?.id ?? s.selection.selectedFeatureId,
+              selectedFeatureIds: createdFeatures.map((f) => f.id),
+              selectedNode: createdFeatures.at(-1)
+                ? { type: 'feature', featureId: createdFeatures.at(-1)!.id }
+                : s.selection.selectedNode,
+            },
+            history: {
+              past: [...s.history.past, deps.cloneProject(s.project)].slice(-100),
+              future: [],
+              transactionStart: null,
+            },
+          }
         }
 
         const transformedFeatures = new Map<string, SketchFeature>()

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -130,6 +130,7 @@ export interface PendingTransformTool {
   entityIds: string[]
   referenceStart: Point | null
   referenceEnd: Point | null
+  keepOriginals: boolean
   session: number
 }
 
@@ -364,7 +365,8 @@ export interface ProjectStore {
   cancelPendingTransform: () => void
   setPendingTransformReferenceStart: (point: Point) => void
   setPendingTransformReferenceEnd: (point: Point) => void
-  completePendingTransform: (previewPoint: Point) => void
+  setPendingTransformKeepOriginals: (keepOriginals: boolean) => void
+  completePendingTransform: (previewPoint: Point, copyCount?: number) => void
 
   addRectFeature: (name: string, x: number, y: number, w: number, h: number, depth: number) => void
   addCircleFeature: (name: string, cx: number, cy: number, r: number, depth: number) => void


### PR DESCRIPTION
## Summary

Extends the rotate tool to support copying — keeping the original features in place and producing one or more rotated copies.

## Changes

### `store/types.ts`
- Added `keepOriginals: boolean` to `PendingTransformTool`
- Added `setPendingTransformKeepOriginals` action signature
- Updated `completePendingTransform` to accept an optional `copyCount` parameter

### `store/slices/pendingActionsSlice.ts`
- Initialises `keepOriginals: false` on all `PendingTransformTool` instances (rotate + resize, feature + backdrop)
- Implements `setPendingTransformKeepOriginals` action

### `store/slices/pendingCompletionSlice.ts`
- Added `buildRotatedCopies` to the deps interface
- When `keepOriginals` is true on a rotate, `completePendingTransform` calls `buildRotatedCopies` to produce `copyCount` cumulative rotated copies (step `i` applies `angle × i`) and appends them to the project, leaving the originals untouched

### `store/projectStore.ts`
- Added `buildRotatedCopies` function — mirrors `buildCopiedFeatures` but applies incremental rotation around the pivot instead of translation
- Wired into the `pendingCompletionSlice` deps

### `components/canvas/SketchCanvas.tsx`
- Added `rotateCopyCountDraft`, `pendingRotateCopyPoint` state and `rotateCopyCountInputRef`
- Added `rotateCopyCountPromptActive` computed flag
- Added focus effect for the rotate copy count input
- Updated canvas focus / pointermove effects to yield when `rotateCopyCountPromptActive`
- Click handler: when `keepOriginals` is true at the commit step, stores the resolved point in `pendingRotateCopyPoint` instead of committing immediately
- Tab / dim-edit Enter handler for rotate also checks `keepOriginals` before committing
- Escape handler clears `pendingRotateCopyPoint` and resets the draft count
- Banner: shows a **Keep originals** checkbox once both rotate reference points are set; when the flag is on and the angle is committed, replaces the banner with the copy-count input (same pattern as the copy-move flow), defaulting to 1

## Flow

1. Start rotate as normal — click origin, click reference direction point.
2. Move to preview the rotation. A **Keep originals** checkbox appears in the banner.
3. Check **Keep originals**, then click to lock in the angle.
4. A copy-count input appears (default 1). Enter the desired count and press Enter.
5. The originals stay in place; `count` evenly-spaced rotated copies are added.