### PR TITLE
Cache toolpath results and show progress indicators

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { SketchCanvas, type SketchCanvasHandle } from './components/canvas/Sketc
 import { applyClampWarnings, applyTabsToEdgeRoute, applyTabWarnings, generateDrillingToolpath, generateEdgeRouteToolpath, generateFinishSurfaceToolpath, generateFollowLineToolpath, generatePocketToolpath, generateRoughSurfaceToolpath, generateSurfaceCleanToolpath, generateVCarveToolpath, generateVCarveRecursiveToolpath } from './engine/toolpaths'
 import { normalizeToolForProject } from './engine/toolpaths/geometry'
 import type { ToolpathResult } from './engine/toolpaths'
+import type { Clamp, Operation, Project, SketchFeature, Stock, Tab, Tool } from './types/project'
 import { createSimulationGrid, simulateOperationHeightfield, simulateReplayItemsHeightfield, type SimulationReplayItem } from './engine/simulation'
 import type { SimulationPlaybackInput } from './components/simulation/SimulationViewport'
 import { FeatureTree } from './components/feature-tree/FeatureTree'
@@ -41,6 +42,31 @@ interface TreeContextMenuState {
   primaryId: string
   x: number
   y: number
+}
+
+interface ToolpathCacheEntry {
+  result: ToolpathResult
+  operation: Operation
+  stock: Stock
+  features: SketchFeature[]
+  tools: Tool[]
+  tabs: Tab[]
+  clamps: Clamp[]
+}
+
+function isCacheHit(entry: ToolpathCacheEntry, operation: Operation, project: Project): boolean {
+  return (
+    entry.operation === operation
+    && entry.stock === project.stock
+    && entry.features === project.features
+    && entry.tools === project.tools
+    && entry.tabs === project.tabs
+    && entry.clamps === project.clamps
+  )
+}
+
+function scheduleAfterPaint(fn: () => void): void {
+  requestAnimationFrame(() => requestAnimationFrame(fn))
 }
 
 type ToolbarOrientation = 'top' | 'left'
@@ -112,9 +138,12 @@ function App() {
   const simulationViewportRef = useRef<SimulationViewportHandle>(null)
   const hasAutoFramed3DRef = useRef(false)
   const menuRef = useRef<HTMLDivElement>(null)
+  const toolpathCacheRef = useRef<Map<string, ToolpathCacheEntry>>(new Map())
+  const [toolpathMap, setToolpathMap] = useState<Map<string, ToolpathResult>>(new Map())
   const {
     project,
     projectKey,
+    projectLoading,
     selection,
     selectFeature,
     enterSketchEdit,
@@ -190,52 +219,146 @@ function App() {
         return null
       }
 
+      const cached = toolpathCacheRef.current.get(operation.id)
+      if (cached && isCacheHit(cached, operation, project)) {
+        return cached.result
+      }
+
+      let result: ToolpathResult | null = null
+
       if (operation.kind === 'pocket') {
-        return applyClampWarnings(project, applyTabWarnings(project, operation, generatePocketToolpath(project, operation)), operation)
-      }
-
-      if (operation.kind === 'v_carve') {
-        return applyClampWarnings(project, generateVCarveToolpath(project, operation), operation)
-      }
-
-      if (operation.kind === 'v_carve_recursive') {
-        return applyClampWarnings(project, generateVCarveRecursiveToolpath(project, operation), operation)
-      }
-
-      if (operation.kind === 'edge_route_inside' || operation.kind === 'edge_route_outside') {
+        result = applyClampWarnings(project, applyTabWarnings(project, operation, generatePocketToolpath(project, operation)), operation)
+      } else if (operation.kind === 'v_carve') {
+        result = applyClampWarnings(project, generateVCarveToolpath(project, operation), operation)
+      } else if (operation.kind === 'v_carve_recursive') {
+        result = applyClampWarnings(project, generateVCarveRecursiveToolpath(project, operation), operation)
+      } else if (operation.kind === 'edge_route_inside' || operation.kind === 'edge_route_outside') {
         const tabAware = applyTabsToEdgeRoute(project, operation, generateEdgeRouteToolpath(project, operation))
-        return applyClampWarnings(project, applyTabWarnings(project, operation, tabAware), operation)
-      }
-
-      if (operation.kind === 'surface_clean') {
-        return applyClampWarnings(project, applyTabWarnings(project, operation, generateSurfaceCleanToolpath(project, operation)), operation)
-      }
-
-      if (operation.kind === 'rough_surface') {
-        return applyClampWarnings(project, applyTabWarnings(project, operation, generateRoughSurfaceToolpath(project, operation)), operation)
-      }
-
-      if (operation.kind === 'finish_surface') {
+        result = applyClampWarnings(project, applyTabWarnings(project, operation, tabAware), operation)
+      } else if (operation.kind === 'surface_clean') {
+        result = applyClampWarnings(project, applyTabWarnings(project, operation, generateSurfaceCleanToolpath(project, operation)), operation)
+      } else if (operation.kind === 'rough_surface') {
+        result = applyClampWarnings(project, applyTabWarnings(project, operation, generateRoughSurfaceToolpath(project, operation)), operation)
+      } else if (operation.kind === 'finish_surface') {
         const tabAware = applyTabsToEdgeRoute(project, operation, generateFinishSurfaceToolpath(project, operation))
-        return applyClampWarnings(project, applyTabWarnings(project, operation, tabAware), operation)
+        result = applyClampWarnings(project, applyTabWarnings(project, operation, tabAware), operation)
+      } else if (operation.kind === 'follow_line') {
+        result = applyClampWarnings(project, generateFollowLineToolpath(project, operation), operation)
+      } else if (operation.kind === 'drilling') {
+        result = applyClampWarnings(project, generateDrillingToolpath(project, operation), operation)
       }
 
-      if (operation.kind === 'follow_line') {
-        return applyClampWarnings(project, generateFollowLineToolpath(project, operation), operation)
+      if (result) {
+        toolpathCacheRef.current.set(operation.id, {
+          result,
+          operation,
+          stock: project.stock,
+          features: project.features,
+          tools: project.tools,
+          tabs: project.tabs,
+          clamps: project.clamps,
+        })
       }
 
-      if (operation.kind === 'drilling') {
-        return applyClampWarnings(project, generateDrillingToolpath(project, operation), operation)
-      }
-
-      return null
+      return result
     },
     [project]
   )
 
-  const selectedToolpath = useMemo<ToolpathResult | null>(() => {
-    return generateToolpathForOperation(selectedOperation)
-  }, [generateToolpathForOperation, selectedOperation])
+  // Operations that need toolpath computation (selected first for priority)
+  const neededOperationIds = useMemo(() => {
+    const ids: string[] = []
+    const seen = new Set<string>()
+    if (selectedOperation) {
+      ids.push(selectedOperation.id)
+      seen.add(selectedOperation.id)
+    }
+    for (const op of project.operations) {
+      if (op.showToolpath && !seen.has(op.id)) {
+        ids.push(op.id)
+      }
+    }
+    return ids
+  }, [selectedOperation, project.operations])
+
+  // Derived during render by checking cache validity — the spinner shows on
+  // the very first render after a parameter change, not one frame late.
+  // toolpathMap is included as a dependency so the memo recomputes when the
+  // async pipeline finishes and updates the map (which also updates the cache).
+  const generatingOperationIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const id of neededOperationIds) {
+      const op = project.operations.find((o) => o.id === id)
+      if (!op) continue
+      const entry = toolpathCacheRef.current.get(id)
+      if (!entry || !isCacheHit(entry, op, project)) {
+        ids.add(id)
+      }
+    }
+    return ids
+  }, [neededOperationIds, project, toolpathMap])
+
+  // Async toolpath pipeline: resolves cached results immediately, defers
+  // uncached operations one-per-frame with a paint gap in between so the
+  // spinner (derived from cache staleness above) stays animated.
+  useEffect(() => {
+    const immediateResults = new Map<string, ToolpathResult>()
+    const toCompute: string[] = []
+
+    for (const id of neededOperationIds) {
+      const op = project.operations.find((o) => o.id === id)
+      if (!op) continue
+
+      const entry = toolpathCacheRef.current.get(id)
+      if (entry && isCacheHit(entry, op, project)) {
+        immediateResults.set(id, entry.result)
+      } else {
+        toCompute.push(id)
+      }
+    }
+
+    setToolpathMap(immediateResults)
+
+    if (toCompute.length === 0) {
+      return
+    }
+
+    let cancelled = false
+    let idx = 0
+
+    function computeNext() {
+      if (cancelled || idx >= toCompute.length) return
+
+      const op = project.operations.find((o) => o.id === toCompute[idx])
+      if (op && !cancelled) {
+        const result = generateToolpathForOperation(op)
+        if (!cancelled) {
+          setToolpathMap((prev) => {
+            const next = new Map(prev)
+            if (result) next.set(op.id, result)
+            return next
+          })
+        }
+      }
+
+      idx++
+      if (idx < toCompute.length && !cancelled) {
+        scheduleAfterPaint(computeNext)
+      }
+    }
+
+    // Double-rAF: the first rAF fires before the current paint, the second
+    // fires in the next frame — guaranteeing one browser paint in between.
+    // This ensures the spinner is visually rendered before computation blocks.
+    requestAnimationFrame(() => {
+      if (!cancelled) requestAnimationFrame(computeNext)
+    })
+    return () => { cancelled = true }
+  }, [neededOperationIds, generateToolpathForOperation, project])
+
+  const selectedToolpath = selectedOperation
+    ? toolpathMap.get(selectedOperation.id) ?? null
+    : null
 
   const simulationResult = useMemo(() => {
     if (centerTab !== 'simulation') {
@@ -398,9 +521,9 @@ function App() {
   const visibleToolpaths = useMemo<ToolpathResult[]>(() => {
     return project.operations
       .filter((operation) => operation.showToolpath)
-      .map((operation) => generateToolpathForOperation(operation))
-      .filter((toolpath): toolpath is ToolpathResult => toolpath !== null)
-  }, [generateToolpathForOperation, project.operations])
+      .map((operation) => toolpathMap.get(operation.id))
+      .filter((toolpath): toolpath is ToolpathResult => toolpath != null)
+  }, [project.operations, toolpathMap])
   const collidingClampIds = useMemo(
     () => [
       ...new Set([
@@ -838,6 +961,7 @@ function App() {
             onSelectedOperationIdChange={setSelectedOperationId}
             onExport={() => setShowExportDialog(true)}
             toolpathWarnings={selectedToolpath?.warnings ?? null}
+            generatingOperationIds={generatingOperationIds}
           />
         }
         centerTab={centerTab}
@@ -872,6 +996,15 @@ function App() {
             })
           }}
         />
+      )}
+
+      {projectLoading && (
+        <div className="toolpath-loading-overlay">
+          <div className="toolpath-loading-content">
+            <span className="toolpath-loading-spinner" />
+            <span className="toolpath-loading-text">Opening project…</span>
+          </div>
+        </div>
       )}
 
       {treeContextMenu && menuPosition && (menuFeature || menuTab || menuClamp) ? (

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -40,6 +40,7 @@ interface CAMPanelProps {
   onSelectedOperationIdChange: (operationId: string | null) => void
   onExport: () => void
   toolpathWarnings?: string[] | null
+  generatingOperationIds?: Set<string>
 }
 
 interface DraftTextInputProps {
@@ -706,6 +707,7 @@ export function CAMPanel({
   onSelectedOperationIdChange,
   onExport,
   toolpathWarnings,
+  generatingOperationIds,
 }: CAMPanelProps) {
   const [selectedToolIdState, setSelectedToolId] = useState<string | null>(null)
   const [libraryTools, setLibraryTools] = useState<ToolLibraryEntry[]>([])
@@ -1272,11 +1274,16 @@ export function CAMPanel({
                           onDragOver={(event) => handleOperationDragOver(event, operation.id)}
                           onDrop={handleOperationDrop}
                         >
-                          <span className="tree-branch" aria-hidden="true" />
+                          <span className={generatingOperationIds?.has(operation.id) ? 'tree-branch tree-branch--generating' : 'tree-branch'} aria-hidden="true" />
                           <span className="tree-label">
                             {operation.name}
                           </span>
                           <span className="tree-row-actions">
+                            {generatingOperationIds?.has(operation.id) ? (
+                              <span className="cam-operation-badge cam-operation-badge--generating">
+                                <span className="cam-generating-spinner" />
+                              </span>
+                            ) : null}
                             <button
                               className="tree-action-btn"
                               type="button"

--- a/src/platform/useDesktopIntegration.ts
+++ b/src/platform/useDesktopIntegration.ts
@@ -163,10 +163,16 @@ export function useDesktopIntegration({ onExportGcode }: DesktopIntegrationOptio
             }
             const result = await platform.openProjectFile()
             if (result) {
+              useProjectStore.setState({ projectLoading: true })
+              await new Promise<void>((resolve) =>
+                requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+              )
               try {
                 store.openProjectFromText(result.content, result.path)
               } catch (error) {
                 alert(error instanceof Error ? error.message : 'Failed to open project.')
+              } finally {
+                useProjectStore.setState({ projectLoading: false })
               }
             }
             break
@@ -233,9 +239,15 @@ export function useDesktopIntegration({ onExportGcode }: DesktopIntegrationOptio
 
         try {
           const content = await readTextFile(camjPath)
+          useProjectStore.setState({ projectLoading: true })
+          await new Promise<void>((resolve) =>
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+          )
           useProjectStore.getState().openProjectFromText(content, camjPath)
         } catch {
           alert('Failed to open dropped file.')
+        } finally {
+          useProjectStore.setState({ projectLoading: false })
         }
       })
       if (isCancelled) { unlistenDrop(); return }

--- a/src/platform/useFileActions.ts
+++ b/src/platform/useFileActions.ts
@@ -23,7 +23,7 @@ import { platform } from './index'
  * operating on the current state.
  */
 export function useFileActions() {
-  const { project, filePath, dirty, saveProject, openProjectFromText, markSaved } =
+  const { project, filePath, dirty, saveProject, markSaved } =
     useProjectStore()
 
   /** Save to the current path (desktop) or trigger a download (browser). */
@@ -60,12 +60,24 @@ export function useFileActions() {
     }
     const result = await platform.openProjectFile()
     if (!result) return false
+
+    const store = useProjectStore.getState()
+    useProjectStore.setState({ projectLoading: true })
+
+    // Yield so the browser can paint the loading overlay before the
+    // synchronous JSON parse + normalize blocks the main thread.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    )
+
     try {
-      openProjectFromText(result.content, result.path)
+      store.openProjectFromText(result.content, result.path)
       return true
     } catch (error) {
       alert(error instanceof Error ? error.message : 'Failed to open project file.')
       return false
+    } finally {
+      useProjectStore.setState({ projectLoading: false })
     }
   }
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -2640,6 +2640,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
   filePath: null,
   lastExportPath: null,
   dirty: false,
+  projectLoading: false,
   projectKey: 0,
   pendingConstraint: null,
   history: {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -199,6 +199,8 @@ export interface ProjectStore {
   history: ProjectHistory
 
   // ---- Session state (not persisted in .camj) ----
+  /** True while a project file is being parsed and loaded. */
+  projectLoading: boolean
   /** Incremented each time a new project is created or loaded. Used by viewports to reset their view state. */
   projectKey: number
   /** Filesystem path of the currently open file. Null in the browser or when no file is open. */

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2537,6 +2537,36 @@
   text-transform: uppercase;
 }
 
+.cam-operation-badge--generating {
+  padding: 0 4px;
+  border-color: rgba(220, 165, 106, 0.45);
+  min-height: 18px;
+}
+
+.cam-generating-spinner {
+  display: block;
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid rgba(220, 165, 106, 0.25);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: cam-spin 0.8s linear infinite;
+}
+
+@keyframes cam-spin {
+  to { transform: rotate(360deg); }
+}
+
+.tree-branch--generating {
+  border-color: rgba(220, 165, 106, 0.45);
+  animation: cam-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes cam-pulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
+}
+
 .cam-tool-list {
   display: grid;
   gap: 8px;
@@ -2952,4 +2982,50 @@
 .properties-constraint-row--invalid .properties-constraint-type {
   color: rgba(220, 60, 60, 0.8);
   background: rgba(220, 60, 60, 0.12);
+}
+
+/* Toolpath loading overlay */
+
+.toolpath-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(8, 16, 24, 0.55);
+  pointer-events: none;
+  animation: toolpath-overlay-in 0.15s ease-out;
+}
+
+@keyframes toolpath-overlay-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.toolpath-loading-content {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 22px;
+  border-radius: 12px;
+  background: rgba(19, 32, 44, 0.92);
+  border: 1px solid rgba(220, 165, 106, 0.25);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.toolpath-loading-spinner {
+  display: block;
+  width: 18px;
+  height: 18px;
+  border: 2px solid rgba(220, 165, 106, 0.2);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: cam-spin 0.8s linear infinite;
+}
+
+.toolpath-loading-text {
+  color: var(--text);
+  font-size: 13px;
+  letter-spacing: 0.02em;
 }


### PR DESCRIPTION
## Summary

- **Toolpath cache** with fine-grained invalidation via Zustand reference equality on operation, stock, features, tools, tabs, and clamps — switching between already-computed operations is now instant
- **Async computation pipeline** processes one uncached operation per animation frame (double-rAF paint yield), keeping tree row spinners animated and the UI responsive between operations
- **CAM tree row spinners** show a rotating indicator on each operation currently being computed
- **Project open overlay** with spinner appears immediately when opening a .camj file, before the heavy JSON parse and toolpath generation block the main thread

## Test plan

- [x] Open a project with multiple 3D surface operations — verify "Opening project…" overlay appears immediately
- [x] Click between operations in the CAM tree — verify instant switching after first computation (cache hit)
- [x] Change an operation parameter (e.g. stepover) — verify the tree row spinner appears immediately during recomputation
- [x] Toggle showToolpath on one operation — verify other operations remain cached (no full recompute)
- [x] Verify simulation still works correctly in both "selected" and "visible" modes
- [x] Verify G-code export still produces correct output