### PR TITLE
feat: multi-cutter cut operation and boolean selection improvements

### DIFF
--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -346,6 +346,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     cancelPendingOffset,
     completePendingShapeAction,
     cancelPendingShapeAction,
+    confirmCutCutters,
     setPendingShapeActionKeepOriginals,
     setBackdropImageLoading,
     beginConstraint,
@@ -3517,6 +3518,12 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       return
     }
 
+    if (event.key === 'Tab' && pendingShapeAction?.kind === 'cut' && pendingShapeAction.phase === 'cutters' && pendingShapeAction.cutterIds.length > 0) {
+      event.preventDefault()
+      confirmCutCutters()
+      return
+    }
+
     if (event.key === 'Escape' && pendingShapeAction) {
       cancelPendingShapeAction()
       return
@@ -4370,11 +4377,13 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
               ? pendingShapeAction.entityIds.length < 2
                 ? 'Join mode. Shift-click closed features to select at least two.'
                 : `Join mode. ${pendingShapeAction.entityIds.length} closed features selected.`
-              : !pendingShapeAction.cutterId
-                ? 'Cut mode. Click one closed feature to use as the cutter.'
+              : pendingShapeAction.phase === 'cutters'
+                ? pendingShapeAction.cutterIds.length === 0
+                  ? <>Cut mode. Click closed features to select cutters. Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm cutters" onClick={confirmCutCutters} onKeyDown={(e) => { if (e.key === 'Enter') confirmCutCutters() }}>Tab</kbd> to confirm cutters.</>
+                  : <>Cut mode. {pendingShapeAction.cutterIds.length} cutter{pendingShapeAction.cutterIds.length === 1 ? '' : 's'} selected. Shift-click to add more, or press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm cutters" onClick={confirmCutCutters} onKeyDown={(e) => { if (e.key === 'Enter') confirmCutCutters() }}>Tab</kbd> to confirm cutters.</>
                 : pendingShapeAction.targetIds.length === 0
-                  ? 'Cut mode. Shift-click closed features that intersect the cutter to select targets.'
-                  : `Cut mode. 1 cutter and ${pendingShapeAction.targetIds.length} target${pendingShapeAction.targetIds.length === 1 ? '' : 's'} selected.`}
+                  ? `Cut mode. ${pendingShapeAction.cutterIds.length} cutter${pendingShapeAction.cutterIds.length === 1 ? '' : 's'} confirmed. Shift-click closed features that intersect a cutter to select targets.`
+                  : `Cut mode. ${pendingShapeAction.cutterIds.length} cutter${pendingShapeAction.cutterIds.length === 1 ? '' : 's'} and ${pendingShapeAction.targetIds.length} target${pendingShapeAction.targetIds.length === 1 ? '' : 's'} selected. Shift-click to add or remove targets.`}
             {' '}
           </span>
           <label className="sketch-place-toggle">

--- a/src/store/helpers/clipping.ts
+++ b/src/store/helpers/clipping.ts
@@ -150,6 +150,45 @@ export function featuresFormConnectedOverlapGroup(features: SketchFeature[]): bo
   return visited.size === features.length
 }
 
+export function largestConnectedOverlapGroup(features: SketchFeature[]): SketchFeature[] {
+  if (features.length <= 1) {
+    return features
+  }
+
+  let bestGroup: number[] = []
+  const assigned = new Set<number>()
+
+  for (let start = 0; start < features.length; start += 1) {
+    if (assigned.has(start)) {
+      continue
+    }
+    const visited = new Set<number>([start])
+    const stack = [start]
+
+    while (stack.length > 0) {
+      const currentIndex = stack.pop()!
+      for (let index = 0; index < features.length; index += 1) {
+        if (visited.has(index)) {
+          continue
+        }
+        if (featuresOverlap(features[currentIndex], features[index])) {
+          visited.add(index)
+          stack.push(index)
+        }
+      }
+    }
+
+    for (const index of visited) {
+      assigned.add(index)
+    }
+    if (visited.size > bestGroup.length) {
+      bestGroup = [...visited]
+    }
+  }
+
+  return bestGroup.map((index) => features[index])
+}
+
 export function offsetClipperPaths(paths: ReturnType<typeof flattenFeatureToClipperPath>[], delta: number) {
   if (paths.length === 0) {
     return []
@@ -612,5 +651,11 @@ export function clipperContourToProfilePreserving(
   }
 
   if (segments.length < 2) return null
+
+  const lastTo = segments[segments.length - 1].to
+  if (Math.abs(lastTo.x - startVertex.x) > 1e-9 || Math.abs(lastTo.y - startVertex.y) > 1e-9) {
+    segments.push({ type: 'line', to: startVertex })
+  }
+
   return { start: startVertex, segments, closed: true }
 }

--- a/src/store/helpers/derivedFeatures.ts
+++ b/src/store/helpers/derivedFeatures.ts
@@ -106,16 +106,16 @@ function collectDerivedFeaturesFromPolyTree(
 
 export function cutFeaturesByCutterGrouped(
   project: Project,
-  cutter: SketchFeature,
+  cutters: SketchFeature[],
   targets: SketchFeature[],
   createDerivedFeature: DerivedFeatureFactory,
 ): DerivedFeatureGroup[] {
-  const clipPaths = [flattenFeatureToClipperPath(cutter)]
+  const clipPaths = cutters.map((cutter) => flattenFeatureToClipperPath(cutter))
   const existingNames = [...project.features.map((feature) => feature.name)]
   const groups: DerivedFeatureGroup[] = []
 
   for (const target of targets) {
-    const sourceFeatures = [cutter, target]
+    const sourceFeatures = [...cutters, target]
     const segAnnotations = buildSegmentAnnotations(sourceFeatures)
     const subjectPaths = [flattenFeatureToClipperPath(target)]
     const polyTree = executeClipTree(subjectPaths, clipPaths, 2)

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -4480,7 +4480,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
 
     const cutter = selectedFeatures[selectedFeatures.length - 1]
     const targets = selectedFeatures.filter((feature) => feature.id !== cutter.id)
-    const createdGroups = cutFeaturesByCutterGrouped(state.project, cutter, targets, createDerivedFeature)
+    const createdGroups = cutFeaturesByCutterGrouped(state.project, [cutter], targets, createDerivedFeature)
     const createdFeatures = createdGroups.flatMap((group) => group.features)
 
     if (createdFeatures.length === 0) {

--- a/src/store/slices/pendingActionsSlice.ts
+++ b/src/store/slices/pendingActionsSlice.ts
@@ -16,6 +16,7 @@
 
 import type { StateCreator } from 'zustand'
 import type { Clamp, Project, SketchFeature, Tab } from '../../types/project'
+import { largestConnectedOverlapGroup } from '../helpers/clipping'
 import { selectedClosedFeaturesFromIds } from '../helpers/derivedFeatures'
 import { nextPlacementSession } from '../helpers/ids'
 import type { ProjectStore } from '../types'
@@ -43,6 +44,7 @@ export type PendingActionsSlice = Pick<
   | 'cancelPendingMove'
   | 'cancelPendingTransform'
   | 'cancelPendingShapeAction'
+  | 'confirmCutCutters'
   | 'setPendingShapeActionKeepOriginals'
   | 'setPendingTransformKeepOriginals'
   | 'cancelPendingOffset'
@@ -275,7 +277,9 @@ export function createPendingActionsSlice(
 
     startJoinSelectedFeatures: () =>
       set((s) => {
-        const featureIds = selectedClosedFeaturesFromIds(s.project, s.selection.selectedFeatureIds).map((feature) => feature.id)
+        const allClosed = selectedClosedFeaturesFromIds(s.project, s.selection.selectedFeatureIds)
+        const connectedGroup = largestConnectedOverlapGroup(allClosed)
+        const featureIds = connectedGroup.map((feature) => feature.id)
 
         return {
           pendingAdd: null,
@@ -297,23 +301,27 @@ export function createPendingActionsSlice(
       }),
 
     startCutSelectedFeatures: () =>
-      set((s) => ({
-        pendingAdd: null,
-        pendingMove: null,
-        pendingTransform: null,
-        pendingOffset: null,
-        pendingShapeAction: { kind: 'cut', cutterId: null, targetIds: [], keepOriginals: false, session: nextPlacementSession() },
-        sketchEditSession: null,
-        selection: {
-          ...s.selection,
-          selectedFeatureId: null,
-          selectedFeatureIds: [],
-          selectedNode: null,
-          mode: 'feature',
-          hoveredFeatureId: null,
-          activeControl: null,
-        },
-      })),
+      set((s) => {
+        const cutterIds = selectedClosedFeaturesFromIds(s.project, s.selection.selectedFeatureIds).map((feature) => feature.id)
+
+        return {
+          pendingAdd: null,
+          pendingMove: null,
+          pendingTransform: null,
+          pendingOffset: null,
+          pendingShapeAction: { kind: 'cut', cutterIds, targetIds: [], phase: 'cutters', keepOriginals: false, session: nextPlacementSession() },
+          sketchEditSession: null,
+          selection: {
+            ...s.selection,
+            selectedFeatureId: cutterIds.at(-1) ?? null,
+            selectedFeatureIds: cutterIds,
+            selectedNode: cutterIds.at(-1) ? { type: 'feature', featureId: cutterIds.at(-1)! } : null,
+            mode: 'feature',
+            hoveredFeatureId: null,
+            activeControl: null,
+          },
+        }
+      }),
 
     startOffsetSelectedFeatures: () =>
       set((s) => {
@@ -448,6 +456,16 @@ export function createPendingActionsSlice(
       })),
 
     cancelPendingShapeAction: () => set({ pendingShapeAction: null }),
+
+    confirmCutCutters: () =>
+      set((s) => {
+        if (!s.pendingShapeAction || s.pendingShapeAction.kind !== 'cut' || s.pendingShapeAction.cutterIds.length === 0) {
+          return {}
+        }
+        return {
+          pendingShapeAction: { ...s.pendingShapeAction, phase: 'targets' },
+        }
+      }),
 
     setPendingShapeActionKeepOriginals: (keepOriginals) =>
       set((s) => ({

--- a/src/store/slices/pendingCompletionSlice.ts
+++ b/src/store/slices/pendingCompletionSlice.ts
@@ -567,22 +567,25 @@ export function createPendingCompletionSlice(
         return result
       }
 
-      if (!pendingShapeAction.cutterId || pendingShapeAction.targetIds.length === 0) {
+      if (pendingShapeAction.cutterIds.length === 0 || pendingShapeAction.targetIds.length === 0) {
         return []
       }
 
-      const cutter = featureById(state.project, pendingShapeAction.cutterId)
+      const cutters = pendingShapeAction.cutterIds
+        .map((cId) => featureById(state.project, cId))
+        .filter((feature): feature is SketchFeature => feature !== null)
+        .filter((feature) => feature.sketch.profile.closed)
       const targets = pendingShapeAction.targetIds
         .map((featureId) => featureById(state.project, featureId))
         .filter((feature): feature is SketchFeature => feature !== null)
         .filter((feature) => feature.sketch.profile.closed)
-      if (!cutter || !cutter.sketch.profile.closed || targets.length !== pendingShapeAction.targetIds.length) {
+      if (cutters.length !== pendingShapeAction.cutterIds.length || targets.length !== pendingShapeAction.targetIds.length) {
         return []
       }
 
       const createdGroups: DerivedFeatureGroup[] = cutFeaturesByCutterGrouped(
         state.project,
-        cutter,
+        cutters,
         targets,
         deps.createDerivedFeature,
       )

--- a/src/store/slices/selectionSlice.ts
+++ b/src/store/slices/selectionSlice.ts
@@ -167,20 +167,25 @@ export function createSelectionSlice(
             return {}
           }
 
+          const existingIds = s.pendingShapeAction?.kind === 'join' ? s.pendingShapeAction.entityIds : []
           const proposedIds =
             !id
               ? []
               : additive
-                ? s.selection.selectedFeatureIds.includes(id)
-                  ? s.selection.selectedFeatureIds.filter((featureId) => featureId !== id)
-                  : [...s.selection.selectedFeatureIds, id]
-                : [id]
+                ? existingIds.includes(id)
+                  ? existingIds.filter((featureId) => featureId !== id)
+                  : [...existingIds, id]
+                : existingIds.length === 0
+                  ? [id]
+                  : existingIds.includes(id)
+                    ? existingIds
+                    : [...existingIds, id]
           const proposedFeatures = proposedIds
             .map((featureId) => featureById(s.project, featureId))
             .filter((feature): feature is SketchFeature => feature !== null)
           const nextIds = featuresFormConnectedOverlapGroup(proposedFeatures)
             ? proposedIds
-            : s.selection.selectedFeatureIds
+            : existingIds
           const nextPrimaryId = nextIds.at(-1) ?? null
 
           return {
@@ -208,13 +213,27 @@ export function createSelectionSlice(
           }
 
           if (!id) {
+            if (pendingShapeAction.phase === 'cutters') {
+              return {
+                pendingOffset: null,
+                pendingShapeAction: { ...pendingShapeAction, cutterIds: [], targetIds: [] },
+                selection: {
+                  ...s.selection,
+                  selectedFeatureId: null,
+                  selectedFeatureIds: [],
+                  selectedNode: null,
+                  mode: 'feature',
+                  activeControl: null,
+                },
+              }
+            }
             return {
               pendingOffset: null,
-              pendingShapeAction: { ...pendingShapeAction, cutterId: null, targetIds: [] },
+              pendingShapeAction: { ...pendingShapeAction, targetIds: [] },
               selection: {
                 ...s.selection,
                 selectedFeatureId: null,
-                selectedFeatureIds: [],
+                selectedFeatureIds: [...pendingShapeAction.cutterIds],
                 selectedNode: null,
                 mode: 'feature',
                 activeControl: null,
@@ -222,14 +241,19 @@ export function createSelectionSlice(
             }
           }
 
-          if (!pendingShapeAction.cutterId) {
+          if (pendingShapeAction.phase === 'cutters') {
+            const nextCutterIds = additive
+              ? pendingShapeAction.cutterIds.includes(id)
+                ? pendingShapeAction.cutterIds.filter((cId) => cId !== id)
+                : [...pendingShapeAction.cutterIds, id]
+              : [id]
             return {
               pendingOffset: null,
-              pendingShapeAction: { ...pendingShapeAction, cutterId: id, targetIds: [] },
+              pendingShapeAction: { ...pendingShapeAction, cutterIds: nextCutterIds, targetIds: [] },
               selection: {
                 ...s.selection,
                 selectedFeatureId: id,
-                selectedFeatureIds: [id],
+                selectedFeatureIds: nextCutterIds,
                 selectedNode: { type: 'feature', featureId: id },
                 mode: 'feature',
                 activeControl: null,
@@ -237,26 +261,14 @@ export function createSelectionSlice(
             }
           }
 
-          if (id === pendingShapeAction.cutterId) {
-            if (additive) {
-              return {}
-            }
-            return {
-              pendingOffset: null,
-              pendingShapeAction: { ...pendingShapeAction, cutterId: id, targetIds: [] },
-              selection: {
-                ...s.selection,
-                selectedFeatureId: id,
-                selectedFeatureIds: [id],
-                selectedNode: { type: 'feature', featureId: id },
-                mode: 'feature',
-                activeControl: null,
-              },
-            }
+          if (pendingShapeAction.cutterIds.includes(id)) {
+            return {}
           }
 
-          const cutter = featureById(s.project, pendingShapeAction.cutterId)
-          if (!cutter || !selectedFeature || !featuresOverlap(cutter, selectedFeature)) {
+          const cutters = pendingShapeAction.cutterIds
+            .map((cId) => featureById(s.project, cId))
+            .filter((f): f is SketchFeature => f !== null)
+          if (!selectedFeature || !cutters.some((cutter) => featuresOverlap(cutter, selectedFeature))) {
             return {}
           }
 
@@ -265,8 +277,8 @@ export function createSelectionSlice(
               ? pendingShapeAction.targetIds.filter((featureId) => featureId !== id)
               : [...pendingShapeAction.targetIds, id]
             : [id]
-          const nextSelectedIds = [pendingShapeAction.cutterId, ...nextTargetIds]
-          const nextPrimaryId = nextTargetIds.at(-1) ?? pendingShapeAction.cutterId
+          const nextSelectedIds = [...pendingShapeAction.cutterIds, ...nextTargetIds]
+          const nextPrimaryId = nextTargetIds.at(-1) ?? pendingShapeAction.cutterIds.at(-1) ?? null
 
           return {
             pendingOffset: null,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -149,8 +149,9 @@ export type PendingShapeActionTool =
     }
   | {
       kind: 'cut'
-      cutterId: string | null
+      cutterIds: string[]
       targetIds: string[]
+      phase: 'cutters' | 'targets'
       keepOriginals: boolean
       session: number
     }
@@ -355,6 +356,7 @@ export interface ProjectStore {
   startJoinSelectedFeatures: () => void
   startCutSelectedFeatures: () => void
   cancelPendingShapeAction: () => void
+  confirmCutCutters: () => void
   setPendingShapeActionKeepOriginals: (keepOriginals: boolean) => void
   completePendingShapeAction: () => string[]
   startOffsetSelectedFeatures: () => void


### PR DESCRIPTION
## Summary

- **Multiple cutters in cut operation**: The cut workflow now supports selecting multiple cutting features. A two-phase selection model uses Tab to confirm cutters before selecting targets. Targets must overlap at least one cutter.
- **Pre-selection honoured**: Both cut and join now pre-populate from the current selection when entering the mode, matching existing UX patterns.
- **Join overlap enforcement**: Join selection now restricts to features that overlap the existing selection. Pre-selected features are filtered to the largest connected overlap group, dropping any isolated features.
- **Boolean closure fix**: Fixed a bug in `clipperContourToProfilePreserving` where the resulting profile was marked as closed but missing the closing segment back to the start vertex, causing broken continuity when editing cut/join results.

## Test plan

- [x] Select multiple features, enter cut mode — verify they appear as pre-selected cutters
- [x] In cut mode, click/shift-click to select cutters, press Tab to confirm, then shift-click overlapping targets
- [x] Verify non-overlapping features cannot be selected as targets
- [x] Press Enter to execute cut with multiple cutters — verify correct boolean result
- [x] Edit resulting cut features — verify continuity is preserved (no broken start/end points)
- [x] Select multiple features, enter join mode — verify non-overlapping features are dropped
- [x] In join mode, verify shift-clicking a non-overlapping feature is rejected
- [x] Test Tab button is clickable in the status bar (tablet-friendly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)