### PR TITLE
Improve project tree and toolbar UX

### DIFF
--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -18,6 +18,7 @@ import { useRef, useState } from 'react'
 import type { DragEvent, MouseEvent as ReactMouseEvent } from 'react'
 import type { FeatureOperation } from '../../types/project'
 import { useProjectStore } from '../../store/projectStore'
+import { Icon } from '../Icon'
 
 interface FeatureTreeProps {
   onFeatureContextMenu?: (featureId: string, x: number, y: number) => void
@@ -281,12 +282,11 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
           depth={0}
           isSelected={selection.selectedNode?.type === 'features_root'}
           isDragging={false}
-          collapsed={featuresCollapsed}
-          onClick={selectFeaturesRoot}
+
+          onClick={() => { selectFeaturesRoot(); setFeaturesCollapsed((value) => !value) }}
           onMouseEnter={() => hoverFeature(null)}
           onMouseLeave={() => hoverFeature(null)}
           onAddFolder={() => addFeatureFolder('features')}
-          onToggleCollapse={() => setFeaturesCollapsed((value) => !value)}
           onShowAll={() => setAllFeaturesVisible(true)}
           onHideAll={() => setAllFeaturesVisible(false)}
           onDragOver={(event) => handleDragOver(event, { kind: 'features' })}
@@ -321,12 +321,11 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                     depth={1}
                     isSelected={selection.selectedNode?.type === 'folder' && selection.selectedNode.folderId === folder.id}
                     isDragging={dragItem?.kind === 'folder' && dragItem.id === folder.id}
-                    collapsed={folder.collapsed}
+
                     visible={folderVisible}
-                    onClick={() => selectFeatureFolder(folder.id)}
+                    onClick={() => { selectFeatureFolder(folder.id); updateFeatureFolder(folder.id, { collapsed: !folder.collapsed }) }}
                     onMouseEnter={() => hoverFeature(null)}
                     onMouseLeave={() => hoverFeature(null)}
-                    onToggleCollapse={() => updateFeatureFolder(folder.id, { collapsed: !folder.collapsed })}
                     onSelectAllFeatures={folderFeatures.length > 0 ? () => selectFolderFeatures(folder.id) : undefined}
                     onToggleVisible={folderFeatures.length > 0 ? () => toggleFolderVisible(folder.id) : undefined}
                     draggable
@@ -355,12 +354,11 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
           depth={0}
           isSelected={selection.selectedNode?.type === 'regions_root'}
           isDragging={false}
-          collapsed={regionsCollapsed}
-          onClick={selectRegionsRoot}
+
+          onClick={() => { selectRegionsRoot(); setRegionsCollapsed((value) => !value) }}
           onMouseEnter={() => hoverFeature(null)}
           onMouseLeave={() => hoverFeature(null)}
           onAddFolder={() => addFeatureFolder('regions')}
-          onToggleCollapse={() => setRegionsCollapsed((value) => !value)}
           onShowAll={() => setAllRegionsVisible(true)}
           onHideAll={() => setAllRegionsVisible(false)}
         />
@@ -394,12 +392,11 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                     depth={1}
                     isSelected={selection.selectedNode?.type === 'folder' && selection.selectedNode.folderId === folder.id}
                     isDragging={dragItem?.kind === 'folder' && dragItem.id === folder.id}
-                    collapsed={folder.collapsed}
+
                     visible={folderVisible}
-                    onClick={() => selectFeatureFolder(folder.id)}
+                    onClick={() => { selectFeatureFolder(folder.id); updateFeatureFolder(folder.id, { collapsed: !folder.collapsed }) }}
                     onMouseEnter={() => hoverFeature(null)}
                     onMouseLeave={() => hoverFeature(null)}
-                    onToggleCollapse={() => updateFeatureFolder(folder.id, { collapsed: !folder.collapsed })}
                     onSelectAllFeatures={folderFeatures.length > 0 ? () => selectFeatures(folderFeatures.map((feature) => feature.id)) : undefined}
                     onToggleVisible={folderFeatures.length > 0 ? () => toggleRegionFolderVisible(folder.id) : undefined}
                     draggable
@@ -428,12 +425,11 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
           depth={0}
           isSelected={selection.selectedNode?.type === 'tabs_root'}
           isDragging={false}
-          collapsed={tabsCollapsed}
-          onClick={selectTabsRoot}
+
+          onClick={() => { selectTabsRoot(); setTabsCollapsed((value) => !value) }}
           onMouseEnter={() => hoverFeature(null)}
           onMouseLeave={() => hoverFeature(null)}
           onAddTab={() => startAddTabPlacement()}
-          onToggleCollapse={() => setTabsCollapsed((value) => !value)}
           onShowAll={() => setAllTabsVisible(true)}
           onHideAll={() => setAllTabsVisible(false)}
         />
@@ -474,12 +470,11 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
           depth={0}
           isSelected={selection.selectedNode?.type === 'clamps_root'}
           isDragging={false}
-          collapsed={clampsCollapsed}
-          onClick={selectClampsRoot}
+
+          onClick={() => { selectClampsRoot(); setClampsCollapsed((value) => !value) }}
           onMouseEnter={() => hoverFeature(null)}
           onMouseLeave={() => hoverFeature(null)}
           onAddClamp={() => startAddClampPlacement()}
-          onToggleCollapse={() => setClampsCollapsed((value) => !value)}
           onShowAll={() => setAllClampsVisible(true)}
           onHideAll={() => setAllClampsVisible(false)}
         />
@@ -528,14 +523,12 @@ interface TreeRowProps {
   visible?: boolean
   operation?: FeatureOperation
   isFirstFeature?: boolean
-  collapsed?: boolean
   onClick: (event: ReactMouseEvent<HTMLDivElement>) => void
   onMouseEnter: () => void
   onMouseLeave: () => void
   onToggleVisible?: () => void
   onSelectAllFeatures?: () => void
   onToggleOperation?: (operation: FeatureOperation) => void
-  onToggleCollapse?: () => void
   onAddFolder?: () => void
   onAddTab?: () => void
   onAddClamp?: () => void
@@ -560,14 +553,12 @@ function TreeRow({
   visible,
   operation,
   isFirstFeature = false,
-  collapsed = false,
   onClick,
   onMouseEnter,
   onMouseLeave,
   onToggleVisible,
   onSelectAllFeatures,
   onToggleOperation,
-  onToggleCollapse,
   onAddFolder,
   onAddTab,
   onAddClamp,
@@ -613,13 +604,11 @@ function TreeRow({
       onDragOver={onDragOver}
       onDrop={onDrop}
       onContextMenu={onContextMenu}
-      style={{ paddingLeft: `${depth * 12}px` }}
+      style={{ paddingLeft: `${depth * 8}px` }}
     >
       <span className={`tree-branch tree-branch--${kind}`} aria-hidden="true">
         {kind === 'folder' ? (
-          <svg viewBox="0 0 16 12" className="tree-icon tree-icon--folder" focusable="false" aria-hidden="true">
-            <path d="M1.5 3.25h3.2l1-1.35h2.15c.43 0 .8.15 1.09.44.29.29.44.66.44 1.09v.32h3.05c.43 0 .8.15 1.09.44.29.29.44.66.44 1.09v4.97c0 .43-.15.8-.44 1.09-.29.29-.66.44-1.09.44H1.75c-.43 0-.8-.15-1.09-.44-.29-.29-.44-.66-.44-1.09V4.78c0-.43.15-.8.44-1.09.29-.29.66-.44 1.09-.44Z" />
-          </svg>
+          <Icon id="open" size={16} className="tree-icon--folder" />
         ) : (
           kind === 'project'
             ? 'proj'
@@ -687,9 +676,7 @@ function TreeRow({
             title={kind === 'regions' ? 'Add region folder' : 'Add folder'}
             aria-label={kind === 'regions' ? 'Add region folder' : 'Add folder'}
           >
-            <svg viewBox="0 0 16 12" width="14" height="11" focusable="false" aria-hidden="true" style={{ display: 'block' }}>
-              <path fill="currentColor" d="M1.5 3.25h3.2l1-1.35h2.15c.43 0 .8.15 1.09.44.29.29.44.66.44 1.09v.32h3.05c.43 0 .8.15 1.09.44.29.29.44.66.44 1.09v4.97c0 .43-.15.8-.44 1.09-.29.29-.66.44-1.09.44H1.75c-.43 0-.8-.15-1.09-.44-.29-.29-.44-.66-.44-1.09V4.78c0-.43.15-.8.44-1.09.29-.29.66-.44 1.09-.44Z" />
-            </svg>
+            <Icon id="open" size={14} />
           </button>
         ) : null}
         {kind === 'tabs' && onAddTab ? (
@@ -718,20 +705,6 @@ function TreeRow({
             aria-label="Add clamp"
           >
             +
-          </button>
-        ) : null}
-        {(kind === 'folder' || kind === 'features' || kind === 'regions' || kind === 'tabs' || kind === 'clamps') && onToggleCollapse ? (
-          <button
-            type="button"
-            className="tree-action-btn"
-            onClick={(event) => {
-              event.stopPropagation()
-              onToggleCollapse()
-            }}
-            title={collapsed ? 'Expand section' : 'Collapse section'}
-            aria-label={collapsed ? 'Expand section' : 'Collapse section'}
-          >
-            {collapsed ? '▸' : '▾'}
           </button>
         ) : null}
         {kind === 'feature' && onToggleOperation ? (

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -688,6 +688,8 @@ function FeatureEditActions({
   onConstraint: () => void
   constraintActive: boolean
 }) {
+  if (!enabled) return null
+
   return (
     <>
       <div className="toolbar-group">
@@ -695,7 +697,6 @@ function FeatureEditActions({
           icon="copy"
           label={pendingMoveMode === 'copy' ? 'Cancel copy' : 'Copy selected features'}
           active={pendingMoveMode === 'copy'}
-          disabled={!enabled}
           tooltipSide={tooltipSide}
           onClick={onCopy}
         />
@@ -703,14 +704,13 @@ function FeatureEditActions({
           icon="move"
           label={pendingMoveMode === 'move' ? 'Cancel move' : 'Move selected features'}
           active={pendingMoveMode === 'move'}
-          disabled={!enabled || hasLockedSelection}
+          disabled={hasLockedSelection}
           tooltipSide={tooltipSide}
           onClick={onMove}
         />
         <ToolbarActionButton
           icon="trash"
           label="Delete selected features"
-          disabled={!enabled}
           tooltipSide={tooltipSide}
           onClick={onDelete}
         />
@@ -718,7 +718,7 @@ function FeatureEditActions({
           icon="resize"
           label={pendingTransformMode === 'resize' ? 'Cancel resize' : 'Resize selected features'}
           active={pendingTransformMode === 'resize'}
-          disabled={!enabled || hasLockedSelection}
+          disabled={hasLockedSelection}
           tooltipSide={tooltipSide}
           onClick={onResize}
         />
@@ -726,7 +726,7 @@ function FeatureEditActions({
           icon="rotate"
           label={pendingTransformMode === 'rotate' ? 'Cancel rotate' : 'Rotate selected features'}
           active={pendingTransformMode === 'rotate'}
-          disabled={!enabled || hasLockedSelection}
+          disabled={hasLockedSelection}
           tooltipSide={tooltipSide}
           onClick={onRotate}
         />
@@ -734,7 +734,7 @@ function FeatureEditActions({
           icon="offset"
           label={pendingOffset ? 'Cancel offset' : 'Create offset feature'}
           active={pendingOffset}
-          disabled={!enabled || hasLockedSelection || !hasClosedSelection}
+          disabled={hasLockedSelection || !hasClosedSelection}
           tooltipSide={tooltipSide}
           onClick={onOffset}
         />
@@ -742,7 +742,7 @@ function FeatureEditActions({
           icon="constraint"
           label={constraintActive ? 'Cancel constraint' : 'Add constraint'}
           active={constraintActive}
-          disabled={!enabled || hasLockedSelection}
+          disabled={hasLockedSelection}
           tooltipSide={tooltipSide}
           onClick={onConstraint}
         />
@@ -864,6 +864,8 @@ function AlignmentActions({
   tooltipSide?: 'bottom' | 'right'
   onAlign: (alignment: FeatureAlignment) => void
 }) {
+  if (!enabled) return null
+
   return (
     <ToolbarPopoverMenu
       triggerIcon="align"
@@ -887,6 +889,8 @@ function DistributionActions({
   tooltipSide?: 'bottom' | 'right'
   onDistribute: (distribution: FeatureDistribution) => void
 }) {
+  if (!enabled) return null
+
   return (
     <ToolbarPopoverMenu
       triggerIcon="distribute"
@@ -947,13 +951,14 @@ function SketchEditActions({
   onDeletePoint: () => void
   onFillet: () => void
 }) {
+  if (!enabled) return null
+
   return (
     <div className="toolbar-group">
       <ToolbarActionButton
         icon="point-add"
         label={activeTool === 'add_point' ? 'Cancel add point' : 'Add point'}
         active={activeTool === 'add_point'}
-        disabled={!enabled}
         tooltipSide={tooltipSide}
         onClick={onAddPoint}
       />
@@ -961,7 +966,6 @@ function SketchEditActions({
         icon="point-delete"
         label={activeTool === 'delete_point' ? 'Cancel delete point' : 'Delete point'}
         active={activeTool === 'delete_point'}
-        disabled={!enabled}
         tooltipSide={tooltipSide}
         onClick={onDeletePoint}
       />
@@ -969,7 +973,6 @@ function SketchEditActions({
         icon="fillet"
         label={activeTool === 'fillet' ? 'Cancel fillet' : 'Round corner / fillet'}
         active={activeTool === 'fillet'}
-        disabled={!enabled}
         tooltipSide={tooltipSide}
         onClick={onFillet}
       />
@@ -996,20 +999,20 @@ function BackdropEditActions({
   onResize: () => void
   onRotate: () => void
 }) {
+  if (!enabled) return null
+
   return (
     <div className="toolbar-group">
       <ToolbarActionButton
         icon="move"
         label={pendingMoveMode === 'move' ? 'Cancel move backdrop' : 'Move backdrop'}
         active={pendingMoveMode === 'move'}
-        disabled={!enabled}
         tooltipSide={tooltipSide}
         onClick={onMove}
       />
       <ToolbarActionButton
         icon="trash"
         label="Delete backdrop"
-        disabled={!enabled}
         tooltipSide={tooltipSide}
         onClick={onDelete}
       />
@@ -1017,7 +1020,6 @@ function BackdropEditActions({
         icon="resize"
         label={pendingTransformMode === 'resize' ? 'Cancel resize backdrop' : 'Resize backdrop'}
         active={pendingTransformMode === 'resize'}
-        disabled={!enabled}
         tooltipSide={tooltipSide}
         onClick={onResize}
       />
@@ -1025,7 +1027,6 @@ function BackdropEditActions({
         icon="rotate"
         label={pendingTransformMode === 'rotate' ? 'Cancel rotate backdrop' : 'Rotate backdrop'}
         active={pendingTransformMode === 'rotate'}
-        disabled={!enabled}
         tooltipSide={tooltipSide}
         onClick={onRotate}
       />

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1292,17 +1292,11 @@
   position: relative;
   display: grid;
   gap: 2px;
-  padding-left: 6px;
+  padding-left: 10px;
 }
 
 .tree-children::before {
-  content: '';
-  position: absolute;
-  top: 2px;
-  bottom: 2px;
-  left: 5px;
-  width: 1px;
-  background: linear-gradient(180deg, rgba(84, 108, 128, 0.55), rgba(60, 82, 101, 0.15));
+  display: none;
 }
 
 .tree-list::before {
@@ -1336,6 +1330,15 @@
   width: 7px;
   height: 1px;
   background: var(--line-strong);
+}
+
+.tree-row--nested,
+.tree-row--deep {
+  grid-template-columns: 0 minmax(0, 1fr) auto;
+}
+
+.tree-row--folder.tree-row--nested {
+  grid-template-columns: 16px minmax(0, 1fr) auto;
 }
 
 .tree-row--nested::before {
@@ -1446,15 +1449,30 @@
   display: none;
 }
 
+.tree-row--nested .tree-branch:not(.tree-branch--folder),
+.tree-row--deep .tree-branch:not(.tree-branch--folder) {
+  width: 0;
+  height: 0;
+  border: none;
+  background: transparent;
+  overflow: hidden;
+}
+
+.tree-row--nested .tree-branch:not(.tree-branch--folder)::before,
+.tree-row--deep .tree-branch:not(.tree-branch--folder)::before {
+  display: none;
+}
+
 .tree-icon {
   display: block;
 }
 
 .tree-icon--folder {
   width: 16px;
-  height: 12px;
-  fill: rgba(214, 226, 236, 0.78);
-  transform: translateX(-1px);
+  height: 16px;
+  color: rgba(214, 226, 236, 0.78);
+  fill: currentColor;
+  stroke: none;
 }
 
 .tree-label {
@@ -1521,13 +1539,13 @@
 }
 
 .feature-tree-empty {
-  padding: 8px 0 0 26px;
+  padding: 8px 0 0 14px;
   color: var(--text-dim);
   font-size: 13px;
 }
 
 .tree-children .feature-tree-empty {
-  padding-left: 36px;
+  padding-left: 22px;
 }
 
 .properties-panel {


### PR DESCRIPTION
## Summary
- **Tree hierarchy redesign**: Remove circle node indicators from nested rows (depth 1/2), reclaiming ~16-20px of horizontal space per nesting level. Top-level circles stay. Folder rows use the Icon component with the "open" folder icon (filled, consistent with toolbar).
- **Click-to-expand**: Expandable rows (Features, Regions, Tabs, Clamps, folders) now toggle collapse on click, removing the separate expand/collapse (▸/▾) buttons.
- **Hide disabled toolbars**: Feature edit, alignment, distribution, sketch edit, and backdrop edit toolbar sections are hidden when not applicable instead of showing as disabled.

## Test plan
- [x] Top-level tree rows (Project, Grid, Stock, Origin, etc.) still show circle indicators
- [x] Nested features/tabs/clamps show no circle, just label + action buttons
- [x] Folder rows show filled folder icon at both low and high DPI
- [x] Clicking Features/Regions/Tabs/Clamps/folder rows toggles expand/collapse
- [x] Toolbar buttons appear only when relevant (select a feature to see edit actions, enter sketch edit for point tools)
- [x] Undo/redo and snap buttons remain always visible
- [x] Drag-and-drop in the tree still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)