### PR TITLE
Add OBJ import and mesh asset storage

### DIFF
--- a/planning/IMPORTED_MODEL_STORAGE_REDESIGN.md
+++ b/planning/IMPORTED_MODEL_STORAGE_REDESIGN.md
@@ -1,0 +1,405 @@
+# Imported Model Storage Redesign
+
+## 1. Problem
+
+Imported 3D models are currently treated as source-file-backed features:
+
+- STL/OBJ file contents are stored in `feature.stl.fileData`.
+- Runtime geometry is parsed from that payload through `loadImportedBufferGeometry(...)` / `loadImportedTriangleMesh(...)`.
+- Toolpaths use transformed internal mesh arrays, but those arrays are derived from the persisted source payload on cache miss or project reload.
+- `.camj` save writes the full project with `JSON.stringify(...)`.
+- Undo/redo history uses `structuredClone(project)`, so large embedded model payloads are cloned into history snapshots.
+
+This is acceptable for small STL files but breaks down for large text OBJ files. A 151 MB OBJ can become hundreds of MB as base64/text and then several more copies as parsed arrays, Three.js geometry, transformed mesh data, top-view images, and history snapshots.
+
+The core design issue: **OBJ/STL should be import formats only. They should not remain the persisted model representation.**
+
+## 2. Goals
+
+- Parse STL/OBJ exactly once at import time.
+- Persist a compact normalized internal triangle mesh in `.camj`.
+- Never require reparsing STL/OBJ after import.
+- Keep legacy `.camj` files with `stl.fileData` loadable.
+- Use one mesh-backed path for STL, OBJ, and future mesh formats.
+- Avoid cloning large immutable mesh payloads through undo/redo history.
+- Keep rough/finish toolpaths, 3D preview, silhouette rendering, and boolean fallback behavior intact.
+
+## 3. Non-Goals
+
+- No full binary `.camj` container in the first pass.
+- No external asset sidecar files in the first pass.
+- No mesh decimation/simplification in the first pass.
+- No split-by-OBJ-object workflow.
+- No material/texture persistence.
+- No full rename from `kind: 'stl'` to `kind: 'model'` in the first pass, unless the implementation scope explicitly includes migration of all call sites.
+
+## 4. New Mental Model
+
+There are three separate concepts:
+
+1. **Source import format**
+   - Examples: `stl`, `obj`.
+   - Used only while reading the selected file.
+
+2. **Persisted model asset**
+   - The normalized triangle mesh saved in `.camj`.
+   - Format-independent.
+   - Reloads without STL/OBJ parsing.
+
+3. **Runtime model geometry**
+   - Typed arrays, Three.js `BufferGeometry`, Manifold meshes, transformed toolpath arrays, and slice caches.
+   - Derived from the persisted model asset.
+   - Cached in memory.
+
+The feature can keep the legacy `stl` property name during migration, but the data inside it should move from source-file-backed to mesh-backed.
+
+## 5. Proposed Data Model
+
+### 5.1. Project Types
+
+Add a new persisted internal mesh type:
+
+```ts
+export type ImportedModelSourceFormat = 'stl' | 'obj'
+
+export interface ImportedMeshBounds {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+  minZ: number
+  maxZ: number
+}
+
+export interface PersistedImportedMesh {
+  storage: 'mesh-v1'
+  sourceFormat?: ImportedModelSourceFormat
+  vertexCount: number
+  triangleCount: number
+  positions: string // base64 Float32Array bytes, little-endian platform representation
+  indices: string // base64 Uint32Array bytes
+  bounds: ImportedMeshBounds
+}
+
+export interface STLFeatureData {
+  /**
+   * Legacy source import format. Missing means legacy STL.
+   * Retained for old files and source attribution.
+   */
+  format?: ImportedModelSourceFormat
+
+  /**
+   * New normalized persisted mesh. Preferred for all new imports.
+   */
+  mesh?: PersistedImportedMesh
+
+  /**
+   * Legacy embedded source file. Only used for old .camj migration.
+   * New imports should not write this field.
+   */
+  fileData?: string
+
+  scale: number
+  axisSwap?: 'none' | 'yz' | 'xz' | 'xy'
+  silhouetteDataUrl?: string
+  silhouettePaths?: Point[][]
+  topViewDataUrl?: string
+}
+```
+
+Notes:
+
+- `positions` stores the original imported model coordinates after import-unit scaling and axis orientation have been applied.
+- `indices` stores the triangulated mesh.
+- `bounds` are for the stored mesh coordinates.
+- `scale` should become a feature transform scale, not the import-unit conversion. For newly imported mesh-backed models, set `scale: 1` after baking import units into positions.
+- `axisSwap` is retained for legacy source-backed files. For new mesh-backed imports, axis orientation should be baked into positions and `axisSwap` should be `'none'` or omitted.
+
+### 5.2. Why Base64 Typed Arrays
+
+Plain JSON cannot store typed arrays compactly. Numeric JSON arrays are much worse for large meshes because every float/index becomes decimal text.
+
+Base64 typed-array bytes are still larger than raw binary, but they are:
+
+- much smaller than OBJ text for typical indexed meshes,
+- faster to decode than reparsing OBJ/STL,
+- compatible with current `.camj` JSON save/load,
+- straightforward to migrate later into a zipped/binary project format.
+
+Expected sizes:
+
+- positions: `vertexCount * 3 * 4` bytes before base64.
+- indices: `triangleCount * 3 * 4` bytes before base64.
+- base64 overhead: roughly 33%.
+
+This will still be large for high-poly models, but it removes OBJ text parsing and reduces duplicate source-file storage.
+
+## 6. Import Pipeline
+
+New flow:
+
+1. User selects `.stl` or `.obj`.
+2. Importer parses the source once into `ImportedTriangleMesh`.
+3. Apply source unit conversion and selected axis orientation directly to the mesh positions.
+4. Optionally merge duplicate vertices if needed for STL.
+5. Compute bounds from the normalized positions.
+6. Generate silhouette paths and sketch profile from the normalized mesh.
+7. Generate top-view preview from the normalized mesh, or skip for very large meshes.
+8. Store `stl.mesh`.
+9. Do not store `stl.fileData` for new imports.
+
+The import format parser should return:
+
+```ts
+interface ImportedTriangleMesh {
+  positions: Float32Array
+  index: Uint32Array
+  bounds: ImportedMeshBounds
+}
+```
+
+Then a serializer converts that into `PersistedImportedMesh`.
+
+## 7. Loader API
+
+Replace source-file-first APIs with mesh-first APIs.
+
+### 7.1. Current Problem APIs
+
+```ts
+loadImportedBufferGeometry(format, fileData, axisOrientation, mergeVertices)
+loadImportedTriangleMesh(format, fileData, axisOrientation)
+```
+
+These force callers to have the source file.
+
+### 7.2. New APIs
+
+```ts
+parseImportedSourceToMesh(format, sourceData, options): ImportedTriangleMesh | null
+
+serializeImportedMesh(mesh, sourceFormat): PersistedImportedMesh
+deserializeImportedMesh(mesh): ImportedTriangleMesh | null
+
+loadFeatureImportedMesh(feature): ImportedTriangleMesh | null
+loadFeatureBufferGeometry(feature, mergeVertices): THREE.BufferGeometry | null
+```
+
+`loadFeatureImportedMesh(feature)` behavior:
+
+1. If `feature.stl.mesh` exists, decode it.
+2. Else if legacy `feature.stl.fileData` exists, parse source file and optionally migrate in memory.
+3. Else return null.
+
+The legacy path should be isolated and clearly marked as migration compatibility.
+
+## 8. Transform Model
+
+Separate import normalization from user transforms.
+
+### 8.1. Baked Into Persisted Mesh
+
+- source units to project units,
+- import axis orientation,
+- triangulation,
+- vertex merging if performed,
+- raw mesh bounds.
+
+### 8.2. Feature Transform
+
+- `sketch.origin.x/y`,
+- `sketch.orientationAngle`,
+- feature scale if still needed,
+- `z_top` / `z_bottom` vertical fitting.
+
+Toolpath transforms should start from the decoded persisted mesh, not from reparsed source geometry.
+
+## 9. Toolpaths and Preview
+
+### 9.1. Rough/Finish Surface
+
+`loadSTLTransformedGeometry(...)` should be renamed or wrapped as:
+
+```ts
+loadModelTransformedGeometry(feature, project): ModelTransformedData | null
+```
+
+It should:
+
+1. Get the persisted/internal mesh via `loadFeatureImportedMesh(feature)`.
+2. Apply feature transforms to produce the existing `positions` and `index` runtime data.
+3. Cache by stable mesh id/version plus feature transform fields.
+
+The path algorithms should not care whether the model came from STL, OBJ, or future mesh import.
+
+### 9.2. 3D Preview
+
+`buildFeatureMesh(...)` should create `BufferGeometry` from the persisted/internal mesh, not from source file data.
+
+### 9.3. Boolean Solid
+
+`buildFeatureSolid(...)` should build Manifold mesh from the persisted/internal mesh. If Manifold rejects it, the fallback silhouette extrusion behavior remains.
+
+## 10. Caching
+
+Add stable identity for persisted mesh:
+
+```ts
+meshId: string
+meshVersion: number
+```
+
+Options:
+
+- Use a generated UUID at import time.
+- Include `meshVersion: 1`.
+- Cache keys use `meshId`, `meshVersion`, vertex/triangle counts, and transform fields.
+
+Avoid using huge `fileData` strings as cache identity.
+
+Caches:
+
+- decoded mesh cache: `meshId -> ImportedTriangleMesh`
+- BufferGeometry cache: `meshId + mergeVertices`
+- transformed geometry cache: `meshId + origin + angle + zTop + zBottom + scale`
+- slice index cache remains attached to transformed data.
+
+Cache entries should not retain the legacy source file.
+
+## 11. Undo/Redo History
+
+This is a separate but related memory issue.
+
+Current `cloneProject(project)` uses `structuredClone(project)`. With mesh base64 in project state, history still duplicates large model strings across up to 100 snapshots.
+
+Recommended first pass:
+
+- Store imported meshes in a project-level asset table by id.
+- Features reference assets by id.
+- History snapshots include feature references, not duplicated mesh payloads.
+
+Example:
+
+```ts
+interface Project {
+  modelAssets?: Record<string, PersistedImportedMesh>
+  features: SketchFeature[]
+}
+
+interface STLFeatureData {
+  meshAssetId?: string
+  // legacy/inlined fallback:
+  mesh?: PersistedImportedMesh
+  fileData?: string
+}
+```
+
+This is a bigger data model change but is the right direction.
+
+Pragmatic phase:
+
+1. First implement `mesh` inline on the feature to stop reparsing and source persistence.
+2. Then move large meshes into `project.modelAssets` to stop history duplication.
+
+If doing both together is acceptable, prefer going straight to `modelAssets`.
+
+## 12. Save/Load Compatibility
+
+### 12.1. New Files
+
+New imports should save:
+
+- `mesh` or `meshAssetId`,
+- source attribution `format`,
+- silhouette paths,
+- top-view data URL if generated,
+- feature transform fields.
+
+New imports should not save:
+
+- original OBJ/STL `fileData`,
+- source `filePath` unless it is just advisory metadata.
+
+### 12.2. Legacy Files
+
+When opening old `.camj` files:
+
+- If `stl.mesh`/`meshAssetId` exists, use it.
+- Else if `stl.fileData` exists:
+  - keep the feature loadable,
+  - parse source through the legacy path,
+  - optionally migrate to mesh-backed storage immediately,
+  - mark project dirty if migration changes persisted data.
+
+Migration can initially happen lazily on first geometry load, but save should write mesh-backed data after migration.
+
+## 13. Large Model Guardrails
+
+Even with mesh-backed storage, very large models can still be too expensive.
+
+Add import warnings:
+
+- source file > 50 MB,
+- decoded mesh > configurable vertex/triangle threshold,
+- projected silhouette union expected to be expensive,
+- top-view preview skipped because model is too large.
+
+Add hard or soft limits:
+
+- Ask for confirmation above a threshold.
+- Skip `topViewDataUrl` generation above a threshold.
+- Consider disabling history snapshot for the import payload itself when using project-level assets.
+
+## 14. Implementation Phases
+
+### Phase 1: Persisted Mesh Format
+
+- [ ] Add `PersistedImportedMesh` and source-format types.
+- [ ] Add typed-array base64 encode/decode helpers.
+- [ ] Add serialize/deserialize tests.
+- [ ] Extend `STLFeatureData` with `mesh?: PersistedImportedMesh`.
+
+### Phase 2: Import-Time Conversion
+
+- [ ] Change STL import to parse once and store `mesh`.
+- [ ] Change OBJ import to parse once and store `mesh`.
+- [ ] Bake unit conversion and axis orientation into positions.
+- [ ] Stop writing `fileData` for new imports.
+- [ ] Generate silhouette/top-view from the parsed mesh without reparsing.
+
+### Phase 3: Runtime Loader Refactor
+
+- [ ] Add `loadFeatureImportedMesh(...)`.
+- [ ] Update 3D preview to load from persisted mesh.
+- [ ] Update transformed geometry/toolpath loader to load from persisted mesh.
+- [ ] Update Manifold solid path to load from persisted mesh.
+- [ ] Keep source-file parsing only as legacy fallback.
+
+### Phase 4: Compatibility and Migration
+
+- [ ] Load old `.camj` files with `fileData`.
+- [ ] Migrate legacy `fileData` to `mesh` on save or first use.
+- [ ] Add tests for legacy STL default format.
+- [ ] Add tests for OBJ mesh-backed save/load.
+
+### Phase 5: Project Asset Table
+
+- [ ] Add `project.modelAssets`.
+- [ ] Store large meshes by asset id.
+- [ ] Make model features reference `meshAssetId`.
+- [ ] Update history cloning to avoid duplicating unchanged model assets.
+- [ ] Add asset garbage collection when model features are deleted.
+
+## 15. Acceptance Criteria
+
+1. New STL imports do not store original STL source in `.camj`.
+2. New OBJ imports do not store original OBJ source in `.camj`.
+3. Saving and reopening a project does not reparse STL/OBJ.
+4. 3D preview, rough surface, and finish surface use decoded persisted mesh data.
+5. Legacy projects with `stl.fileData` still open and work.
+6. History no longer duplicates large model source payloads for new imports after the asset-table phase.
+7. `npm run build` passes.
+
+## 16. Decision
+
+Proceed with mesh-backed persistence. Treat STL/OBJ as one-time import formats. Keep legacy source-file support only for old project compatibility.

--- a/planning/MESH_WATERLINE_SLICING_REPAIR.md
+++ b/planning/MESH_WATERLINE_SLICING_REPAIR.md
@@ -1,0 +1,61 @@
+# Mesh Waterline Slicing Repair
+
+## Problem
+
+Imported STL and OBJ meshes are expected to produce clean waterline contours at each Z level, but real files often contain small cracks, duplicated-but-not-identical vertices, T-junctions, or non-manifold edges. A horizontal slice may therefore return open segment chains even when the visual model looks continuous.
+
+The slicer must repair small numerical gaps without inventing large shortcut edges. A previous behavior closed every open chain, which could create long diagonal shortcuts across the model. The opposite behavior, rejecting every open chain, is too strict and can remove valid contours that only need a small stitch.
+
+## Desired Behavior
+
+At one Z level:
+
+- Treat triangle intersections as an undirected set of segment chains.
+- Emit every naturally closed loop.
+- Stitch only endpoints of open chains to endpoints of other open chains.
+- Consider both ends of every open chain. Reverse a chain before joining when needed so the connected path direction remains continuous.
+- Use 3D distance for the stitch test: `sqrt(dx^2 + dy^2 + dz^2)`.
+- Stitch only when the endpoint gap is below a strict model-scale tolerance.
+- Close a single open chain only when its start/end endpoints are within that same 3D tolerance.
+- Never connect into the middle of a chain or a closed loop.
+- Never bridge a large gap. Large gaps remain open and downstream operations must treat that slice level as unreliable or conservative.
+- Return multiple closed loops when a level has multiple offsets, islands, or valley/pond contours. Do not force them into one contour.
+
+## Algorithm
+
+1. Intersect candidate triangles with the requested slice plane.
+2. Build exact segment chains from endpoints that already share the same rounded 3D key.
+3. Split results into closed loops and open chains.
+4. Compute a stitch tolerance from the slice bounds:
+
+   ```text
+   tolerance = max(slice_diagonal * 1e-5, 2e-6)
+   ```
+
+   The tolerance is intentionally small. It should repair numeric cracks, not visible missing geometry.
+
+5. Repeatedly find the closest valid endpoint pair under tolerance:
+   - open chain end -> another open chain start
+   - open chain end -> another open chain end, with reversal
+   - open chain start -> another open chain start, with reversal
+   - open chain start -> another open chain end
+   - same-chain start/end only when that closes the chain
+6. Promote newly closed chains to output loops.
+7. Leave remaining open chains un-emitted and report their count in `MeshSliceResult.openChainCount`.
+
+## Operation Semantics
+
+Roughing and waterline finish should consume the same repaired closed-loop output. If `openChainCount > 0`, the slicer is reporting that some geometry at that level could not be trusted without inventing a shortcut. Roughing should remain conservative for those levels because missing protection can become an unsafe cut.
+
+Waterline finish can still skip unrepairable open chains because it follows contour rings rather than clearing the area between them.
+
+## Tests
+
+The slicer needs regression coverage for:
+
+- normal watertight box slices
+- separated islands at the same Z level
+- small open-chain endpoint gaps are stitched into a closed loop
+- long open-chain gaps are not shortcut-closed
+- multiple separate loops stay separate
+

--- a/planning/OBJ_IMPORT_Implementation_Plan.md
+++ b/planning/OBJ_IMPORT_Implementation_Plan.md
@@ -1,0 +1,368 @@
+# OBJ Import - Implementation Plan
+
+## 1. Overview
+
+Add support for importing Wavefront OBJ (`.obj`) files as 3D model features. OBJ should enter the same mesh-backed workflow currently used by STL: parse file data into a triangle mesh, derive a top-down silhouette for sketch view, render the full mesh in the 3D viewport, and make the model available to rough/finish surface operations.
+
+This is a mesh import feature, not a general OBJ scene/material import feature. The first implementation should deliberately ignore materials, textures, lights, cameras, curves, and animation-like scene concerns.
+
+## 2. Goals
+
+- Import common OBJ files exported from Blender, CAD-adjacent mesh tools, sculpting tools, and model libraries.
+- Reuse the existing imported mesh path as much as possible:
+  - `src/engine/importedMesh.ts`
+  - `src/import/stl.ts` silhouette/top-view logic, generalized where useful
+  - model feature rendering in `src/engine/csg.ts`
+  - import UI in `src/components/project/ImportGeometryDialog.tsx`
+- Preserve existing `.camj` files with legacy STL model features.
+- Keep the first pass focused on reliable geometry import.
+
+## 3. Non-Goals
+
+- No `.mtl` material parsing in the first pass.
+- No texture loading.
+- No OBJ freeform curves or NURBS surfaces.
+- No multi-object editing UI.
+- No automatic unit detection. OBJ does not reliably encode units.
+- No dependency on external files referenced by `mtllib` or texture paths.
+- No support for zipped OBJ packages.
+
+## 4. Current Architecture Fit
+
+The current code is already close to a generic imported mesh pipeline:
+
+- `STLFeatureData.format?: 'stl'` exists, with missing format treated as legacy STL.
+- `ImportedModelFormat` exists, but is currently only `'stl'`.
+- `loadImportedBufferGeometry(...)` and `loadImportedTriangleMesh(...)` dispatch by format.
+- `extractStlProfileAndBounds(...)` works from `loadImportedTriangleMesh(...)` and is mostly format-agnostic after parsing.
+- `renderStlTopViewToDataUrl(...)` also works from `loadImportedTriangleMesh(...)` and can be generalized.
+- `loadSTLTransformedGeometry(...)` in `src/engine/csg.ts` is named for STL but already asks `importedModelFormat(feature.stl)`.
+
+The implementation should avoid creating a parallel OBJ feature kind. OBJ is another imported mesh format, not a new modeling primitive.
+
+## 5. Data Model
+
+### 5.1. Extend Existing Model Feature Data
+
+Keep `SketchFeature.kind === 'stl'` for imported mesh features for now to avoid broad UI and project compatibility churn. Treat the name as legacy/internal terminology until a later cleanup can rename it to `model`.
+
+Update:
+
+```ts
+export type ImportedModelFormat = 'stl' | 'obj'
+
+export interface STLFeatureData {
+  /** Imported model file format. Missing means legacy STL. */
+  format?: 'stl' | 'obj'
+  filePath?: string
+  fileData?: string
+  scale: number
+  axisSwap?: 'none' | 'yz' | 'xz' | 'xy'
+  silhouetteDataUrl?: string
+  silhouettePaths?: Point[][]
+  topViewDataUrl?: string
+}
+```
+
+Compatibility rules:
+
+- Missing `format` means `'stl'`.
+- Existing `kind: 'stl'` remains valid for both STL and OBJ-backed model features.
+- UI labels should say "model" or "imported model" where possible, but code renaming can be deferred.
+
+### 5.2. File Data
+
+For consistency with STL, store OBJ file contents in `fileData` as a data URL or base64 payload.
+
+Recommendation:
+
+- Allow `data:text/plain;base64,...` or bare base64 internally.
+- Decode OBJ as UTF-8 text before parsing.
+- Keep import cache keys based on format, axis orientation, merge mode, and file data length/content guard as the existing STL path does.
+
+## 6. OBJ Parser Scope
+
+### 6.1. Supported Records
+
+Support:
+
+- `v x y z`
+- `vt ...` accepted and ignored.
+- `vn ...` accepted and ignored for CAM geometry, optionally used by Three.js geometry later only if easy.
+- `f ...`
+- `o name` and `g name` accepted as optional metadata, but not required for v1 behavior.
+- `s ...`, `usemtl ...`, `mtllib ...` accepted and ignored with warnings only when useful.
+- Blank lines and `#` comments.
+- Line continuations with trailing `\` if practical. If not implemented initially, fail clearly or add a warning.
+
+Reject or ignore:
+
+- `p`, `l`, `curv`, `curv2`, `surf`, `parm`, `trim`, `hole`, and other freeform records.
+- Faces with fewer than 3 valid vertices.
+- Non-finite coordinates.
+
+### 6.2. Face Syntax
+
+Support the common OBJ face variants:
+
+```txt
+f v1 v2 v3
+f v1/vt1 v2/vt2 v3/vt3
+f v1//vn1 v2//vn2 v3//vn3
+f v1/vt1/vn1 v2/vt2/vn2 v3/vt3/vn3
+```
+
+Index handling:
+
+- OBJ indices are 1-based.
+- Negative indices are relative to the current end of the vertex list.
+- Index `0` is invalid.
+- Texture/normal indices can be parsed enough to skip them.
+
+### 6.3. Triangulation
+
+OBJ faces may be triangles, quads, or n-gons. Convert faces to triangles with fan triangulation:
+
+```txt
+f a b c d e -> (a b c), (a c d), (a d e)
+```
+
+This is sufficient for the first pass and works well for common convex or mostly planar faces. It can produce incorrect triangles for concave n-gons, but those are uncommon in manufacturing mesh exports and should be documented as a limitation.
+
+Future improvement: use a polygon triangulation library or project each n-gon to its best-fit plane and triangulate concave polygons. Do not block v1 on that.
+
+### 6.4. Multiple Objects and Groups
+
+For v1, merge all OBJ objects/groups into one imported model feature.
+
+Rationale:
+
+- The current model feature pipeline expects one mesh and one silhouette.
+- CAM rough/finish operations target one imported model as the surface.
+- Most users importing OBJ for CNC relief/surface work expect the visible combined model.
+
+Future improvement: optional "split by object/group" import mode that creates one model feature per OBJ object.
+
+## 7. Geometry Pipeline
+
+### 7.1. Shared Mesh Loader
+
+Update `src/engine/importedMesh.ts`:
+
+- Extend `ImportedModelFormat` to `'stl' | 'obj'`.
+- Add `loadObjBufferGeometry(fileData, axisOrientation, mergeVertices)`.
+- Add `loadObjTriangleMesh(fileData, axisOrientation)`.
+- Route `loadImportedBufferGeometry(...)` and `loadImportedTriangleMesh(...)` through the new OBJ loaders.
+
+The OBJ loader should produce the same core shape as STL:
+
+```ts
+export interface ImportedTriangleMesh {
+  positions: Float32Array
+  index: Uint32Array
+  bounds: ImportedMeshBounds
+}
+```
+
+Implementation detail:
+
+- Prefer a small local parser over adding a heavy dependency.
+- Build indexed geometry directly from parsed vertices and triangulated faces.
+- Apply axis orientation after parsing, using the existing `applyAxisOrientationToPositions(...)`.
+- Call `BufferGeometryUtils.mergeVertices(...)` only for `BufferGeometry` callers when requested.
+
+### 7.2. Generalize STL Import Helpers
+
+Create format-neutral helpers, then keep STL wrappers for compatibility:
+
+```ts
+extractImportedModelProfileAndBounds(format, base64Data, scale, axisSwap, onProgress?)
+renderImportedModelTopViewToDataUrl(format, base64Data, scale, axisSwap)
+```
+
+Then:
+
+```ts
+extractStlProfileAndBounds(...) {
+  return extractImportedModelProfileAndBounds('stl', ...)
+}
+
+renderStlTopViewToDataUrl(...) {
+  return renderImportedModelTopViewToDataUrl('stl', ...)
+}
+```
+
+OBJ import should call the generic helpers with `'obj'`.
+
+### 7.3. Silhouette Extraction
+
+Use the existing projection behavior:
+
+1. Load triangle mesh.
+2. Build a `manifold-3d` mesh.
+3. Attempt `Manifold.project()`.
+4. If Manifold rejects the mesh as non-manifold, fall back to projecting all triangles to 2D and unioning with Clipper.
+5. Filter tiny silhouette artifacts through `significantSilhouettePaths(...)`.
+6. Store:
+   - largest path as `sketch.profile`
+   - significant paths as `stl.silhouettePaths`
+
+OBJ files are often not watertight, so the Clipper projection fallback should be considered normal, not exceptional.
+
+### 7.4. 3D Rendering and CSG
+
+Existing rendering and transformed geometry paths should continue to work after `loadImportedBufferGeometry(...)` and `loadImportedTriangleMesh(...)` support OBJ.
+
+Rename only where it reduces confusion and blast radius is low:
+
+- Low-risk: warning text from "STL" to "model".
+- Defer: `loadSTLTransformedGeometry`, `STLFeatureData`, `kind: 'stl'`.
+
+## 8. Import UI
+
+Update `ImportGeometryDialog`:
+
+- Detect `.obj`.
+- Include OBJ in the file input accept list if present.
+- Read OBJ as text or data URL. Prefer data URL for consistency with STL persistence.
+- Use the same units selector and axis orientation selector as STL.
+- Default source units to project units, because OBJ has no reliable unit metadata.
+- Summary text: `OBJ file - 3D mesh imported by top-down silhouette projection`.
+- Import name: strip `.obj` extension.
+- Store `stl.format: 'obj'`.
+
+Error and warning behavior:
+
+- If the file has vertices but no faces, show "OBJ has no polygon faces to import."
+- If unsupported records are present, do not fail by default. Warnings can be surfaced later; first pass can silently ignore materials/curves.
+- If all faces are invalid after parsing, fail import.
+
+## 9. Units and Coordinates
+
+OBJ has no reliable unit metadata. The import dialog should treat source units exactly like STL:
+
+- Default to project units.
+- Let the user choose `mm` or `inch`.
+- Convert using the same scale rule:
+  - project `mm`, source `inch`: `25.4`
+  - project `inch`, source `mm`: `1 / 25.4`
+  - same units: `1`
+
+Coordinate handling:
+
+- Preserve OBJ X/Y/Z by default.
+- Apply the existing axis orientation option after parsing and before bounds/silhouette extraction.
+- Do not invert Y during import. The app's existing machine-coordinate conversion handles G-code Y inversion.
+
+## 10. Performance
+
+Initial performance targets:
+
+- Small files under 100k triangles should import without noticeable delay.
+- Large files should use existing progress reporting during silhouette union.
+- Parser should avoid per-line regular expression work where simple splitting is enough.
+
+Potential issues:
+
+- OBJ text files can be much larger than equivalent binary STL.
+- Non-manifold OBJ files may hit the slower Clipper projection fallback.
+- Concave n-gons fan-triangulated incorrectly may create bad silhouettes.
+
+Future improvement:
+
+- Move OBJ parsing and silhouette generation into a worker with cancellation.
+- Add a triangle-count warning threshold.
+- Add optional decimation/simplification before top-view preview generation.
+
+## 11. Testing Plan
+
+### 11.1. Parser and Mesh Tests
+
+Add tests to `src/engine/importedMesh.test.ts` or a new `src/engine/objMesh.test.ts`:
+
+- Parses triangle OBJ with `v` and `f`.
+- Parses quad and triangulates to two triangles.
+- Parses n-gon and triangulates to `n - 2` triangles.
+- Supports `v/vt`, `v//vn`, and `v/vt/vn` face tokens.
+- Supports negative indices.
+- Rejects invalid index `0`.
+- Ignores comments, blank lines, `o`, `g`, `s`, `usemtl`, and `mtllib`.
+- Computes bounds correctly.
+- Applies all axis orientation modes correctly.
+- Generic `loadImportedTriangleMesh('obj', ...)` dispatch works.
+- Buffer geometry cache returns clones for mutable callers.
+
+### 11.2. Import Extraction Tests
+
+Add tests beside `src/import/stl.test.ts` or generalize it:
+
+- Extracts profile and Z bounds from a simple OBJ box/frustum.
+- Produces at least one silhouette path.
+- Filters tiny projected artifacts the same way STL import does.
+- Handles a non-manifold open OBJ mesh through the Clipper fallback.
+
+### 11.3. UI/Project Flow Tests
+
+Manual verification:
+
+- Import `.obj`.
+- Verify 2D silhouette appears.
+- Verify top-view image appears in sketch view if generated.
+- Verify 3D viewport shows the mesh.
+- Move, rotate, scale, copy, delete.
+- Save `.camj`, reload, and verify the OBJ model persists.
+- Generate rough surface and finish surface operations against the OBJ model.
+- Existing STL import still works.
+
+## 12. Implementation Phases
+
+### Phase 1: Core OBJ Mesh Support
+
+- [ ] Extend `ImportedModelFormat` to include `'obj'`.
+- [ ] Add base64/data URL text decode helper for OBJ.
+- [ ] Implement OBJ parser for `v` and `f`.
+- [ ] Triangulate faces.
+- [ ] Add OBJ triangle mesh and buffer geometry loaders.
+- [ ] Add parser/dispatch unit tests.
+
+### Phase 2: Generic Imported Model Helpers
+
+- [ ] Add `extractImportedModelProfileAndBounds(...)`.
+- [ ] Add `renderImportedModelTopViewToDataUrl(...)`.
+- [ ] Keep STL wrapper exports for existing callers.
+- [ ] Add OBJ extraction tests.
+
+### Phase 3: UI Wiring
+
+- [ ] Add `obj` to `ImportSourceType`.
+- [ ] Add `.obj` detection and accepted file types.
+- [ ] Read OBJ files and import as `kind: 'stl'` with `stl.format: 'obj'`.
+- [ ] Update import dialog copy and errors.
+- [ ] Verify save/load behavior.
+
+### Phase 4: Terminology Cleanup
+
+- [ ] Change user-facing rough/finish warnings from "STL" to "model".
+- [ ] Audit labels/tooltips for "STL" where "model" is more accurate.
+- [ ] Consider later renaming internal types/functions from STL-specific names to model/imported-mesh names.
+
+## 13. Acceptance Criteria
+
+1. `.obj` files can be selected from the existing import dialog.
+2. Imported OBJ files create a model feature using the existing mesh-backed feature path.
+3. Triangle, quad, and common indexed face syntaxes import correctly.
+4. Imported OBJ models render in 2D and 3D.
+5. Rough surface and finish surface operations can use OBJ model features.
+6. `.camj` save/load preserves imported OBJ models.
+7. Existing STL imports and legacy STL project files still work.
+8. `npm run build` passes.
+
+## 14. Backlog
+
+- Material/color preview from `.mtl`.
+- Split import by OBJ object/group.
+- Better triangulation for concave n-gons.
+- Worker-based parsing/projection with cancellation.
+- Import-time mesh validation and repair hints.
+- Optional mesh simplification for very large OBJ files.
+- Rename internal `stl` feature terminology to `model` after format support is stable.

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -594,7 +594,7 @@ function getOperationAddHint(project: Project, selection: SelectionState, kind: 
 
   if (kind === 'rough_surface') {
     if (selection.selectedFeatureIds.length === 0) {
-      return 'Select a model (STL) feature first'
+      return 'Select an imported model feature first'
     }
 
     const features = selection.selectedFeatureIds
@@ -610,7 +610,7 @@ function getOperationAddHint(project: Project, selection: SelectionState, kind: 
     const hasModel = machiningFeatures.some((f) => f.operation === 'model' && f.kind === 'stl')
 
     if (!hasModel) {
-      return 'Rough surface requires at least one model (STL) feature; closed regions are optional filters'
+      return 'Rough surface requires at least one imported model feature; closed regions are optional filters'
     }
     if (!regionFeatures.every((feature) => featureHasClosedGeometry(feature))) {
       return 'Region filters must be closed profiles'
@@ -621,7 +621,7 @@ function getOperationAddHint(project: Project, selection: SelectionState, kind: 
 
   if (kind === 'finish_surface') {
     if (selection.selectedFeatureIds.length === 0) {
-      return 'Select a model (STL) feature first'
+      return 'Select an imported model feature first'
     }
 
     const features = selection.selectedFeatureIds
@@ -637,7 +637,7 @@ function getOperationAddHint(project: Project, selection: SelectionState, kind: 
     const hasModel = machiningFeatures.some((f) => f.operation === 'model' && f.kind === 'stl')
 
     if (!hasModel) {
-      return 'Finish surface requires at least one model (STL) feature; closed regions are optional filters'
+      return 'Finish surface requires at least one imported model feature; closed regions are optional filters'
     }
     if (!regionFeatures.every((feature) => featureHasClosedGeometry(feature))) {
       return 'Region filters must be closed profiles'

--- a/src/components/project/ImportGeometryDialog.tsx
+++ b/src/components/project/ImportGeometryDialog.tsx
@@ -17,14 +17,26 @@
 import { useEffect, useRef, useState } from 'react'
 import type { CSSProperties, ChangeEvent } from 'react'
 import { importDxfString, importSvgString, inspectDxfString, inspectSvgString, type ImportInspection, type ImportSourceType } from '../../import'
-import { extractStlProfileAndBounds, renderStlTopViewToDataUrl } from '../../import/stl'
+import {
+  clampImportedMeshSilhouetteZSteps,
+  extractImportedMeshProfileAndBounds,
+  renderImportedMeshTopViewToDataUrl,
+} from '../../import/stl'
 import { useProjectStore } from '../../store/projectStore'
+import {
+  clearImportedSourceCaches,
+  loadImportedTriangleMesh,
+  normalizeImportedMeshForStorage,
+  serializeImportedMesh,
+  type ImportedModelFormat,
+  type ModelAxisOrientation,
+} from '../../engine/importedMesh'
 import type { Units } from '../../utils/units'
 
 interface LoadedImportFile {
   fileName: string
   text: string
-  dataUrl?: string // For STL
+  modelBuffer?: ArrayBuffer
   sourceType: ImportSourceType
   inspection: ImportInspection
 }
@@ -38,7 +50,12 @@ function sourceTypeLabel(sourceType: ImportSourceType): string {
   if (sourceType === 'svg') return 'SVG'
   if (sourceType === 'dxf') return 'DXF'
   if (sourceType === 'stl') return 'STL'
+  if (sourceType === 'obj') return 'OBJ'
   return 'Unknown'
+}
+
+function isModelSourceType(sourceType: ImportSourceType): sourceType is ImportedModelFormat {
+  return sourceType === 'stl' || sourceType === 'obj'
 }
 
 function unitsLabel(units: Units): string {
@@ -53,11 +70,31 @@ function joinToleranceStep(units: Units): string {
   return units === 'inch' ? '0.001' : '0.01'
 }
 
+function defaultSilhouetteZStepSize(units: Units): number {
+  return units === 'inch' ? 0.02 : 0.5
+}
+
+function recommendedSilhouetteZSteps(modelHeight: number, units: Units): number {
+  if (!(modelHeight > 0)) return clampImportedMeshSilhouetteZSteps(96)
+  return clampImportedMeshSilhouetteZSteps(Math.ceil(modelHeight / defaultSilhouetteZStepSize(units)))
+}
+
+function parseSilhouetteZStepsInput(value: string): number | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const parsed = Number(trimmed)
+  if (!Number.isInteger(parsed) || parsed < 8 || parsed > 512) {
+    throw new Error('Silhouette Z steps must be between 8 and 512.')
+  }
+  return parsed
+}
+
 function detectSourceType(fileName: string): ImportSourceType | null {
   const lowerName = fileName.toLowerCase()
   if (lowerName.endsWith('.svg')) return 'svg'
   if (lowerName.endsWith('.dxf')) return 'dxf'
   if (lowerName.endsWith('.stl')) return 'stl'
+  if (lowerName.endsWith('.obj')) return 'obj'
   return null
 }
 
@@ -71,7 +108,9 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
   const [dialogError, setDialogError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [loadingProgress, setLoadingProgress] = useState<number | null>(null)
+  const [loadingStage, setLoadingStage] = useState<string>('Processing model')
   const [axisSwap, setAxisSwap] = useState<'none' | 'yz' | 'xz' | 'xy'>('none')
+  const [silhouetteZSteps, setSilhouetteZSteps] = useState('')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -93,23 +132,26 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
       setJoinTolerance(defaultJoinTolerance(project.meta.units))
       setAllowCrossLayerJoins(false)
       setSelectedLayers(new Set())
-      setDialogError('Unsupported import format. Use .svg or .dxf.')
+      setSilhouetteZSteps('')
+      setDialogError('Unsupported import format. Use .svg, .dxf, .stl, or .obj.')
       return
     }
 
     const reader = new FileReader()
     reader.onload = (readerEvent) => {
       try {
-        if (nextSourceType === 'stl') {
-          const dataUrl = String(readerEvent.target?.result ?? '')
+        if (isModelSourceType(nextSourceType)) {
+          const modelBuffer = readerEvent.target?.result
+          if (!(modelBuffer instanceof ArrayBuffer)) throw new Error('Failed to read model file.')
+          const label = sourceTypeLabel(nextSourceType)
           setLoadedFile({
             fileName: file.name,
             text: '',
-            dataUrl,
+            modelBuffer,
             sourceType: nextSourceType,
-            inspection: { layers: [], warnings: [], sourceUnitScale: 1, detectedUnits: null, unitsReliable: false, summary: 'STL file - 3D mesh imported by top-down silhouette projection' }
+            inspection: { layers: [], warnings: [], sourceUnitScale: 1, detectedUnits: null, unitsReliable: false, summary: `${label} file - 3D mesh imported by top-down silhouette projection` }
           })
-          setSourceUnits(project.meta.units) // Default to project units for STL
+          setSourceUnits(project.meta.units)
         } else {
           const text = String(readerEvent.target?.result ?? '')
           const inspection = nextSourceType === 'svg' ? inspectSvgString(text) : inspectDxfString(text)
@@ -118,7 +160,8 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
         }
         setJoinTolerance(defaultJoinTolerance(project.meta.units))
         setAllowCrossLayerJoins(false)
-        if (nextSourceType !== 'stl') {
+        setSilhouetteZSteps('')
+        if (!isModelSourceType(nextSourceType)) {
           const text = String(readerEvent.target?.result ?? '')
           const inspection = nextSourceType === 'svg' ? inspectSvgString(text) : inspectDxfString(text)
           setSelectedLayers(new Set(inspection.layers))
@@ -132,11 +175,12 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
         setJoinTolerance(defaultJoinTolerance(project.meta.units))
         setAllowCrossLayerJoins(false)
         setSelectedLayers(new Set())
+        setSilhouetteZSteps('')
         setDialogError(error instanceof Error ? error.message : 'Failed to inspect geometry file.')
       }
     }
-    if (nextSourceType === 'stl') {
-      reader.readAsDataURL(file)
+    if (isModelSourceType(nextSourceType)) {
+      reader.readAsArrayBuffer(file)
     } else {
       reader.readAsText(file)
     }
@@ -157,7 +201,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
 
   async function handleImport() {
     if (!loadedFile) {
-      setDialogError('Choose an SVG, DXF, or STL file to import.')
+      setDialogError('Choose an SVG, DXF, STL, or OBJ file to import.')
       return
     }
     if (!sourceUnits) {
@@ -167,6 +211,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
 
     setBusy(true)
     setLoadingProgress(0)
+    setLoadingStage('Preparing import')
     setDialogError(null)
 
     try {
@@ -184,56 +229,84 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
 
       let createdIds: string[] = []
 
-      if (loadedFile.sourceType === 'stl') {
-        const stlScale = sourceUnits === project.meta.units ? 1 : (sourceUnits === 'inch' ? 25.4 : 1/25.4)
+      if (isModelSourceType(loadedFile.sourceType)) {
+        const modelFormat = loadedFile.sourceType
+        const modelLabel = sourceTypeLabel(loadedFile.sourceType)
+        const modelScale = sourceUnits === project.meta.units ? 1 : (sourceUnits === 'inch' ? 25.4 : 1/25.4)
+        const requestedSilhouetteZSteps = parseSilhouetteZStepsInput(silhouetteZSteps)
         
-        // Wait for WebAssembly to parse and project the STL footprint
-        const base64Data = loadedFile.dataUrl?.split(',')[1]
-        if (!base64Data) throw new Error('Missing file data')
-        
-        const stlInfo = await extractStlProfileAndBounds(base64Data, stlScale, axisSwap, (p) => setLoadingProgress(p))
-        if (!stlInfo) throw new Error('Failed to parse STL or generate silhouette')
+        const fileData = loadedFile.modelBuffer
+        if (!fileData) throw new Error('Missing file data')
 
+        setLoadingStage('Parsing mesh')
+        setLoadingProgress(5)
+        let parsedMesh = loadImportedTriangleMesh(modelFormat, fileData, axisSwap)
+        if (!parsedMesh) throw new Error(`Failed to parse ${modelLabel} mesh`)
+        setLoadingProgress(12)
+
+        setLoadingStage('Normalizing mesh')
+        const importedMesh = normalizeImportedMeshForStorage(parsedMesh, modelScale)
+        parsedMesh = null
+        clearImportedSourceCaches()
+        const automaticSilhouetteZSteps = recommendedSilhouetteZSteps(
+          importedMesh.bounds.maxZ - importedMesh.bounds.minZ,
+          project.meta.units,
+        )
+        const resolvedSilhouetteZSteps = requestedSilhouetteZSteps ?? automaticSilhouetteZSteps
+        
+        setLoadingStage(`Projecting silhouette (${resolvedSilhouetteZSteps} Z steps)`)
+        setLoadingProgress(15)
+        const modelInfo = await extractImportedMeshProfileAndBounds(importedMesh, (p) => {
+          setLoadingProgress(15 + Math.round(p * 0.7))
+        }, { silhouetteZSteps: resolvedSilhouetteZSteps })
+        if (!modelInfo) throw new Error(`Failed to parse ${modelLabel} or generate silhouette`)
+
+        setLoadingStage('Preparing preview')
+        setLoadingProgress(88)
         let topViewDataUrl: string | undefined
         try {
-          const url = renderStlTopViewToDataUrl(base64Data, stlScale, axisSwap)
+          const url = renderImportedMeshTopViewToDataUrl(importedMesh)
           if (url) topViewDataUrl = url
         } catch {
           // top-view rendering is best-effort
         }
 
+        setLoadingStage('Storing model')
+        setLoadingProgress(95)
         const { addFeature } = useProjectStore.getState()
         const featureId = crypto.randomUUID()
         
         addFeature({
           id: featureId,
-          name: loadedFile.fileName.replace(/\.stl$/i, ''),
+          name: loadedFile.fileName.replace(/\.(stl|obj)$/i, ''),
           kind: 'stl',
           folderId: null,
           stl: {
-            format: 'stl',
+            format: modelFormat,
             filePath: undefined,
-            fileData: loadedFile.dataUrl,
-            scale: stlScale,
-            axisSwap: axisSwap,
-            silhouettePaths: stlInfo.silhouettePaths,
+            mesh: serializeImportedMesh(importedMesh, modelFormat),
+            scale: 1,
+            axisSwap: 'none',
+            silhouettePaths: modelInfo.silhouettePaths,
             topViewDataUrl,
           },
           sketch: {
-            profile: stlInfo.profile,
+            profile: modelInfo.profile,
             origin: { x: 0, y: 0 },
             orientationAngle: 0,
             dimensions: [],
             constraints: []
           },
           operation: 'model',
-          z_top: stlInfo.z_top,
-          z_bottom: stlInfo.z_bottom,
+          z_top: modelInfo.z_top,
+          z_bottom: modelInfo.z_bottom,
           visible: true,
           locked: false
         })
+        setLoadingProgress(100)
         createdIds = [featureId]
       } else {
+        setLoadingStage('Importing geometry')
         const result = loadedFile.sourceType === 'svg'
           ? importSvgString(loadedFile.text, {
               fileName: loadedFile.fileName,
@@ -278,6 +351,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
       setDialogError(error instanceof Error ? error.message : 'Failed to import geometry file.')
       setBusy(false)
       setLoadingProgress(null)
+      setLoadingStage('Processing model')
     }
   }
 
@@ -317,9 +391,9 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
               >
-                {loadedFile ? 'Choose Different File' : 'Choose SVG, DXF, or STL'}
+                {loadedFile ? 'Choose Different File' : 'Choose SVG, DXF, STL, or OBJ'}
               </button>
-              <input ref={fileInputRef} type="file" accept=".svg,.dxf,.stl" onChange={handleFileChange} style={{ display: 'none' }} />
+              <input ref={fileInputRef} type="file" accept=".svg,.dxf,.stl,.obj" onChange={handleFileChange} style={{ display: 'none' }} />
               <div className="import-dialog__file-name">
                 {loadedFile ? loadedFile.fileName : 'No file selected.'}
               </div>
@@ -348,7 +422,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
                     <option value="inch">Inch</option>
                   </select>
                 </div>
-                {!loadedFile.inspection.detectedUnits && loadedFile.sourceType !== 'stl' ? (
+                {!loadedFile.inspection.detectedUnits && !isModelSourceType(loadedFile.sourceType) ? (
                   <div className="import-dialog__field-note import-dialog__field-note--warn">
                     Units not detected — choose the source units before importing.
                   </div>
@@ -360,19 +434,34 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
                   <strong>{unitsLabel(project.meta.units)}</strong>
                 </div>
 
-                {/* Axis Swap (STL Only) */}
-                {loadedFile.sourceType === 'stl' ? (
+                {/* Axis orientation for imported 3D models */}
+                {isModelSourceType(loadedFile.sourceType) ? (
                   <div className="import-dialog__info-row">
                     <span>Axis Orientation</span>
                     <select
                       value={axisSwap}
-                      onChange={(event) => setAxisSwap(event.target.value as any)}
+                      onChange={(event) => setAxisSwap(event.target.value as ModelAxisOrientation)}
                     >
                       <option value="none">Original (Z-Up)</option>
                       <option value="yz">Swap Y / Z (Y-Up)</option>
                       <option value="xz">Swap X / Z</option>
                       <option value="xy">Swap X / Y</option>
                     </select>
+                  </div>
+                ) : null}
+
+                {isModelSourceType(loadedFile.sourceType) ? (
+                  <div className="import-dialog__info-row">
+                    <span>Silhouette Z Steps</span>
+                    <input
+                      type="number"
+                      min="8"
+                      max="512"
+                      step="1"
+                      placeholder="Auto"
+                      value={silhouetteZSteps}
+                      onChange={(event) => setSilhouetteZSteps(event.target.value)}
+                    />
                   </div>
                 ) : null}
 
@@ -415,7 +504,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
                 {/* Progress */}
                 {busy && loadingProgress !== null ? (
                   <div className="import-progress-container">
-                    <div className="import-progress-label">Processing STL... {progressPercent}%</div>
+                    <div className="import-progress-label">{loadingStage}... {progressPercent}%</div>
                     <div className="import-progress-track">
                       <div className="import-progress-fill" style={progressStyle} />
                     </div>

--- a/src/engine/csg.ts
+++ b/src/engine/csg.ts
@@ -17,9 +17,9 @@
 import * as THREE from 'three'
 import ManifoldModule, { type Manifold as ManifoldSolid, type ManifoldToplevel } from 'manifold-3d'
 import { bezierPoint, rectProfile } from '../types/project'
-import type { Clamp, DimensionRef, MachineOrigin, Project, SketchFeature, SketchProfile, Segment, Stock, STLFeatureData, Tab } from '../types/project'
+import type { Clamp, DimensionRef, MachineOrigin, Project, SketchFeature, SketchProfile, Segment, Stock, Tab } from '../types/project'
 import { expandFeatureGeometry } from '../text'
-import { loadImportedBufferGeometry, type ImportedModelFormat } from './importedMesh'
+import { loadPersistedBufferGeometry, loadPersistedTriangleMesh } from './importedMesh'
 import type { MeshSliceIndex } from './toolpaths/meshSlicing'
 
 const ARC_STEP_RADIANS = Math.PI / 18
@@ -244,14 +244,20 @@ export interface STLTransformedData {
 const STL_TRANSFORM_CACHE_LIMIT = 6
 
 interface STLTransformedCacheEntry {
-  fileData: string
+  positionsData: string
+  indicesData: string
   data: STLTransformedData
 }
 
 const stlTransformedGeometryCache = new Map<string, STLTransformedCacheEntry>()
 
-function importedModelFormat(stl: STLFeatureData): ImportedModelFormat {
-  return stl.format ?? 'stl'
+export function clearSTLTransformedGeometryCache(): void {
+  stlTransformedGeometryCache.clear()
+}
+
+function featureModelAsset(project: Project, feature: SketchFeature) {
+  const assetId = feature.stl?.meshAssetId
+  return assetId ? project.modelAssets?.[assetId] ?? null : null
 }
 
 function stlTransformedGeometryCacheKey(
@@ -259,6 +265,7 @@ function stlTransformedGeometryCacheKey(
   project: Project,
 ): string {
   const stl = feature.stl
+  const asset = featureModelAsset(project, feature)
   const zTop = resolveDimension(feature.z_top, project)
   const zBottom = resolveDimension(feature.z_bottom, project)
   return [
@@ -271,16 +278,23 @@ function stlTransformedGeometryCacheKey(
     feature.sketch.orientationAngle ?? 0,
     zTop,
     zBottom,
-    stl?.fileData?.length ?? 0,
+    stl?.meshAssetId ?? 'missing',
+    asset?.storage ?? 'missing',
+    asset?.sourceFormat ?? 'unknown',
+    asset?.vertexCount ?? 0,
+    asset?.triangleCount ?? 0,
+    asset?.positions.length ?? 0,
+    asset?.indices.length ?? 0,
   ].join('|')
 }
 
 function getCachedSTLTransformedGeometry(
   key: string,
-  fileData: string,
+  positionsData: string,
+  indicesData: string,
 ): STLTransformedData | null {
   const entry = stlTransformedGeometryCache.get(key)
-  if (!entry || entry.fileData !== fileData) {
+  if (!entry || entry.positionsData !== positionsData || entry.indicesData !== indicesData) {
     return null
   }
 
@@ -292,10 +306,11 @@ function getCachedSTLTransformedGeometry(
 
 function setCachedSTLTransformedGeometry(
   key: string,
-  fileData: string,
+  positionsData: string,
+  indicesData: string,
   data: STLTransformedData,
 ): void {
-  stlTransformedGeometryCache.set(key, { fileData, data })
+  stlTransformedGeometryCache.set(key, { positionsData, indicesData, data })
   while (stlTransformedGeometryCache.size > STL_TRANSFORM_CACHE_LIMIT) {
     const oldestKey = stlTransformedGeometryCache.keys().next().value
     if (!oldestKey) break
@@ -317,32 +332,29 @@ export function loadSTLTransformedGeometry(
   feature: SketchFeature,
   project: Project
 ): STLTransformedData | null {
-  if (feature.kind !== 'stl' || !feature.stl?.fileData) return null
+  const asset = feature.kind === 'stl' ? featureModelAsset(project, feature) : null
+  if (!asset) return null
 
   const cacheKey = stlTransformedGeometryCacheKey(feature, project)
-  const cached = getCachedSTLTransformedGeometry(cacheKey, feature.stl.fileData)
+  const cached = getCachedSTLTransformedGeometry(cacheKey, asset.positions, asset.indices)
   if (cached) return cached
 
-  const geometry = loadImportedBufferGeometry(importedModelFormat(feature.stl), feature.stl.fileData, feature.stl.axisSwap || 'none', true)
-  if (!geometry) return null
+  const sourceMesh = loadPersistedTriangleMesh(asset)
+  if (!sourceMesh) return null
+  const stl = feature.stl
 
-  const rawPos = geometry.attributes.position.array as Float32Array
+  const rawPos = sourceMesh.positions
   const numVerts = rawPos.length / 3
 
   // Compute raw Z bounds
-  let rawMinZ = Infinity
-  let rawMaxZ = -Infinity
-  for (let i = 0; i < rawPos.length; i += 3) {
-    const z = rawPos[i + 2]
-    if (z < rawMinZ) rawMinZ = z
-    if (z > rawMaxZ) rawMaxZ = z
-  }
+  const rawMinZ = sourceMesh.bounds.minZ
+  const rawMaxZ = sourceMesh.bounds.maxZ
 
   const meshHeight = rawMaxZ - rawMinZ
   if (meshHeight < 0.001) return null
 
   // BuildFeatureSolid-style transformations (same as buildFeatureMesh)
-  const scale = feature.stl.scale ?? 1
+  const scale = stl?.scale ?? 1
   const angleDeg = feature.sketch.orientationAngle ?? 0
   const zTop = resolveDimension(feature.z_top, project)
   const zBottom = resolveDimension(feature.z_bottom, project)
@@ -387,23 +399,24 @@ export function loadSTLTransformedGeometry(
     positions[iz] = z
   }
 
-  const index = geometry.index
-    ? new Uint32Array(geometry.index.array)
-    : new Uint32Array(numVerts).map((_, i) => i)
+  const index = new Uint32Array(sourceMesh.index)
 
   const data = { positions, index, rawMinZ: rawMinZ * scale, meshHeight: meshHeight * scale }
-  setCachedSTLTransformedGeometry(cacheKey, feature.stl.fileData, data)
+  setCachedSTLTransformedGeometry(cacheKey, asset.positions, asset.indices, data)
   return data
 }
 
 export function buildFeatureMesh(
+  project: Project,
   feature: SketchFeature,
   selected = false,
   hovered = false,
   stockThickness?: number,
 ): THREE.Mesh {
-  if (feature.kind === 'stl' && feature.stl?.fileData) {
-    const geometry = loadImportedBufferGeometry(importedModelFormat(feature.stl), feature.stl.fileData, feature.stl.axisSwap || 'none', false)
+  const asset = feature.kind === 'stl' ? featureModelAsset(project, feature) : null
+  if (asset) {
+    const stl = feature.stl
+    const geometry = loadPersistedBufferGeometry(asset, false)
     const material = new THREE.MeshStandardMaterial({
       color: selected ? 0xffaa00 : hovered ? 0x44aaff : 0xb7c2cf,
       roughness: 0.82,
@@ -411,10 +424,8 @@ export function buildFeatureMesh(
       side: THREE.DoubleSide,
     })
     if (!geometry) return new THREE.Mesh(new THREE.BufferGeometry(), material)
-    
-    geometry.computeVertexNormals()
-    
-    const scale = feature.stl.scale ?? 1
+
+    const scale = stl?.scale ?? 1
     const angleRad = (feature.sketch.orientationAngle ?? 0) * (Math.PI / 180)
     
     // Initial uniform scale
@@ -633,37 +644,26 @@ export function buildFeatureSolid(
   project: Project,
   feature: SketchFeature
 ): ManifoldSolid | null {
-  if (feature.kind === 'stl' && feature.stl?.fileData) {
+  const asset = feature.kind === 'stl' ? featureModelAsset(project, feature) : null
+  if (asset) {
     try {
-      const geometry = loadImportedBufferGeometry(importedModelFormat(feature.stl), feature.stl.fileData, feature.stl.axisSwap || 'none', true)
-      if (!geometry) return null
-      
-      const positions = geometry.attributes.position.array
-      const numVerts = positions.length / 3
-      let triVerts: Uint32Array
-      
-      if (geometry.index) {
-        triVerts = new Uint32Array(geometry.index.array)
-      } else {
-        triVerts = new Uint32Array(numVerts)
-        for (let i = 0; i < numVerts; i++) {
-          triVerts[i] = i
-        }
-      }
+      const mesh = loadPersistedTriangleMesh(asset)
+      if (!mesh) return null
+      const stl = feature.stl
       
       const manifoldMesh = new module.Mesh({
         numProp: 3,
-        vertProperties: new Float32Array(positions),
-        triVerts: triVerts,
+        vertProperties: new Float32Array(mesh.positions),
+        triVerts: new Uint32Array(mesh.index),
         halfedgeTangent: new Float32Array(0),
         runIndex: new Uint32Array([0]),
         runOriginalID: new Uint32Array([0]),
         runTransform: new Float32Array(12).fill(0),
-        faceID: new Uint32Array(triVerts.length / 3).fill(0),
+        faceID: new Uint32Array(mesh.index.length / 3).fill(0),
       })
       
       const solid = new module.Manifold(manifoldMesh)
-      const scale = feature.stl.scale ?? 1
+      const scale = stl?.scale ?? 1
       const angleDeg = feature.sketch.orientationAngle ?? 0
       
       // Resolve z dimensions (DimensionRef → number)
@@ -859,14 +859,14 @@ export async function buildScene(
     // Region features also get their own mesh since they are visual-only (not part of boolean model).
     for (const feature of visibleFeatures) {
       if (feature.kind === 'stl' || feature.operation === 'region') {
-        featureMeshes.set(feature.id, buildFeatureMesh(feature, false, false, project.stock.thickness))
+        featureMeshes.set(feature.id, buildFeatureMesh(project, feature, false, false, project.stock.thickness))
       }
       
       // If buildBooleanModel failed, we need the rest of the meshes too
       if (!modelMesh) {
         for (const expanded of expandFeatureGeometry(feature)) {
           if (expanded.kind !== 'stl' && expanded.operation !== 'region') {
-            featureMeshes.set(expanded.id, buildFeatureMesh(expanded, false, false, project.stock.thickness))
+            featureMeshes.set(expanded.id, buildFeatureMesh(project, expanded, false, false, project.stock.thickness))
           }
         }
       }

--- a/src/engine/importedMesh.test.ts
+++ b/src/engine/importedMesh.test.ts
@@ -7,8 +7,14 @@
 import {
   loadImportedBufferGeometry,
   loadImportedTriangleMesh,
+  loadObjBufferGeometry,
+  loadObjTriangleMesh,
+  loadPersistedBufferGeometry,
+  loadPersistedTriangleMesh,
   loadStlBufferGeometry,
   loadStlTriangleMesh,
+  normalizeImportedMeshForStorage,
+  serializeImportedMesh,
   type ModelAxisOrientation,
 } from './importedMesh'
 
@@ -34,6 +40,24 @@ endsolid wedge
   return btoa(stl)
 }
 
+function makeObjBase64(text: string): string {
+  return btoa(text)
+}
+
+function makeObjBuffer(text: string): ArrayBuffer {
+  const bytes = new TextEncoder().encode(text)
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+}
+
+function makeWedgeObjBase64(): string {
+  return makeObjBase64(`# wedge
+v 0 0 0
+v 2 0 0
+v 0 3 4
+f 1 2 3
+`)
+}
+
 function testBounds(axisOrientation: ModelAxisOrientation, expected: { maxX: number; maxY: number; maxZ: number }): void {
   const mesh = loadStlTriangleMesh(makeAsciiStlBase64(), axisOrientation)
   if (!mesh) throw new Error(`mesh should parse for axis ${axisOrientation}`)
@@ -45,12 +69,29 @@ function testBounds(axisOrientation: ModelAxisOrientation, expected: { maxX: num
   assert(approx(mesh.bounds.maxZ, expected.maxZ), `maxZ should be ${expected.maxZ} for ${axisOrientation}, got ${mesh.bounds.maxZ}`)
 }
 
+function testObjBounds(axisOrientation: ModelAxisOrientation, expected: { maxX: number; maxY: number; maxZ: number }): void {
+  const mesh = loadObjTriangleMesh(makeWedgeObjBase64(), axisOrientation)
+  if (!mesh) throw new Error(`OBJ mesh should parse for axis ${axisOrientation}`)
+  assert(approx(mesh.bounds.minX, 0), `OBJ minX should be 0 for ${axisOrientation}`)
+  assert(approx(mesh.bounds.minY, 0), `OBJ minY should be 0 for ${axisOrientation}`)
+  assert(approx(mesh.bounds.minZ, 0), `OBJ minZ should be 0 for ${axisOrientation}`)
+  assert(approx(mesh.bounds.maxX, expected.maxX), `OBJ maxX should be ${expected.maxX} for ${axisOrientation}, got ${mesh.bounds.maxX}`)
+  assert(approx(mesh.bounds.maxY, expected.maxY), `OBJ maxY should be ${expected.maxY} for ${axisOrientation}, got ${mesh.bounds.maxY}`)
+  assert(approx(mesh.bounds.maxZ, expected.maxZ), `OBJ maxZ should be ${expected.maxZ} for ${axisOrientation}, got ${mesh.bounds.maxZ}`)
+}
+
 function testAxisOrientations(): void {
   console.log('Testing STL axis orientation bounds...')
   testBounds('none', { maxX: 2, maxY: 3, maxZ: 4 })
   testBounds('yz', { maxX: 2, maxY: 4, maxZ: 3 })
   testBounds('xz', { maxX: 4, maxY: 3, maxZ: 2 })
   testBounds('xy', { maxX: 3, maxY: 2, maxZ: 4 })
+
+  console.log('Testing OBJ axis orientation bounds...')
+  testObjBounds('none', { maxX: 2, maxY: 3, maxZ: 4 })
+  testObjBounds('yz', { maxX: 2, maxY: 4, maxZ: 3 })
+  testObjBounds('xz', { maxX: 4, maxY: 3, maxZ: 2 })
+  testObjBounds('xy', { maxX: 3, maxY: 2, maxZ: 4 })
 }
 
 function testTriangleMeshCacheReuse(): void {
@@ -87,11 +128,113 @@ function testGenericFormatDispatch(): void {
   const geometry = loadImportedBufferGeometry('stl', base64, 'none', true)
   assert(mesh !== null, 'generic triangle mesh dispatch should load STL')
   assert(geometry !== null, 'generic buffer geometry dispatch should load STL')
+
+  const objBase64 = makeWedgeObjBase64()
+  const objMesh = loadImportedTriangleMesh('obj', objBase64, 'none')
+  const objGeometry = loadImportedBufferGeometry('obj', objBase64, 'none', true)
+  assert(objMesh !== null, 'generic triangle mesh dispatch should load OBJ')
+  assert(objGeometry !== null, 'generic buffer geometry dispatch should load OBJ')
+}
+
+function testArrayBufferModelInput(): void {
+  console.log('Testing ArrayBuffer model input...')
+  const objBuffer = makeObjBuffer(`# wedge
+v 0 0 0
+v 2 0 0
+v 0 3 4
+f 1 2 3
+`)
+  const mesh = loadImportedTriangleMesh('obj', objBuffer, 'none')
+  const geometry = loadImportedBufferGeometry('obj', objBuffer, 'none', false)
+  assert(mesh !== null, 'ArrayBuffer OBJ input should parse')
+  assert(geometry !== null, 'ArrayBuffer OBJ input should build geometry')
+  assert(mesh !== null && approx(mesh.bounds.maxZ, 4), `expected ArrayBuffer OBJ maxZ=4, got ${mesh?.bounds.maxZ}`)
+}
+
+function testObjFaceSyntaxAndTriangulation(): void {
+  console.log('Testing OBJ face syntax and triangulation...')
+  const obj = makeObjBase64(`
+# square with texture and normal indices
+v 0 0 0
+v 2 0 0
+v 2 2 0
+v 0 2 0
+v 1 3 0
+vt 0 0
+vn 0 0 1
+o part
+g main
+s off
+usemtl ignored
+f 1/1/1 2/1/1 3/1/1 4/1/1 5/1/1
+f -5//1 -4//1 -3//1
+`)
+  const mesh = loadObjTriangleMesh(obj, 'none')
+  if (!mesh) throw new Error('OBJ mesh should parse common face syntax')
+  assert(mesh.index.length === 12, `expected 4 triangles from n-gon plus negative-index triangle, got ${mesh.index.length / 3}`)
+  assert(approx(mesh.bounds.maxX, 2), `expected OBJ maxX=2, got ${mesh.bounds.maxX}`)
+  assert(approx(mesh.bounds.maxY, 3), `expected OBJ maxY=3, got ${mesh.bounds.maxY}`)
+}
+
+function testObjInvalidFaces(): void {
+  console.log('Testing OBJ invalid faces are rejected...')
+  const obj = makeObjBase64(`
+v 0 0 0
+v 1 0 0
+v 0 1 0
+f 0 1 2
+`)
+  assert(loadObjTriangleMesh(obj, 'none') === null, 'OBJ with only invalid face index 0 should not load')
+}
+
+function testObjGeometryCloneCache(): void {
+  console.log('Testing OBJ buffer geometry cache clone behavior...')
+  const base64 = makeWedgeObjBase64()
+  const first = loadObjBufferGeometry(base64, 'none', false)
+  const second = loadObjBufferGeometry(base64, 'none', false)
+  if (!first || !second) throw new Error('OBJ geometry should parse')
+  assert(first !== second, 'OBJ buffer geometry cache should return clones for mutable callers')
+
+  first.translate(100, 0, 0)
+  first.computeBoundingBox()
+  second.computeBoundingBox()
+  const firstBounds = first.boundingBox
+  const secondBounds = second.boundingBox
+  if (!firstBounds || !secondBounds) throw new Error('OBJ bounding boxes should compute')
+  assert(firstBounds.min.x > 99, 'first OBJ geometry should be translated')
+  assert(approx(secondBounds.min.x, 0), 'second OBJ geometry should not inherit first geometry mutation')
+}
+
+function testPersistedMeshRoundTrip(): void {
+  console.log('Testing persisted imported mesh round trip...')
+  const parsed = loadObjTriangleMesh(makeWedgeObjBase64(), 'none')
+  if (!parsed) throw new Error('OBJ mesh should parse')
+
+  const normalized = normalizeImportedMeshForStorage(parsed, 2)
+  const persisted = serializeImportedMesh(normalized, 'obj')
+  const decoded = loadPersistedTriangleMesh(persisted)
+  if (!decoded) throw new Error('persisted mesh should decode')
+
+  assert(decoded.positions.length === normalized.positions.length, 'decoded positions length should match')
+  assert(decoded.index.length === normalized.index.length, 'decoded index length should match')
+  assert(approx(decoded.bounds.maxX, 4), `expected decoded maxX=4, got ${decoded.bounds.maxX}`)
+  assert(approx(decoded.bounds.maxY, 6), `expected decoded maxY=6, got ${decoded.bounds.maxY}`)
+  assert(approx(decoded.bounds.maxZ, 8), `expected decoded maxZ=8, got ${decoded.bounds.maxZ}`)
+
+  const firstGeometry = loadPersistedBufferGeometry(persisted, false)
+  const secondGeometry = loadPersistedBufferGeometry(persisted, false)
+  if (!firstGeometry || !secondGeometry) throw new Error('persisted geometry should load')
+  assert(firstGeometry !== secondGeometry, 'persisted geometry cache should return mutable clones')
 }
 
 testAxisOrientations()
 testTriangleMeshCacheReuse()
 testGeometryCloneCache()
 testGenericFormatDispatch()
+testArrayBufferModelInput()
+testObjFaceSyntaxAndTriangulation()
+testObjInvalidFaces()
+testObjGeometryCloneCache()
+testPersistedMeshRoundTrip()
 
 console.log('importedMesh tests passed')

--- a/src/engine/importedMesh.ts
+++ b/src/engine/importedMesh.ts
@@ -17,8 +17,9 @@
 import * as THREE from 'three'
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js'
 import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js'
+import type { PersistedImportedMesh } from '../types/project'
 
-export type ImportedModelFormat = 'stl'
+export type ImportedModelFormat = 'stl' | 'obj'
 export type ModelAxisOrientation = 'none' | 'yz' | 'xz' | 'xy'
 
 export interface ImportedMeshBounds {
@@ -36,20 +37,53 @@ export interface ImportedTriangleMesh {
   bounds: ImportedMeshBounds
 }
 
+export type ImportedSourceData = string | ArrayBuffer
+
 interface CachedGeometryEntry {
-  fileData: string
+  sourceData: ImportedSourceData
   geometry: THREE.BufferGeometry
 }
 
 interface CachedTriangleMeshEntry {
-  fileData: string
+  sourceData: ImportedSourceData
   mesh: ImportedTriangleMesh
+}
+
+interface CachedPersistedTriangleMeshEntry {
+  positionsData: string
+  indicesData: string
+  mesh: ImportedTriangleMesh
+}
+
+interface CachedPersistedGeometryEntry {
+  positionsData: string
+  indicesData: string
+  geometry: THREE.BufferGeometry
 }
 
 const GEOMETRY_CACHE_LIMIT = 6
 const TRIANGLE_MESH_CACHE_LIMIT = 6
 const geometryCache = new Map<string, CachedGeometryEntry>()
 const triangleMeshCache = new Map<string, CachedTriangleMeshEntry>()
+const persistedTriangleMeshCache = new Map<string, CachedPersistedTriangleMeshEntry>()
+const persistedGeometryCache = new Map<string, CachedPersistedGeometryEntry>()
+
+export function clearImportedSourceCaches(): void {
+  for (const entry of geometryCache.values()) {
+    entry.geometry.dispose()
+  }
+  geometryCache.clear()
+  triangleMeshCache.clear()
+}
+
+export function clearImportedModelCaches(): void {
+  clearImportedSourceCaches()
+  persistedTriangleMeshCache.clear()
+  for (const entry of persistedGeometryCache.values()) {
+    entry.geometry.dispose()
+  }
+  persistedGeometryCache.clear()
+}
 
 function decodeBase64Data(data: string): ArrayBuffer | null {
   const base64 = data.includes(',') ? data.split(',')[1] : data
@@ -81,9 +115,99 @@ function decodeBase64Data(data: string): ArrayBuffer | null {
   return new Uint8Array(bytes).buffer
 }
 
+function encodeBytesToBase64(bytes: Uint8Array): string {
+  if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
+    const CHUNK_SIZE = 0x8000
+    let binary = ''
+    for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+      const chunk = bytes.subarray(i, i + CHUNK_SIZE)
+      for (let j = 0; j < chunk.length; j += 1) {
+        binary += String.fromCharCode(chunk[j])
+      }
+    }
+    return window.btoa(binary)
+  }
+
+  const maybeBuffer = (globalThis as {
+    Buffer?: { from: (data: Uint8Array) => { toString: (encoding: 'base64') => string } }
+  }).Buffer
+  if (maybeBuffer) {
+    return maybeBuffer.from(bytes).toString('base64')
+  }
+
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+  let output = ''
+  for (let i = 0; i < bytes.length; i += 3) {
+    const a = bytes[i]
+    const b = i + 1 < bytes.length ? bytes[i + 1] : 0
+    const c = i + 2 < bytes.length ? bytes[i + 2] : 0
+    output += chars[a >> 2]
+    output += chars[((a & 3) << 4) | (b >> 4)]
+    output += i + 1 < bytes.length ? chars[((b & 15) << 2) | (c >> 6)] : '='
+    output += i + 2 < bytes.length ? chars[c & 63] : '='
+  }
+  return output
+}
+
+function decodeSourceData(data: ImportedSourceData): ArrayBuffer | null {
+  if (data instanceof ArrayBuffer) return data
+  return decodeBase64Data(data)
+}
+
+function decodeSourceText(data: ImportedSourceData): string | null {
+  const buffer = decodeSourceData(data)
+  if (!buffer) return null
+
+  try {
+    return new TextDecoder('utf-8', { fatal: false }).decode(buffer)
+  } catch {
+    return null
+  }
+}
+
+export function normalizeImportedMeshForStorage(mesh: ImportedTriangleMesh, scale: number): ImportedTriangleMesh {
+  const positions = new Float32Array(mesh.positions.length)
+  for (let i = 0; i < mesh.positions.length; i += 1) {
+    positions[i] = mesh.positions[i] * scale
+  }
+  const index = new Uint32Array(mesh.index)
+  return { positions, index, bounds: computeMeshBounds(positions) }
+}
+
+export function serializeImportedMesh(
+  mesh: ImportedTriangleMesh,
+  sourceFormat?: ImportedModelFormat,
+): PersistedImportedMesh {
+  return {
+    storage: 'mesh-v1',
+    sourceFormat,
+    vertexCount: mesh.positions.length / 3,
+    triangleCount: mesh.index.length / 3,
+    positions: encodeBytesToBase64(new Uint8Array(mesh.positions.buffer, mesh.positions.byteOffset, mesh.positions.byteLength)),
+    indices: encodeBytesToBase64(new Uint8Array(mesh.index.buffer, mesh.index.byteOffset, mesh.index.byteLength)),
+    bounds: { ...mesh.bounds },
+  }
+}
+
+export function deserializeImportedMesh(mesh: PersistedImportedMesh): ImportedTriangleMesh | null {
+  if (mesh.storage !== 'mesh-v1') return null
+
+  const positionBuffer = decodeBase64Data(mesh.positions)
+  const indexBuffer = decodeBase64Data(mesh.indices)
+  if (!positionBuffer || !indexBuffer) return null
+  if (positionBuffer.byteLength !== mesh.vertexCount * 3 * Float32Array.BYTES_PER_ELEMENT) return null
+  if (indexBuffer.byteLength !== mesh.triangleCount * 3 * Uint32Array.BYTES_PER_ELEMENT) return null
+
+  return {
+    positions: new Float32Array(positionBuffer),
+    index: new Uint32Array(indexBuffer),
+    bounds: { ...mesh.bounds },
+  }
+}
+
 function cacheKey(
-  format: 'stl',
-  fileData: string,
+  format: ImportedModelFormat,
+  sourceData: ImportedSourceData,
   axisOrientation: ModelAxisOrientation,
   mergeVertices: boolean,
 ): string {
@@ -91,8 +215,16 @@ function cacheKey(
     format,
     axisOrientation,
     mergeVertices ? 'merged' : 'raw',
-    fileData.length,
+    sourceDataLength(sourceData),
   ].join('|')
+}
+
+function sourceDataLength(sourceData: ImportedSourceData): number {
+  return typeof sourceData === 'string' ? sourceData.length : sourceData.byteLength
+}
+
+function sameSourceData(a: ImportedSourceData, b: ImportedSourceData): boolean {
+  return a === b
 }
 
 export function applyAxisOrientationToPositions(
@@ -118,17 +250,17 @@ export function applyAxisOrientationToPositions(
   }
 }
 
-function getCachedGeometry(key: string, fileData: string): THREE.BufferGeometry | null {
+function getCachedGeometry(key: string, sourceData: ImportedSourceData): THREE.BufferGeometry | null {
   const entry = geometryCache.get(key)
-  if (!entry || entry.fileData !== fileData) return null
+  if (!entry || !sameSourceData(entry.sourceData, sourceData)) return null
 
   geometryCache.delete(key)
   geometryCache.set(key, entry)
   return entry.geometry.clone()
 }
 
-function setCachedGeometry(key: string, fileData: string, geometry: THREE.BufferGeometry): void {
-  geometryCache.set(key, { fileData, geometry: geometry.clone() })
+function setCachedGeometry(key: string, sourceData: ImportedSourceData, geometry: THREE.BufferGeometry): void {
+  geometryCache.set(key, { sourceData, geometry: geometry.clone() })
   while (geometryCache.size > GEOMETRY_CACHE_LIMIT) {
     const oldestKey = geometryCache.keys().next().value
     if (!oldestKey) break
@@ -138,8 +270,110 @@ function setCachedGeometry(key: string, fileData: string, geometry: THREE.Buffer
   }
 }
 
+function persistedMeshCacheKey(mesh: PersistedImportedMesh, mergeVertices?: boolean): string {
+  return [
+    mesh.storage,
+    mesh.sourceFormat ?? 'unknown',
+    mesh.vertexCount,
+    mesh.triangleCount,
+    mesh.positions.length,
+    mesh.indices.length,
+    mergeVertices ? 'merged' : 'raw',
+  ].join('|')
+}
+
+function getCachedPersistedTriangleMesh(key: string, mesh: PersistedImportedMesh): ImportedTriangleMesh | null {
+  const entry = persistedTriangleMeshCache.get(key)
+  if (!entry || entry.positionsData !== mesh.positions || entry.indicesData !== mesh.indices) return null
+
+  persistedTriangleMeshCache.delete(key)
+  persistedTriangleMeshCache.set(key, entry)
+  return entry.mesh
+}
+
+function setCachedPersistedTriangleMesh(key: string, persisted: PersistedImportedMesh, mesh: ImportedTriangleMesh): void {
+  persistedTriangleMeshCache.set(key, {
+    positionsData: persisted.positions,
+    indicesData: persisted.indices,
+    mesh,
+  })
+  while (persistedTriangleMeshCache.size > TRIANGLE_MESH_CACHE_LIMIT) {
+    const oldestKey = persistedTriangleMeshCache.keys().next().value
+    if (!oldestKey) break
+    persistedTriangleMeshCache.delete(oldestKey)
+  }
+}
+
+function getCachedPersistedGeometry(key: string, mesh: PersistedImportedMesh): THREE.BufferGeometry | null {
+  const entry = persistedGeometryCache.get(key)
+  if (!entry || entry.positionsData !== mesh.positions || entry.indicesData !== mesh.indices) return null
+
+  persistedGeometryCache.delete(key)
+  persistedGeometryCache.set(key, entry)
+  return entry.geometry.clone()
+}
+
+function setCachedPersistedGeometry(key: string, persisted: PersistedImportedMesh, geometry: THREE.BufferGeometry): void {
+  persistedGeometryCache.set(key, {
+    positionsData: persisted.positions,
+    indicesData: persisted.indices,
+    geometry: geometry.clone(),
+  })
+  while (persistedGeometryCache.size > GEOMETRY_CACHE_LIMIT) {
+    const oldestKey = persistedGeometryCache.keys().next().value
+    if (!oldestKey) break
+    const entry = persistedGeometryCache.get(oldestKey)
+    entry?.geometry.dispose()
+    persistedGeometryCache.delete(oldestKey)
+  }
+}
+
+export function loadPersistedTriangleMesh(mesh: PersistedImportedMesh): ImportedTriangleMesh | null {
+  const key = persistedMeshCacheKey(mesh)
+  const cached = getCachedPersistedTriangleMesh(key, mesh)
+  if (cached) return cached
+
+  const decoded = deserializeImportedMesh(mesh)
+  if (!decoded) return null
+
+  setCachedPersistedTriangleMesh(key, mesh, decoded)
+  return decoded
+}
+
+export function triangleMeshToBufferGeometry(
+  mesh: ImportedTriangleMesh,
+  mergeVertices: boolean,
+): THREE.BufferGeometry {
+  let geometry = new THREE.BufferGeometry()
+  geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(mesh.positions), 3))
+  geometry.setIndex(new THREE.BufferAttribute(new Uint32Array(mesh.index), 1))
+
+  if (mergeVertices) {
+    geometry = BufferGeometryUtils.mergeVertices(geometry, 1e-5)
+  }
+
+  geometry.computeVertexNormals()
+  return geometry
+}
+
+export function loadPersistedBufferGeometry(
+  mesh: PersistedImportedMesh,
+  mergeVertices: boolean,
+): THREE.BufferGeometry | null {
+  const key = persistedMeshCacheKey(mesh, mergeVertices)
+  const cached = getCachedPersistedGeometry(key, mesh)
+  if (cached) return cached
+
+  const triangleMesh = loadPersistedTriangleMesh(mesh)
+  if (!triangleMesh) return null
+
+  const geometry = triangleMeshToBufferGeometry(triangleMesh, mergeVertices)
+  setCachedPersistedGeometry(key, mesh, geometry)
+  return geometry
+}
+
 export function loadStlBufferGeometry(
-  fileData: string,
+  fileData: ImportedSourceData,
   axisOrientation: ModelAxisOrientation,
   mergeVertices: boolean,
 ): THREE.BufferGeometry | null {
@@ -147,7 +381,7 @@ export function loadStlBufferGeometry(
   const cached = getCachedGeometry(key, fileData)
   if (cached) return cached
 
-  const buffer = decodeBase64Data(fileData)
+  const buffer = decodeSourceData(fileData)
   if (!buffer) return null
 
   const loader = new STLLoader()
@@ -162,15 +396,194 @@ export function loadStlBufferGeometry(
   return geometry
 }
 
+function parseObjVertexIndex(token: string, vertexCount: number): number | null {
+  const slashIndex = token.indexOf('/')
+  const rawVertexIndex = slashIndex >= 0 ? token.slice(0, slashIndex) : token
+  if (!rawVertexIndex) return null
+
+  const parsedIndex = Number.parseInt(rawVertexIndex, 10)
+  if (!Number.isInteger(parsedIndex) || parsedIndex === 0) return null
+
+  const resolvedIndex = parsedIndex > 0 ? parsedIndex - 1 : vertexCount + parsedIndex
+  return resolvedIndex >= 0 && resolvedIndex < vertexCount ? resolvedIndex : null
+}
+
+function forEachObjLogicalLine(text: string, callback: (line: string) => boolean | void): boolean {
+  let start = 0
+  let continuedLine = ''
+
+  while (start <= text.length) {
+    const newlineIndex = text.indexOf('\n', start)
+    const end = newlineIndex >= 0 ? newlineIndex : text.length
+    let line = text.slice(start, end)
+    if (line.endsWith('\r')) line = line.slice(0, -1)
+
+    const trimmedRight = line.trimEnd()
+    if (trimmedRight.endsWith('\\')) {
+      continuedLine += `${trimmedRight.slice(0, -1)} `
+    } else {
+      const logicalLine = continuedLine ? continuedLine + line : line
+      continuedLine = ''
+      if (callback(logicalLine) === false) return false
+    }
+
+    if (newlineIndex < 0) break
+    start = newlineIndex + 1
+  }
+
+  if (continuedLine && callback(continuedLine) === false) return false
+  return true
+}
+
+function uncommentAndTrimObjLine(line: string): string {
+  const commentIndex = line.indexOf('#')
+  const uncommented = commentIndex >= 0 ? line.slice(0, commentIndex) : line
+  return uncommented.trim()
+}
+
+function countObjFaceTriangles(parts: string[], vertexCount: number): number {
+  if (parts.length < 4) return 0
+
+  let faceVertexCount = 0
+  for (let i = 1; i < parts.length; i += 1) {
+    const vertexIndex = parseObjVertexIndex(parts[i], vertexCount)
+    if (vertexIndex === null) return 0
+    faceVertexCount += 1
+  }
+
+  return faceVertexCount >= 3 ? faceVertexCount - 2 : 0
+}
+
+function parseObjTriangleMesh(objText: string): ImportedTriangleMesh | null {
+  let vertexCount = 0
+  let triangleCount = 0
+
+  const counted = forEachObjLogicalLine(objText, (line) => {
+    const uncommentedLine = uncommentAndTrimObjLine(line)
+    if (!uncommentedLine) return
+
+    const parts = uncommentedLine.split(/\s+/)
+    const keyword = parts[0]
+
+    if (keyword === 'v') {
+      vertexCount += 1
+      return
+    }
+
+    if (keyword !== 'f') return
+    triangleCount += countObjFaceTriangles(parts, vertexCount)
+  })
+
+  if (!counted || vertexCount === 0 || triangleCount === 0) return null
+
+  const positions = new Float32Array(vertexCount * 3)
+  const indices = new Uint32Array(triangleCount * 3)
+  const faceIndices: number[] = []
+  let positionOffset = 0
+  let indexOffset = 0
+  let currentVertexCount = 0
+
+  const filled = forEachObjLogicalLine(objText, (line) => {
+    const uncommentedLine = uncommentAndTrimObjLine(line)
+    if (!uncommentedLine) return
+
+    const parts = uncommentedLine.split(/\s+/)
+    const keyword = parts[0]
+
+    if (keyword === 'v') {
+      if (parts.length < 4) return false
+      const x = Number.parseFloat(parts[1])
+      const y = Number.parseFloat(parts[2])
+      const z = Number.parseFloat(parts[3])
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) return false
+      positions[positionOffset] = x
+      positions[positionOffset + 1] = y
+      positions[positionOffset + 2] = z
+      positionOffset += 3
+      currentVertexCount += 1
+      return
+    }
+
+    if (keyword !== 'f' || parts.length < 4) return
+
+    faceIndices.length = 0
+    for (let i = 1; i < parts.length; i += 1) {
+      const vertexIndex = parseObjVertexIndex(parts[i], currentVertexCount)
+      if (vertexIndex === null) {
+        faceIndices.length = 0
+        break
+      }
+      faceIndices.push(vertexIndex)
+    }
+
+    if (faceIndices.length < 3) return
+
+    const firstIndex = faceIndices[0]
+    for (let i = 1; i < faceIndices.length - 1; i += 1) {
+      indices[indexOffset] = firstIndex
+      indices[indexOffset + 1] = faceIndices[i]
+      indices[indexOffset + 2] = faceIndices[i + 1]
+      indexOffset += 3
+    }
+  })
+
+  if (!filled || positionOffset !== positions.length || indexOffset === 0) return null
+
+  return {
+    positions,
+    index: indexOffset === indices.length ? indices : indices.slice(0, indexOffset),
+    bounds: computeMeshBounds(positions),
+  }
+}
+
+export function loadObjTriangleMesh(
+  fileData: ImportedSourceData,
+  axisOrientation: ModelAxisOrientation,
+): ImportedTriangleMesh | null {
+  const key = cacheKey('obj', fileData, axisOrientation, true)
+  const cached = getCachedTriangleMesh(key, fileData)
+  if (cached) return cached
+
+  const text = decodeSourceText(fileData)
+  if (!text) return null
+
+  const mesh = parseObjTriangleMesh(text)
+  if (!mesh) return null
+
+  applyAxisOrientationToPositions(mesh.positions, axisOrientation)
+  mesh.bounds = computeMeshBounds(mesh.positions)
+  setCachedTriangleMesh(key, fileData, mesh)
+  return mesh
+}
+
+export function loadObjBufferGeometry(
+  fileData: ImportedSourceData,
+  axisOrientation: ModelAxisOrientation,
+  mergeVertices: boolean,
+): THREE.BufferGeometry | null {
+  const key = cacheKey('obj', fileData, axisOrientation, mergeVertices)
+  const cached = getCachedGeometry(key, fileData)
+  if (cached) return cached
+
+  const mesh = loadObjTriangleMesh(fileData, axisOrientation)
+  if (!mesh) return null
+
+  const geometry = triangleMeshToBufferGeometry(mesh, mergeVertices)
+  setCachedGeometry(key, fileData, geometry)
+  return geometry
+}
+
 export function loadImportedBufferGeometry(
   format: ImportedModelFormat,
-  fileData: string,
+  fileData: ImportedSourceData,
   axisOrientation: ModelAxisOrientation,
   mergeVertices: boolean,
 ): THREE.BufferGeometry | null {
   switch (format) {
     case 'stl':
       return loadStlBufferGeometry(fileData, axisOrientation, mergeVertices)
+    case 'obj':
+      return loadObjBufferGeometry(fileData, axisOrientation, mergeVertices)
   }
 }
 
@@ -194,17 +607,17 @@ export function computeMeshBounds(positions: Float32Array): ImportedMeshBounds {
   return { minX, maxX, minY, maxY, minZ, maxZ }
 }
 
-function getCachedTriangleMesh(key: string, fileData: string): ImportedTriangleMesh | null {
+function getCachedTriangleMesh(key: string, fileData: ImportedSourceData): ImportedTriangleMesh | null {
   const entry = triangleMeshCache.get(key)
-  if (!entry || entry.fileData !== fileData) return null
+  if (!entry || !sameSourceData(entry.sourceData, fileData)) return null
 
   triangleMeshCache.delete(key)
   triangleMeshCache.set(key, entry)
   return entry.mesh
 }
 
-function setCachedTriangleMesh(key: string, fileData: string, mesh: ImportedTriangleMesh): void {
-  triangleMeshCache.set(key, { fileData, mesh })
+function setCachedTriangleMesh(key: string, fileData: ImportedSourceData, mesh: ImportedTriangleMesh): void {
+  triangleMeshCache.set(key, { sourceData: fileData, mesh })
   while (triangleMeshCache.size > TRIANGLE_MESH_CACHE_LIMIT) {
     const oldestKey = triangleMeshCache.keys().next().value
     if (!oldestKey) break
@@ -213,7 +626,7 @@ function setCachedTriangleMesh(key: string, fileData: string, mesh: ImportedTria
 }
 
 export function loadStlTriangleMesh(
-  fileData: string,
+  fileData: ImportedSourceData,
   axisOrientation: ModelAxisOrientation,
 ): ImportedTriangleMesh | null {
   const key = cacheKey('stl', fileData, axisOrientation, true)
@@ -247,11 +660,13 @@ export function loadStlTriangleMesh(
 
 export function loadImportedTriangleMesh(
   format: ImportedModelFormat,
-  fileData: string,
+  fileData: ImportedSourceData,
   axisOrientation: ModelAxisOrientation,
 ): ImportedTriangleMesh | null {
   switch (format) {
     case 'stl':
       return loadStlTriangleMesh(fileData, axisOrientation)
+    case 'obj':
+      return loadObjTriangleMesh(fileData, axisOrientation)
   }
 }

--- a/src/engine/toolpaths/finishSurface.test.ts
+++ b/src/engine/toolpaths/finishSurface.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { defaultTool, newProject, rectProfile, type Operation, type Project, type SketchFeature, type Tool } from '../../types/project'
+import { normalizeProject } from '../../store/projectStore'
 import { generateFinishSurfaceToolpath, maxContourGap } from './finishSurface'
 import { generateRoughSurfaceToolpath } from './roughSurface'
 import { toClipperPath, normalizeWinding, DEFAULT_CLIPPER_SCALE } from './geometry'
@@ -319,7 +320,11 @@ function makeProject(): { project: Project; operation: Operation } {
     tools: [makeTool()],
     features: [makeModelFeature()],
   }
-  return { project, operation: makeOperation() }
+  return { project: normalizeProject(project), operation: makeOperation() }
+}
+
+function normalizeProjectFeatures(project: Project): void {
+  project.features = normalizeProject(project).features
 }
 
 function cutMoves(moves: ToolpathMove[]): ToolpathMove[] {
@@ -736,6 +741,7 @@ function testWaterlineRegionActsAsFilterNotBoundaryContour(): void {
   console.log('Testing waterline region is a filter (no boundary contour cuts)...')
   const { project } = makeProject()
   project.features = [makeTaperedModelFeature(), makeRegionFeatureRect('region1', 9, 0, 4, 10)]
+  normalizeProjectFeatures(project)
   const operation: Operation = {
     ...makeWaterlineOperation(),
     target: { source: 'features', featureIds: ['model1', 'region1'] },
@@ -761,6 +767,7 @@ function testWaterlineUsesCoarseZLevelsOnly(): void {
   console.log('Testing waterline uses coarse constant-Z levels only...')
   const { project } = makeProject()
   project.features = [makeTaperedModelFeature()]
+  normalizeProjectFeatures(project)
   const operation: Operation = {
     ...makeWaterlineOperation(),
     stepover: 0.3,
@@ -777,6 +784,7 @@ function testWaterlineLevelsAreConstantBands(): void {
   console.log('Testing waterline levels are constant Z bands...')
   const { project } = makeProject()
   project.features = [makeTaperedModelFeature()]
+  normalizeProjectFeatures(project)
   const operation = makeWaterlineOperation()
   project.operations = [operation]
   const result = generateFinishSurfaceToolpath(project, operation)
@@ -791,6 +799,7 @@ function testWaterlineEmitsBandBoundaryLevels(): void {
   console.log('Testing waterline emits current band boundary levels...')
   const { project } = makeProject()
   project.features = [makeTaperedModelFeature()]
+  normalizeProjectFeatures(project)
   const operation: Operation = {
     ...makeWaterlineOperation(),
     stepover: 0.3,
@@ -810,6 +819,7 @@ function testWaterlineBallEndmillUsesSideContactZ(): void {
   console.log('Testing waterline ball-endmill stays on constant slice Z levels...')
   const { project } = makeProject()
   project.features = [makeTaperedModelFeature()]
+  normalizeProjectFeatures(project)
   const operation = makeWaterlineOperation()
   project.operations = [operation]
   const result = generateFinishSurfaceToolpath(project, operation)
@@ -841,6 +851,7 @@ function testWaterlineBlendsWithRoughInCombinedSimulation(): void {
   console.log('Testing rough + waterline combined replay remains stable...')
   const { project } = makeProject()
   project.features = [makeTaperedModelFeature()]
+  normalizeProjectFeatures(project)
   project.stock = {
     ...project.stock,
     profile: rectProfile(0, 0, 20, 10),
@@ -899,6 +910,7 @@ function testWaterlinePocketBlockSimplification(): void {
   console.log('Testing waterline simplification on steep pocket block...')
   const { project } = makeProject()
   project.features = [makePocketBlockModelFeature()]
+  normalizeProjectFeatures(project)
   const operation: Operation = {
     ...makeWaterlineOperation(),
     stepdown: 0.5,
@@ -918,6 +930,7 @@ function testWaterlineRespectsTabZRange(): void {
   console.log('Testing waterline respects tab Z range...')
   const { project } = makeProject()
   project.features = [makePocketBlockModelFeature()]
+  normalizeProjectFeatures(project)
   const tabRect = { x: 0, y: 0, w: 3, h: 3 }
   project.tabs = [{
     id: 'tab1',
@@ -970,6 +983,7 @@ function testWaterlineRespectsClampFootprint(): void {
   console.log('Testing waterline respects clamp footprint...')
   const { project } = makeProject()
   project.features = [makePocketBlockModelFeature()]
+  normalizeProjectFeatures(project)
   const clampRect = { x: 0, y: 0, w: 3, h: 3 }
   project.clamps = [{
     id: 'clamp1',

--- a/src/engine/toolpaths/finishSurface.ts
+++ b/src/engine/toolpaths/finishSurface.ts
@@ -69,7 +69,7 @@ export function generateFinishSurfaceToolpath(
     return {
       operationId: operation.id,
       moves: [],
-      warnings: ['Finish surface requires a model feature (imported STL)'],
+      warnings: ['Finish surface requires an imported mesh model feature'],
       bounds: null,
       stepLevels: [],
     }
@@ -111,7 +111,7 @@ export function generateFinishSurfaceToolpath(
     return {
       operationId: operation.id,
       moves: [],
-      warnings: ['Failed to load STL geometry'],
+      warnings: ['Failed to load model geometry'],
       bounds: null,
       stepLevels: [],
     }

--- a/src/engine/toolpaths/meshSlicing.test.ts
+++ b/src/engine/toolpaths/meshSlicing.test.ts
@@ -133,8 +133,32 @@ function testSeparatedIslands(): void {
   assert(approx(areas[1], 100), `expected larger area 100, got ${areas[1]}`)
 }
 
+function testOpenSliceIsNotClosedWithShortcut(): void {
+  console.log('Testing open slice is not closed with shortcut...')
+
+  const positions = new Float32Array([
+    0, 0, -1,
+    10, 0, -1,
+    10, 5, -1,
+    0, 0, 1,
+    10, 0, 1,
+    10, 5, 1,
+  ])
+  const index = new Uint32Array([
+    0, 1, 4,
+    0, 4, 3,
+    1, 2, 5,
+    1, 5, 4,
+  ])
+  const sliceIndex = buildMeshSliceIndex(positions, index)
+  const polygons = sliceMeshAtZ(sliceIndex, 0)
+
+  assert(polygons.length === 0, `expected no closed polygons from open sliced wall, got ${polygons.length}`)
+}
+
 testCubeMidSlice()
 testSliceCacheReuse()
 testSeparatedIslands()
+testOpenSliceIsNotClosedWithShortcut()
 
 console.log('meshSlicing tests passed')

--- a/src/engine/toolpaths/meshSlicing.test.ts
+++ b/src/engine/toolpaths/meshSlicing.test.ts
@@ -4,7 +4,7 @@
  * Run with: npx tsx src/engine/toolpaths/meshSlicing.test.ts
  */
 
-import { buildMeshSliceIndex, sliceMeshAtZ } from './meshSlicing'
+import { buildMeshSliceIndex, sliceMeshAtZ, sliceMeshAtZDetailed } from './meshSlicing'
 
 function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
@@ -86,6 +86,24 @@ function makeBoxes(boxes: Array<[number, number, number, number, number, number]
   }
 }
 
+function appendVerticalQuad(
+  vertices: number[],
+  indices: number[],
+  a: [number, number],
+  b: [number, number],
+  minZ = -1,
+  maxZ = 1,
+): void {
+  const offset = vertices.length / 3
+  vertices.push(
+    a[0], a[1], minZ,
+    b[0], b[1], minZ,
+    b[0], b[1], maxZ,
+    a[0], a[1], maxZ,
+  )
+  indices.push(offset, offset + 1, offset + 2, offset, offset + 2, offset + 3)
+}
+
 function testCubeMidSlice(): void {
   console.log('Testing cube mid-slice...')
 
@@ -133,6 +151,50 @@ function testSeparatedIslands(): void {
   assert(approx(areas[1], 100), `expected larger area 100, got ${areas[1]}`)
 }
 
+function testSmallOpenGapsAreStitched(): void {
+  console.log('Testing small open gaps are stitched...')
+
+  const gap = 1e-5
+  const vertices: number[] = []
+  const indices: number[] = []
+  appendVerticalQuad(vertices, indices, [0, 0], [10, 0])
+  appendVerticalQuad(vertices, indices, [10 + gap, 0], [10 + gap, 10])
+  appendVerticalQuad(vertices, indices, [10, 10 + gap], [0, 10 + gap])
+  appendVerticalQuad(vertices, indices, [-gap, 10], [-gap, 0])
+
+  const sliceIndex = buildMeshSliceIndex(new Float32Array(vertices), new Uint32Array(indices))
+  const result = sliceMeshAtZDetailed(sliceIndex, 0)
+
+  assert(result.polygons.length === 1, `expected stitched polygon, got ${result.polygons.length}`)
+  assert(result.openChainCount === 0, `expected no remaining open chains, got ${result.openChainCount}`)
+  assert(approx(polygonArea(result.polygons[0]), 100, 1e-3), `expected area near 100, got ${polygonArea(result.polygons[0])}`)
+}
+
+function testMultipleSmallGapLoopsStaySeparate(): void {
+  console.log('Testing multiple small-gap loops stay separate...')
+
+  const gap = 1e-5
+  const vertices: number[] = []
+  const indices: number[] = []
+  appendVerticalQuad(vertices, indices, [0, 0], [10, 0])
+  appendVerticalQuad(vertices, indices, [10 + gap, 0], [10 + gap, 10])
+  appendVerticalQuad(vertices, indices, [10, 10 + gap], [0, 10 + gap])
+  appendVerticalQuad(vertices, indices, [-gap, 10], [-gap, 0])
+  appendVerticalQuad(vertices, indices, [20, 20], [25, 20])
+  appendVerticalQuad(vertices, indices, [25 + gap, 20], [25 + gap, 25])
+  appendVerticalQuad(vertices, indices, [25, 25 + gap], [20, 25 + gap])
+  appendVerticalQuad(vertices, indices, [20 - gap, 25], [20 - gap, 20])
+
+  const sliceIndex = buildMeshSliceIndex(new Float32Array(vertices), new Uint32Array(indices))
+  const result = sliceMeshAtZDetailed(sliceIndex, 0)
+  const areas = result.polygons.map(polygonArea).sort((a, b) => a - b)
+
+  assert(result.polygons.length === 2, `expected two separate stitched polygons, got ${result.polygons.length}`)
+  assert(result.openChainCount === 0, `expected no remaining open chains, got ${result.openChainCount}`)
+  assert(approx(areas[0], 25, 1e-3), `expected smaller area near 25, got ${areas[0]}`)
+  assert(approx(areas[1], 100, 1e-3), `expected larger area near 100, got ${areas[1]}`)
+}
+
 function testOpenSliceIsNotClosedWithShortcut(): void {
   console.log('Testing open slice is not closed with shortcut...')
 
@@ -151,14 +213,18 @@ function testOpenSliceIsNotClosedWithShortcut(): void {
     1, 5, 4,
   ])
   const sliceIndex = buildMeshSliceIndex(positions, index)
-  const polygons = sliceMeshAtZ(sliceIndex, 0)
+  const result = sliceMeshAtZDetailed(sliceIndex, 0)
+  const polygons = result.polygons
 
   assert(polygons.length === 0, `expected no closed polygons from open sliced wall, got ${polygons.length}`)
+  assert(result.openChainCount > 0, 'expected open chains to be reported')
 }
 
 testCubeMidSlice()
 testSliceCacheReuse()
 testSeparatedIslands()
+testSmallOpenGapsAreStitched()
+testMultipleSmallGapLoopsStaySeparate()
 testOpenSliceIsNotClosedWithShortcut()
 
 console.log('meshSlicing tests passed')

--- a/src/engine/toolpaths/meshSlicing.ts
+++ b/src/engine/toolpaths/meshSlicing.ts
@@ -34,13 +34,19 @@ export interface MeshSliceIndex {
   bucketStep: number
   buckets: SliceTriangle[][]
   wideTriangles: SliceTriangle[]
-  sliceCache: Map<number, Array<Array<[number, number]>>>
+  sliceCache: Map<number, MeshSliceResult>
 }
 
 export interface MeshSliceIndexHost {
   positions: Float32Array
   index: Uint32Array
   sliceIndex?: MeshSliceIndex
+}
+
+export interface MeshSliceResult {
+  polygons: Array<Array<[number, number]>>
+  segmentCount: number
+  openChainCount: number
 }
 
 function lerp(a: Vec3, b: Vec3, t: number): Vec3 {
@@ -134,6 +140,13 @@ export function sliceMeshAtZ(
   mesh: MeshSliceIndex,
   z: number,
 ): Array<Array<[number, number]>> {
+  return sliceMeshAtZDetailed(mesh, z).polygons
+}
+
+export function sliceMeshAtZDetailed(
+  mesh: MeshSliceIndex,
+  z: number,
+): MeshSliceResult {
   const cacheKey = Math.round(z / Z_EPS)
   const cached = mesh.sliceCache.get(cacheKey)
   if (cached) return cached
@@ -176,9 +189,9 @@ export function sliceMeshAtZ(
     appendSegments(mesh.triangles)
   }
 
-  const polygons = chainSegments(segments)
-  mesh.sliceCache.set(cacheKey, polygons)
-  return polygons
+  const result = chainSegments(segments)
+  mesh.sliceCache.set(cacheKey, result)
+  return result
 }
 
 function ptKey(x: number, y: number): string {
@@ -187,8 +200,8 @@ function ptKey(x: number, y: number): string {
 
 function chainSegments(
   segments: Array<[[number, number], [number, number]]>,
-): Array<Array<[number, number]>> {
-  if (segments.length === 0) return []
+): MeshSliceResult {
+  if (segments.length === 0) return { polygons: [], segmentCount: 0, openChainCount: 0 }
 
   const graph = new Map<
     string,
@@ -212,6 +225,7 @@ function chainSegments(
 
   const visited = new Set<string>()
   const polygons: Array<Array<[number, number]>> = []
+  let openChainCount = 0
 
   for (const [startKey] of graph) {
     if (visited.has(startKey)) continue
@@ -259,8 +273,10 @@ function chainSegments(
         poly.push(first)
       }
       polygons.push(poly)
+    } else {
+      openChainCount += 1
     }
   }
 
-  return polygons
+  return { polygons, segmentCount: segments.length, openChainCount }
 }

--- a/src/engine/toolpaths/meshSlicing.ts
+++ b/src/engine/toolpaths/meshSlicing.ts
@@ -16,6 +16,7 @@
 
 const Z_EPS = 1e-8
 const PT_EPS = 1e-6
+const STITCH_TOLERANCE_SCALE = 1e-5
 
 interface Vec3 { x: number; y: number; z: number }
 
@@ -47,6 +48,28 @@ export interface MeshSliceResult {
   polygons: Array<Array<[number, number]>>
   segmentCount: number
   openChainCount: number
+}
+
+interface SliceSegment {
+  a: Vec3
+  b: Vec3
+}
+
+interface SegmentEdge {
+  a: string
+  b: string
+  visited: boolean
+}
+
+interface SegmentNode {
+  key: string
+  pt: Vec3
+  edges: number[]
+}
+
+interface SegmentChain {
+  points: Vec3[]
+  closed: boolean
 }
 
 function lerp(a: Vec3, b: Vec3, t: number): Vec3 {
@@ -151,7 +174,7 @@ export function sliceMeshAtZDetailed(
   const cached = mesh.sliceCache.get(cacheKey)
   if (cached) return cached
 
-  const segments: Array<[[number, number], [number, number]]> = []
+  const segments: SliceSegment[] = []
   const bucketIndex = mesh.bucketStep > 0
     ? Math.max(0, Math.min(mesh.buckets.length - 1, Math.floor((z - mesh.minZ) / mesh.bucketStep)))
     : -1
@@ -168,16 +191,16 @@ export function sliceMeshAtZDetailed(
       const below = (dz0 < -Z_EPS ? 1 : 0) + (dz1 < -Z_EPS ? 1 : 0) + (dz2 < -Z_EPS ? 1 : 0)
       if (above === 0 || below === 0) continue
 
-      const pts: Array<[number, number]> = []
+      const pts: Vec3[] = []
       const e01 = edgeCrossZ(p0, p1, z)
-      if (e01) pts.push([e01.x, e01.y])
+      if (e01) pts.push(e01)
       const e12 = edgeCrossZ(p1, p2, z)
-      if (e12) pts.push([e12.x, e12.y])
+      if (e12) pts.push(e12)
       const e20 = edgeCrossZ(p2, p0, z)
-      if (e20) pts.push([e20.x, e20.y])
+      if (e20) pts.push(e20)
 
       if (pts.length >= 2) {
-        segments.push([pts[0], pts[1]])
+        segments.push({ a: pts[0], b: pts[1] })
       }
     }
   }
@@ -194,89 +217,227 @@ export function sliceMeshAtZDetailed(
   return result
 }
 
-function ptKey(x: number, y: number): string {
-  return `${x.toFixed(6)},${y.toFixed(6)}`
+function ptKey(point: Vec3): string {
+  return `${point.x.toFixed(6)},${point.y.toFixed(6)},${point.z.toFixed(6)}`
+}
+
+function distance3D(a: Vec3, b: Vec3): number {
+  return Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z)
+}
+
+function computeStitchTolerance(segments: SliceSegment[]): number {
+  let minX = Infinity
+  let maxX = -Infinity
+  let minY = Infinity
+  let maxY = -Infinity
+  let minZ = Infinity
+  let maxZ = -Infinity
+
+  for (const segment of segments) {
+    for (const point of [segment.a, segment.b]) {
+      minX = Math.min(minX, point.x)
+      maxX = Math.max(maxX, point.x)
+      minY = Math.min(minY, point.y)
+      maxY = Math.max(maxY, point.y)
+      minZ = Math.min(minZ, point.z)
+      maxZ = Math.max(maxZ, point.z)
+    }
+  }
+
+  const diagonal = Math.hypot(maxX - minX, maxY - minY, maxZ - minZ)
+  return Math.max(diagonal * STITCH_TOLERANCE_SCALE, PT_EPS * 2)
+}
+
+function closeChain(points: Vec3[]): Vec3[] {
+  const first = points[0]
+  const last = points[points.length - 1]
+  if (distance3D(first, last) <= PT_EPS) {
+    return [...points.slice(0, -1), first]
+  }
+  return [...points, first]
+}
+
+function chainToPolygon(chain: SegmentChain): Array<[number, number]> | null {
+  if (!chain.closed || chain.points.length < 3) return null
+  return closeChain(chain.points).map((point) => [point.x, point.y])
+}
+
+function otherEdgeNode(edge: SegmentEdge, key: string): string {
+  return edge.a === key ? edge.b : edge.a
+}
+
+function chooseStartNode(nodes: Map<string, SegmentNode>, edge: SegmentEdge): string {
+  const aDegree = nodes.get(edge.a)?.edges.length ?? 0
+  const bDegree = nodes.get(edge.b)?.edges.length ?? 0
+  if (aDegree !== 2) return edge.a
+  if (bDegree !== 2) return edge.b
+  return edge.a
+}
+
+interface StitchCandidate {
+  aIndex: number
+  bIndex: number
+  distance: number
+  aEnd: 'start' | 'end'
+  bEnd: 'start' | 'end'
+}
+
+function endpoint(points: Vec3[], end: 'start' | 'end'): Vec3 {
+  return end === 'start' ? points[0] : points[points.length - 1]
+}
+
+function mergeChainPair(a: Vec3[], b: Vec3[], aEnd: 'start' | 'end', bEnd: 'start' | 'end'): Vec3[] {
+  if (aEnd === 'end' && bEnd === 'start') return [...a, ...b]
+  if (aEnd === 'end' && bEnd === 'end') return [...a, ...b.slice().reverse()]
+  if (aEnd === 'start' && bEnd === 'start') return [...a.slice().reverse(), ...b]
+  return [...b, ...a]
+}
+
+function findBestStitchCandidate(chains: SegmentChain[], stitchTolerance: number): StitchCandidate | null {
+  let best: StitchCandidate | null = null
+
+  function consider(candidate: StitchCandidate): void {
+    if (candidate.distance > stitchTolerance) return
+    if (!best || candidate.distance < best.distance) {
+      best = candidate
+    }
+  }
+
+  for (let i = 0; i < chains.length; i += 1) {
+    if (chains[i].closed) continue
+    const a = chains[i].points
+    if (a.length < 2) continue
+
+    const selfDistance = distance3D(endpoint(a, 'start'), endpoint(a, 'end'))
+    consider({ aIndex: i, bIndex: i, distance: selfDistance, aEnd: 'start', bEnd: 'end' })
+
+    for (let j = i + 1; j < chains.length; j += 1) {
+      if (chains[j].closed) continue
+      const b = chains[j].points
+      if (b.length < 2) continue
+
+      for (const aEnd of ['start', 'end'] as const) {
+        for (const bEnd of ['start', 'end'] as const) {
+          consider({
+            aIndex: i,
+            bIndex: j,
+            distance: distance3D(endpoint(a, aEnd), endpoint(b, bEnd)),
+            aEnd,
+            bEnd,
+          })
+        }
+      }
+    }
+  }
+
+  return best
+}
+
+function stitchOpenChains(chains: SegmentChain[], stitchTolerance: number): SegmentChain[] {
+  const stitched = chains.map((chain) => ({ points: [...chain.points], closed: chain.closed }))
+
+  while (true) {
+    const candidate = findBestStitchCandidate(stitched, stitchTolerance)
+    if (!candidate) break
+
+    const a = stitched[candidate.aIndex]
+    if (candidate.aIndex === candidate.bIndex) {
+      a.closed = true
+      a.points = closeChain(a.points).slice(0, -1)
+      continue
+    }
+
+    const b = stitched[candidate.bIndex]
+    const mergedPoints = mergeChainPair(a.points, b.points, candidate.aEnd, candidate.bEnd)
+    const closed = distance3D(mergedPoints[0], mergedPoints[mergedPoints.length - 1]) <= stitchTolerance
+    const merged: SegmentChain = {
+      points: closed ? closeChain(mergedPoints).slice(0, -1) : mergedPoints,
+      closed,
+    }
+
+    stitched[candidate.aIndex] = merged
+    stitched.splice(candidate.bIndex, 1)
+  }
+
+  return stitched
 }
 
 function chainSegments(
-  segments: Array<[[number, number], [number, number]]>,
+  segments: SliceSegment[],
 ): MeshSliceResult {
   if (segments.length === 0) return { polygons: [], segmentCount: 0, openChainCount: 0 }
 
-  const graph = new Map<
-    string,
-    { pt: [number, number]; neighbors: Array<{ key: string; pt: [number, number] }> }
-  >()
+  const nodes = new Map<string, SegmentNode>()
+  const edges: SegmentEdge[] = []
 
-  function ensureNode(x: number, y: number): string {
-    const key = ptKey(x, y)
-    if (!graph.has(key)) {
-      graph.set(key, { pt: [x, y], neighbors: [] })
+  function ensureNode(point: Vec3): string {
+    const key = ptKey(point)
+    if (!nodes.has(key)) {
+      nodes.set(key, { key, pt: point, edges: [] })
     }
     return key
   }
 
-  for (const [a, b] of segments) {
-    const ka = ensureNode(a[0], a[1])
-    const kb = ensureNode(b[0], b[1])
-    graph.get(ka)!.neighbors.push({ key: kb, pt: b })
-    graph.get(kb)!.neighbors.push({ key: ka, pt: a })
+  for (const segment of segments) {
+    const a = ensureNode(segment.a)
+    const b = ensureNode(segment.b)
+    if (a === b) continue
+    const edgeIndex = edges.length
+    edges.push({ a, b, visited: false })
+    nodes.get(a)!.edges.push(edgeIndex)
+    nodes.get(b)!.edges.push(edgeIndex)
   }
 
-  const visited = new Set<string>()
-  const polygons: Array<Array<[number, number]>> = []
-  let openChainCount = 0
+  const chains: SegmentChain[] = []
+  for (let edgeIndex = 0; edgeIndex < edges.length; edgeIndex += 1) {
+    const firstEdge = edges[edgeIndex]
+    if (firstEdge.visited) continue
 
-  for (const [startKey] of graph) {
-    if (visited.has(startKey)) continue
-
-    const poly: Array<[number, number]> = []
+    const startKey = chooseStartNode(nodes, firstEdge)
     let currentKey = startKey
     let prevKey: string | null = null
-    let closed = false
+    const points: Vec3[] = [nodes.get(startKey)!.pt]
 
     while (true) {
-      if (visited.has(currentKey)) break
-      visited.add(currentKey)
-
-      const node = graph.get(currentKey)!
-      if (poly.length === 0) {
-        poly.push(node.pt)
-      }
-
-      let next: { key: string; pt: [number, number] } | null = null
-      for (const n of node.neighbors) {
-        if (n.key !== prevKey) {
-          next = n
+      const node = nodes.get(currentKey)!
+      let nextEdgeIndex: number | null = null
+      for (const candidateEdgeIndex of node.edges) {
+        const candidateEdge = edges[candidateEdgeIndex]
+        if (candidateEdge.visited) continue
+        const nextKey = otherEdgeNode(candidateEdge, currentKey)
+        if (nextKey !== prevKey || node.edges.every((index) => edges[index].visited || index === candidateEdgeIndex)) {
+          nextEdgeIndex = candidateEdgeIndex
           break
         }
       }
-      if (!next) break
-      if (next.key === startKey) {
-        closed = true
+
+      if (nextEdgeIndex === null) break
+
+      const edge = edges[nextEdgeIndex]
+      edge.visited = true
+      const nextKey = otherEdgeNode(edge, currentKey)
+      if (nextKey === startKey) {
+        chains.push({ points, closed: true })
         break
       }
 
-      poly.push(next.pt)
+      points.push(nodes.get(nextKey)!.pt)
       prevKey = currentKey
-      currentKey = next.key
-      if (poly.length > segments.length * 2) break
+      currentKey = nextKey
+      if (points.length > segments.length * 2) break
     }
 
-    if (closed && poly.length >= 3) {
-      const first = poly[0]
-      const last = poly[poly.length - 1]
-      if (
-        Math.abs(last[0] - first[0]) > PT_EPS ||
-        Math.abs(last[1] - first[1]) > PT_EPS
-      ) {
-        poly.push(first)
-      }
-      polygons.push(poly)
-    } else {
-      openChainCount += 1
+    if (!chains.at(-1)?.closed || chains.at(-1)?.points !== points) {
+      chains.push({ points, closed: false })
     }
   }
+
+  const stitchTolerance = computeStitchTolerance(segments)
+  const stitchedChains = stitchOpenChains(chains, stitchTolerance)
+  const polygons = stitchedChains
+    .map(chainToPolygon)
+    .filter((polygon): polygon is Array<[number, number]> => polygon !== null)
+  const openChainCount = stitchedChains.filter((chain) => !chain.closed).length
 
   return { polygons, segmentCount: segments.length, openChainCount }
 }

--- a/src/engine/toolpaths/meshSlicing.ts
+++ b/src/engine/toolpaths/meshSlicing.ts
@@ -219,6 +219,7 @@ function chainSegments(
     const poly: Array<[number, number]> = []
     let currentKey = startKey
     let prevKey: string | null = null
+    let closed = false
 
     while (true) {
       if (visited.has(currentKey)) break
@@ -237,7 +238,10 @@ function chainSegments(
         }
       }
       if (!next) break
-      if (next.key === startKey) break
+      if (next.key === startKey) {
+        closed = true
+        break
+      }
 
       poly.push(next.pt)
       prevKey = currentKey
@@ -245,7 +249,7 @@ function chainSegments(
       if (poly.length > segments.length * 2) break
     }
 
-    if (poly.length >= 3) {
+    if (closed && poly.length >= 3) {
       const first = poly[0]
       const last = poly[poly.length - 1]
       if (

--- a/src/engine/toolpaths/roughSurface.test.ts
+++ b/src/engine/toolpaths/roughSurface.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { defaultTool, newProject, rectProfile, type Operation, type Project, type SketchFeature, type Tool } from '../../types/project'
+import { normalizeProject } from '../../store/projectStore'
 import { generateRoughSurfaceToolpath } from './roughSurface'
 import type { ToolpathMove } from './types'
 
@@ -240,7 +241,7 @@ function makeProject(featureIds: string[]): { project: Project; operation: Opera
     tools: [makeTool()],
     features: [model, region],
   }
-  return { project, operation: makeRoughOperation(featureIds) }
+  return { project: normalizeProject(project), operation: makeRoughOperation(featureIds) }
 }
 
 function makeLegacyProject(featureIds: string[]): { project: Project; operation: Operation } {
@@ -251,7 +252,7 @@ function makeLegacyProject(featureIds: string[]): { project: Project; operation:
     tools: [makeTool()],
     features: [model, region],
   }
-  return { project, operation: makeRoughOperation(featureIds) }
+  return { project: normalizeProject(project), operation: makeRoughOperation(featureIds) }
 }
 
 function makeInvertedProject(featureIds: string[]): { project: Project; operation: Operation } {
@@ -262,7 +263,7 @@ function makeInvertedProject(featureIds: string[]): { project: Project; operatio
     tools: [makeTool()],
     features: [model, region],
   }
-  return { project, operation: makeRoughOperation(featureIds) }
+  return { project: normalizeProject(project), operation: makeRoughOperation(featureIds) }
 }
 
 function cutMoves(moves: ToolpathMove[]): ToolpathMove[] {
@@ -291,7 +292,7 @@ function testRoughSurfaceFindsModelWhenRegionIsFirst(): void {
   const { project, operation } = makeProject(['region1', 'model1'])
   const result = generateRoughSurfaceToolpath(project, operation)
 
-  assert(!result.warnings.includes('Model feature must be an imported STL model'), 'model lookup should not depend on first target feature')
+  assert(!result.warnings.includes('Model feature must be an imported mesh model'), 'model lookup should not depend on first target feature')
   assert(cutMoves(result.moves).length > 0, 'expected rough surface moves with region-first target order')
 }
 

--- a/src/engine/toolpaths/roughSurface.test.ts
+++ b/src/engine/toolpaths/roughSurface.test.ts
@@ -6,6 +6,7 @@
 
 import { defaultTool, newProject, rectProfile, type Operation, type Project, type SketchFeature, type Tool } from '../../types/project'
 import { normalizeProject } from '../../store/projectStore'
+import { serializeImportedMesh } from '../importedMesh'
 import { generateRoughSurfaceToolpath } from './roughSurface'
 import type { ToolpathMove } from './types'
 
@@ -266,6 +267,112 @@ function makeInvertedProject(featureIds: string[]): { project: Project; operatio
   return { project: normalizeProject(project), operation: makeRoughOperation(featureIds) }
 }
 
+function appendMeshBox(
+  vertices: number[],
+  indices: number[],
+  minX: number,
+  maxX: number,
+  minY: number,
+  maxY: number,
+  minZ: number,
+  maxZ: number,
+): void {
+  const offset = vertices.length / 3
+  vertices.push(
+    minX, minY, minZ,
+    maxX, minY, minZ,
+    maxX, maxY, minZ,
+    minX, maxY, minZ,
+    minX, minY, maxZ,
+    maxX, minY, maxZ,
+    maxX, maxY, maxZ,
+    minX, maxY, maxZ,
+  )
+  const faces = [
+    [0, 1, 2], [0, 2, 3],
+    [4, 6, 5], [4, 7, 6],
+    [0, 4, 5], [0, 5, 1],
+    [1, 5, 6], [1, 6, 2],
+    [2, 6, 7], [2, 7, 3],
+    [3, 7, 4], [3, 4, 0],
+  ]
+  for (const face of faces) {
+    indices.push(offset + face[0], offset + face[1], offset + face[2])
+  }
+}
+
+function appendVerticalQuad(
+  vertices: number[],
+  indices: number[],
+  a: [number, number],
+  b: [number, number],
+  minZ: number,
+  maxZ: number,
+): void {
+  const offset = vertices.length / 3
+  vertices.push(
+    a[0], a[1], minZ,
+    b[0], b[1], minZ,
+    b[0], b[1], maxZ,
+    a[0], a[1], maxZ,
+  )
+  indices.push(offset, offset + 1, offset + 2, offset, offset + 2, offset + 3)
+}
+
+function makeOpenSliceProject(): { project: Project; operation: Operation } {
+  const vertices: number[] = []
+  const indices: number[] = []
+  appendMeshBox(vertices, indices, 4, 8, 2, 6, 3, 6)
+
+  // A non-watertight lower shell: this produces open horizontal slice chains.
+  appendVerticalQuad(vertices, indices, [0, 0], [12, 0], 0, 3)
+  appendVerticalQuad(vertices, indices, [12, 0], [12, 8], 0, 3)
+  appendVerticalQuad(vertices, indices, [12, 8], [0, 8], 0, 3)
+
+  const positions = new Float32Array(vertices)
+  const index = new Uint32Array(indices)
+  const mesh = serializeImportedMesh({
+    positions,
+    index,
+    bounds: {
+      minX: 0,
+      maxX: 12,
+      minY: 0,
+      maxY: 8,
+      minZ: 0,
+      maxZ: 6,
+    },
+  }, 'stl')
+
+  const model: SketchFeature = {
+    ...makeModelFeature(),
+    stl: {
+      format: 'stl',
+      meshAssetId: 'open-shell',
+      scale: 1,
+      axisSwap: 'none',
+      silhouettePaths: [[
+        { x: 0, y: 0 },
+        { x: 12, y: 0 },
+        { x: 12, y: 8 },
+        { x: 0, y: 8 },
+        { x: 0, y: 0 },
+      ]],
+    },
+  }
+  const project = {
+    ...newProject('rough-surface-open-shell-test', 'mm'),
+    tools: [makeTool()],
+    modelAssets: { 'open-shell': mesh },
+    features: [model],
+  }
+  const operation = {
+    ...makeRoughOperation(['model1']),
+    stepdown: 2,
+  }
+  return { project: normalizeProject(project), operation }
+}
+
 function cutMoves(moves: ToolpathMove[]): ToolpathMove[] {
   return moves.filter((move) => move.kind === 'cut')
 }
@@ -321,6 +428,27 @@ function testRoughSurfaceProtectsOverhangingModelShadow(): void {
   assert(result.warnings.length === 0, `unexpected warnings: ${result.warnings.join(', ')}`)
   assert(cutMoves(result.moves).length > 0, 'expected rough surface moves for inverted taper')
   assert(destructiveCuts.length === 0, `expected no lower-level cuts inside upper model shadow, got ${destructiveCuts.length}`)
+}
+
+function testRoughSurfaceProtectsOpenMeshSlicesConservatively(): void {
+  console.log('Testing rough_surface protects open mesh slices conservatively...')
+  const { project, operation } = makeOpenSliceProject()
+  const result = generateRoughSurfaceToolpath(project, operation)
+  const destructiveCuts = cutMoves(result.moves).filter((move) => {
+    if (move.to.z > 2 + 1e-9) return false
+    const endpoints = [move.from, move.to]
+    return endpoints.some((point) => (
+      point.x > 0.25 && point.x < 11.75 &&
+      point.y > 0.25 && point.y < 7.75
+    ))
+  })
+
+  assert(
+    result.warnings.some((warning) => warning.includes('open/non-watertight slices')),
+    `expected open-slice warning, got: ${result.warnings.join(', ')}`,
+  )
+  assert(cutMoves(result.moves).length > 0, 'expected rough surface moves')
+  assert(destructiveCuts.length === 0, `expected no rough cuts inside open-slice silhouette, got ${destructiveCuts.length}`)
 }
 
 function testRoughSurfaceAvoidsSurroundingAddFeature(): void {
@@ -386,6 +514,7 @@ testRoughSurfaceGeneratesChangingZCuts()
 testRoughSurfaceFindsModelWhenRegionIsFirst()
 testRoughSurfaceDefaultsLegacyModelFormatToStl()
 testRoughSurfaceProtectsOverhangingModelShadow()
+testRoughSurfaceProtectsOpenMeshSlicesConservatively()
 testRoughSurfaceAvoidsSurroundingAddFeature()
 testRoughSurfaceIgnoresContainingBaseFeature()
 testRoughSurfaceRespectsContainingPocketDepth()

--- a/src/engine/toolpaths/roughSurface.ts
+++ b/src/engine/toolpaths/roughSurface.ts
@@ -55,7 +55,7 @@ import {
   updateBounds,
 } from './pocket'
 import { loadSTLTransformedGeometry } from '../csg'
-import { getMeshSliceIndex, sliceMeshAtZ } from './meshSlicing'
+import { getMeshSliceIndex, sliceMeshAtZDetailed } from './meshSlicing'
 import { buildRegionMask, splitFeatureTargets } from './regions'
 import { significantSilhouettePaths } from './silhouette'
 import {
@@ -335,6 +335,7 @@ export function generateRoughSurfaceToolpath(
 
   let currentPosition: ToolpathPoint | null = null
   let protectedSlicePaths: ClipperPath[] = []
+  let usedOpenSliceFallback = false
   const sliceSampleEpsilon = Math.max(Math.abs(modelTopZ - modelBottomZ) * 1e-6, 1e-6)
 
   for (const z of stepLevels) {
@@ -344,12 +345,23 @@ export function generateRoughSurfaceToolpath(
     const sliceZ = z >= modelTopZ - sliceSampleEpsilon
       ? Math.max(modelBottomZ + sliceSampleEpsilon, modelTopZ - sliceSampleEpsilon)
       : z
-    const slicePolygons = sliceMeshAtZ(sliceIndex, sliceZ)
+    const sliceResult = sliceMeshAtZDetailed(sliceIndex, sliceZ)
+    const slicePolygons = sliceResult.polygons
     if (slicePolygons.length > 0) {
       protectedSlicePaths = unionClipperPaths([
         ...protectedSlicePaths,
         ...slicePolygonsToClipperPaths(slicePolygons),
       ])
+    }
+    if (sliceResult.openChainCount > 0) {
+      protectedSlicePaths = unionClipperPaths([
+        ...protectedSlicePaths,
+        ...modelFootprintPaths,
+      ])
+      if (!usedOpenSliceFallback) {
+        warnings.push('Model has open/non-watertight slices; roughing used conservative silhouette protection')
+        usedOpenSliceFallback = true
+      }
     }
 
     if (protectedSlicePaths.length === 0) {

--- a/src/engine/toolpaths/roughSurface.ts
+++ b/src/engine/toolpaths/roughSurface.ts
@@ -251,7 +251,10 @@ export function generateRoughSurfaceToolpath(
 
   const safeZ = getOperationSafeZ(project)
   const stepoverDistance = tool.diameter * stepoverRatio
-  const maxLinkDistance = tool.diameter
+  // Surface roughing contours are derived from mesh slices, not from a simple
+  // 2D pocket floor. Keep contour-to-contour transitions at safe Z so noisy
+  // mesh offsets cannot create short diagonal cut links through the model.
+  const maxLinkDistance = 0
   const direction: CutDirection = operation.cutDirection ?? 'conventional'
   const initialInset = tool.radius + radialLeave
   const minStepover = 1 / DEFAULT_CLIPPER_SCALE

--- a/src/engine/toolpaths/roughSurface.ts
+++ b/src/engine/toolpaths/roughSurface.ts
@@ -152,11 +152,11 @@ export function generateRoughSurfaceToolpath(
   const modelFeature = splitTargets.machiningFeatures.find((feature) => feature.operation === 'model' && feature.kind === 'stl') ?? null
   const regionFeatures = splitTargets.regionFeatures.filter((feature) => feature.sketch.profile.closed)
   const regionMask = buildRegionMask(regionFeatures)
-  if (!modelFeature?.stl?.fileData) {
+  if (!modelFeature?.stl?.meshAssetId || !project.modelAssets?.[modelFeature.stl.meshAssetId]) {
     return {
       operationId: operation.id,
       moves: [],
-      warnings: ['Model feature must be an imported STL model'],
+      warnings: ['Model feature must be an imported mesh model'],
       bounds: null,
       stepLevels: [],
     }
@@ -202,7 +202,7 @@ export function generateRoughSurfaceToolpath(
     return {
       operationId: operation.id,
       moves: [],
-      warnings: ['Failed to load STL geometry'],
+      warnings: ['Failed to load model geometry'],
       bounds: null,
       stepLevels: [],
     }

--- a/src/import/obj.test.ts
+++ b/src/import/obj.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for OBJ import profile and bounds extraction.
+ *
+ * Run with: npx tsx src/import/obj.test.ts
+ */
+
+import { extractImportedModelProfileAndBounds } from './stl'
+
+type AxisSwap = 'none' | 'yz' | 'xz' | 'xy'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function approx(a: number, b: number, epsilon = 1e-6): boolean {
+  return Math.abs(a - b) < epsilon
+}
+
+function makeObjBase64(text: string): string {
+  return btoa(text)
+}
+
+function makeFrustumObjBase64(): string {
+  return makeObjBase64(`
+v 0 0 0
+v 12 0 0
+v 12 8 0
+v 0 8 0
+v 4 2 6
+v 8 2 6
+v 8 6 6
+v 4 6 6
+f 1 3 2
+f 1 4 3
+f 5 6 7
+f 5 7 8
+f 1 2 6 5
+f 2 3 7 6
+f 3 4 8 7
+f 4 1 5 8
+`)
+}
+
+function makeArtifactObjBase64(): string {
+  return makeObjBase64(`
+v 0 0 0
+v 20 0 0
+v 20 10 0
+v 0 10 0
+v 10 5 1
+v 10.002 5 1
+v 10.002 5.002 1
+f 1 2 3 4
+f 5 6 7
+`)
+}
+
+async function testAxisBounds(): Promise<void> {
+  console.log('Testing OBJ import axis-oriented Z bounds...')
+
+  const cases: Array<{ axis: AxisSwap; zTop: number }> = [
+    { axis: 'none', zTop: 6 },
+    { axis: 'yz', zTop: 8 },
+    { axis: 'xz', zTop: 12 },
+    { axis: 'xy', zTop: 6 },
+  ]
+
+  for (const { axis, zTop } of cases) {
+    const result = await extractImportedModelProfileAndBounds('obj', makeFrustumObjBase64(), 1, axis)
+    assert(result !== null, `expected extraction result for axis ${axis}`)
+    assert(approx(result!.z_bottom, 0), `expected z_bottom=0 for axis ${axis}, got ${result!.z_bottom}`)
+    assert(approx(result!.z_top, zTop), `expected z_top=${zTop} for axis ${axis}, got ${result!.z_top}`)
+    assert(result!.profile.closed, `expected closed profile for axis ${axis}`)
+    assert(result!.profile.segments.length >= 3, `expected polygon profile for axis ${axis}`)
+    assert(result!.silhouettePaths.length >= 1, `expected at least one silhouette path for axis ${axis}`)
+  }
+}
+
+async function testSilhouetteArtifactsAreFiltered(): Promise<void> {
+  console.log('Testing OBJ import filters tiny silhouette artifacts...')
+
+  const result = await extractImportedModelProfileAndBounds('obj', makeArtifactObjBase64(), 1, 'none')
+  assert(result !== null, 'expected artifact OBJ extraction result')
+  assert(result!.silhouettePaths.length === 1, `expected one significant silhouette path, got ${result!.silhouettePaths.length}`)
+}
+
+testAxisBounds()
+  .then(() => testSilhouetteArtifactsAreFiltered())
+  .then(() => console.log('obj import tests passed'))
+  .catch((error) => {
+    console.error(error)
+    throw error
+  })

--- a/src/import/stl.ts
+++ b/src/import/stl.ts
@@ -15,109 +15,178 @@
  */
 
 import { getManifoldModule } from '../engine/csg'
-import { loadImportedTriangleMesh, type ModelAxisOrientation } from '../engine/importedMesh'
+import {
+  loadImportedTriangleMesh,
+  normalizeImportedMeshForStorage,
+  type ImportedSourceData,
+  type ImportedModelFormat,
+  type ImportedTriangleMesh,
+  type ModelAxisOrientation,
+} from '../engine/importedMesh'
+import { DEFAULT_CLIPPER_SCALE, normalizeWinding, toClipperPath } from '../engine/toolpaths/geometry'
+import { getMeshSliceIndex, sliceMeshAtZ } from '../engine/toolpaths/meshSlicing'
+import { clipperPathsToPointContours, unionClipperPaths } from '../engine/toolpaths/modelProtection'
 import { significantSilhouettePaths } from '../engine/toolpaths/silhouette'
+import type { ClipperPath } from '../engine/toolpaths/types'
 import { polygonProfile, type Point, type SketchProfile } from '../types/project'
-import { unionClipperPaths } from '../store/helpers/clipping'
 
-export async function extractStlProfileAndBounds(
-  base64Data: string,
-  scale: number,
-  axisSwap: ModelAxisOrientation = 'none',
-  onProgress?: (percent: number) => void
-): Promise<{ profile: SketchProfile, silhouettePaths: Point[][], z_bottom: number, z_top: number } | null> {
-  const mesh = loadImportedTriangleMesh('stl', base64Data, axisSwap)
-  if (!mesh) return null
+const MAX_TOP_VIEW_PX = 1024
+const DEFAULT_IMPORT_SILHOUETTE_Z_STEPS = 96
+const MIN_IMPORT_SILHOUETTE_Z_STEPS = 8
+const MAX_IMPORT_SILHOUETTE_Z_STEPS = 512
+const MANIFOLD_PROJECT_TRIANGLE_LIMIT = 200_000
 
-  const { positions, index: triVerts, bounds } = mesh
-  const z_bottom = Number.isFinite(bounds.minZ) ? bounds.minZ * scale : 0
-  const z_top = Number.isFinite(bounds.maxZ) ? bounds.maxZ * scale : 5
+export interface ImportedMeshProfileOptions {
+  silhouetteZSteps?: number
+}
 
-  const module = await getManifoldModule()
-  const manifoldMesh = new module.Mesh({
-    numProp: 3,
-    vertProperties: new Float32Array(positions),
-    triVerts: triVerts,
-    halfedgeTangent: new Float32Array(0),
-    runIndex: new Uint32Array([0]),
-    runOriginalID: new Uint32Array([0]),
-    runTransform: new Float32Array(12).fill(0),
-    faceID: new Uint32Array(triVerts.length / 3).fill(0),
-  })
+export function clampImportedMeshSilhouetteZSteps(steps: number): number {
+  if (!Number.isFinite(steps)) return DEFAULT_IMPORT_SILHOUETTE_Z_STEPS
+  return Math.max(
+    MIN_IMPORT_SILHOUETTE_Z_STEPS,
+    Math.min(MAX_IMPORT_SILHOUETTE_Z_STEPS, Math.round(steps)),
+  )
+}
 
-  let polys: Point[][] = []
+function slicePolygonsToClipperPaths(slicePolygons: Array<Array<[number, number]>>): ClipperPath[] {
+  return slicePolygons
+    .filter((poly) => poly.length >= 3)
+    .map((poly) => toClipperPath(
+      normalizeWinding(poly.map(([x, y]) => ({ x, y })), false),
+      DEFAULT_CLIPPER_SCALE,
+    ))
+}
 
-  try {
-    const solid = new module.Manifold(manifoldMesh)
-    const scaledSolid = solid.scale([scale, scale, scale])
-    const crossSection = scaledSolid.project()
-    polys = crossSection.toPolygons().map(poly =>
-      poly.map(([x, y]) => ({ x, y }))
-    )
-    
-    solid.delete()
-    scaledSolid.delete()
-    crossSection.delete()
-  } catch (error) {
-    console.warn('STL is not manifold, falling back to ClipperLib 2D projection...', error)
-    // Fallback: Project all triangles to 2D and union them using ClipperLib
-    const paths: Array<Array<{X: number, Y: number}>> = []
-    const clipperScale = 10000 // 0.1 micron precision is plenty for silhouette
-    
-    for (let i = 0; i < triVerts.length; i += 3) {
-      const a = triVerts[i] * 3
-      const b = triVerts[i + 1] * 3
-      const c = triVerts[i + 2] * 3
-      
-      const p1 = { X: Math.round(positions[a] * scale * clipperScale), Y: Math.round(positions[a + 1] * scale * clipperScale) }
-      const p2 = { X: Math.round(positions[b] * scale * clipperScale), Y: Math.round(positions[b + 1] * scale * clipperScale) }
-      const p3 = { X: Math.round(positions[c] * scale * clipperScale), Y: Math.round(positions[c + 1] * scale * clipperScale) }
-      
-      // Compute 2D cross product to reject degenerate projected triangles and
-      // normalize winding. STL triangle winding is not reliable enough to use
-      // as a front/back filter for silhouettes.
-      const crossProduct = (p2.X - p1.X) * (p3.Y - p1.Y) - (p2.Y - p1.Y) * (p3.X - p1.X)
-      
-      // Skip completely flat/degenerate triangles in 2D projection.
-      if (crossProduct === 0) {
-        continue
-      }
-      
-      paths.push(crossProduct > 0 ? [p1, p2, p3] : [p1, p3, p2])
+async function extractWaterlineShadowSilhouette(
+  mesh: ImportedTriangleMesh,
+  zSteps: number,
+  onProgress?: (percent: number) => void,
+): Promise<Point[][]> {
+  const { positions, index, bounds } = mesh
+  const height = bounds.maxZ - bounds.minZ
+  if (!(height > 1e-9)) return []
+
+  const stepCount = clampImportedMeshSilhouetteZSteps(zSteps)
+  const sliceIndex = getMeshSliceIndex({ positions, index })
+  const zEpsilon = Math.max(height * 1e-6, 1e-6)
+  const lowZ = bounds.minZ + zEpsilon
+  const highZ = bounds.maxZ - zEpsilon
+  const span = Math.max(0, highZ - lowZ)
+  let shadowPaths: ClipperPath[] = []
+
+  onProgress?.(5)
+  for (let step = 0; step < stepCount; step += 1) {
+    const t = stepCount === 1 ? 0.5 : step / (stepCount - 1)
+    const z = highZ - span * t
+    const slicePaths = unionClipperPaths(slicePolygonsToClipperPaths(sliceMeshAtZ(sliceIndex, z)))
+    if (slicePaths.length > 0) {
+      shadowPaths = shadowPaths.length === 0
+        ? slicePaths
+        : unionClipperPaths([...shadowPaths, ...slicePaths])
     }
-    
-    if (onProgress) {
-      onProgress(10) // Report initial parsing done
-    }
-    
-    // Batch union to prevent ClipperLib from freezing on huge meshes (O(N log N) complexity)
-    // We use a small yield to the event loop to keep the UI responsive during large imports
-    const BATCH_SIZE = 20000
-    let unionedPaths: Array<Array<{X: number, Y: number}>> = []
-    
-    for (let i = 0; i < paths.length; i += BATCH_SIZE) {
-      const batch = paths.slice(i, i + BATCH_SIZE)
-      const batchUnion = unionClipperPaths(batch)
-      if (unionedPaths.length === 0) {
-        unionedPaths = batchUnion
-      } else {
-        unionedPaths = unionClipperPaths([...unionedPaths, ...batchUnion])
-      }
-      
-      if (onProgress) {
-        const percent = Math.min(95, 10 + Math.floor((i / paths.length) * 85))
-        onProgress(percent)
-      }
-      
-      // Yield to event loop every batch to keep UI responsive
+
+    onProgress?.(5 + Math.round(((step + 1) / stepCount) * 90))
+    if (step % 8 === 7) {
       await new Promise(resolve => setTimeout(resolve, 0))
     }
-    
-    if (onProgress) {
-      onProgress(100)
+  }
+
+  onProgress?.(100)
+  return clipperPathsToPointContours(shadowPaths)
+}
+
+async function extractTriangleProjectionSilhouette(
+  mesh: ImportedTriangleMesh,
+  onProgress?: (percent: number) => void,
+): Promise<Point[][]> {
+  const { positions, index: triVerts } = mesh
+  const paths: ClipperPath[] = []
+
+  for (let i = 0; i < triVerts.length; i += 3) {
+    const a = triVerts[i] * 3
+    const b = triVerts[i + 1] * 3
+    const c = triVerts[i + 2] * 3
+
+    const p1 = { X: Math.round(positions[a] * DEFAULT_CLIPPER_SCALE), Y: Math.round(positions[a + 1] * DEFAULT_CLIPPER_SCALE) }
+    const p2 = { X: Math.round(positions[b] * DEFAULT_CLIPPER_SCALE), Y: Math.round(positions[b + 1] * DEFAULT_CLIPPER_SCALE) }
+    const p3 = { X: Math.round(positions[c] * DEFAULT_CLIPPER_SCALE), Y: Math.round(positions[c + 1] * DEFAULT_CLIPPER_SCALE) }
+
+    const crossProduct = (p2.X - p1.X) * (p3.Y - p1.Y) - (p2.Y - p1.Y) * (p3.X - p1.X)
+    if (crossProduct === 0) continue
+    paths.push(crossProduct > 0 ? [p1, p2, p3] : [p1, p3, p2])
+  }
+
+  onProgress?.(10)
+
+  const batchSize = 20000
+  let unionedPaths: ClipperPath[] = []
+  for (let i = 0; i < paths.length; i += batchSize) {
+    const batchUnion = unionClipperPaths(paths.slice(i, i + batchSize))
+    unionedPaths = unionedPaths.length === 0
+      ? batchUnion
+      : unionClipperPaths([...unionedPaths, ...batchUnion])
+
+    onProgress?.(Math.min(95, 10 + Math.floor((i / paths.length) * 85)))
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+
+  onProgress?.(100)
+  return clipperPathsToPointContours(unionedPaths)
+}
+
+async function extractWaterlineOrTriangleProjectionSilhouette(
+  mesh: ImportedTriangleMesh,
+  zSteps: number,
+  onProgress?: (percent: number) => void,
+): Promise<Point[][]> {
+  const polys = await extractWaterlineShadowSilhouette(mesh, zSteps, onProgress)
+  if (polys.length > 0) return polys
+
+  console.warn('Waterline silhouette projection returned no contours, falling back to triangle projection.')
+  return extractTriangleProjectionSilhouette(mesh, onProgress)
+}
+
+export async function extractImportedMeshProfileAndBounds(
+  mesh: ImportedTriangleMesh,
+  onProgress?: (percent: number) => void,
+  options: ImportedMeshProfileOptions = {},
+): Promise<{ profile: SketchProfile, silhouettePaths: Point[][], z_bottom: number, z_top: number } | null> {
+  const { positions, index: triVerts, bounds } = mesh
+  const z_bottom = Number.isFinite(bounds.minZ) ? bounds.minZ : 0
+  const z_top = Number.isFinite(bounds.maxZ) ? bounds.maxZ : 5
+
+  let polys: Point[][] = []
+  const zSteps = clampImportedMeshSilhouetteZSteps(options.silhouetteZSteps ?? DEFAULT_IMPORT_SILHOUETTE_Z_STEPS)
+  const triangleCount = triVerts.length / 3
+
+  if (triangleCount > MANIFOLD_PROJECT_TRIANGLE_LIMIT) {
+    polys = await extractWaterlineOrTriangleProjectionSilhouette(mesh, zSteps, onProgress)
+  } else {
+    const module = await getManifoldModule()
+    const manifoldMesh = new module.Mesh({
+      numProp: 3,
+      vertProperties: new Float32Array(positions),
+      triVerts: triVerts,
+      halfedgeTangent: new Float32Array(0),
+      runIndex: new Uint32Array([0]),
+      runOriginalID: new Uint32Array([0]),
+      runTransform: new Float32Array(12).fill(0),
+      faceID: new Uint32Array(triVerts.length / 3).fill(0),
+    })
+
+    try {
+      const solid = new module.Manifold(manifoldMesh)
+      const crossSection = solid.project()
+      polys = crossSection.toPolygons().map(poly =>
+        poly.map(([x, y]) => ({ x, y }))
+      )
+
+      solid.delete()
+      crossSection.delete()
+    } catch (error) {
+      console.warn('Imported model is not manifold, falling back to waterline silhouette projection...', error)
+      polys = await extractWaterlineOrTriangleProjectionSilhouette(mesh, zSteps, onProgress)
     }
-    
-    polys = unionedPaths.map(path => path.map(p => ({ x: p.X / clipperScale, y: p.Y / clipperScale })))
   }
 
   if (!polys || polys.length === 0) {
@@ -152,10 +221,30 @@ export async function extractStlProfileAndBounds(
   return { profile, silhouettePaths, z_bottom, z_top }
 }
 
-export function renderStlTopViewToDataUrl(
+export async function extractImportedModelProfileAndBounds(
+  format: ImportedModelFormat,
+  base64Data: ImportedSourceData,
+  scale: number,
+  axisSwap: ModelAxisOrientation = 'none',
+  onProgress?: (percent: number) => void,
+  options: ImportedMeshProfileOptions = {},
+): Promise<{ profile: SketchProfile, silhouettePaths: Point[][], z_bottom: number, z_top: number } | null> {
+  const mesh = loadImportedTriangleMesh(format, base64Data, axisSwap)
+  if (!mesh) return null
+  return extractImportedMeshProfileAndBounds(normalizeImportedMeshForStorage(mesh, scale), onProgress, options)
+}
+
+export async function extractStlProfileAndBounds(
   base64Data: string,
   scale: number,
   axisSwap: ModelAxisOrientation = 'none',
+  onProgress?: (percent: number) => void
+): Promise<{ profile: SketchProfile, silhouettePaths: Point[][], z_bottom: number, z_top: number } | null> {
+  return extractImportedModelProfileAndBounds('stl', base64Data, scale, axisSwap, onProgress)
+}
+
+export function renderImportedMeshTopViewToDataUrl(
+  mesh: ImportedTriangleMesh,
 ): string | null {
   let canvas: HTMLCanvasElement | undefined
   try {
@@ -164,24 +253,20 @@ export function renderStlTopViewToDataUrl(
     return null
   }
 
-  const mesh = loadImportedTriangleMesh('stl', base64Data, axisSwap)
-  if (!mesh) return null
-
   const { positions, index, bounds } = mesh
-  const minX = bounds.minX * scale
-  const maxX = bounds.maxX * scale
-  const minY = bounds.minY * scale
-  const maxY = bounds.maxY * scale
-  const minZ = bounds.minZ * scale
-  const maxZ = bounds.maxZ * scale
+  const minX = bounds.minX
+  const maxX = bounds.maxX
+  const minY = bounds.minY
+  const maxY = bounds.maxY
+  const minZ = bounds.minZ
+  const maxZ = bounds.maxZ
 
   const widthWorld = maxX - minX
   const heightWorld = maxY - minY
   const depthWorld = maxZ - minZ
   if (!(widthWorld > 1e-9) || !(heightWorld > 1e-9)) return null
 
-  const MAX_PX = 1024
-  const imageScale = MAX_PX / Math.max(widthWorld, heightWorld)
+  const imageScale = MAX_TOP_VIEW_PX / Math.max(widthWorld, heightWorld)
   const canvasW = Math.max(1, Math.round(widthWorld * imageScale))
   const canvasH = Math.max(1, Math.round(heightWorld * imageScale))
   canvas.width = canvasW
@@ -191,24 +276,21 @@ export function renderStlTopViewToDataUrl(
   if (!ctx) return null
   ctx.clearRect(0, 0, canvasW, canvasH)
 
-  const triangles: Array<{
-    ax: number; ay: number
-    bx: number; by: number
-    cx: number; cy: number
-    z: number
-    shade: number
-  }> = []
+  const pixelCount = canvasW * canvasH
+  const zBuffer = new Float32Array(pixelCount)
+  const shadeBuffer = new Float32Array(pixelCount)
+  zBuffer.fill(-Infinity)
 
   function px(vertexIndex: number): number {
-    return ((positions[vertexIndex * 3] * scale) - minX) * imageScale
+    return (positions[vertexIndex * 3] - minX) * imageScale
   }
 
   function py(vertexIndex: number): number {
-    return ((positions[vertexIndex * 3 + 1] * scale) - minY) * imageScale
+    return (positions[vertexIndex * 3 + 1] - minY) * imageScale
   }
 
   function pz(vertexIndex: number): number {
-    return positions[vertexIndex * 3 + 2] * scale
+    return positions[vertexIndex * 3 + 2]
   }
 
   for (let i = 0; i < index.length; i += 3) {
@@ -219,7 +301,7 @@ export function renderStlTopViewToDataUrl(
     const bx = px(ib), by = py(ib), bz = pz(ib)
     const cx = px(ic), cy = py(ic), cz = pz(ic)
     const area = (bx - ax) * (cy - ay) - (by - ay) * (cx - ax)
-    if (Math.abs(area) < 0.01) continue
+    if (Math.abs(area) < 1e-8) continue
 
     const ux = positions[ib * 3] - positions[ia * 3]
     const uy = positions[ib * 3 + 1] - positions[ia * 3 + 1]
@@ -235,34 +317,83 @@ export function renderStlTopViewToDataUrl(
     const sideLight = Math.max(0, (-0.35 * nx - 0.45 * ny + 0.82 * nz) / normalLength)
     const shade = Math.max(0.18, Math.min(1, 0.35 + topLight * 0.45 + sideLight * 0.2))
 
-    triangles.push({
-      ax,
-      ay,
-      bx,
-      by,
-      cx,
-      cy,
-      z: (az + bz + cz) / 3,
-      shade,
-    })
+    const minPx = Math.max(0, Math.floor(Math.min(ax, bx, cx) - 1))
+    const maxPx = Math.min(canvasW - 1, Math.ceil(Math.max(ax, bx, cx) + 1))
+    const minPy = Math.max(0, Math.floor(Math.min(ay, by, cy) - 1))
+    const maxPy = Math.min(canvasH - 1, Math.ceil(Math.max(ay, by, cy) + 1))
+    const areaSign = area > 0 ? 1 : -1
+    const edgeTolerance = 0.35 * (
+      Math.hypot(bx - ax, by - ay)
+      + Math.hypot(cx - bx, cy - by)
+      + Math.hypot(ax - cx, ay - cy)
+    )
+
+    let touchedPixel = false
+    for (let pyIndex = minPy; pyIndex <= maxPy; pyIndex += 1) {
+      const sampleY = pyIndex + 0.5
+      for (let pxIndex = minPx; pxIndex <= maxPx; pxIndex += 1) {
+        const sampleX = pxIndex + 0.5
+        const wA = ((bx - sampleX) * (cy - sampleY) - (by - sampleY) * (cx - sampleX)) * areaSign
+        const wB = ((cx - sampleX) * (ay - sampleY) - (cy - sampleY) * (ax - sampleX)) * areaSign
+        const wC = ((ax - sampleX) * (by - sampleY) - (ay - sampleY) * (bx - sampleX)) * areaSign
+        if (wA < -edgeTolerance || wB < -edgeTolerance || wC < -edgeTolerance) continue
+
+        const baryA = (wA * areaSign) / area
+        const baryB = (wB * areaSign) / area
+        const baryC = (wC * areaSign) / area
+        const z = baryA * az + baryB * bz + baryC * cz
+        const pixelIndex = pyIndex * canvasW + pxIndex
+        if (z <= zBuffer[pixelIndex]) continue
+        zBuffer[pixelIndex] = z
+        shadeBuffer[pixelIndex] = shade
+        touchedPixel = true
+      }
+    }
+
+    if (!touchedPixel) {
+      const pxIndex = Math.max(0, Math.min(canvasW - 1, Math.round((ax + bx + cx) / 3)))
+      const pyIndex = Math.max(0, Math.min(canvasH - 1, Math.round((ay + by + cy) / 3)))
+      const pixelIndex = pyIndex * canvasW + pxIndex
+      const z = (az + bz + cz) / 3
+      if (z > zBuffer[pixelIndex]) {
+        zBuffer[pixelIndex] = z
+        shadeBuffer[pixelIndex] = shade
+      }
+    }
   }
 
-  triangles.sort((a, b) => a.z - b.z)
-
-  for (const tri of triangles) {
-    const zT = depthWorld > 1e-9 ? (tri.z - minZ) / depthWorld : 0.5
-    const r = Math.round((52 + zT * 72) * tri.shade)
-    const g = Math.round((92 + zT * 80) * tri.shade)
-    const b = Math.round((118 + zT * 88) * tri.shade)
-
-    ctx.beginPath()
-    ctx.moveTo(tri.ax, tri.ay)
-    ctx.lineTo(tri.bx, tri.by)
-    ctx.lineTo(tri.cx, tri.cy)
-    ctx.closePath()
-    ctx.fillStyle = `rgb(${r}, ${g}, ${b})`
-    ctx.fill()
+  const imageData = ctx.createImageData(canvasW, canvasH)
+  const data = imageData.data
+  for (let pixelIndex = 0; pixelIndex < pixelCount; pixelIndex += 1) {
+    const z = zBuffer[pixelIndex]
+    const hasDepth = Number.isFinite(z)
+    const zT = hasDepth && depthWorld > 1e-9 ? (z - minZ) / depthWorld : 0.35
+    const shade = hasDepth ? shadeBuffer[pixelIndex] : 0.34
+    const base = pixelIndex * 4
+    data[base] = Math.round((52 + zT * 72) * shade)
+    data[base + 1] = Math.round((92 + zT * 80) * shade)
+    data[base + 2] = Math.round((118 + zT * 88) * shade)
+    data[base + 3] = 255
   }
-
+  ctx.putImageData(imageData, 0, 0)
   return canvas.toDataURL('image/png')
+}
+
+export function renderImportedModelTopViewToDataUrl(
+  format: ImportedModelFormat,
+  base64Data: ImportedSourceData,
+  scale: number,
+  axisSwap: ModelAxisOrientation = 'none',
+): string | null {
+  const mesh = loadImportedTriangleMesh(format, base64Data, axisSwap)
+  if (!mesh) return null
+  return renderImportedMeshTopViewToDataUrl(normalizeImportedMeshForStorage(mesh, scale))
+}
+
+export function renderStlTopViewToDataUrl(
+  base64Data: string,
+  scale: number,
+  axisSwap: ModelAxisOrientation = 'none',
+): string | null {
+  return renderImportedModelTopViewToDataUrl('stl', base64Data, scale, axisSwap)
 }

--- a/src/import/types.ts
+++ b/src/import/types.ts
@@ -17,7 +17,7 @@
 import type { SketchProfile } from '../types/project'
 import type { Units } from '../utils/units'
 
-export type ImportSourceType = 'svg' | 'dxf' | 'stl'
+export type ImportSourceType = 'svg' | 'dxf' | 'stl' | 'obj'
 
 export interface ImportedShape {
   name: string

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -18,6 +18,14 @@ import { create } from 'zustand'
 import { copyBundledDefinitions } from '../engine/gcode/definitions'
 import { validateMachineDefinition } from '../engine/gcode/types'
 import type { MachineDefinition } from '../engine/gcode/types'
+import {
+  clearImportedModelCaches,
+  loadImportedTriangleMesh,
+  normalizeImportedMeshForStorage,
+  serializeImportedMesh,
+  type ImportedModelFormat,
+} from '../engine/importedMesh'
+import { clearSTLTransformedGeometryCache } from '../engine/csg'
 import { createImportedFeature, isProfileDegenerate, uniqueName } from '../import'
 import {
   type Segment,
@@ -56,6 +64,7 @@ import type {
   Project,
   SketchProfile,
   SketchFeature,
+  PersistedImportedMesh,
   STLFeatureData,
   Tab,
   Tool,
@@ -836,6 +845,73 @@ function transformStlFeatureData(
     ...stl,
     silhouettePaths: stl.silhouettePaths.map((path) => path.map(transformPoint)),
   }
+}
+
+function modelAssetIdForFeature(featureId: string): string {
+  return `model-asset-${featureId}`
+}
+
+function normalizeImportedModelStorage(
+  featureId: string,
+  stl: STLFeatureData | null | undefined,
+  modelAssets: Record<string, PersistedImportedMesh>,
+): STLFeatureData | null | undefined {
+  if (!stl) return stl
+  if (stl.meshAssetId && modelAssets[stl.meshAssetId]) {
+    const { mesh: _mesh, fileData: _fileData, filePath: _filePath, ...rest } = stl
+    return rest
+  }
+
+  const transientMesh = stl.mesh
+  if (transientMesh) {
+    const meshAssetId = stl.meshAssetId ?? modelAssetIdForFeature(featureId)
+    modelAssets[meshAssetId] = transientMesh
+    const { mesh: _mesh, fileData: _fileData, filePath: _filePath, ...rest } = stl
+    return {
+      ...rest,
+      meshAssetId,
+      scale: stl.scale ?? 1,
+      axisSwap: 'none',
+    }
+  }
+
+  if (!stl.fileData) return stl
+
+  const format: ImportedModelFormat = stl.format ?? 'stl'
+  const mesh = loadImportedTriangleMesh(format, stl.fileData, stl.axisSwap ?? 'none')
+  if (!mesh) return stl
+
+  const normalizedMesh = normalizeImportedMeshForStorage(mesh, stl.scale ?? 1)
+  const meshAssetId = stl.meshAssetId ?? modelAssetIdForFeature(featureId)
+  modelAssets[meshAssetId] = serializeImportedMesh(normalizedMesh, format)
+  return {
+    ...stl,
+    format,
+    meshAssetId,
+    filePath: undefined,
+    fileData: undefined,
+    mesh: undefined,
+    scale: 1,
+    axisSwap: 'none',
+  }
+}
+
+function pruneUnusedModelAssets(project: Project): Project {
+  const usedAssetIds = new Set(
+    project.features
+      .map((feature) => feature.stl?.meshAssetId ?? null)
+      .filter((id): id is string => id !== null),
+  )
+  const nextAssets: Record<string, PersistedImportedMesh> = {}
+  for (const [id, asset] of Object.entries(project.modelAssets ?? {})) {
+    if (usedAssetIds.has(id)) {
+      nextAssets[id] = asset
+    }
+  }
+  if (Object.keys(nextAssets).length === Object.keys(project.modelAssets ?? {}).length) {
+    return project
+  }
+  return { ...project, modelAssets: nextAssets }
 }
 
 function arcToBezierSegments(start: Point, segment: Extract<Segment, { type: 'arc' }>): Array<Extract<Segment, { type: 'bezier' }>> {
@@ -1729,7 +1805,7 @@ function defaultOperationForTarget(
     feed: tool.defaultFeed,
     plungeFeed: tool.defaultPlungeFeed,
     rpm: tool.defaultRpm,
-    pocketPattern: kind === 'finish_surface' ? 'waterline' : 'offset',
+    pocketPattern: kind === 'finish_surface' ? 'parallel' : 'offset',
     pocketAngle: 0,
     stockToLeaveRadial: 0,
     stockToLeaveAxial: 0,
@@ -2341,8 +2417,10 @@ function normalizeMachineDefinitions(project: Project): {
 }
 
 export function normalizeProject(project: Project): Project {
+  const modelAssets: Record<string, PersistedImportedMesh> = { ...(project.modelAssets ?? {}) }
   // Migration: convert 4-arc circles to native circle segments
   const upgradedFeatures = project.features.map((feature) => {
+    let upgradedFeature = feature
     if (feature.kind === 'circle' && feature.sketch.profile.segments.length === 4) {
       const { profile } = feature.sketch
       const firstArc = profile.segments[0]
@@ -2350,7 +2428,7 @@ export function normalizeProject(project: Project): Project {
         const cx = firstArc.center.x
         const cy = firstArc.center.y
         const r = Math.hypot(profile.start.x - cx, profile.start.y - cy)
-        return {
+        upgradedFeature = {
           ...feature,
           sketch: {
             ...feature.sketch,
@@ -2359,7 +2437,10 @@ export function normalizeProject(project: Project): Project {
         }
       }
     }
-    return feature
+    return {
+      ...upgradedFeature,
+      stl: normalizeImportedModelStorage(upgradedFeature.id, upgradedFeature.stl, modelAssets),
+    }
   })
 
   const normalizedMachines = normalizeMachineDefinitions(project)
@@ -2385,6 +2466,7 @@ export function normalizeProject(project: Project): Project {
   const normalizedBase = syncFeatureTreeProject(dedupeProjectIds({
     ...project,
     meta,
+    modelAssets,
     stock: {
       ...project.stock,
       profile: {
@@ -2403,18 +2485,20 @@ export function normalizeProject(project: Project): Project {
       : defaultOrigin(project.stock),
   }))
 
-  const normalizedProject = {
+  const normalizedProject = pruneUnusedModelAssets({
     ...normalizedBase,
     backdrop: normalizeBackdrop(project.backdrop, normalizedBase),
     operations: project.operations.map((operation, index) => normalizeOperation(operation, normalizedBase, index)),
-  }
+  })
 
   syncIdCounter(normalizedProject)
   return normalizedProject
 }
 
 function cloneProject(project: Project): Project {
-  return structuredClone(project)
+  const cloned = structuredClone(project)
+  cloned.modelAssets = project.modelAssets
+  return cloned
 }
 
 function instantiateProjectTemplate(template?: Project, name?: string): Project {
@@ -2435,6 +2519,7 @@ function instantiateProjectTemplate(template?: Project, name?: string): Project 
     },
     backdrop: null,
     dimensions: {},
+    modelAssets: {},
     features: [],
     featureFolders: [],
     featureTree: [],
@@ -2445,6 +2530,11 @@ function instantiateProjectTemplate(template?: Project, name?: string): Project 
     clamps: [],
     ai_history: [],
   }
+}
+
+function clearProjectMemoryCaches(): void {
+  clearImportedModelCaches()
+  clearSTLTransformedGeometryCache()
 }
 
 function projectsEqual(a: Project, b: Project): boolean {
@@ -2571,6 +2661,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
 
   createNewProject: (template, name) =>
     set((state) => {
+      clearProjectMemoryCaches()
       const nextProject = normalizeProject(instantiateProjectTemplate(template, name))
       return {
         project: nextProject,
@@ -2583,7 +2674,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         selection: emptySelection(),
         projectKey: state.projectKey + 1,
         history: {
-          past: [...state.history.past, cloneProject(state.project)].slice(-100),
+          past: [],
           future: [],
           transactionStart: null,
         },
@@ -2964,6 +3055,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
 
   loadProject: (p) =>
     set((state) => {
+      clearProjectMemoryCaches()
       const normalizedProject = normalizeProject(p)
       const stockDefaults = defaultStock(undefined, undefined, undefined, normalizedProject.meta.units)
       const gridDefaults = defaultGrid(normalizedProject.meta.units)
@@ -2981,6 +3073,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         },
         origin: normalizedProject.origin ?? defaultOrigin(normalizedProject.stock ?? stockDefaults),
       }
+      clearProjectMemoryCaches()
       return {
         project: nextProject,
         pendingAdd: null,
@@ -2990,7 +3083,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         selection: emptySelection(),
         projectKey: state.projectKey + 1,
         history: {
-          past: [...state.history.past, cloneProject(state.project)].slice(-100),
+          past: [],
           future: [],
           transactionStart: null,
         },
@@ -2998,7 +3091,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
     }),
 
   saveProject: () => {
-    const p = get().project
+    const p = pruneUnusedModelAssets(get().project)
     const updated = {
       ...p,
       meta: { ...p.meta, modified: new Date().toISOString() },
@@ -3016,6 +3109,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
     const normalized = normalizeProject(parsed as ReturnType<typeof normalizeProject>)
     const stockDefaults = defaultStock(undefined, undefined, undefined, normalized.meta.units)
     const gridDefaults = defaultGrid(normalized.meta.units)
+    clearProjectMemoryCaches()
     set((state) => ({
       project: {
         ...normalized,
@@ -3035,8 +3129,9 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
       pendingTransform: null,
       pendingOffset: null,
       selection: emptySelection(),
+      projectKey: state.projectKey + 1,
       history: {
-        past: [...state.history.past, cloneProject(state.project)].slice(-100),
+        past: [],
         future: [],
         transactionStart: null,
       },
@@ -4094,9 +4189,14 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
       if (feature.operation !== 'region' && effectiveFolderSection === 'regions') {
         effectiveFolderId = null
       }
-      const safeFeature: SketchFeature = isFirstMachiningFeature && !preserveImportedModelOperation
+      const safeFeatureBase: SketchFeature = isFirstMachiningFeature && !preserveImportedModelOperation
         ? normalizeFeatureZRange({ ...feature, id: safeId, folderId: effectiveFolderId, operation: 'add' })
         : normalizeFeatureZRange({ ...feature, id: safeId, folderId: effectiveFolderId })
+      const nextModelAssets = { ...s.project.modelAssets }
+      const safeFeature: SketchFeature = {
+        ...safeFeatureBase,
+        stl: normalizeImportedModelStorage(safeFeatureBase.id, safeFeatureBase.stl, nextModelAssets),
+      }
       // Build features and featureTree arrays with correct insertion position.
       let nextFeatures: SketchFeature[]
       let nextTree: FeatureTreeEntry[]
@@ -4123,6 +4223,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
       }
       const nextProject = syncFeatureTreeProject({
         ...s.project,
+        modelAssets: nextModelAssets,
         features: nextFeatures,
         featureTree: nextTree,
         meta: { ...s.project.meta, modified: new Date().toISOString() },
@@ -4366,12 +4467,12 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
           }
           return feature
         })
-      const nextProject = syncFeatureTreeProject({
+      const nextProject = pruneUnusedModelAssets(syncFeatureTreeProject({
         ...s.project,
         features: featuresWithInvalidatedConstraints,
         featureTree: s.project.featureTree.filter((entry) => !(entry.type === 'feature' && idsToDelete.has(entry.featureId))),
         meta: { ...s.project.meta, modified: new Date().toISOString() },
-      })
+      }))
       if (projectsEqual(nextProject, s.project)) {
         return {}
       }

--- a/src/store/projectStoreTransform.test.ts
+++ b/src/store/projectStoreTransform.test.ts
@@ -4,8 +4,8 @@
  * Run with: npx tsx src/store/projectStoreTransform.test.ts
  */
 
-import { getProfileBounds, rectProfile, type SketchFeature } from '../types/project'
-import { resizeFeatureFromReference } from './projectStore'
+import { defaultGrid, defaultStock, getProfileBounds, rectProfile, type SketchFeature } from '../types/project'
+import { normalizeProject, resizeFeatureFromReference } from './projectStore'
 
 function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
@@ -87,7 +87,66 @@ function testStlFeatureResizeIsUniform(): void {
   assert(approx(path![2].y, 10), `expected silhouette path y scaled to 10, got ${path![2].y}`)
 }
 
+function testLegacyModelMovesToAssetTable(): void {
+  console.log('Testing legacy STL model migrates to project asset table...')
+  const stl = `solid tri
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0
+      vertex 2 0 0
+      vertex 0 3 4
+    endloop
+  endfacet
+endsolid tri
+`
+  const project = normalizeProject({
+    version: '1.0',
+    meta: {
+      name: 'legacy-model',
+      created: '2026-01-01T00:00:00.000Z',
+      modified: '2026-01-01T00:00:00.000Z',
+      units: 'mm',
+      showFeatureInfo: true,
+      maxTravelZ: 10,
+      operationClearanceZ: 3,
+      clampClearanceXY: 2,
+      clampClearanceZ: 2,
+      machineDefinitions: [],
+      selectedMachineId: null,
+    },
+    grid: defaultGrid('mm'),
+    stock: defaultStock(10, 10, 5, 'mm'),
+    origin: { name: 'Origin', x: 0, y: 0, z: 5, visible: true },
+    backdrop: null,
+    dimensions: {},
+    modelAssets: {},
+    features: [makeFeature('stl')].map((feature) => ({
+      ...feature,
+      stl: {
+        ...feature.stl!,
+        fileData: `data:model/stl;base64,${btoa(stl)}`,
+      },
+    })),
+    featureFolders: [],
+    featureTree: [],
+    global_constraints: [],
+    tools: [],
+    operations: [],
+    tabs: [],
+    clamps: [],
+    ai_history: [],
+  })
+
+  const model = project.features[0]
+  assert(model.stl?.meshAssetId !== undefined, 'legacy model should reference a model asset')
+  assert(model.stl?.fileData === undefined, 'legacy source file should be removed after migration')
+  assert(model.stl?.mesh === undefined, 'transient inline mesh should not be retained')
+  assert(Object.keys(project.modelAssets).length === 1, 'model asset should be stored once at project level')
+  assert(project.modelAssets[model.stl!.meshAssetId!] !== undefined, 'referenced model asset should exist')
+}
+
 testRegularFeatureCanResizeOneAxis()
 testStlFeatureResizeIsUniform()
+testLegacyModelMovesToAssetTable()
 
 console.log('projectStore transform tests passed')

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -192,10 +192,36 @@ export interface TextFeatureData {
   size: number
 }
 
+export type ImportedModelSourceFormat = 'stl' | 'obj'
+
+export interface PersistedImportedMeshBounds {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+  minZ: number
+  maxZ: number
+}
+
+export interface PersistedImportedMesh {
+  storage: 'mesh-v1'
+  sourceFormat?: ImportedModelSourceFormat
+  vertexCount: number
+  triangleCount: number
+  positions: string // base64 Float32Array bytes
+  indices: string // base64 Uint32Array bytes
+  bounds: PersistedImportedMeshBounds
+}
+
 export interface STLFeatureData {
   /** Imported model file format. Missing means legacy STL. */
-  format?: 'stl'
+  format?: ImportedModelSourceFormat
   filePath?: string
+  /** Project modelAssets key. Preferred persisted representation for imported models. */
+  meshAssetId?: string
+  /** Transient/import migration mesh. Normalization moves this into Project.modelAssets. */
+  mesh?: PersistedImportedMesh
+  /** Legacy embedded source file. New imports should not write this field. */
   fileData?: string // base64
   scale: number
   axisSwap?: 'none' | 'yz' | 'xz' | 'xy'
@@ -423,6 +449,7 @@ export interface Project {
   origin: MachineOrigin
   backdrop: BackdropImage | null
   dimensions: Record<string, NamedDimension>
+  modelAssets: Record<string, PersistedImportedMesh>
   features: SketchFeature[]
   featureFolders: FeatureFolder[]
   featureTree: FeatureTreeEntry[]
@@ -990,6 +1017,7 @@ export function newProject(name = 'Untitled', units: ProjectMeta['units'] = 'inc
     origin: defaultOrigin(stock),
     backdrop: null,
     dimensions: {},
+    modelAssets: {},
     features: [],
     featureFolders: [],
     featureTree: [],


### PR DESCRIPTION
## Summary
- add OBJ mesh import alongside STL, including typed-array parsing and ArrayBuffer file reads
- persist imported models as normalized project-level mesh assets instead of reparsing source files
- add waterline-style silhouette fallback, bounded top-view preview rendering, and import Z-step override
- clear mesh caches/history on project replacement to release large project memory sooner
- make parallel the default pattern for new 3D surface finish operations

## Verification
- npx tsx src/engine/importedMesh.test.ts
- npx tsx src/import/obj.test.ts
- npx tsx src/import/stl.test.ts
- npx tsx src/engine/toolpaths/meshSlicing.test.ts
- npx tsx src/engine/toolpaths/roughSurface.test.ts
- npx tsx src/engine/toolpaths/finishSurface.test.ts
- npx tsx src/engine/toolpaths/toolpaths.test.ts
- npx tsx src/store/projectStoreTransform.test.ts
- npx tsx src/store/createRestOperation.test.ts
- npm run build