### PR TITLE
feat: resizable centre/right panel divider

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, type ReactNode } from 'react'
+import { useCallback, useRef, useState, type ReactNode } from 'react'
 import { useProjectStore } from '../../store/projectStore'
 import { getStockBounds } from '../../types/project'
 import { formatLength } from '../../utils/units'
@@ -71,6 +71,56 @@ export function AppShell({
   statusBarExtras,
 }: AppShellProps) {
   const [rightDrawerOpen, setRightDrawerOpen] = useState(false)
+
+  const CR_STORAGE_KEY = 'panel-split:center-right'
+  const MIN_CENTER_WIDTH = 300
+  const MIN_RIGHT_WIDTH = 200
+
+  const [rightPanelRatio, setRightPanelRatio] = useState<number>(() => {
+    const stored = localStorage.getItem(CR_STORAGE_KEY)
+    if (stored !== null) {
+      const parsed = parseFloat(stored)
+      if (Number.isFinite(parsed) && parsed > 0 && parsed < 1) return parsed
+    }
+    return 0.265
+  })
+
+  const centrePanelRef = useRef<HTMLElement>(null)
+  const rightPanelRef = useRef<HTMLElement>(null)
+
+  const showRight = workspaceLayout === 'lcr' || workspaceLayout === 'cr'
+
+  const handleDividerPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }, [])
+
+  const handleDividerPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!e.currentTarget.hasPointerCapture(e.pointerId)) return
+      const centreEl = centrePanelRef.current
+      const rightEl = rightPanelRef.current
+      if (!centreEl || !rightEl) return
+      const centreRect = centreEl.getBoundingClientRect()
+      const rightRect = rightEl.getBoundingClientRect()
+      const totalWidth = rightRect.right - centreRect.left
+      const offsetX = e.clientX - centreRect.left
+      const minRatio = MIN_RIGHT_WIDTH / totalWidth
+      const maxRatio = 1 - MIN_CENTER_WIDTH / totalWidth
+      const newRatio = Math.max(minRatio, Math.min(maxRatio, 1 - offsetX / totalWidth))
+      setRightPanelRatio(newRatio)
+      localStorage.setItem(CR_STORAGE_KEY, String(newRatio))
+    },
+    [],
+  )
+
+  const bodyStyle: React.CSSProperties = {}
+  if (showRight) {
+    const railPrefix = toolbarOrientation === 'left' ? '32px ' : ''
+    const leftPrefix = workspaceLayout === 'lcr' ? 'minmax(200px, 17%) ' : ''
+    bodyStyle.gridTemplateColumns = `${railPrefix}${leftPrefix}minmax(${MIN_CENTER_WIDTH}px, ${1 - rightPanelRatio}fr) minmax(${MIN_RIGHT_WIDTH}px, ${rightPanelRatio}fr)`
+  }
+
   const { project } = useProjectStore()
   const stockBounds = getStockBounds(project.stock)
   const stockWidth = stockBounds.maxX - stockBounds.minX
@@ -109,7 +159,7 @@ export function AppShell({
       </header>
 
       {/* Main work area */}
-      <div className={`app-body app-body--${workspaceLayout} app-body--toolbar-${toolbarOrientation}`}>
+      <div className={`app-body app-body--${workspaceLayout} app-body--toolbar-${toolbarOrientation}`} style={bodyStyle}>
         {toolbarOrientation === 'left' ? (
           <aside className="app-left-rail" aria-label="Creation tools">
             {creationToolbar}
@@ -134,7 +184,7 @@ export function AppShell({
           </PanelSplit>
         </aside>
 
-        <main className="panel-centre">
+        <main className="panel-centre" ref={centrePanelRef}>
           <div className="panel centre-workspace">
             <div className="panel-tabs-header" role="tablist" aria-label="Workspace Views">
               <button
@@ -295,9 +345,18 @@ export function AppShell({
               </div>
             </div>
           </div>
+          {showRight && (
+            <div
+              className="panel-resize-divider"
+              role="separator"
+              aria-orientation="vertical"
+              onPointerDown={handleDividerPointerDown}
+              onPointerMove={handleDividerPointerMove}
+            />
+          )}
         </main>
 
-        <aside className="panel-right" aria-label="CAM panel">
+        <aside className="panel-right" ref={rightPanelRef} aria-label="CAM panel">
           <section className="panel panel-tabs">
             <div className="panel-tabs-header" role="tablist" aria-label="Right Sidebar">
               <button

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -72,9 +72,20 @@ export function AppShell({
 }: AppShellProps) {
   const [rightDrawerOpen, setRightDrawerOpen] = useState(false)
 
+  const LC_STORAGE_KEY = 'panel-split:left-center'
   const CR_STORAGE_KEY = 'panel-split:center-right'
+  const MIN_LEFT_WIDTH = 200
   const MIN_CENTER_WIDTH = 300
   const MIN_RIGHT_WIDTH = 200
+
+  const [leftPanelRatio, setLeftPanelRatio] = useState<number>(() => {
+    const stored = localStorage.getItem(LC_STORAGE_KEY)
+    if (stored !== null) {
+      const parsed = parseFloat(stored)
+      if (Number.isFinite(parsed) && parsed > 0 && parsed < 1) return parsed
+    }
+    return 0.17
+  })
 
   const [rightPanelRatio, setRightPanelRatio] = useState<number>(() => {
     const stored = localStorage.getItem(CR_STORAGE_KEY)
@@ -85,9 +96,11 @@ export function AppShell({
     return 0.265
   })
 
+  const leftPanelRef = useRef<HTMLElement>(null)
   const centrePanelRef = useRef<HTMLElement>(null)
   const rightPanelRef = useRef<HTMLElement>(null)
 
+  const showLeft = workspaceLayout === 'lcr' || workspaceLayout === 'lc'
   const showRight = workspaceLayout === 'lcr' || workspaceLayout === 'cr'
 
   const handleDividerPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
@@ -95,7 +108,26 @@ export function AppShell({
     e.currentTarget.setPointerCapture(e.pointerId)
   }, [])
 
-  const handleDividerPointerMove = useCallback(
+  const handleLeftDividerPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!e.currentTarget.hasPointerCapture(e.pointerId)) return
+      const leftEl = leftPanelRef.current
+      const centreEl = centrePanelRef.current
+      if (!leftEl || !centreEl) return
+      const leftRect = leftEl.getBoundingClientRect()
+      const centreRect = centreEl.getBoundingClientRect()
+      const totalWidth = centreRect.right - leftRect.left
+      const offsetX = e.clientX - leftRect.left
+      const minRatio = MIN_LEFT_WIDTH / totalWidth
+      const maxRatio = 1 - MIN_CENTER_WIDTH / totalWidth
+      const newRatio = Math.max(minRatio, Math.min(maxRatio, offsetX / totalWidth))
+      setLeftPanelRatio(newRatio)
+      localStorage.setItem(LC_STORAGE_KEY, String(newRatio))
+    },
+    [],
+  )
+
+  const handleRightDividerPointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (!e.currentTarget.hasPointerCapture(e.pointerId)) return
       const centreEl = centrePanelRef.current
@@ -114,11 +146,18 @@ export function AppShell({
     [],
   )
 
+  // left=L/(L+C), right=R/(C+R) → express as fr with centre always 1fr:
+  //   L fr = leftRatio/(1-leftRatio), R fr = rightRatio/(1-rightRatio)
   const bodyStyle: React.CSSProperties = {}
-  if (showRight) {
+  if (showLeft || showRight) {
     const railPrefix = toolbarOrientation === 'left' ? '32px ' : ''
-    const leftPrefix = workspaceLayout === 'lcr' ? 'minmax(200px, 17%) ' : ''
-    bodyStyle.gridTemplateColumns = `${railPrefix}${leftPrefix}minmax(${MIN_CENTER_WIDTH}px, ${1 - rightPanelRatio}fr) minmax(${MIN_RIGHT_WIDTH}px, ${rightPanelRatio}fr)`
+    const leftCol = showLeft
+      ? `minmax(${MIN_LEFT_WIDTH}px, ${leftPanelRatio / (1 - leftPanelRatio)}fr) `
+      : ''
+    const rightCol = showRight
+      ? ` minmax(${MIN_RIGHT_WIDTH}px, ${rightPanelRatio / (1 - rightPanelRatio)}fr)`
+      : ''
+    bodyStyle.gridTemplateColumns = `${railPrefix}${leftCol}minmax(${MIN_CENTER_WIDTH}px, 1fr)${rightCol}`
   }
 
   const { project } = useProjectStore()
@@ -166,7 +205,7 @@ export function AppShell({
           </aside>
         ) : null}
 
-        <aside className="panel-left">
+        <aside className="panel-left" ref={leftPanelRef}>
           <PanelSplit storageKey="project-tree" initialRatio={0.55} minFirst={160} minSecond={160}>
             <section className="panel panel-tree">
               <div className="panel-header">
@@ -182,6 +221,13 @@ export function AppShell({
               <div className="panel-content">{propertiesPanel}</div>
             </section>
           </PanelSplit>
+          <div
+            className="panel-resize-divider"
+            role="separator"
+            aria-orientation="vertical"
+            onPointerDown={handleDividerPointerDown}
+            onPointerMove={handleLeftDividerPointerMove}
+          />
         </aside>
 
         <main className="panel-centre" ref={centrePanelRef}>
@@ -351,7 +397,7 @@ export function AppShell({
               role="separator"
               aria-orientation="vertical"
               onPointerDown={handleDividerPointerDown}
-              onPointerMove={handleDividerPointerMove}
+              onPointerMove={handleRightDividerPointerMove}
             />
           )}
         </main>

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -445,6 +445,7 @@
 
 .panel-left {
   min-height: 0;
+  position: relative;
 }
 
 .panel {
@@ -2225,6 +2226,11 @@
 .panel-resize-divider:hover::before,
 .panel-resize-divider:active::before {
   background: var(--line-bright);
+}
+
+/* Left-toolbar layout uses gap: 4px — recenter: -(4+10)/2 = -7 */
+.app-body--toolbar-left .panel-resize-divider {
+  right: -7px;
 }
 
 .cam-section {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -494,6 +494,7 @@
 
 .panel-centre {
   min-height: 0;
+  position: relative;
 }
 
 .app-body--c .panel-left,
@@ -2197,6 +2198,35 @@
   background: var(--line-bright);
 }
 
+.panel-resize-divider {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: -10px;
+  width: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: col-resize;
+  user-select: none;
+  touch-action: none;
+  z-index: 10;
+}
+
+.panel-resize-divider::before {
+  content: '';
+  width: 3px;
+  height: 24px;
+  border-radius: 2px;
+  background: var(--line-strong);
+  transition: background 0.15s;
+}
+
+.panel-resize-divider:hover::before,
+.panel-resize-divider:active::before {
+  background: var(--line-bright);
+}
+
 .cam-section {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
@@ -2577,7 +2607,7 @@
 
 @media (max-width: 920px) {
   .app-body {
-    grid-template-columns: 220px 1fr;
+    grid-template-columns: 220px 1fr !important;
     grid-template-areas:
       'left centre'
       'right right';
@@ -2599,7 +2629,7 @@
 
 @media (max-width: 760px) {
   .app-body {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr !important;
     grid-template-areas:
       'left'
       'centre'


### PR DESCRIPTION
## Summary

- Adds a draggable vertical divider between the centre canvas and the right CAM panel
- Split ratio persists to `localStorage` (`panel-split:center-right`, default ~26.5% right)
- Divider is only rendered when the right panel is visible (`lcr`/`cr` layouts); hidden panels are unaffected
- Responsive breakpoints override the inline grid style with `!important` so tablet/mobile layout is unchanged
- Handle is a slim 3×24px pill absolutely positioned in the centre of the 10px gap — no extra grid column consumed

## Test plan

- [x] Drag the divider left/right and confirm both panels resize
- [x] Reload — confirm ratio is restored from localStorage
- [x] Toggle to `lc` and `c` layouts — confirm no divider appears and layout is normal
- [x] Toggle back to `lcr`/`cr` — confirm divider reappears at the saved ratio
- [x] Resize window to tablet width (<920px) — confirm layout reverts to stacked grid correctly