### PR TITLE
Reset viewports to default camera when creating/loading a new project

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,6 +112,7 @@ function App() {
   const menuRef = useRef<HTMLDivElement>(null)
   const {
     project,
+    projectKey,
     selection,
     selectFeature,
     enterSketchEdit,
@@ -809,6 +810,7 @@ function App() {
             zoomWindowActive={zoomWindowActive && centerTab === 'simulation'}
             onZoomWindowComplete={() => setZoomWindowActive(false)}
             playbackInput={simulationPlaybackInput}
+            projectKey={projectKey}
           />
         }
         featureTree={<FeatureTree onFeatureContextMenu={openFeatureContextMenu} onTabContextMenu={openTabContextMenu} onClampContextMenu={openClampContextMenu} />}
@@ -842,7 +844,18 @@ function App() {
       )}
 
       {showNewProjectDialog && (
-        <NewProjectDialog onClose={() => setShowNewProjectDialog(false)} />
+        <NewProjectDialog
+          onClose={() => setShowNewProjectDialog(false)}
+          onCreated={() => {
+            hasAutoFramed3DRef.current = false
+            setCenterTab('sketch')
+            window.requestAnimationFrame(() => {
+              window.requestAnimationFrame(() => {
+                sketchCanvasRef.current?.zoomToModel()
+              })
+            })
+          }}
+        />
       )}
 
       {treeContextMenu && menuPosition && (menuFeature || menuTab || menuClamp) ? (

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -290,6 +290,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
   const {
     project,
+    projectKey,
     pendingAdd,
     pendingMove,
     pendingTransform,
@@ -1676,9 +1677,17 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     zoomToModel: () => {
       const canvas = canvasRef.current
       if (!canvas) return
-      setViewState(computeFitViewState(project, canvas.width, canvas.height))
+      setViewState(computeFitViewState(projectRef.current, canvas.width, canvas.height))
     },
-  }), [project])
+  }), [])
+
+  useEffect(() => {
+    if (projectKey === 0) return
+    const canvas = canvasRef.current
+    if (!canvas) return
+    setViewState(computeFitViewState(projectRef.current, canvas.width, canvas.height))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectKey])
 
   useEffect(() => {
     const container = containerRef.current

--- a/src/components/project/NewProjectDialog.tsx
+++ b/src/components/project/NewProjectDialog.tsx
@@ -25,6 +25,7 @@ type TemplateKind = 'blank_metric' | 'blank_imperial' | 'current' | 'file'
 
 interface NewProjectDialogProps {
   onClose: () => void
+  onCreated?: () => void
 }
 
 function suggestedProjectName(kind: TemplateKind, currentProject: Project, fileTemplate: Project | null): string {
@@ -71,7 +72,7 @@ function setupOnlyTemplate(template: Project): Project {
   }
 }
 
-export function NewProjectDialog({ onClose }: NewProjectDialogProps) {
+export function NewProjectDialog({ onClose, onCreated }: NewProjectDialogProps) {
   const { project, createNewProject } = useProjectStore()
   const [templateKind, setTemplateKind] = useState<TemplateKind>('blank_metric')
   const [fileTemplate, setFileTemplate] = useState<Project | null>(null)
@@ -145,6 +146,7 @@ export function NewProjectDialog({ onClose }: NewProjectDialogProps) {
 
     createNewProject(activeTemplate, projectName.trim() || suggestedProjectName(templateKind, project, fileTemplate))
     onClose()
+    onCreated?.()
   }
 
   function handleTemplateFileChange(event: ChangeEvent<HTMLInputElement>) {

--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -113,6 +113,8 @@ interface SimulationViewportProps {
   zoomWindowActive?: boolean
   onZoomWindowComplete?: () => void
   playbackInput: SimulationPlaybackInput | null
+  /** Incremented each time the project changes so the viewport can reset its camera. */
+  projectKey?: number
 }
 
 export interface SimulationViewportHandle {
@@ -442,6 +444,7 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   zoomWindowActive = false,
   onZoomWindowComplete,
   playbackInput,
+  projectKey,
 }, ref) {
   const playbackUnits = playbackInput?.units ?? 'mm'
   const fallbackFeed = playbackUnits === 'in' ? PLAYBACK_FALLBACK_FEED_IN : PLAYBACK_FALLBACK_FEED_MM
@@ -940,6 +943,30 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
       disposeOriginMesh(scene)
     }
   }, [disposeOriginMesh, origin, simulation])
+
+  // Reset camera on project change so the viewport doesn't keep the previous
+  // project's camera position/orientation when a new project is created.
+  useEffect(() => {
+    if (!projectKey) return
+    hasAutoFramedRef.current = false
+    const controls = controlsRef.current
+    if (!controls) return
+    controls.setPreset('iso')
+    // Wait for any pending simulation build (debounced 150ms) to complete,
+    // then auto-frame if a mesh exists.
+    const timer = setTimeout(() => {
+      const object = objectRef.current
+      if (object instanceof THREE.Mesh) {
+        const bounds = new THREE.Box3().setFromObject(object)
+        if (!bounds.isEmpty()) {
+          controls.fitToBounds(bounds, true)
+          hasAutoFramedRef.current = true
+        }
+      }
+    }, 300)
+    return () => clearTimeout(timer)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectKey])
 
   useImperativeHandle(ref, () => ({
     zoomToModel,

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -619,7 +619,7 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
   const [zoomWindowBox, setZoomWindowBox] = useState<{ startX: number; startY: number; currentX: number; currentY: number } | null>(null)
   const zoomWindowBoxRef = useRef<{ startX: number; startY: number; currentX: number; currentY: number } | null>(null)
 
-  const { project, selection } = useProjectStore()
+  const { project, selection, projectKey } = useProjectStore()
   zoomWindowActiveRef.current = zoomWindowActive
   zoomWindowBoxRef.current = zoomWindowBox
 
@@ -979,10 +979,37 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
       clearOriginObject(scene)
     }
   }, [clearOriginObject, originVisible, project.origin, project.stock])
+// Reset to default isometric view when a new project is created/loaded
+useEffect(() => {
+  if (projectKey === 0) return
+  const controls = controlsRef.current
+  if (!controls) return
 
-  useImperativeHandle(ref, () => ({
-    zoomToModel,
-  }), [zoomToModel])
+  // Scene objects are rebuilt in a separate effect with a 150ms timeout.
+  // Wait for them to be available before fitting to bounds.
+  const timer = setTimeout(() => {
+    const bounds = new THREE.Box3()
+    let hasRenderableObject = false
+    for (const object of objectsRef.current) {
+      if (!object.visible) continue
+      bounds.expandByObject(object)
+      hasRenderableObject = true
+    }
+    if (!hasRenderableObject || bounds.isEmpty()) {
+      controls.reset()
+      return
+    }
+    controls.fitToBounds(bounds, true)
+  }, 250)
+
+  return () => clearTimeout(timer)
+// eslint-disable-next-line react-hooks/exhaustive-deps
+}, [projectKey])
+
+useImperativeHandle(ref, () => ({
+  zoomToModel,
+}), [zoomToModel])
+
 
   useEffect(() => {
     if (!zoomWindowActive) {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -2509,6 +2509,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
   filePath: null,
   lastExportPath: null,
   dirty: false,
+  projectKey: 0,
   pendingConstraint: null,
   history: {
     past: [],
@@ -2580,6 +2581,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         pendingTransform: null,
         pendingOffset: null,
         selection: emptySelection(),
+        projectKey: state.projectKey + 1,
         history: {
           past: [...state.history.past, cloneProject(state.project)].slice(-100),
           future: [],
@@ -2986,6 +2988,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         pendingTransform: null,
         pendingOffset: null,
         selection: emptySelection(),
+        projectKey: state.projectKey + 1,
         history: {
           past: [...state.history.past, cloneProject(state.project)].slice(-100),
           future: [],

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -199,6 +199,8 @@ export interface ProjectStore {
   history: ProjectHistory
 
   // ---- Session state (not persisted in .camj) ----
+  /** Incremented each time a new project is created or loaded. Used by viewports to reset their view state. */
+  projectKey: number
   /** Filesystem path of the currently open file. Null in the browser or when no file is open. */
   filePath: string | null
   /** Path of the most recent G-code export. Null until first export this session. */


### PR DESCRIPTION
## Summary

When a new project is created or an existing project is loaded, all three viewports now reset their camera position/orientation to the default isometric view fitting the model bounds.

## Changes

### Infrastructure
- **`src/store/types.ts`** — Added `projectKey: number` session field with doc comment
- **`src/store/projectStore.ts`** — Initialized `projectKey` to 0, increments on `createNewProject()` and `loadProject()`

### 2D Sketch Canvas
- **`src/components/canvas/SketchCanvas.tsx`** — Added `useEffect` watching `projectKey` that fits the stock bounds to the canvas view via `computeFitViewState()`

### 3D Viewport
- **`src/components/viewport3d/Viewport3D.tsx`** — Added `useEffect` watching `projectKey` that resets the camera to default isometric orientation and fits all visible scene objects

### Simulation Viewport
- **`src/components/simulation/SimulationViewport.tsx`** — Added optional `projectKey` prop and a `useEffect` that resets `hasAutoFramedRef`, calls `setPreset('iso')`, and fits the simulation mesh bounds after scene rebuild
- **`src/App.tsx`** — Destructures `projectKey` from the store and passes it to `SimulationViewport`

### Dialog
- **`src/components/project/NewProjectDialog.tsx`** — Added `onCreated` callback prop so the caller can react after project creation