### PR TITLE
fix: arc direction for single-vertex runs in boolean ops

### DIFF
--- a/src/store/helpers/clipping.ts
+++ b/src/store/helpers/clipping.ts
@@ -572,12 +572,10 @@ export function clipperContourToProfilePreserving(
     } else if (seg.type === 'arc' || seg.type === 'circle') {
       const center = seg.center
       // Determine clockwise from actual vertex traversal direction (normalizeWinding may have reversed)
-      let clockwise = seg.clockwise
-      if (run.endIdx > run.startIdx) {
-        const v0 = vertices[run.startIdx % n]
-        const v1 = vertices[(run.startIdx + 1) % n]
-        clockwise = arcIsClockwise(center, v0, v1)
-      }
+      const prevEnd = r > 0 ? vertices[runs[r - 1].endIdx % n] : startVertex
+      const clockwise = run.endIdx > run.startIdx
+        ? arcIsClockwise(center, vertices[run.startIdx % n], vertices[(run.startIdx + 1) % n])
+        : arcIsClockwise(center, prevEnd, vertices[run.startIdx % n])
       if (isComplete && seg.type === 'circle') {
         segments.push({ type: 'circle', to: runEndPoint, center: { x: center.x, y: center.y }, clockwise })
       } else {


### PR DESCRIPTION
## Summary
- Fixes incorrect arc direction for single-vertex circle runs in `clipperContourToProfilePreserving`
- When a circle arc between two boolean intersection points has only one sample vertex, the previous code fell back to `seg.clockwise` which is wrong when `normalizeWinding` reversed the path
- Now computes direction from the previous segment's endpoint, consistent with multi-vertex runs

## Test plan
- [x] Load `work/cut-test2.camj` (circle + 12 rectangles) → join → verify clean gear shape with all arcs curving inward
- [x] Load `work/cut-test.camj` (composite + circle) → join and cut → verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)