### PR TITLE
Reduce retractions and improve ordering for V-carve toolpaths

### DIFF
--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -1387,8 +1387,6 @@ export function CAMPanel({
                     </label>
                   ) : null}
                   {(selectedOperation.kind === 'pocket'
-                    || selectedOperation.kind === 'v_carve'
-                    || selectedOperation.kind === 'v_carve_recursive'
                     || selectedOperation.kind === 'edge_route_inside'
                     || selectedOperation.kind === 'edge_route_outside') ? (
                     <label className="properties-field">

--- a/src/engine/toolpaths/vcarve.ts
+++ b/src/engine/toolpaths/vcarve.ts
@@ -15,12 +15,93 @@
  */
 
 import ClipperLib from 'clipper-lib'
-import type { Operation, Project } from '../../types/project'
+import type { Operation, Point, Project } from '../../types/project'
 import type { ToolpathBounds, ToolpathMove, ToolpathPoint, ToolpathResult } from './types'
 import { applyContourDirection, checkMaxCutDepthWarning, getOperationSafeZ, normalizeToolForProject } from './geometry'
 import { isFeatureFirst, mergeToolpathResults, perFeatureOperations } from './multiFeature'
-import { buildContourLoops, buildInsetRegions, contourStartPoint, pushRapidAndPlunge, retractToSafe, toClosedCutMoves, updateBounds } from './pocket'
+import { buildContourLoops, buildInsetRegions, contourStartPoint, retractToSafe, toClosedCutMoves, transitionToCutEntry, updateBounds } from './pocket'
 import { resolvePocketRegions } from './resolver'
+
+function regionCentroid(region: { outer: Point[] }): { x: number; y: number } {
+  let sx = 0
+  let sy = 0
+  for (const p of region.outer) { sx += p.x; sy += p.y }
+  const n = region.outer.length || 1
+  return { x: sx / n, y: sy / n }
+}
+
+function sortRegionsNearestNeighbor<T extends { outer: Point[] }>(
+  regions: T[],
+  currentPosition: ToolpathPoint | null,
+): T[] {
+  if (regions.length <= 1) return regions
+  const remaining = regions.slice()
+  const sorted: T[] = []
+  let curX = currentPosition?.x ?? 0
+  let curY = currentPosition?.y ?? 0
+
+  while (remaining.length > 0) {
+    let bestIdx = 0
+    let bestDist = Infinity
+    for (let i = 0; i < remaining.length; i++) {
+      const c = regionCentroid(remaining[i])
+      const d = Math.hypot(c.x - curX, c.y - curY)
+      if (d < bestDist) { bestDist = d; bestIdx = i }
+    }
+    const chosen = remaining.splice(bestIdx, 1)[0]
+    const c = regionCentroid(chosen)
+    curX = c.x
+    curY = c.y
+    sorted.push(chosen)
+  }
+  return sorted
+}
+
+/**
+ * Re-order contours so each starts as close as possible (in XY) to where
+ * the previous one ended.  Closed contours are rotated so the nearest
+ * vertex becomes the entry point.
+ */
+function sortContoursNearestNeighbor(
+  contours: Point[][],
+  currentPosition: ToolpathPoint | null,
+): Point[][] {
+  if (contours.length <= 1) return contours
+
+  const remaining = contours.slice()
+  const sorted: Point[][] = []
+  let curX = currentPosition?.x ?? 0
+  let curY = currentPosition?.y ?? 0
+
+  while (remaining.length > 0) {
+    let bestIdx = 0
+    let bestDist = Infinity
+    let bestVertexIdx = 0
+
+    for (let i = 0; i < remaining.length; i++) {
+      const contour = remaining[i]
+      for (let j = 0; j < contour.length; j++) {
+        const d = Math.hypot(contour[j].x - curX, contour[j].y - curY)
+        if (d < bestDist) {
+          bestDist = d
+          bestIdx = i
+          bestVertexIdx = j
+        }
+      }
+    }
+
+    const chosen = remaining.splice(bestIdx, 1)[0]
+    const rotated = bestVertexIdx > 0
+      ? [...chosen.slice(bestVertexIdx), ...chosen.slice(0, bestVertexIdx)]
+      : chosen
+    sorted.push(rotated)
+
+    curX = rotated[0].x
+    curY = rotated[0].y
+  }
+
+  return sorted
+}
 
 function computeBounds(moves: ToolpathMove[]): ToolpathBounds | null {
   let bounds: ToolpathBounds | null = null
@@ -133,31 +214,47 @@ function generateVCarveToolpathSingle(project: Project, operation: Operation): T
     }
 
     const vcarveJoinType = ClipperLib.JoinType.jtRound
-    let currentDepth = Math.min(stepoverDistance / slope, maxBandDepth)
-    let currentRegions = band.regions.flatMap((region) => buildInsetRegions(region, currentDepth * slope, vcarveJoinType))
+    const sortedRegions = sortRegionsNearestNeighbor(band.regions, currentPosition)
 
-    while (currentRegions.length > 0 && currentDepth <= maxBandDepth + 1e-9) {
-      const rawContours = buildContourLoops(currentRegions)
-      if (rawContours.length === 0) {
-        break
-      }
+    for (const region of sortedRegions) {
+      let currentDepth = Math.min(stepoverDistance / slope, maxBandDepth)
+      let currentRegions = buildInsetRegions(region, currentDepth * slope, vcarveJoinType)
 
-      const contours = applyContourDirection(rawContours, direction)
-      const z = band.topZ - currentDepth
-      for (const contour of contours) {
-        const entryPoint = contourStartPoint(contour, z)
-        const safePosition = retractToSafe(moves, currentPosition, safeZ)
-        currentPosition = pushRapidAndPlunge(moves, safePosition, entryPoint, safeZ)
-        const cutMoves = toClosedCutMoves(contour, z)
-        moves.push(...cutMoves)
-        currentPosition = cutMoves.at(-1)?.to ?? currentPosition
-        currentPosition = retractToSafe(moves, currentPosition, safeZ)
+      while (currentRegions.length > 0 && currentDepth <= maxBandDepth + 1e-9) {
+        const rawContours = buildContourLoops(currentRegions)
+        if (rawContours.length === 0) {
+          break
+        }
+
+        const contours = sortContoursNearestNeighbor(
+          applyContourDirection(rawContours, direction),
+          currentPosition,
+        )
+        const z = band.topZ - currentDepth
+        for (const contour of contours) {
+          const entryPoint = contourStartPoint(contour, z)
+          // For cross-Z transitions (between depth levels) use a generous link
+          // budget so the tool ramps diagonally to the next level rather than
+          // retracting.  Curved features like "C" can shift the entry point
+          // significantly between levels, so 8 × stepover is needed.
+          // For same-Z transitions (multiple counter-loops at the same depth)
+          // always retract: a direct cut between disjoint loops would gouge
+          // across the gap and ruin the work piece.
+          const isCrossZ = currentPosition !== null && Math.abs(currentPosition.z - z) > 1e-6
+          const linkBudget = isCrossZ ? stepoverDistance * 8 : 0
+          currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, linkBudget)
+          const cutMoves = toClosedCutMoves(contour, z)
+          moves.push(...cutMoves)
+          currentPosition = cutMoves.at(-1)?.to ?? currentPosition
+        }
+        currentDepth += stepoverDistance / slope
+        if (currentDepth > maxBandDepth + 1e-9) {
+          break
+        }
+        currentRegions = currentRegions.flatMap((r) => buildInsetRegions(r, stepoverDistance, vcarveJoinType))
       }
-      currentDepth += stepoverDistance / slope
-      if (currentDepth > maxBandDepth + 1e-9) {
-        break
-      }
-      currentRegions = currentRegions.flatMap((region) => buildInsetRegions(region, stepoverDistance, vcarveJoinType))
+      // Retract once after completing all depth levels for this region.
+      currentPosition = retractToSafe(moves, currentPosition, safeZ)
     }
   }
 

--- a/src/engine/toolpaths/vcarveRecursive.ts
+++ b/src/engine/toolpaths/vcarveRecursive.ts
@@ -2516,6 +2516,46 @@ function rotateClosedPath(path: Path3D, startIdx: number): Path3D {
 }
 
 // ---------------------------------------------------------------------------
+// Region ordering — nearest-neighbour sort to complete each region before
+// moving to the next, minimising long-distance rapids between letters.
+// ---------------------------------------------------------------------------
+
+function sortRegionsNearestNeighbor<T extends { outer: { x: number; y: number }[] }>(
+  regions: T[],
+  currentPosition: { x: number; y: number } | null,
+): T[] {
+  if (regions.length <= 1) return regions
+  const remaining = regions.slice()
+  const sorted: T[] = []
+  let curX = currentPosition?.x ?? 0
+  let curY = currentPosition?.y ?? 0
+
+  while (remaining.length > 0) {
+    let bestIdx = 0
+    let bestDist = Infinity
+    for (let i = 0; i < remaining.length; i++) {
+      const outer = remaining[i].outer
+      let sx = 0
+      let sy = 0
+      for (const p of outer) { sx += p.x; sy += p.y }
+      const n = outer.length || 1
+      const d = Math.hypot(sx / n - curX, sy / n - curY)
+      if (d < bestDist) { bestDist = d; bestIdx = i }
+    }
+    const chosen = remaining.splice(bestIdx, 1)[0]
+    const outer = chosen.outer
+    let sx = 0
+    let sy = 0
+    for (const p of outer) { sx += p.x; sy += p.y }
+    const n = outer.length || 1
+    curX = sx / n
+    curY = sy / n
+    sorted.push(chosen)
+  }
+  return sorted
+}
+
+// ---------------------------------------------------------------------------
 // Path ordering — nearest-neighbour sort to minimise rapid travel
 // ---------------------------------------------------------------------------
 
@@ -2539,9 +2579,20 @@ function rotateClosedPath(path: Path3D, startIdx: number): Path3D {
  * Only XY distance is used for cost: all rapids happen at safeZ so the Z
  * component of path endpoints does not contribute to air-travel time.
  */
+/**
+ * Sort cost: if this orientation can be entered without a retraction (same Z
+ * within noise tolerance, XY within link budget) the cost is the raw XY
+ * distance.  Otherwise a large fixed penalty is added, making every
+ * no-retraction candidate beat every retraction candidate regardless of
+ * XY distance — while still ordering among candidates of the same class by
+ * proximity.
+ */
+const RETRACT_SORT_PENALTY = 1e6
+
 function sortPathsNearestNeighbor(
   paths: Path3D[],
-  startXY: { x: number; y: number } | null,
+  startXY: { x: number; y: number; z?: number } | null,
+  maxLinkDistance = 0,
 ): Path3D[] {
   if (paths.length === 0) return []
 
@@ -2553,14 +2604,31 @@ function sortPathsNearestNeighbor(
     return Math.hypot(last.x - first.x, last.y - first.y) < 1e-6
   }
 
+  /** Cost of reaching `entry` from the current position.  A direct-link
+   *  (no retraction) transition costs just the XY distance; a retraction
+   *  transition gets a large penalty so that any directly-linkable path is
+   *  always preferred over any path requiring a retraction. */
+  function cost(xyDist: number, entryZ: number, curZ: number | undefined): number {
+    if (
+      maxLinkDistance > 0
+      && curZ !== undefined
+      && entryZ <= curZ + 2e-3   // same depth or going deeper — diagonal cut is safe
+      && xyDist <= maxLinkDistance
+    ) {
+      return xyDist                        // direct link — no retraction
+    }
+    return xyDist + RETRACT_SORT_PENALTY   // retraction required
+  }
+
   const remaining = paths.slice()
   const ordered: Path3D[] = []
   let curX = startXY?.x ?? 0
   let curY = startXY?.y ?? 0
+  let curZ = startXY?.z           // undefined until first path is chosen
 
   while (remaining.length > 0) {
     let bestIdx       = 0
-    let bestDist      = Infinity
+    let bestCost      = Infinity
     let bestReverse   = false
     let bestRotateIdx = -1  // -1 = no rotation; ≥0 = rotate so this vertex becomes path[0]
 
@@ -2581,30 +2649,36 @@ function sortPathsNearestNeighbor(
             closestIdx  = j
           }
         }
-        const d   = closestDist
-        const rev = false  // reversal meaningless for a closed loop
-        // Store rotateIdx only if rotation is needed (non-zero index)
-        const rotateIdx = closestIdx > 0 ? closestIdx : -1
-
-        if (d < bestDist) {
-          bestDist      = d
+        const c = cost(closestDist, path[closestIdx].z, curZ)
+        if (c < bestCost) {
+          bestCost      = c
           bestIdx       = i
-          bestReverse   = rev
-          bestRotateIdx = rotateIdx
+          bestReverse   = false
+          bestRotateIdx = closestIdx > 0 ? closestIdx : -1
         }
       } else {
-        // Open path — try both forward and reverse orientation
+        // Open path — try both orientations; prefer whichever can be entered
+        // without a retraction, and break ties by XY distance.
         const distToStart = Math.hypot(first.x - curX, first.y - curY)
-        const distToEnd   = Math.hypot(last.x - curX, last.y - curY)
+        const distToEnd   = Math.hypot(last.x - curX,  last.y - curY)
 
-        const d   = Math.min(distToStart, distToEnd)
-        const rev = distToEnd < distToStart
+        const costFwd = cost(distToStart, first.z, curZ)
+        const costRev = cost(distToEnd,   last.z,  curZ)
 
-        if (d < bestDist) {
-          bestDist      = d
-          bestIdx       = i
-          bestReverse   = rev
-          bestRotateIdx = -1  // no rotation for open paths
+        if (costFwd <= costRev) {
+          if (costFwd < bestCost) {
+            bestCost      = costFwd
+            bestIdx       = i
+            bestReverse   = false
+            bestRotateIdx = -1
+          }
+        } else {
+          if (costRev < bestCost) {
+            bestCost      = costRev
+            bestIdx       = i
+            bestReverse   = true
+            bestRotateIdx = -1
+          }
         }
       }
     }
@@ -2628,6 +2702,7 @@ function sortPathsNearestNeighbor(
     const tail = emitted[emitted.length - 1]
     curX = tail.x
     curY = tail.y
+    curZ = tail.z
   }
 
   return ordered
@@ -2647,7 +2722,8 @@ function pathsToMoves(
   const chainedPaths = chainPaths(paths)
   const chained = sortPathsNearestNeighbor(
     chainedPaths,
-    startPosition ? { x: startPosition.x, y: startPosition.y } : null,
+    startPosition ?? null,   // pass full XYZ so the sort can prefer no-retraction orientations
+    maxLinkDistance,
   )
 
   for (let pi = 0; pi < chained.length; pi++) {
@@ -2672,12 +2748,11 @@ function pathsToMoves(
         })
       }
       // If Z is identical, no transition move is needed
-    } else if (pos.z === entry.z && maxLinkDistance > 0) {
-      // Same Z, different XY — if the gap is short enough, cut directly
-      // instead of retracting.  The nearest-neighbour sort already places
-      // paths close together, so most gaps are within a few stepSizes.
-      // Using the same budget as the direct-connect heuristic (4 × stepSize)
-      // ensures we only link genuinely adjacent paths.
+    } else if (maxLinkDistance > 0 && entry.z <= pos.z + 2e-3) {
+      // Entry is at the same depth or going deeper (within 2 mil float noise),
+      // different XY — cut directly if the gap is within the link budget.
+      // Going deeper is always safe: the tool is cutting into already-grooved
+      // material.  Rising moves (entry.z > pos.z + 2e-3) require a retract.
       const dx = entry.x - pos.x
       const dy = entry.y - pos.y
       const dist = Math.hypot(dx, dy)
@@ -2688,9 +2763,7 @@ function pathsToMoves(
         pos = pushRapidAndPlunge(moves, pos, entry, safeZ)
       }
     } else {
-      // Different Z or gap exceeds maxLinkDistance — retract and plunge.
-      // Direct-link cuts across disconnected XY were shown to produce
-      // spurious diagonal gouges across the interior of letter A (move [29]).
+      // Entry is shallower (rising Z) or gap exceeds maxLinkDistance — retract.
       pos = retractToSafe(moves, pos, safeZ)
       pos = pushRapidAndPlunge(moves, pos, entry, safeZ)
     }
@@ -2810,10 +2883,14 @@ function generateVCarveRecursiveToolpathSingle(project: Project, operation: Oper
       continue
     }
 
-    for (const region of band.regions) {
+    const sortedRegions = sortRegionsNearestNeighbor(band.regions, currentPosition)
+    for (const region of sortedRegions) {
       const paths: Path3D[] = []
       traceRegion(region, band.topZ, slope, maxBandDepth, stepSize, 0, 0, paths)
-      currentPosition = pathsToMoves(paths, safeZ, moves, currentPosition, stepSize * 4)
+      // Link budget: 12 × stepSize covers same-Z adjacent arms that the NN
+      // sort places consecutively.  Per-region ordering (above) ensures these
+      // are locally adjacent skeleton arms, not cross-letter jumps.
+      currentPosition = pathsToMoves(paths, safeZ, moves, currentPosition, stepSize * 12)
     }
   }
 


### PR DESCRIPTION
## Summary

- **Letter-by-letter ordering**: both offset and skeleton generators now process regions (letters) in nearest-neighbour order, fully completing each letter before moving to the next.
- **Offset — smarter level transitions**: adjacent depth levels ramp diagonally (8× stepover link budget) instead of retracting between every contour. Same-Z transitions between disjoint counter-loops (e.g. inner loops of a letter) still retract to avoid gouging.
- **Skeleton — Z-aware linking**: the nearest-neighbour sort and the direct-link check now allow diagonal cuts when the next path is at the same depth or deeper. Retractions are only emitted when the tool would need to rise to reach the next path entry, which eliminates most of the short retract-plunge sequences previously visible on the machine.
- **UI cleanup**: removed the non-functional "Machining Order" control from the V-carve and skeleton operation panels (ordering is now automatic).

## Test plan

- [x] Open the test project (`purecutcnc.camj`) and preview both V-carve Offset and V-carve Skeleton operations — confirm letters are machined one at a time
- [x] Verify Offset op: no retraction between consecutive depth levels on curved letters (N, C, P, etc.)
- [x] Verify Skeleton op: significantly fewer short retract+plunge sequences; most closely-spaced skeleton arms link with a direct cut
- [x] Verify Offset op: counter-loops (inner loops on letters like B, P, R) still retract correctly — no gouging cuts across the gap
- [x] Check that the Machining Order field no longer appears for V-carve or Skeleton operations in the CAM panel
- [x] `npm run build` passes cleanly