### PR TITLE
feat: preserve original segments through boolean operations

### DIFF
--- a/src/store/helpers/clipping.ts
+++ b/src/store/helpers/clipping.ts
@@ -22,7 +22,7 @@ import {
   normalizeWinding,
   toClipperPath,
 } from '../../engine/toolpaths/geometry'
-import { getProfileBounds, polygonProfile } from '../../types/project'
+import { bezierPoint, getProfileBounds, polygonProfile } from '../../types/project'
 import type { Point, Segment, SketchFeature, SketchProfile } from '../../types/project'
 
 export interface KnownCircle {
@@ -334,4 +334,285 @@ function reconstructArcsInProfile(vertices: Point[], knownCircles: KnownCircle[]
     segments: result.segments,
     closed: true,
   }
+}
+
+// ── Segment-preserving boolean reconstruction ─────────────────────────────────
+// Instead of reconstructing curves from a flattened polygon, this approach
+// maps Clipper output vertices back to their original segments and preserves
+// them exactly. Only intersection points become line segments.
+
+const FLATTEN_CURVE_SAMPLES = 24
+const FLATTEN_ARC_STEP = Math.PI / 36
+
+export interface SegmentAnnotation {
+  featureIdx: number
+  segIdx: number
+  sampleIdx: number
+  totalSamples: number
+}
+
+function annKey(X: number, Y: number): string {
+  return `${X},${Y}`
+}
+
+function getSegmentSampleCount(seg: Segment, segStart: Point): number {
+  if (seg.type === 'line') return 1
+  if (seg.type === 'bezier') return FLATTEN_CURVE_SAMPLES
+  if (seg.type === 'circle') return 64
+  const startAngle = Math.atan2(segStart.y - seg.center.y, segStart.x - seg.center.x)
+  const endAngle = Math.atan2(seg.to.y - seg.center.y, seg.to.x - seg.center.x)
+  let sweep = endAngle - startAngle
+  if (seg.clockwise && sweep > 0) sweep -= Math.PI * 2
+  else if (!seg.clockwise && sweep < 0) sweep += Math.PI * 2
+  return Math.max(8, Math.ceil(Math.abs(sweep) / FLATTEN_ARC_STEP))
+}
+
+export function buildSegmentAnnotations(
+  features: SketchFeature[],
+  scale: number = DEFAULT_CLIPPER_SCALE,
+): Map<string, SegmentAnnotation> {
+  const map = new Map<string, SegmentAnnotation>()
+
+  for (let fi = 0; fi < features.length; fi++) {
+    const profile = features[fi].sketch.profile
+    let current = profile.start
+
+    for (let si = 0; si < profile.segments.length; si++) {
+      const seg = profile.segments[si]
+      const totalSamples = getSegmentSampleCount(seg, current)
+
+      if (seg.type === 'line') {
+        const k = annKey(Math.round(seg.to.x * scale), Math.round(seg.to.y * scale))
+        if (!map.has(k)) map.set(k, { featureIdx: fi, segIdx: si, sampleIdx: 1, totalSamples: 1 })
+        current = seg.to
+      } else if (seg.type === 'bezier') {
+        for (let s = 1; s <= FLATTEN_CURVE_SAMPLES; s++) {
+          const pt = bezierPoint(current, seg.control1, seg.control2, seg.to, s / FLATTEN_CURVE_SAMPLES)
+          const k = annKey(Math.round(pt.x * scale), Math.round(pt.y * scale))
+          if (!map.has(k)) map.set(k, { featureIdx: fi, segIdx: si, sampleIdx: s, totalSamples: FLATTEN_CURVE_SAMPLES })
+        }
+        current = seg.to
+      } else if (seg.type === 'arc') {
+        const startAngle = Math.atan2(current.y - seg.center.y, current.x - seg.center.x)
+        const endAngle = Math.atan2(seg.to.y - seg.center.y, seg.to.x - seg.center.x)
+        const radius = Math.hypot(current.x - seg.center.x, current.y - seg.center.y)
+        let sweep = endAngle - startAngle
+        if (seg.clockwise && sweep > 0) sweep -= Math.PI * 2
+        else if (!seg.clockwise && sweep < 0) sweep += Math.PI * 2
+        for (let s = 1; s <= totalSamples; s++) {
+          const angle = startAngle + (sweep * s) / totalSamples
+          const pt = { x: seg.center.x + Math.cos(angle) * radius, y: seg.center.y + Math.sin(angle) * radius }
+          const k = annKey(Math.round(pt.x * scale), Math.round(pt.y * scale))
+          if (!map.has(k)) map.set(k, { featureIdx: fi, segIdx: si, sampleIdx: s, totalSamples })
+        }
+        current = seg.to
+      } else if (seg.type === 'circle') {
+        const radius = Math.hypot(current.x - seg.center.x, current.y - seg.center.y)
+        const startAngle = Math.atan2(current.y - seg.center.y, current.x - seg.center.x)
+        for (let s = 1; s <= 64; s++) {
+          const angle = startAngle + (seg.clockwise ? -1 : 1) * (Math.PI * 2 * s) / 64
+          const pt = { x: seg.center.x + Math.cos(angle) * radius, y: seg.center.y + Math.sin(angle) * radius }
+          const k = annKey(Math.round(pt.x * scale), Math.round(pt.y * scale))
+          if (!map.has(k)) map.set(k, { featureIdx: fi, segIdx: si, sampleIdx: s, totalSamples: 64 })
+        }
+        current = profile.start
+      }
+    }
+  }
+
+  return map
+}
+
+function lerp(a: Point, b: Point, t: number): Point {
+  return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t }
+}
+
+function splitBezierAt(
+  p0: Point, p1: Point, p2: Point, p3: Point, t: number,
+): { left: [Point, Point, Point, Point]; right: [Point, Point, Point, Point] } {
+  const a = lerp(p0, p1, t)
+  const b = lerp(p1, p2, t)
+  const c = lerp(p2, p3, t)
+  const ab = lerp(a, b, t)
+  const bc = lerp(b, c, t)
+  const mid = lerp(ab, bc, t)
+  return {
+    left: [p0, a, ab, mid],
+    right: [mid, bc, c, p3],
+  }
+}
+
+function subBezierControlPoints(
+  p0: Point, p1: Point, p2: Point, p3: Point,
+  tStart: number, tEnd: number,
+): { control1: Point; control2: Point; to: Point } {
+  if (tStart <= 0 && tEnd >= 1) {
+    return { control1: p1, control2: p2, to: p3 }
+  }
+  if (tStart <= 0) {
+    const { left } = splitBezierAt(p0, p1, p2, p3, tEnd)
+    return { control1: left[1], control2: left[2], to: left[3] }
+  }
+  const { right } = splitBezierAt(p0, p1, p2, p3, tStart)
+  if (tEnd >= 1) {
+    return { control1: right[1], control2: right[2], to: right[3] }
+  }
+  const tAdj = (tEnd - tStart) / (1 - tStart)
+  const { left } = splitBezierAt(right[0], right[1], right[2], right[3], tAdj)
+  return { control1: left[1], control2: left[2], to: left[3] }
+}
+
+function getSegmentStart(profile: SketchProfile, segIdx: number): Point {
+  return segIdx === 0 ? profile.start : profile.segments[segIdx - 1].to
+}
+
+export function clipperContourToProfilePreserving(
+  contour: ReturnType<typeof flattenFeatureToClipperPath>,
+  features: SketchFeature[],
+  annotations: Map<string, SegmentAnnotation>,
+  scale: number = DEFAULT_CLIPPER_SCALE,
+): SketchProfile | null {
+  const points = fromClipperPath(contour, scale)
+  if (points.length < 3) return null
+
+  const first = points[0]
+  const last = points[points.length - 1]
+  const vertices = (Math.abs(first.x - last.x) <= 1e-9 && Math.abs(first.y - last.y) <= 1e-9)
+    ? points.slice(0, -1)
+    : points
+  if (vertices.length < 3) return null
+
+  const n = vertices.length
+  const anns: (SegmentAnnotation | null)[] = vertices.map((v) => {
+    const k = annKey(Math.round(v.x * scale), Math.round(v.y * scale))
+    return annotations.get(k) ?? null
+  })
+
+  // Group consecutive vertices into runs by (featureIdx, segIdx).
+  // Unannotated vertices (intersection points) break runs.
+  interface Run {
+    startIdx: number
+    endIdx: number
+    annotation: SegmentAnnotation | null
+  }
+
+  const runs: Run[] = []
+  let ri = 0
+  while (ri < n) {
+    const ann = anns[ri]
+    if (ann === null) {
+      runs.push({ startIdx: ri, endIdx: ri, annotation: null })
+      ri++
+      continue
+    }
+    let rj = ri + 1
+    while (rj < n && anns[rj] !== null
+      && anns[rj]!.featureIdx === ann.featureIdx
+      && anns[rj]!.segIdx === ann.segIdx) {
+      rj++
+    }
+    runs.push({ startIdx: ri, endIdx: rj - 1, annotation: ann })
+    ri = rj
+  }
+
+  // Handle wrap-around: if the first and last runs are from the same segment,
+  // merge them (Clipper's arbitrary start point may have split a segment).
+  if (runs.length >= 2) {
+    const firstRun = runs[0]
+    const lastRun = runs[runs.length - 1]
+    if (firstRun.annotation && lastRun.annotation
+      && firstRun.annotation.featureIdx === lastRun.annotation.featureIdx
+      && firstRun.annotation.segIdx === lastRun.annotation.segIdx) {
+      // Rotate so the split segment is contiguous: move runs[0] to the end
+      const merged = runs.slice(1, -1)
+      merged.push({
+        startIdx: lastRun.startIdx,
+        endIdx: firstRun.endIdx + n,
+        annotation: lastRun.annotation,
+      })
+      // Adjust: we'll treat indices >= n as wrapping (mod n)
+      runs.length = 0
+      runs.push(...merged)
+    }
+  }
+
+  // Emit segments for each run
+  const segments: Segment[] = []
+  // Determine profile start: the first vertex at the start of runs[0]
+  const startVertex = vertices[runs[0].startIdx % n]
+
+  for (let r = 0; r < runs.length; r++) {
+    const run = runs[r]
+
+    if (run.annotation === null) {
+      // Intersection point → emit line
+      segments.push({ type: 'line', to: vertices[run.startIdx % n] })
+      continue
+    }
+
+    const { featureIdx, segIdx } = run.annotation
+    const profile = features[featureIdx].sketch.profile
+    const seg = profile.segments[segIdx]
+    const segStart = getSegmentStart(profile, segIdx)
+
+    // Gather sample indices in this run
+    const runLen = (run.endIdx >= run.startIdx)
+      ? run.endIdx - run.startIdx + 1
+      : (run.endIdx - run.startIdx + 1) // wrapped case already adjusted above
+    const firstSample = anns[run.startIdx % n]!.sampleIdx
+    const lastSample = anns[run.endIdx % n]!.sampleIdx
+    const totalSamples = anns[run.startIdx % n]!.totalSamples
+    const runEndPoint = vertices[run.endIdx % n]
+
+    // Check if this run represents a complete segment
+    const isComplete = (firstSample === 0 || firstSample === 1) && lastSample === totalSamples && runLen >= totalSamples
+
+    if (seg.type === 'line') {
+      segments.push({ type: 'line', to: runEndPoint })
+    } else if (seg.type === 'arc' || seg.type === 'circle') {
+      const center = seg.center
+      // Determine clockwise from actual vertex traversal direction (normalizeWinding may have reversed)
+      let clockwise = seg.clockwise
+      if (run.endIdx > run.startIdx) {
+        const v0 = vertices[run.startIdx % n]
+        const v1 = vertices[(run.startIdx + 1) % n]
+        clockwise = arcIsClockwise(center, v0, v1)
+      }
+      if (isComplete && seg.type === 'circle') {
+        segments.push({ type: 'circle', to: runEndPoint, center: { x: center.x, y: center.y }, clockwise })
+      } else {
+        segments.push({ type: 'arc', to: runEndPoint, center: { x: center.x, y: center.y }, clockwise })
+      }
+    } else if (seg.type === 'bezier') {
+      const reversed = firstSample > lastSample
+      const isCompleteBezier = reversed
+        ? firstSample === totalSamples && (lastSample === 0 || lastSample === 1) && runLen >= totalSamples
+        : isComplete
+      if (isCompleteBezier) {
+        if (reversed) {
+          segments.push({ type: 'bezier', to: segStart, control1: seg.control2, control2: seg.control1 })
+        } else {
+          segments.push({ type: 'bezier', to: seg.to, control1: seg.control1, control2: seg.control2 })
+        }
+      } else {
+        const tLow = Math.min(firstSample, lastSample) / totalSamples
+        const tHigh = Math.max(firstSample, lastSample) / totalSamples
+        if (tHigh - tLow < 1e-9 || runLen < 3) {
+          for (let k = run.startIdx; k < run.endIdx; k++) {
+            segments.push({ type: 'line', to: vertices[(k + 1) % n] })
+          }
+        } else {
+          const sub = subBezierControlPoints(segStart, seg.control1, seg.control2, seg.to, tLow, tHigh)
+          if (reversed) {
+            segments.push({ type: 'bezier', to: runEndPoint, control1: sub.control2, control2: sub.control1 })
+          } else {
+            segments.push({ type: 'bezier', to: runEndPoint, control1: sub.control1, control2: sub.control2 })
+          }
+        }
+      }
+    }
+  }
+
+  if (segments.length < 2) return null
+  return { start: startVertex, segments, closed: true }
 }

--- a/src/store/helpers/derivedFeatures.ts
+++ b/src/store/helpers/derivedFeatures.ts
@@ -24,12 +24,15 @@ import type {
   SketchProfile,
 } from '../../types/project'
 import {
+  buildSegmentAnnotations,
   clipperContourToProfile,
+  clipperContourToProfilePreserving,
   executeClipTree,
   flattenFeatureToClipperPath,
   getClipperChildren,
   offsetClipperPaths,
   type ClipperPolyNode,
+  type SegmentAnnotation,
   unionClipperPaths,
 } from './clipping'
 
@@ -61,6 +64,8 @@ function collectDerivedFeaturesFromPolyTree(
   baseOperation: FeatureOperation,
   baseName: string,
   createDerivedFeature: DerivedFeatureFactory,
+  sourceFeatures: SketchFeature[],
+  segAnnotations: Map<string, SegmentAnnotation>,
   contourDepth = 0,
 ): SketchFeature[] {
   const created: SketchFeature[] = []
@@ -68,7 +73,8 @@ function collectDerivedFeaturesFromPolyTree(
   const nextContourDepth = contour.length > 0 ? contourDepth + 1 : contourDepth
 
   if (contour.length > 0) {
-    const profile = clipperContourToProfile(contour)
+    const profile = clipperContourToProfilePreserving(contour, sourceFeatures, segAnnotations)
+      ?? clipperContourToProfile(contour)
     if (profile) {
       const logicalDepth = nextContourDepth - 1
       const operation = logicalDepth % 2 === 0 ? baseOperation : (baseOperation === 'add' ? 'subtract' : 'add')
@@ -89,6 +95,8 @@ function collectDerivedFeaturesFromPolyTree(
       baseOperation,
       baseName,
       createDerivedFeature,
+      sourceFeatures,
+      segAnnotations,
       nextContourDepth,
     ))
   }
@@ -107,6 +115,8 @@ export function cutFeaturesByCutterGrouped(
   const groups: DerivedFeatureGroup[] = []
 
   for (const target of targets) {
+    const sourceFeatures = [cutter, target]
+    const segAnnotations = buildSegmentAnnotations(sourceFeatures)
     const subjectPaths = [flattenFeatureToClipperPath(target)]
     const polyTree = executeClipTree(subjectPaths, clipPaths, 2)
     const cutNameStem = normalizeDerivedFeatureNameStem(target.name)
@@ -117,6 +127,8 @@ export function cutFeaturesByCutterGrouped(
       target.operation,
       `${cutNameStem} Cut`,
       createDerivedFeature,
+      sourceFeatures,
+      segAnnotations,
     )
 
     const groupedFeatures: SketchFeature[] = []

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -82,8 +82,9 @@ import {
   subtractPoint,
 } from './helpers/geometry'
 import {
+  buildSegmentAnnotations,
   clipperContourToProfile,
-  collectKnownCircles,
+  clipperContourToProfilePreserving,
   flattenFeatureToClipperPath,
   unionClipperPaths,
 } from './helpers/clipping'
@@ -4408,11 +4409,12 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
     const anchorFeature = selectedFeatures[0]
     const baseFeature = anchorFeature
     const joinNameStem = normalizeDerivedFeatureNameStem(baseFeature.name)
-    const knownCircles = collectKnownCircles(selectedFeatures)
+    const segAnnotations = buildSegmentAnnotations(selectedFeatures)
     const unionPaths = unionClipperPaths(selectedFeatures.map((feature) => flattenFeatureToClipperPath(feature)))
     const createdFeatures = unionPaths
       .map((path, index) => {
-        const profile = clipperContourToProfile(path, undefined, knownCircles)
+        const profile = clipperContourToProfilePreserving(path, selectedFeatures, segAnnotations)
+          ?? clipperContourToProfile(path)
         if (!profile) {
           return null
         }


### PR DESCRIPTION
## Summary
- Adds segment-preserving reconstruction for boolean join/cut operations — original arcs, beziers, and circles pass through untouched instead of being flattened to polylines
- Maps Clipper output vertices back to source segments via coordinate-based annotations, only emitting line segments at actual intersection points
- Handles reversed winding direction correctly for both arc (clockwise detection from vertex traversal) and bezier (reversed control point emission) segments

## Test plan
- [x] Load `work/cut-test.camj` (composite shape + circle)
- [x] Perform join → verify shapes merge correctly with smooth curves
- [x] Perform cut → verify cut pieces retain original bezier curves and circle arcs without deformation
- [x] Test with features that have different natural winding directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)