### PR TITLE
Feature-as-Stock: Allow any closed-profile sketch feature to serve as stock

### DIFF
--- a/planning/FEATURE_AS_STOCK_Design.md
+++ b/planning/FEATURE_AS_STOCK_Design.md
@@ -1,0 +1,187 @@
+# Feature-as-Stock Design
+
+## Goal
+
+Allow any sketch feature to serve as the stock definition, instead of only supporting a plain rectangular block. The user selects an existing feature and the app adopts its 2D profile and Z extent as the stock boundary.
+
+## Current Behavior
+
+Stock is defined as a `Stock` object with a `SketchProfile`, `thickness`, `origin`, `material`, `color`, and `visible` flag. Today `defaultStock()` always creates a `rectProfile()`. The UI in PropertiesPanel only exposes width/height/thickness inputs and recreates a rectangle on every edit.
+
+## Proposed Data Model Change
+
+Add `sourceFeatureId` and `sourceFeature` fields to `Stock`:
+
+```typescript
+export interface Stock {
+  profile: SketchProfile
+  thickness: number
+  material: string
+  color: string
+  visible: boolean
+  origin: Point
+  sourceFeatureId?: string | null   // NEW — links stock to a feature
+  sourceFeature?: SketchFeature | null  // NEW — the full feature data, removed from the features array
+}
+```
+
+When `sourceFeatureId` is set:
+- The source feature is **removed from `project.features` and `project.featureTree`** — it no longer participates as a regular feature.
+- The full `SketchFeature` is stored in `stock.sourceFeature` so it can be edited from the stock properties panel and restored to the tree later.
+- `stock.profile` is kept in sync with the source feature's `sketch.profile` (transformed by the feature's `sketch.origin` and `orientationAngle`).
+- `stock.thickness` is derived from the feature's z_top (assuming z_bottom = 0 for stock).
+- Edits to the source feature's sketch automatically update the stock boundary.
+
+When `sourceFeatureId` is null/undefined (default), behavior is identical to today — the stock is an independent rectangle or user-defined shape.
+
+## Impact Analysis
+
+### No changes needed (already profile-agnostic)
+
+| Component | File | Why |
+|-----------|------|-----|
+| 3D CSG mesh | `src/engine/csg.ts:174-192` | `profileToShape()` handles any profile; `ExtrudeGeometry` extrudes any 2D shape |
+| 3D wireframe | `src/engine/csg.ts:805-820` | Same `profileToShape()` path |
+| 2D canvas rendering | `src/components/canvas/SketchCanvas.tsx:770-781` | `traceProfilePath()` is generic |
+| View transforms | `src/components/canvas/viewTransform.ts` | Uses `stock.profile` directly |
+| Snap candidates | `src/components/canvas/snappingHelpers.ts:231` | Generic profile snapping |
+| Grid centering | `src/components/canvas/scenePrimitives.ts:213-264` | Uses `getStockBounds()` |
+| Import/export | `src/store/projectStore.ts:2968-3029` | Preserves `stock.profile` as-is |
+| Unit conversion | `src/utils/units.ts:193-200` | Converts any profile generically |
+| Toolpath engine | `src/engine/toolpaths/*.ts` | Works with feature/region profiles, not stock shape |
+| Safe Z calculation | `src/engine/toolpaths/geometry.ts:173-177` | Uses `stock.thickness` only |
+| Depth levels | `src/engine/toolpaths/surface.ts:235` | Uses `stock.thickness` only |
+
+### Changes required
+
+#### 1. Stock type & defaults (`src/types/project.ts`)
+
+- Add `sourceFeatureId?: string | null` to `Stock` interface.
+- Keep `defaultStock()` as-is for the rectangle path.
+- Add a helper `stockFromFeature(feature: SketchFeature): Stock` that builds a Stock from a feature's profile and Z span.
+- Add `getEffectiveStockProfile(project: Project): SketchProfile` — returns the derived profile when `sourceFeatureId` is set, or `stock.profile` otherwise.
+
+**Complexity: Low**
+
+#### 2. Store actions (`src/store/projectStore.ts`)
+
+- Add a `setStockSourceFeature(featureId: string | null)` action that:
+  - Sets `stock.sourceFeatureId`.
+  - Syncs `stock.profile` and `stock.thickness` from the feature.
+  - **Removes the feature from `features`, `featureTree`, and its folder** — it now lives only as the stock source. The feature data is preserved in a new `stock.sourceFeature` field (see data model).
+  - Updates origin if needed.
+  - Pushes to undo history.
+- When calling `setStockSourceFeature(null)` (resetting to rectangle):
+  - If a previous source feature exists, **restore it back into `features` and `featureTree`** at its original position (or end of tree).
+  - Reset `stock.profile` to a `rectProfile` matching the previous bounds.
+- When calling `setStockSourceFeature(newId)` while another feature is already the source:
+  - **Restore the old source feature** back into the tree first.
+  - Then remove the new source feature from the tree.
+- Modify feature mutation actions (move, resize, edit profile, delete) to re-sync stock when the mutated feature is the stock source:
+  - On profile/position/Z change: update `stock.profile` and `stock.thickness`.
+  - On delete: clear `sourceFeatureId`, restore to rectangle.
+
+**Complexity: Medium-High**
+
+#### 3a. Feature context menu — "Use as Stock" (`src/components/feature-tree/FeatureTree.tsx`)
+
+The primary way to assign a feature as stock. The feature tree's right-click context menu already exists for features. Add a new item:
+
+- **"Use as Stock"** — visible only for features with `operation === 'add'` and `sketch.profile.closed === true`. Calls `setStockSourceFeature(featureId)`. The feature disappears from the tree.
+- The stock node itself does not need a context menu for this — "Reset to Rectangle" lives in the properties panel.
+
+**Complexity: Low**
+
+#### 3b. Stock properties panel (`src/components/feature-tree/PropertiesPanel.tsx:510-600`)
+
+Currently hard-codes rectangular editing via `defaultStock(width, height, thickness)`.
+
+New layout when stock node is selected:
+
+```
+Stock
+  -- When Rectangle (sourceFeatureId is null) --
+  Width:  [____]
+  Height: [____]
+  Thickness: [____]
+  
+  -- When sourced from a feature --
+  Source: "Feature Name"  (read-only label)
+  Thickness: [____]  (derived from feature z_top, editable → updates feature z_top)
+  Bounding Size: 120 x 85  (read-only info)
+  [Edit Sketch]  button — enters sketch editing mode for the source feature
+  [Reset to Rectangle]  button — calls setStockSourceFeature(null), restores feature to tree
+```
+
+- Width/Height inputs are hidden when a feature source is active (shape is controlled by the feature's sketch).
+- "Edit Sketch" activates the same sketch editing flow used for regular features, but targeted at the source feature stored in `stock.sourceFeature`.
+- Color, material, visible remain unchanged in both modes.
+
+**Complexity: Medium**
+
+#### 4. Simulation grid (`src/engine/simulation/grid.ts`)
+
+The voxel grid is rectangular and fills every cell with `stockTopZ`. For non-rectangular stock, cells outside the stock profile should start empty (Z = 0).
+
+Changes to `createSimulationGrid()`:
+- After filling `topZ`, iterate each cell and test whether its center point is inside `stock.profile` using a point-in-polygon test.
+- Cells outside the profile get `topZ[i] = stockBottomZ` (empty).
+- Use `sampleProfilePoints()` to get the polygon boundary and a standard ray-casting PIP test.
+
+The grid spec (`resolveSimulationGridSpec`) remains unchanged — it uses bounding box dimensions which is correct (the grid must cover the full extent; individual cells are masked).
+
+**Complexity: Low-Medium** — straightforward PIP test, but must be efficient since cell counts can reach 30k+.
+
+#### 5. Bounds validation (`src/types/project.ts:959-968`)
+
+`profileExceedsStock()` currently does a bounding-box-only check. For non-rectangular stock this is overly permissive — a feature could be inside the bounding box but outside the actual stock profile.
+
+For now, keep the bbox check. It remains correct as a quick conservative test (if a feature exceeds the stock bbox, it definitely exceeds the stock). False negatives (feature reported as "within stock" when it's actually outside a concave stock boundary) are acceptable in the first iteration — the simulation and CSG will correctly handle the geometry regardless.
+
+A tighter point-in-polygon validation can be added later if users request visual warnings for features extending past non-rectangular stock edges.
+
+**Complexity: None (defer)**
+
+#### 6. CSG scene building (`src/engine/csg.ts:833-893`)
+
+No special exclusion logic needed. Since the source feature is already removed from `project.features` by the store action, `buildScene()` will naturally not include it in the feature mesh list. The stock mesh — built from `stock.profile` — represents the source feature's volume.
+
+**Complexity: None**
+
+#### 7. Sketch editing from stock panel
+
+The "Edit Sketch" button in the stock properties panel must enter the same sketch editing mode used for regular features, but operating on `stock.sourceFeature` instead of a feature from the `features` array.
+
+- Reuse the existing sketch editing infrastructure (selection, vertex dragging, segment manipulation).
+- On commit, update both `stock.sourceFeature` and `stock.profile`/`stock.thickness` in a single undo-able action.
+- The 2D canvas renders the stock profile with the stock's dashed-line style during editing, overlaid with the sketch editing handles.
+
+**Complexity: Medium**
+
+## Implementation Order
+
+1. **Data model** — Add `sourceFeatureId` and `sourceFeature` to Stock interface and helpers.
+2. **Store actions** — `setStockSourceFeature` (remove/restore feature from tree, sync profile). Handle swap and reset flows.
+3. **Context menu** — "Use as Stock" in feature right-click menu.
+4. **PropertiesPanel** — Conditional rendering: rectangle fields vs. feature-source display with "Edit Sketch" and "Reset to Rectangle".
+5. **Sketch editing from stock** — Wire "Edit Sketch" button to existing sketch editor targeting `stock.sourceFeature`.
+6. **Simulation masking** — Point-in-polygon cell initialization for non-rectangular stock.
+7. **Testing** — Create projects with circular, polygon, and freeform stock profiles. Verify swap, reset, undo/redo, and file save/load.
+
+## Edge Cases
+
+- **Feature with holes/subtract children**: Stock profile should use only the outer boundary of the source feature, ignoring any subtract operations. Stock is the raw material block shape.
+- **Feature moved off-origin**: The stock profile must account for the feature's `sketch.origin` offset. Transform the profile to project coordinates before assigning to stock.
+- **Open profiles**: Only closed profiles can be stock. The context menu item should only appear for features with `sketch.profile.closed === true`.
+- **STL features**: STL features have a `silhouettePaths` that could serve as the stock profile. Support this in a later iteration.
+- **Swapping stock source**: When a second feature is declared as stock while one already is, the old source feature is restored to the feature tree first, then the new one is removed. This is a single undo-able action.
+- **Reset to rectangle**: "Reset to Rectangle" restores the source feature to the tree and sets `stock.profile` to a `rectProfile` matching the previous stock bounds. Single undo-able action.
+- **Undo/redo**: `setStockSourceFeature` captures the full before/after state (feature array, feature tree, stock) as one undo entry. Undoing restores the feature to the tree and reverts stock to its previous profile.
+- **File save/load**: `stock.sourceFeature` is serialized as part of the `.camj` file. On load, no migration needed — old files without the field load as rectangle stock. New files with `sourceFeature` restore correctly since the feature data is self-contained in the stock object.
+
+## What This Does NOT Change
+
+- The `Stock` interface keeps its existing `profile` field as the source of truth for stock shape. When `sourceFeatureId` is set, the profile is *derived* from the feature but still stored explicitly — downstream code never needs to know about the source linkage.
+- Toolpath generation is unaffected — it works with feature profiles and regions, not stock shape.
+- G-code export is unaffected — it uses operation clearance Z and feature Z spans, not stock profile geometry.
+- File format remains backward-compatible — old files without `sourceFeatureId` load exactly as before.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,6 +135,7 @@ function App() {
     startCopyTab,
     startMoveClamp,
     startCopyClamp,
+    setStockSourceFeature,
   } = useProjectStore()
 
   const menuFeature = useMemo(
@@ -711,6 +712,14 @@ function App() {
     : null
 
   const menuHasMultipleSelection = treeContextMenu?.entityType === 'feature' && (treeContextMenu?.ids.length ?? 0) > 1
+  const menuCanUseAsStock =
+    treeContextMenu?.entityType === 'feature' &&
+    !menuHasMultipleSelection &&
+    menuFeature !== null &&
+    menuFeature.operation === 'add' &&
+    menuFeature.sketch.profile.closed === true &&
+    menuFeature.kind !== 'text' &&
+    menuFeature.kind !== 'stl'
   const menuHasLockedSelection =
     treeContextMenu?.entityType === 'feature' && (treeContextMenu?.ids.some((featureId) =>
       project.features.some((feature) => feature.id === featureId && feature.locked)
@@ -945,6 +954,16 @@ function App() {
                 disabled={menuHasLockedSelection}
               >
                 Cut
+              </button>
+              <div className="feature-context-menu__separator" />
+              <button
+                className="feature-context-menu__item"
+                type="button"
+                onClick={() => setStockSourceFeature(treeContextMenu.primaryId)}
+                disabled={!menuCanUseAsStock}
+                title={!menuCanUseAsStock ? 'Feature must be an add operation with a closed profile' : undefined}
+              >
+                Use as Stock
               </button>
               <div className="feature-context-menu__separator" />
               <button

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -1778,7 +1778,13 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     if (selection.mode !== 'sketch_edit') return null
     if (selection.selectedFeatureIds.length !== 1) return null
     if (!selection.selectedFeatureId) return null
-    return project.features.find((feature) => feature.id === selection.selectedFeatureId) ?? null
+    // Check features array first, then stock source feature
+    return (
+      project.features.find((feature) => feature.id === selection.selectedFeatureId) ??
+      (project.stock.sourceFeatureId === selection.selectedFeatureId && project.stock.sourceFeature
+        ? project.stock.sourceFeature
+        : null)
+    )
   }
 
   function editableClamp(): Clamp | null {
@@ -3644,7 +3650,10 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
   const editingFeature =
     selection.mode === 'sketch_edit' && selection.selectedFeatureId
-      ? project.features.find((feature) => feature.id === selection.selectedFeatureId) ?? null
+      ? project.features.find((feature) => feature.id === selection.selectedFeatureId) ??
+        (project.stock.sourceFeatureId === selection.selectedFeatureId && project.stock.sourceFeature
+          ? project.stock.sourceFeature
+          : null)
       : null
   const editingClamp = (() => {
     if (selection.mode !== 'sketch_edit') return null

--- a/src/components/feature-tree/PropertiesPanel.tsx
+++ b/src/components/feature-tree/PropertiesPanel.tsx
@@ -178,6 +178,7 @@ export function PropertiesPanel() {
     startRotateBackdrop,
     setGrid,
     setStock,
+    setStockSourceFeature,
     setUnits,
     updateTab,
     updateClamp,
@@ -187,6 +188,7 @@ export function PropertiesPanel() {
     deleteFeature,
     deleteFeatures,
     enterSketchEdit,
+    enterStockSketchEdit,
     enterTabEdit,
     enterClampEdit,
     deleteConstraint,
@@ -508,9 +510,76 @@ export function PropertiesPanel() {
   }
 
   if (selection.selectedNode?.type === 'stock') {
+    const isFeatureStock = !!project.stock.sourceFeatureId && !!project.stock.sourceFeature
     const bounds = getStockBounds(project.stock)
     const width = bounds.maxX - bounds.minX
     const height = bounds.maxY - bounds.minY
+
+    if (isFeatureStock) {
+      const sourceFeature = project.stock.sourceFeature!
+      return (
+        <div className="properties-panel">
+          <div className="properties-group">
+            <label className="properties-field">
+              <span>Name</span>
+              <DraftTextInput value="Stock" disabled />
+            </label>
+            <label className="properties-field">
+              <span>Source Feature</span>
+              <DraftTextInput value={sourceFeature.name} disabled />
+            </label>
+            <label className="properties-field">
+              <span>Thickness</span>
+              <DraftNumberInput
+                key={`stock-thickness-${project.stock.thickness}`}
+                value={project.stock.thickness}
+                units={units}
+                min={minimumLength}
+                onCommit={(next) => {
+                  setStock({ ...project.stock, thickness: next })
+                }}
+              />
+            </label>
+            <label className="properties-field">
+              <span>Color</span>
+              <input
+                type="color"
+                value={project.stock.color}
+                onChange={(event) => {
+                  setStock({ ...project.stock, color: event.target.value })
+                }}
+              />
+            </label>
+            <label className="properties-check">
+              <input
+                type="checkbox"
+                checked={project.stock.visible}
+                onChange={(event) => {
+                  setStock({ ...project.stock, visible: event.target.checked })
+                }}
+              />
+              <span>Visible</span>
+            </label>
+            <div className="properties-actions" style={{ display: 'flex', gap: '8px', marginTop: '12px', flexDirection: 'column' }}>
+              <button
+                className="feature-context-menu__item"
+                type="button"
+                onClick={() => enterStockSketchEdit(sourceFeature.id)}
+              >
+                Edit Sketch
+              </button>
+              <button
+                className="feature-context-menu__item"
+                type="button"
+                onClick={() => setStockSourceFeature(null)}
+              >
+                Reset to Rectangle
+              </button>
+            </div>
+          </div>
+        </div>
+      )
+    }
 
     return (
       <div className="properties-panel">

--- a/src/engine/simulation/grid.ts
+++ b/src/engine/simulation/grid.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { Project } from '../../types/project'
-import { getStockBounds } from '../../types/project'
+import type { Project, Point } from '../../types/project'
+import { getStockBounds, getEffectiveStockProfile, profileVertices } from '../../types/project'
 import type { SimulationBuildOptions, SimulationGrid } from './types'
 
 const DEFAULT_LONG_AXIS_CELLS = 180
@@ -46,6 +46,18 @@ export function resolveSimulationGridSpec(
   }
 }
 
+function pointInPolygon(x: number, y: number, polygon: Point[]): boolean {
+  let inside = false
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].x, yi = polygon[i].y
+    const xj = polygon[j].x, yj = polygon[j].y
+    if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) {
+      inside = !inside
+    }
+  }
+  return inside
+}
+
 export function createSimulationGrid(
   project: Project,
   options: SimulationBuildOptions = {},
@@ -54,6 +66,24 @@ export function createSimulationGrid(
   const cellCount = spec.cols * spec.rows
   const topZ = new Float32Array(cellCount)
   topZ.fill(spec.stockTopZ)
+
+  // If stock has a non-rectangular profile (from a source feature), mask cells outside the profile
+  const effectiveProfile = getEffectiveStockProfile(project.stock)
+  if (effectiveProfile && project.stock.sourceFeatureId) {
+    const vertices = profileVertices(effectiveProfile)
+    if (vertices.length >= 3) {
+      const halfCell = spec.cellSize / 2
+      for (let row = 0; row < spec.rows; row++) {
+        for (let col = 0; col < spec.cols; col++) {
+          const cx = spec.originX + col * spec.cellSize + halfCell
+          const cy = spec.originY + row * spec.cellSize + halfCell
+          if (!pointInPolygon(cx, cy, vertices)) {
+            topZ[row * spec.cols + col] = 0
+          }
+        }
+      }
+    }
+  }
 
   return {
     ...spec,

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -39,6 +39,7 @@ import {
   ellipseProfile,
   polygonProfile,
   splineProfile,
+  stockFromFeature,
   type TextFeatureData,
 } from '../types/project'
 import type {
@@ -2046,6 +2047,46 @@ function syncFeatureTreeProject(project: Project): Project {
   }
 }
 
+/**
+ * When a feature that serves as the stock source is modified, sync the stock
+ * profile and thickness to match. Returns the updated project, or the original
+ * if the featureId does not match the stock source.
+ */
+function syncStockFromSourceFeature(project: Project, featureId: string): Project {
+  const stock = project.stock
+  if (!stock.sourceFeature || stock.sourceFeatureId !== featureId) {
+    return project
+  }
+
+  // Find the updated source feature (it may be in features temporarily during sketch edit)
+  const updatedFeature = project.features.find((f) => f.id === featureId)
+  if (updatedFeature) {
+    // Feature was temporarily restored for editing; update sourceFeature copy.
+    // Use the feature's profile directly — it's already in world coordinates.
+    const syncedStock = {
+      ...stock,
+      sourceFeature: updatedFeature,
+      profile: updatedFeature.sketch.profile,
+      thickness: typeof updatedFeature.z_top === 'number' ? updatedFeature.z_top : stock.thickness,
+    }
+    return {
+      ...project,
+      stock: syncedStock,
+    }
+  }
+
+  // Feature is not in features array — sync from stock.sourceFeature directly
+  const source = stock.sourceFeature
+  return {
+    ...project,
+    stock: {
+      ...stock,
+      profile: source.sketch.profile,
+      thickness: typeof source.z_top === 'number' ? source.z_top : stock.thickness,
+    },
+  }
+}
+
 function dedupeProjectIds(project: Project): Project {
   let localCounter = [
     ...project.features.map((feature) => idNumericSuffix(feature.id)),
@@ -3175,6 +3216,159 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
       }
     }),
 
+  /**
+   * Set a feature as the stock source. The feature is removed from project.features
+   * and its geometry is used as the stock profile/thickness.
+   * Pass null to reset to rectangle stock (restores the feature to the tree).
+   *
+   * This is a single undo-able action that captures full before/after state.
+   */
+  setStockSourceFeature: (featureId: string | null) =>
+    set((s) => {
+      if (featureId === null) {
+        // Reset to rectangle stock
+        if (!s.project.stock.sourceFeatureId && !s.project.stock.sourceFeature) {
+          return {} // Already rectangle stock, no-op
+        }
+
+        const restoredFeature = s.project.stock.sourceFeature
+        if (!restoredFeature) return {}
+
+        const stockBounds = getStockBounds(s.project.stock)
+        const width = stockBounds.maxX - stockBounds.minX
+        const height = stockBounds.maxY - stockBounds.minY
+        const rectW = Math.max(width, 1)
+        const rectH = Math.max(height, 1)
+
+        const nextStock = {
+          ...s.project.stock,
+          profile: rectProfile(stockBounds.minX, stockBounds.minY, rectW, rectH),
+          sourceFeatureId: null as string | null | undefined,
+          sourceFeature: null as SketchFeature | null | undefined,
+        }
+
+        const nextProject = syncFeatureTreeProject({
+          ...s.project,
+          stock: nextStock,
+          features: [...s.project.features, restoredFeature],
+          meta: { ...s.project.meta, modified: new Date().toISOString() },
+        })
+
+        if (projectsEqual(nextProject, s.project)) {
+          return {}
+        }
+        if (s.history.transactionStart) {
+          return { project: nextProject }
+        }
+        return {
+          project: nextProject,
+          history: {
+            past: [...s.history.past, cloneProject(s.project)].slice(-100),
+            future: [],
+            transactionStart: null,
+          },
+        }
+      }
+
+      // Set a feature as stock source
+      const feature = s.project.features.find((f) => f.id === featureId)
+      if (!feature) return {}
+      if (!feature.sketch.profile.closed) return {} // Only closed profiles can be stock
+
+      // If another feature is already the stock source, restore it first
+      let features = s.project.features
+      let stock = { ...s.project.stock }
+
+      if (stock.sourceFeature && stock.sourceFeatureId) {
+        // Restore old source feature to features array
+        features = [...features, stock.sourceFeature]
+      }
+
+      // Remove the new source feature from features and tree
+      features = features.filter((f) => f.id !== featureId)
+      const featureTree = s.project.featureTree.filter(
+        (entry) => !(entry.type === 'feature' && entry.featureId === featureId)
+      )
+
+      // Build stock from feature
+      const newStock = stockFromFeature(feature)
+      stock = {
+        ...stock,
+        profile: newStock.profile,
+        thickness: newStock.thickness,
+        sourceFeatureId: feature.id,
+        sourceFeature: feature,
+      }
+
+      const nextProject = syncFeatureTreeProject({
+        ...s.project,
+        stock,
+        features,
+        featureTree,
+        meta: { ...s.project.meta, modified: new Date().toISOString() },
+      })
+
+      if (projectsEqual(nextProject, s.project)) {
+        return {}
+      }
+      if (s.history.transactionStart) {
+        return { project: nextProject }
+      }
+      return {
+        project: nextProject,
+        history: {
+          past: [...s.history.past, cloneProject(s.project)].slice(-100),
+          future: [],
+          transactionStart: null,
+        },
+      }
+    }),
+
+  /**
+   * Enter sketch edit mode for the stock source feature.
+   * Temporarily adds the source feature back to project.features and project.featureTree
+   * so that mutation actions (moveFeatureControl, insertFeaturePoint, etc.) can find and edit it.
+   * The feature is removed from features/tree on applySketchEdit (handled in selectionSlice).
+   */
+  enterStockSketchEdit: (featureId: string) =>
+    set((s) => {
+      const stock = s.project.stock
+      if (stock.sourceFeatureId !== featureId || !stock.sourceFeature) {
+        return {}
+      }
+
+      const feature = stock.sourceFeature
+
+      // Temporarily add the feature to features array and feature tree for editing
+      const nextProject = syncFeatureTreeProject({
+        ...s.project,
+        features: [...s.project.features, feature],
+        featureTree: [...s.project.featureTree, { type: 'feature' as const, featureId: feature.id }],
+      })
+
+      return {
+        project: nextProject,
+        pendingTransform: null,
+        pendingOffset: null,
+        selection: {
+          ...s.selection,
+          selectedFeatureId: featureId,
+          selectedFeatureIds: [featureId],
+          selectedNode: { type: 'feature', featureId },
+          mode: 'sketch_edit',
+          sketchEditTool: null,
+          activeControl: null,
+        },
+        sketchEditSession: {
+          entityType: 'feature',
+          entityId: featureId,
+          snapshot: cloneProject(s.project),
+          pastLength: s.history.past.length,
+        },
+        pendingConstraint: null,
+      }
+    }),
+
   setGrid: (grid) =>
     set((s) => {
       const nextProject = {
@@ -4263,7 +4457,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
           ? { ...zSafePatch, operation: 'add' }
           : zSafePatch
       const safeOperation = safePatch.operation ?? existingFeature?.operation
-      const nextProject = {
+      let nextProject: Project = {
         ...s.project,
         features: features.map((f) =>
           f.id === id
@@ -4276,6 +4470,8 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         ),
         meta: { ...s.project.meta, modified: new Date().toISOString() },
       }
+      // Sync stock if the updated feature is the stock source
+      nextProject = syncStockFromSourceFeature(nextProject, id)
       if (projectsEqual(nextProject, s.project)) {
         return {}
       }
@@ -4366,8 +4562,24 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
           }
           return feature
         })
+
+      // If deleting the stock source feature, reset stock to rectangular
+      let stock = s.project.stock
+      if (stock.sourceFeatureId && idsToDelete.has(stock.sourceFeatureId)) {
+        const stockBounds = getStockBounds(stock)
+        const width = Math.max(stockBounds.maxX - stockBounds.minX, 1)
+        const height = Math.max(stockBounds.maxY - stockBounds.minY, 1)
+        stock = {
+          ...stock,
+          profile: rectProfile(stockBounds.minX, stockBounds.minY, width, height),
+          sourceFeatureId: null as string | null | undefined,
+          sourceFeature: null as SketchFeature | null | undefined,
+        }
+      }
+
       const nextProject = syncFeatureTreeProject({
         ...s.project,
+        stock,
         features: featuresWithInvalidatedConstraints,
         featureTree: s.project.featureTree.filter((entry) => !(entry.type === 'feature' && idsToDelete.has(entry.featureId))),
         meta: { ...s.project.meta, modified: new Date().toISOString() },
@@ -4997,7 +5209,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
 
   moveFeatureControl: (featureId, control, point) =>
     set((s) => {
-      const nextProject = {
+      let nextProject = {
         ...s.project,
         features: s.project.features.map((feature) => {
           if (feature.id !== featureId || feature.locked) return feature
@@ -5208,6 +5420,8 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         if (f.sketch.constraints.every((c) => c.type !== 'fixed_distance')) return f
         return validateConstraintsOnFeature(f, featureByIdMap)
       })
+      // Sync stock if the edited feature is the stock source
+      nextProject = syncStockFromSourceFeature(nextProject, featureId)
       if (projectsEqual(nextProject, s.project)) {
         return {}
       }
@@ -5227,7 +5441,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
   insertFeaturePoint: (featureId, target) =>
     set((s) => {
       let changed = false
-      const nextProject = {
+      let nextProject = {
         ...s.project,
         features: s.project.features.map((feature) => {
           if (feature.id !== featureId || feature.locked) {
@@ -5256,6 +5470,8 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         return {}
       }
 
+      nextProject = syncStockFromSourceFeature(nextProject, featureId)
+
       return {
         project: nextProject,
         selection: {
@@ -5273,7 +5489,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
   deleteFeaturePoint: (featureId, anchorIndex) =>
     set((s) => {
       let changed = false
-      const nextProject = {
+      let nextProject = {
         ...s.project,
         features: s.project.features.map((feature) => {
           if (feature.id !== featureId || feature.locked) {
@@ -5303,6 +5519,8 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         return {}
       }
 
+      nextProject = syncStockFromSourceFeature(nextProject, featureId)
+
       return {
         project: nextProject,
         selection: {
@@ -5320,7 +5538,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
   filletFeaturePoint: (featureId, anchorIndex, radius) =>
     set((s) => {
       let changed = false
-      const nextProject = {
+      let nextProject = {
         ...s.project,
         features: s.project.features.map((feature) => {
           if (feature.id !== featureId || feature.locked) {
@@ -5348,6 +5566,8 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
       if (!changed || projectsEqual(nextProject, s.project)) {
         return {}
       }
+
+      nextProject = syncStockFromSourceFeature(nextProject, featureId)
 
       return {
         project: nextProject,

--- a/src/store/slices/selectionSlice.ts
+++ b/src/store/slices/selectionSlice.ts
@@ -616,11 +616,49 @@ export function createSelectionSlice(
       })),
 
     applySketchEdit: () =>
-      set((s) => ({
-        selection: { ...s.selection, mode: 'feature', sketchEditTool: null, activeControl: null },
-        sketchEditSession: null,
-        pendingConstraint: null,
-      })),
+      set((s) => {
+        // Check if we were editing a stock source feature (feature temporarily in features)
+        const stock = s.project.stock
+        if (stock.sourceFeatureId && s.project.features.some((f) => f.id === stock.sourceFeatureId)) {
+          // Remove feature from features and featureTree, keep stock as-is (already synced each mutation)
+          const nextFeatures = s.project.features.filter((f) => f.id !== stock.sourceFeatureId)
+          const nextFeatureTree = s.project.featureTree.filter(
+            (entry) => !(entry.type === 'feature' && entry.featureId === stock.sourceFeatureId),
+          )
+
+          // Capture the pre-edit snapshot as the undo point so the entire edit session is one atomic step
+          const preEditSnapshot = s.sketchEditSession?.snapshot
+          const pastLength = s.sketchEditSession?.pastLength ?? s.history.past.length
+
+          return {
+            project: {
+              ...s.project,
+              features: nextFeatures,
+              featureTree: nextFeatureTree,
+              meta: { ...s.project.meta, modified: new Date().toISOString() },
+            },
+            selection: { ...s.selection, mode: 'feature', sketchEditTool: null, activeControl: null },
+            sketchEditSession: null,
+            pendingConstraint: null,
+            history: {
+              // Trim mutations during the edit session, push pre-edit state as the undo point
+              past: [
+                ...s.history.past.slice(0, pastLength),
+                ...(preEditSnapshot ? [preEditSnapshot] : []),
+              ].slice(-100),
+              future: [],
+              transactionStart: null,
+            },
+          }
+        }
+
+        // Normal case: not a stock source feature
+        return {
+          selection: { ...s.selection, mode: 'feature', sketchEditTool: null, activeControl: null },
+          sketchEditSession: null,
+          pendingConstraint: null,
+        }
+      }),
 
     cancelSketchEdit: () =>
       set((s) => {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -239,6 +239,8 @@ export interface ProjectStore {
   cancelHistoryTransaction: () => void
 
   setStock: (stock: Stock) => void
+  setStockSourceFeature: (featureId: string | null) => void
+  enterStockSketchEdit: (featureId: string) => void
   setGrid: (grid: GridSettings) => void
   setUnits: (units: Project['meta']['units']) => void
   setCreationTarget: (target: CreationTarget) => void

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -245,6 +245,10 @@ export interface Stock {
   color: string
   visible: boolean
   origin: Point               // machine coordinate of stock corner
+  /** When set, stock is derived from a feature. Feature is removed from features array and stored here. */
+  sourceFeatureId?: string | null
+  /** The full feature data when stock is sourced from a feature. Null/undefined when using rectangle stock. */
+  sourceFeature?: SketchFeature | null
 }
 
 export interface GridSettings {
@@ -667,6 +671,86 @@ export function defaultStock(
     visible: true,
     origin: { x: 0, y: 0 },
   }
+}
+
+/**
+ * Build a Stock object from a SketchFeature's geometry.
+ * The feature's profile (transformed by sketch.origin/orientationAngle) becomes the stock profile.
+ * The feature's z_top becomes the stock thickness (z_bottom is assumed 0).
+ */
+export function stockFromFeature(feature: SketchFeature): Stock {
+  // Use the feature's profile directly — it's already in project (world) coordinates.
+  // The sketch.origin and orientationAngle describe the feature's local axis alignment,
+  // not a rotation/translation to apply to the profile itself.
+  const profile = feature.sketch.profile
+  const zTop = typeof feature.z_top === 'number' ? feature.z_top : 20
+  return {
+    profile,
+    thickness: zTop,
+    material: 'aluminum_6061',
+    color: '#b9a83c',
+    visible: true,
+    origin: { x: 0, y: 0 },
+    sourceFeatureId: feature.id,
+    sourceFeature: feature,
+  }
+}
+
+/**
+ * Transform a feature's sketch profile by applying sketch.origin translation and
+ * orientationAngle rotation, producing a profile in project coordinates.
+ */
+export function transformFeatureProfile(feature: SketchFeature): SketchProfile {
+  const { profile, origin, orientationAngle } = feature.sketch
+  if ((origin.x === 0 && origin.y === 0 && orientationAngle === 0)) {
+    return profile
+  }
+
+  const angleRad = (orientationAngle * Math.PI) / 180
+  const cosA = Math.cos(angleRad)
+  const sinA = Math.sin(angleRad)
+
+  function transformPoint(p: Point): Point {
+    const x = p.x * cosA - p.y * sinA + origin.x
+    const y = p.x * sinA + p.y * cosA + origin.y
+    return { x, y }
+  }
+
+  const newSegments = profile.segments.map((seg) => {
+    const transformedTo = transformPoint(seg.to)
+    if (seg.type === 'line') {
+      return { ...seg, to: transformedTo }
+    }
+    if (seg.type === 'arc') {
+      return { ...seg, to: transformedTo, center: transformPoint(seg.center) }
+    }
+    if (seg.type === 'bezier') {
+      return { ...seg, to: transformedTo, control1: transformPoint(seg.control1), control2: transformPoint(seg.control2) }
+    }
+    if (seg.type === 'circle') {
+      return { ...seg, to: transformedTo, center: transformPoint(seg.center) }
+    }
+    return seg
+  })
+
+  return {
+    start: transformPoint(profile.start),
+    segments: newSegments,
+    closed: profile.closed,
+  }
+}
+
+/**
+ * Returns the effective stock profile. When stock has a sourceFeatureId set,
+ * returns the profile derived from the source feature. Otherwise returns
+ * stock.profile directly (e.g. rectangle).
+ */
+export function getEffectiveStockProfile(stock: Stock): SketchProfile {
+  // Use the source feature's profile directly — it's already in project (world) coordinates.
+  if (stock.sourceFeature && stock.sourceFeatureId) {
+    return stock.sourceFeature.sketch.profile
+  }
+  return stock.profile
 }
 
 export function defaultGrid(units: ProjectMeta['units'] = 'mm'): GridSettings {


### PR DESCRIPTION
## Summary

Implements the Feature-as-Stock feature from `planning/FEATURE_AS_STOCK_Design.md`. Any closed-profile add-operation sketch feature can now serve as the stock definition via a "Use as Stock" context menu item.

## Changes

### Data Model (`src/types/project.ts`)
- Added `sourceFeatureId` and `sourceFeature` to `Stock` interface
- Added `stockFromFeature(feature)` helper
- Added `getEffectiveStockProfile(stock)` helper

### Store Actions (`src/store/projectStore.ts`)
- Added `setStockSourceFeature(featureId)` — set/reset stock source
- Added `syncStockFromSourceFeature(project, featureId)` — sync stock when source feature is modified
- Added `enterStockSketchEdit(featureId)` — temporarily adds source feature to features array for sketch editing
- Modified mutation actions to call stock sync
- Modified `deleteFeatures` to reset stock when source feature is deleted

### Selection Slice (`src/store/slices/selectionSlice.ts`)
- Modified `applySketchEdit` to clean up temporarily-added stock source feature from features/featureTree

### UI
- **App.tsx**: "Use as Stock" button in feature context menu
- **PropertiesPanel.tsx**: Stock panel shows source feature info with "Edit Sketch"/"Reset to Rectangle"
- **SketchCanvas.tsx**: `editableFeature()` fallback to `stock.sourceFeature`

### Simulation (`src/engine/simulation/grid.ts`)
- Masking for non-rectangular stock profiles

## Bug Fixes

### Bug 1 — Stock rotation/position error
`transformFeatureProfile()` incorrectly applied `orientationAngle` rotation. Profiles are already in world coordinates — `orientationAngle` describes local axis alignment, not a rotation. Fixed by using `feature.sketch.profile` directly.

### Bug 2 — Sketch edit from stock panel not working
Mutation actions could not find the stock source feature (stored in `stock.sourceFeature`, not `project.features`). Fixed via `enterStockSketchEdit` which temporarily adds the feature to `project.features` during editing, with cleanup on `applySketchEdit`.