### PR TITLE
fix: UI polish — styled dropdowns, scrollbars, stock colour, operation panel cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -811,7 +811,7 @@ function App() {
             playbackInput={simulationPlaybackInput}
           />
         }
-        featureTree={<FeatureTree onFeatureContextMenu={openFeatureContextMenu} onTabContextMenu={openTabContextMenu} onClampContextMenu={openClampContextMenu} onEditTab={handleEditTab} onEditClamp={handleEditClamp} />}
+        featureTree={<FeatureTree onFeatureContextMenu={openFeatureContextMenu} onTabContextMenu={openTabContextMenu} onClampContextMenu={openClampContextMenu} />}
         propertiesPanel={<PropertiesPanel />}
         camPanel={
           <CAMPanel

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+
+export interface SelectOption<T extends string> {
+  value: T
+  label: string
+}
+
+interface SelectProps<T extends string> {
+  value: T
+  options: SelectOption<T>[]
+  onChange: (value: T) => void
+  disabled?: boolean
+}
+
+export function Select<T extends string>({ value, options, onChange, disabled }: SelectProps<T>) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const selectedLabel = options.find((o) => o.value === value)?.label ?? value
+
+  useEffect(() => {
+    if (!open) return
+    function handlePointerDown(event: PointerEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('pointerdown', handlePointerDown)
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown)
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  return (
+    <div ref={rootRef} className={`ui-select ${open ? 'ui-select--open' : ''} ${disabled ? 'ui-select--disabled' : ''}`}>
+      <button
+        type="button"
+        className="ui-select__trigger"
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setOpen((v) => !v) }
+          if (e.key === 'ArrowDown') { e.preventDefault(); setOpen(true) }
+          if (e.key === 'Escape') setOpen(false)
+        }}
+      >
+        <span className="ui-select__label">{selectedLabel}</span>
+        <span className="ui-select__arrow" aria-hidden="true" />
+      </button>
+      {open && (
+        <div className="ui-select__dropdown" role="listbox">
+          {options.map((option) => (
+            <div
+              key={option.value}
+              className={`ui-select__option ${option.value === value ? 'ui-select__option--selected' : ''}`}
+              role="option"
+              aria-selected={option.value === value}
+              onPointerDown={(e) => {
+                e.preventDefault()
+                onChange(option.value)
+                setOpen(false)
+              }}
+            >
+              {option.label}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -19,10 +19,9 @@ import type { DragEvent } from 'react'
 import type { SelectionState } from '../../store/types'
 import { useProjectStore } from '../../store/projectStore'
 import { loadBundledToolLibrary, type ToolLibraryEntry } from '../../toolLibrary'
+import { Select } from '../Select'
 import type {
-  CutDirection,
   DrillType,
-  MachiningOrder,
   OperationKind,
   OperationPass,
   PocketPattern,
@@ -334,6 +333,16 @@ function pocketPatternLabel(pattern: PocketPattern): string {
 
 function operationRequiresClosedProfiles(kind: OperationKind): boolean {
   return kind === 'pocket' || kind === 'v_carve' || kind === 'v_carve_recursive' || kind === 'edge_route_inside' || kind === 'edge_route_outside' || kind === 'surface_clean'
+}
+
+function showStepdown(operation: Project['operations'][number]): boolean {
+  if (operation.kind === 'v_carve' || operation.kind === 'v_carve_recursive' || operation.kind === 'drilling') {
+    return false
+  }
+  if ((operation.kind === 'edge_route_inside' || operation.kind === 'edge_route_outside') && operation.pass === 'finish') {
+    return false
+  }
+  return true
 }
 
 function getValidOperationTarget(project: Project, selection: SelectionState, kind: OperationKind): OperationTarget | null {
@@ -1333,13 +1342,14 @@ export function CAMPanel({
                   {selectedOperation.kind !== 'v_carve' && selectedOperation.kind !== 'v_carve_recursive' && selectedOperation.kind !== 'drilling' && selectedOperation.kind !== 'rough_surface' && selectedOperation.kind !== 'finish_surface' ? (
                     <label className="properties-field">
                       <span>Pass</span>
-                      <select
+                      <Select
                         value={selectedOperation.pass}
-                        onChange={(event) => updateOperation(selectedOperation.id, { pass: event.target.value as OperationPass })}
-                      >
-                        <option value="rough">Rough</option>
-                        <option value="finish">Finish</option>
-                      </select>
+                        options={[
+                          { value: 'rough', label: 'Rough' },
+                          { value: 'finish', label: 'Finish' },
+                        ]}
+                        onChange={(value) => updateOperation(selectedOperation.id, { pass: value })}
+                      />
                     </label>
                   ) : null}
                   {selectedOperation.kind === 'v_carve' || selectedOperation.kind === 'v_carve_recursive' ? (
@@ -1356,13 +1366,14 @@ export function CAMPanel({
                   {selectedOperation.kind === 'pocket' || selectedOperation.kind === 'surface_clean' ? (
                     <label className="properties-field">
                       <span>Pattern</span>
-                      <select
+                      <Select
                         value={selectedOperation.pocketPattern}
-                        onChange={(event) => updateOperation(selectedOperation.id, { pocketPattern: event.target.value as PocketPattern })}
-                      >
-                        <option value="offset">{pocketPatternLabel('offset')}</option>
-                        <option value="parallel">{pocketPatternLabel('parallel')}</option>
-                      </select>
+                        options={[
+                          { value: 'offset', label: pocketPatternLabel('offset') },
+                          { value: 'parallel', label: pocketPatternLabel('parallel') },
+                        ]}
+                        onChange={(value) => updateOperation(selectedOperation.id, { pocketPattern: value })}
+                      />
                     </label>
                   ) : null}
                   {(selectedOperation.kind === 'pocket' || selectedOperation.kind === 'surface_clean' || selectedOperation.kind === 'finish_surface') && selectedOperation.pocketPattern === 'parallel' ? (
@@ -1377,13 +1388,14 @@ export function CAMPanel({
                   {(selectedOperation.kind === 'pocket' || selectedOperation.kind === 'edge_route_inside' || selectedOperation.kind === 'edge_route_outside' || selectedOperation.kind === 'v_carve' || selectedOperation.kind === 'surface_clean' || selectedOperation.kind === 'rough_surface' || selectedOperation.kind === 'finish_surface') ? (
                     <label className="properties-field">
                       <span>Cut Direction</span>
-                      <select
+                      <Select
                         value={selectedOperation.cutDirection ?? 'conventional'}
-                        onChange={(event) => updateOperation(selectedOperation.id, { cutDirection: event.target.value as CutDirection })}
-                      >
-                        <option value="conventional">Conventional</option>
-                        <option value="climb">Climb</option>
-                      </select>
+                        options={[
+                          { value: 'conventional', label: 'Conventional' },
+                          { value: 'climb', label: 'Climb' },
+                        ]}
+                        onChange={(value) => updateOperation(selectedOperation.id, { cutDirection: value })}
+                      />
                     </label>
                   ) : null}
                   {(selectedOperation.kind === 'pocket'
@@ -1393,13 +1405,14 @@ export function CAMPanel({
                     || selectedOperation.kind === 'edge_route_outside') ? (
                     <label className="properties-field">
                       <span>Machining Order</span>
-                      <select
+                      <Select
                         value={selectedOperation.machiningOrder ?? 'level_first'}
-                        onChange={(event) => updateOperation(selectedOperation.id, { machiningOrder: event.target.value as MachiningOrder })}
-                      >
-                        <option value="feature_first">Feature first</option>
-                        <option value="level_first">Level first</option>
-                      </select>
+                        options={[
+                          { value: 'feature_first', label: 'Feature first' },
+                          { value: 'level_first', label: 'Level first' },
+                        ]}
+                        onChange={(value) => updateOperation(selectedOperation.id, { machiningOrder: value })}
+                      />
                     </label>
                   ) : null}
                   {selectedOperation.kind === 'follow_line' ? (
@@ -1417,15 +1430,16 @@ export function CAMPanel({
                     <>
                       <label className="properties-field">
                         <span>Drill Type</span>
-                        <select
+                        <Select
                           value={selectedOperation.drillType ?? 'simple'}
-                          onChange={(event) => updateOperation(selectedOperation.id, { drillType: event.target.value as DrillType })}
-                        >
-                          <option value="simple">{drillTypeLabel('simple')}</option>
-                          <option value="peck">{drillTypeLabel('peck')}</option>
-                          <option value="dwell">{drillTypeLabel('dwell')}</option>
-                          <option value="chip_breaking">{drillTypeLabel('chip_breaking')}</option>
-                        </select>
+                          options={[
+                            { value: 'simple', label: drillTypeLabel('simple') },
+                            { value: 'peck', label: drillTypeLabel('peck') },
+                            { value: 'dwell', label: drillTypeLabel('dwell') },
+                            { value: 'chip_breaking', label: drillTypeLabel('chip_breaking') },
+                          ]}
+                          onChange={(value) => updateOperation(selectedOperation.id, { drillType: value })}
+                        />
                       </label>
                       {(selectedOperation.drillType === 'peck' || selectedOperation.drillType === 'chip_breaking') ? (
                         <label className="properties-field">
@@ -1510,7 +1524,7 @@ export function CAMPanel({
                   {(selectedOperation.kind === 'pocket' || selectedOperation.kind === 'edge_route_inside' || selectedOperation.kind === 'edge_route_outside') ? (
                     <div className="properties-field">
                       <span>Rest Machining</span>
-                      <button className="feat-btn feat-btn--primary" type="button" onClick={handleCreateRestOperation}>
+                      <button className="feat-btn" type="button" onClick={handleCreateRestOperation}>
                         Create rest operation
                       </button>
                       {operationActionMessage?.operationId === selectedOperation.id ? (
@@ -1540,17 +1554,24 @@ export function CAMPanel({
                   ) : null}
                   <label className="properties-field">
                     <span>Tool</span>
-                    <select
+                    <Select
                       value={selectedOperation.toolRef ?? ''}
-                      onChange={(event) => {
-                        const newToolId = event.target.value || null
-                        const newTool = newToolId ? project.tools.find((t) => t.id === newToolId) ?? null : null
+                      options={[
+                        { value: '', label: 'No Tool' },
+                        ...(selectedOperation.kind === 'v_carve' || selectedOperation.kind === 'v_carve_recursive'
+                          ? project.tools.filter((tool) => tool.type === 'v_bit')
+                          : project.tools
+                        ).map((tool) => ({ value: tool.id, label: tool.name })),
+                      ]}
+                      onChange={(newToolId) => {
+                        const id = newToolId || null
+                        const newTool = id ? project.tools.find((t) => t.id === id) ?? null : null
                         const toolInProjectUnits = newTool && newTool.units !== project.meta.units
                           ? convertToolUnits(newTool, project.meta.units)
                           : newTool
                         const isVCarve = selectedOperation.kind === 'v_carve' || selectedOperation.kind === 'v_carve_recursive'
                         updateOperation(selectedOperation.id, {
-                          toolRef: newToolId,
+                          toolRef: id,
                           ...(toolInProjectUnits ? {
                             feed: toolInProjectUnits.defaultFeed,
                             plungeFeed: toolInProjectUnits.defaultPlungeFeed,
@@ -1563,17 +1584,7 @@ export function CAMPanel({
                           } : {}),
                         })
                       }}
-                    >
-                      <option value="">No Tool</option>
-                      {(selectedOperation.kind === 'v_carve' || selectedOperation.kind === 'v_carve_recursive'
-                        ? project.tools.filter((tool) => tool.type === 'v_bit')
-                        : project.tools
-                      ).map((tool) => (
-                        <option key={tool.id} value={tool.id}>
-                          {tool.name}
-                        </option>
-                      ))}
-                    </select>
+                    />
                   </label>
                   <label className="properties-check">
                     <input
@@ -1583,7 +1594,7 @@ export function CAMPanel({
                     />
                     <span>Enabled</span>
                   </label>
-                  {selectedOperation.kind !== 'v_carve' && selectedOperation.kind !== 'v_carve_recursive' && selectedOperation.kind !== 'drilling' ? (
+                  {showStepdown(selectedOperation) ? (
                     <label className="properties-field">
                       <span>Stepdown</span>
                       <DraftLengthInput
@@ -1836,31 +1847,30 @@ export function CAMPanel({
                       </label>
                       <label className="properties-field">
                         <span>Type</span>
-                        <select
+                        <Select
                           value={selectedTool.type}
-                          onChange={(event) => {
-                            const nextType = event.target.value as ToolType
-                            updateTool(selectedTool.id, {
-                              type: nextType,
-                              vBitAngle: nextType === 'v_bit' ? (selectedTool.vBitAngle ?? 60) : null,
-                            })
-                          }}
-                        >
-                          <option value="flat_endmill">Flat Endmill</option>
-                          <option value="ball_endmill">Ball Endmill</option>
-                          <option value="v_bit">V-Bit</option>
-                          <option value="drill">Drill</option>
-                        </select>
+                          options={[
+                            { value: 'flat_endmill', label: 'Flat Endmill' },
+                            { value: 'ball_endmill', label: 'Ball Endmill' },
+                            { value: 'v_bit', label: 'V-Bit' },
+                            { value: 'drill', label: 'Drill' },
+                          ]}
+                          onChange={(nextType) => updateTool(selectedTool.id, {
+                            type: nextType,
+                            vBitAngle: nextType === 'v_bit' ? (selectedTool.vBitAngle ?? 60) : null,
+                          })}
+                        />
                       </label>
                       <label className="properties-field">
                         <span>Units</span>
-                        <select
+                        <Select
                           value={selectedTool.units}
-                          onChange={(event) => updateTool(selectedTool.id, convertToolUnits(selectedTool, event.target.value as Tool['units']))}
-                        >
-                          <option value="mm">Millimeters</option>
-                          <option value="inch">Inches</option>
-                        </select>
+                          options={[
+                            { value: 'mm', label: 'Millimeters' },
+                            { value: 'inch', label: 'Inches' },
+                          ]}
+                          onChange={(value) => updateTool(selectedTool.id, convertToolUnits(selectedTool, value))}
+                        />
                       </label>
                       <label className="properties-field">
                         <span>Diameter</span>
@@ -1893,13 +1903,14 @@ export function CAMPanel({
                       </label>
                       <label className="properties-field">
                         <span>Material</span>
-                        <select
+                        <Select
                           value={selectedTool.material}
-                          onChange={(event) => updateTool(selectedTool.id, { material: event.target.value as Tool['material'] })}
-                        >
-                          <option value="carbide">Carbide</option>
-                          <option value="hss">HSS</option>
-                        </select>
+                          options={[
+                            { value: 'carbide', label: 'Carbide' },
+                            { value: 'hss', label: 'HSS' },
+                          ]}
+                          onChange={(value) => updateTool(selectedTool.id, { material: value })}
+                        />
                       </label>
                       <label className="properties-field">
                         <span>Default RPM</span>

--- a/src/components/feature-tree/PropertiesPanel.tsx
+++ b/src/components/feature-tree/PropertiesPanel.tsx
@@ -17,6 +17,7 @@
 import { useRef } from 'react'
 import type { ChangeEvent } from 'react'
 import { Icon } from '../Icon'
+import { Select } from '../Select'
 import { validateMachineDefinition } from '../../engine/gcode'
 import { defaultStock, getStockBounds, profileExceedsStock, profileHasSelfIntersection } from '../../types/project'
 import { useProjectStore } from '../../store/projectStore'
@@ -321,21 +322,15 @@ export function PropertiesPanel() {
 
   function renderFolderSelect(value: string | '__mixed__' | null, onChange: (folderId: string | null) => void) {
     return (
-      <select
+      <Select
         value={value ?? ''}
-        onChange={(event) =>
-          onChange(event.target.value === '' || event.target.value === '__mixed__' ? null : event.target.value)}
-      >
-        {value === '__mixed__' ? (
-          <option value="__mixed__">Mixed folders</option>
-        ) : null}
-        <option value="">Root</option>
-        {project.featureFolders.map((folder) => (
-          <option key={folder.id} value={folder.id}>
-            {folder.name}
-          </option>
-        ))}
-      </select>
+        options={[
+          ...(value === '__mixed__' ? [{ value: '__mixed__', label: 'Mixed folders' }] : []),
+          { value: '', label: 'Root' },
+          ...project.featureFolders.map((folder) => ({ value: folder.id, label: folder.name })),
+        ]}
+        onChange={(next) => onChange(next === '' || next === '__mixed__' ? null : next)}
+      />
     )
   }
 
@@ -353,13 +348,14 @@ export function PropertiesPanel() {
           </label>
           <label className="properties-field">
             <span>Units</span>
-            <select
+            <Select
               value={project.meta.units}
-              onChange={(event) => setUnits(event.target.value as 'mm' | 'inch')}
-            >
-              <option value="mm">Millimeters</option>
-              <option value="inch">Inches</option>
-            </select>
+              options={[
+                { value: 'mm', label: 'Millimeters' },
+                { value: 'inch', label: 'Inches' },
+              ]}
+              onChange={(value) => setUnits(value)}
+            />
           </label>
           <label className="properties-check">
             <input
@@ -422,17 +418,14 @@ export function PropertiesPanel() {
                 <Icon id="refresh" size={15} />
               </button>
             </div>
-            <select
+            <Select
               value={project.meta.selectedMachineId ?? ''}
-              onChange={(event) => setSelectedMachineId(event.target.value || null)}
-            >
-              <option value="">None</option>
-              {project.meta.machineDefinitions.map((definition) => (
-                <option key={definition.id} value={definition.id}>
-                  {definition.name}
-                </option>
-              ))}
-            </select>
+              options={[
+                { value: '', label: 'None' },
+                ...project.meta.machineDefinitions.map((definition) => ({ value: definition.id, label: definition.name })),
+              ]}
+              onChange={(value) => setSelectedMachineId(value || null)}
+            />
           </label>
           <div className="properties-actions">
             <button type="button" onClick={handleAddMachine}>
@@ -1032,25 +1025,24 @@ export function PropertiesPanel() {
             </label>
             <label className="properties-field">
               <span>Operation</span>
-              {allSelectedFeatures.some((f) => f.operation === 'model' || f.operation === 'region') ? (
-                <div className="properties-locked-field" title="Model and region entries cannot change operation type here">
-                  <span>{allSelectedFeatures.some((f) => f.operation === 'region') ? 'Contains regions' : 'Contains model features'}</span>
+              {allSelectedFeatures.some((f) => f.operation === 'model') ? (
+                <div className="properties-locked-field" title="Model entries cannot change operation type here">
+                  <span>Contains model features</span>
                   <span className="properties-locked-hint" aria-hidden="true">🔒</span>
                 </div>
               ) : (
-                <select
+                <Select
                   value={commonSelectedOperation ?? ''}
-                  onChange={(event) =>
-                    updateFeatures(selectedFeatureIds, {
-                      operation: event.target.value as import('../../types/project').FeatureOperation,
-                    })}
-                >
-                  {commonSelectedOperation === '__mixed__' ? (
-                    <option value="__mixed__">Mixed operations</option>
-                  ) : null}
-                  <option value="subtract">Subtract</option>
-                  <option value="add">Add</option>
-                </select>
+                  options={[
+                    ...(commonSelectedOperation === '__mixed__' ? [{ value: '__mixed__', label: 'Mixed operations' }] : []),
+                    { value: 'subtract', label: 'Subtract' },
+                    { value: 'add', label: 'Add' },
+                    { value: 'region', label: 'Region' },
+                  ]}
+                  onChange={(value) => updateFeatures(selectedFeatureIds, {
+                    operation: value as import('../../types/project').FeatureOperation,
+                  })}
+                />
               )}
             </label>
             {selectedZEditableFeatures.length > 0 ? (
@@ -1137,28 +1129,27 @@ export function PropertiesPanel() {
         </label>
         <label className="properties-field">
           <span>Operation</span>
-          {operationLockedToAdd || selectedFeature.operation === 'model' || selectedFeature.operation === 'region' ? (
+          {operationLockedToAdd || selectedFeature.operation === 'model' ? (
             <div className="properties-locked-field" title={
               selectedFeature.operation === 'model'
                 ? 'Model features are imported 3D objects and cannot change operation type'
-                : selectedFeature.operation === 'region'
-                  ? 'Regions are machining filters. Create regions from the toolbar.'
                 : 'The first 2.5D feature must be Add — it defines the base solid of the part model'
             }>
-              <span>{selectedFeature.operation === 'model' ? 'Model' : selectedFeature.operation === 'region' ? 'Region' : 'Add'}</span>
+              <span>{selectedFeature.operation === 'model' ? 'Model' : 'Add'}</span>
               <span className="properties-locked-hint" aria-hidden="true">🔒</span>
             </div>
           ) : (
-            <select
+            <Select
               value={selectedFeature.operation}
-              onChange={(event) =>
-                updateFeature(selectedFeature.id, {
-                  operation: event.target.value as import('../../types/project').FeatureOperation,
-                })}
-            >
-              <option value="subtract">Subtract</option>
-              <option value="add">Add</option>
-            </select>
+              options={[
+                { value: 'subtract', label: 'Subtract' },
+                { value: 'add', label: 'Add' },
+                { value: 'region', label: 'Region' },
+              ]}
+              onChange={(value) => updateFeature(selectedFeature.id, {
+                operation: value as import('../../types/project').FeatureOperation,
+              })}
+            />
           )}
         </label>
         <label className="properties-field">
@@ -1185,41 +1176,30 @@ export function PropertiesPanel() {
             </label>
             <label className="properties-field">
               <span>Style</span>
-              <select
+              <Select
                 value={textFeature.style}
-                onChange={(event) => {
-                  const style = event.target.value as typeof textFeature.style
-                  updateFeature(selectedFeature.id, {
-                    text: {
-                      ...textFeature,
-                      style,
-                      fontId: defaultFontIdForStyle(style),
-                    },
-                  })
-                }}
-              >
-                <option value="skeleton">Skeleton</option>
-                <option value="outline">Outline</option>
-              </select>
+                options={[
+                  { value: 'skeleton', label: 'Skeleton' },
+                  { value: 'outline', label: 'Outline' },
+                ]}
+                onChange={(style) => updateFeature(selectedFeature.id, {
+                  text: {
+                    ...textFeature,
+                    style,
+                    fontId: defaultFontIdForStyle(style),
+                  },
+                })}
+              />
             </label>
             <label className="properties-field">
               <span>Font</span>
-              <select
+              <Select
                 value={textFeature.fontId}
-                onChange={(event) =>
-                  updateFeature(selectedFeature.id, {
-                    text: {
-                      ...textFeature,
-                      fontId: event.target.value as typeof textFeature.fontId,
-                    },
-                  })}
-              >
-                {textFontOptions.map((font) => (
-                  <option key={font.id} value={font.id}>
-                    {font.label}
-                  </option>
-                ))}
-              </select>
+                options={textFontOptions.map((font) => ({ value: font.id, label: font.label }))}
+                onChange={(fontId) => updateFeature(selectedFeature.id, {
+                  text: { ...textFeature, fontId },
+                })}
+              />
             </label>
           </>
         ) : null}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1577,14 +1577,164 @@
 .properties-field input,
 .properties-field select,
 .properties-field textarea,
-.properties-field button:not(.tree-action-btn) {
-  background: #0f1820;
+.properties-field button:not(.tree-action-btn):not(.feat-btn) {
+  background-color: #0f1820;
   border: 1px solid var(--line-strong);
   color: var(--text);
   border-radius: 7px;
   height: 32px;
   padding: 0 8px;
   min-width: 0;
+}
+
+.properties-field select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%2394aabc'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 9px center;
+  padding-right: 26px;
+  cursor: pointer;
+  transition: border-color 120ms ease;
+}
+
+.properties-field select:hover {
+  border-color: color-mix(in oklab, var(--accent) 50%, var(--line-strong));
+}
+
+.properties-field select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent) 35%, transparent);
+}
+
+/* ── Scrollbars ─────────────────────────────────────────── */
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-strong) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--line-strong);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-dim);
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/* ── ui-select ─────────────────────────────────────────── */
+
+.ui-select {
+  position: relative;
+  min-width: 0;
+}
+
+.ui-select__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 32px;
+  padding: 0 8px;
+  background-color: #0f1820;
+  border: 1px solid var(--line-strong);
+  border-radius: 7px;
+  color: var(--text);
+  font: inherit;
+  font-size: inherit;
+  cursor: pointer;
+  transition: border-color 120ms ease;
+  text-align: left;
+}
+
+.ui-select__trigger:hover {
+  border-color: color-mix(in oklab, var(--accent) 50%, var(--line-strong));
+}
+
+.ui-select--open .ui-select__trigger,
+.ui-select__trigger:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent) 35%, transparent);
+}
+
+.ui-select--disabled .ui-select__trigger {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.ui-select__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ui-select__arrow {
+  flex-shrink: 0;
+  width: 0;
+  height: 0;
+  margin-left: 7px;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid var(--text-dim);
+  transition: transform 120ms ease;
+}
+
+.ui-select--open .ui-select__arrow {
+  transform: rotate(180deg);
+}
+
+.ui-select__dropdown {
+  position: absolute;
+  top: calc(100% + 3px);
+  left: 0;
+  right: 0;
+  z-index: 200;
+  background: #16222d;
+  border: 1px solid var(--line-strong);
+  border-radius: 7px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+  padding: 3px;
+}
+
+.ui-select__option {
+  padding: 5px 8px;
+  border-radius: 5px;
+  font-size: inherit;
+  color: var(--text);
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ui-select__option:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.ui-select__option--selected {
+  color: var(--accent);
+}
+
+.ui-select__option--selected:hover {
+  background: rgba(220, 165, 106, 0.1);
 }
 
 .properties-field textarea {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -618,7 +618,7 @@ export function defaultStock(
     profile: rectProfile(0, 0, width, height),
     thickness: stockThickness,
     material: 'aluminum_6061',
-    color: '#8899aa',
+    color: '#b9a83c',
     visible: true,
     origin: { x: 0, y: 0 },
   }


### PR DESCRIPTION
## Summary

A batch of UI polish changes across the properties panels and global styles.

## Changes

### `src/components/Select.tsx` (new)
Generic `Select<T>` component replacing all native `<select>` elements in the properties panels. Renders a styled trigger button with a CSS arrow and a fully custom dropdown list — dark background, accent highlight on the selected option, hover states, focus ring, closes on outside click or Escape.

### `src/styles/layout.css`
- Added `ui-select` component styles
- Added global scrollbar styling: 6px width, transparent track, `--line-strong` thumb with `--text-dim` on hover, covers both WebKit (`::-webkit-scrollbar`) and Firefox (`scrollbar-color`)
- Excluded `feat-btn` from the `.properties-field button` override so button styling comes through correctly

### `src/components/cam/CAMPanel.tsx`
- Replaced all 9 native selects in operation and tool properties with `Select`
- Extracted `showStepdown(operation)` helper — hides stepdown for v-carve, drilling, and edge route finish pass (both inside and outside)
- Removed unused `CutDirection` and `MachiningOrder` type imports

### `src/components/feature-tree/PropertiesPanel.tsx`
- Replaced all 7 native selects (Units, Machine, feature Operation ×2, text Style, text Font, folder) with `Select`
- Added **Region** as a choosable option in both operation selects (single and multi-feature); lock now only applies to `model` features

### `src/App.tsx`
- Removed `onEditTab` and `onEditClamp` props from `FeatureTree` — edit is already available in the context menu, no need for a dedicated button in the tree row

### `src/types/project.ts`
- Default stock colour changed from `#8899aa` to `#b9a83c` (rgb 185, 168, 60)