### PR TITLE
Add open profile edit tools

### DIFF
--- a/public/icons.svg
+++ b/public/icons.svg
@@ -245,6 +245,19 @@
     <path d="M 9.5 4.5 L 14.5 9.5" />
     <path d="M 14.5 4.5 L 9.5 9.5" />
   </symbol>
+  <symbol id="segment-delete" viewBox="0 0 24 24">
+    <path d="M 3 12 L 21 12" />
+    <path d="M 9 8 L 15 16" />
+    <path d="M 15 8 L 9 16" />
+    <path d="M 23.5 12 A 2.5 2.5 0 1 0 18.5 12 A 2.5 2.5 0 1 0 23.5 12 Z" />
+    <path d="M 5.5 12 A 2.5 2.5 0 1 0 0.5 12 A 2.5 2.5 0 1 0 5.5 12 Z" />
+  </symbol>
+  <symbol id="disconnect" viewBox="0 0 24 24">
+    <path d="M 1.3976747329573724 12 L 10 12" />
+    <path d="M 14 12 L 22.602325267042627 12" />
+    <path d="M 11.5 12 A 2.5 2.5 0 1 0 6.5 12 A 2.5 2.5 0 1 0 11.5 12 Z" />
+    <path d="M 17.5 12 A 2.5 2.5 0 1 0 12.5 12 A 2.5 2.5 0 1 0 17.5 12 Z" />
+  </symbol>
   <symbol id="merge" viewBox="0 0 24 24">
     <path d="M 5 7 L 12 7 L 12 14 L 5 14 L 5 7 Z" />
     <path d="M 12 10 L 19 10 L 19 17 L 12 17 L 12 10 Z" />

--- a/src/assets/icons.camj
+++ b/src/assets/icons.camj
@@ -3,7 +3,7 @@
   "meta": {
     "name": "icons",
     "created": "2026-04-20T18:28:41.075Z",
-    "modified": "2026-04-23T02:08:17.744Z",
+    "modified": "2026-05-13T01:50:35.279Z",
     "units": "mm",
     "showFeatureInfo": false,
     "maxTravelZ": 50,
@@ -7564,7 +7564,7 @@
       "operation": "add",
       "z_top": 0,
       "z_bottom": -1,
-      "visible": true,
+      "visible": false,
       "locked": false,
       "text": null
     },
@@ -7696,7 +7696,7 @@
       "operation": "add",
       "z_top": 0,
       "z_bottom": -1,
-      "visible": true,
+      "visible": false,
       "locked": false,
       "text": null
     },
@@ -7754,7 +7754,65 @@
       "operation": "subtract",
       "z_top": 1,
       "z_bottom": 0,
-      "visible": true,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "f0095",
+      "name": "Rect 522 Copy",
+      "kind": "rect",
+      "folderId": "folder_snap",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 13,
+            "y": 14
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 18,
+                "y": 14
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 18,
+                "y": 18
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 13,
+                "y": 18
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 13,
+                "y": 14
+              }
+            }
+          ],
+          "closed": true
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 90,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "subtract",
+      "z_top": 1,
+      "z_bottom": 0,
+      "visible": false,
       "locked": false,
       "text": null
     },
@@ -13388,6 +13446,317 @@
       "z_top": 0,
       "z_bottom": -1,
       "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_segment-delete",
+      "name": "segment-delete_shape_0",
+      "kind": "polygon",
+      "folderId": "folder_segment-delete",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 3,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 21,
+                "y": 12
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_segment-delete_1",
+      "name": "segment-delete_shape_1",
+      "kind": "composite",
+      "folderId": "folder_segment-delete",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 9,
+            "y": 8
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 15,
+                "y": 16
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_segment-delete_2",
+      "name": "segment-delete_shape_2",
+      "kind": "composite",
+      "folderId": "folder_segment-delete",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 15,
+            "y": 8
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 9,
+                "y": 16
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "f0096",
+      "name": "Circle 533",
+      "kind": "circle",
+      "folderId": "folder_segment-delete",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 23.5,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "circle",
+              "center": {
+                "x": 21,
+                "y": 12
+              },
+              "to": {
+                "x": 23.5,
+                "y": 12
+              },
+              "clockwise": true
+            }
+          ],
+          "closed": true
+        },
+        "origin": {
+          "x": -31.5,
+          "y": -3.552713678800501e-15
+        },
+        "orientationAngle": 90,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "subtract",
+      "z_top": 1,
+      "z_bottom": 0,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_disconnect",
+      "name": "disconnect_shape_0",
+      "kind": "polygon",
+      "folderId": "folder_disconnect",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 1.3976747329573724,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 10,
+                "y": 12
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": -4.739659979109978,
+          "y": 9.210056670148337
+        },
+        "orientationAngle": 324.4623222080256,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": true,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_disconnect_1",
+      "name": "disconnect_shape_1",
+      "kind": "polygon",
+      "folderId": "folder_disconnect",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 14,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 22.602325267042627,
+                "y": 12
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 9.210056670148337,
+          "y": -4.739659979109978
+        },
+        "orientationAngle": 35.53767779197438,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": true,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "f0098",
+      "name": "Circle 533",
+      "kind": "circle",
+      "folderId": "folder_disconnect",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 11.5,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "circle",
+              "center": {
+                "x": 9,
+                "y": 12
+              },
+              "to": {
+                "x": 11.5,
+                "y": 12
+              },
+              "clockwise": true
+            }
+          ],
+          "closed": true
+        },
+        "origin": {
+          "x": -15,
+          "y": -1.7763568394002505e-15
+        },
+        "orientationAngle": 90,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "subtract",
+      "z_top": 1,
+      "z_bottom": 0,
+      "visible": true,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "f0099",
+      "name": "Circle 534",
+      "kind": "circle",
+      "folderId": "folder_disconnect",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 17.5,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "circle",
+              "center": {
+                "x": 15,
+                "y": 12
+              },
+              "to": {
+                "x": 17.5,
+                "y": 12
+              },
+              "clockwise": true
+            }
+          ],
+          "closed": true
+        },
+        "origin": {
+          "x": -21,
+          "y": -1.7763568394002505e-15
+        },
+        "orientationAngle": 90,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "subtract",
+      "z_top": 1,
+      "z_bottom": 0,
+      "visible": true,
       "locked": false,
       "text": null
     },
@@ -22023,51 +22392,35 @@
       "text": null
     },
     {
-      "id": "f0095",
-      "name": "Rect 522 Copy",
-      "kind": "rect",
-      "folderId": "folder_snap",
+      "id": "f0100",
+      "name": "Circle 533 Copy",
+      "kind": "circle",
+      "folderId": "folder_segment-delete",
       "sketch": {
         "profile": {
           "start": {
-            "x": 13,
-            "y": 14
+            "x": 5.5,
+            "y": 12
           },
           "segments": [
             {
-              "type": "line",
+              "type": "circle",
+              "center": {
+                "x": 3,
+                "y": 12
+              },
               "to": {
-                "x": 18,
-                "y": 14
-              }
-            },
-            {
-              "type": "line",
-              "to": {
-                "x": 18,
-                "y": 18
-              }
-            },
-            {
-              "type": "line",
-              "to": {
-                "x": 13,
-                "y": 18
-              }
-            },
-            {
-              "type": "line",
-              "to": {
-                "x": 13,
-                "y": 14
-              }
+                "x": 5.5,
+                "y": 12
+              },
+              "clockwise": true
             }
           ],
           "closed": true
         },
         "origin": {
-          "x": 0,
-          "y": 0
+          "x": -31.5,
+          "y": -3.552713678800501e-15
         },
         "orientationAngle": 90,
         "dimensions": [],
@@ -22076,7 +22429,7 @@
       "operation": "subtract",
       "z_top": 1,
       "z_bottom": 0,
-      "visible": true,
+      "visible": false,
       "locked": false,
       "text": null
     }
@@ -22225,7 +22578,7 @@
     {
       "id": "folder_snap",
       "name": "snap",
-      "collapsed": false
+      "collapsed": true
     },
     {
       "id": "folder_snap-grid",
@@ -22321,6 +22674,16 @@
       "id": "folder_point-delete",
       "name": "point-delete",
       "collapsed": true
+    },
+    {
+      "id": "folder_segment-delete",
+      "name": "segment-delete",
+      "collapsed": true
+    },
+    {
+      "id": "folder_disconnect",
+      "name": "disconnect",
+      "collapsed": false
     },
     {
       "id": "folder_merge",
@@ -22678,6 +23041,14 @@
     },
     {
       "type": "folder",
+      "folderId": "folder_segment-delete"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_disconnect"
+    },
+    {
+      "type": "folder",
       "folderId": "folder_merge"
     },
     {
@@ -22806,7 +23177,7 @@
     },
     {
       "type": "feature",
-      "featureId": "f0095"
+      "featureId": "f0100"
     }
   ],
   "global_constraints": [],
@@ -22814,5 +23185,6 @@
   "operations": [],
   "tabs": [],
   "clamps": [],
-  "ai_history": []
+  "ai_history": [],
+  "modelAssets": {}
 }

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -19,7 +19,7 @@ import type { KeyboardEvent, MouseEvent, WheelEvent } from 'react'
 import type { ToolpathResult } from '../../engine/toolpaths/types'
 import { ToolpathVisibilityPanel, type ToolpathVisibility } from '../ToolpathVisibilityPanel'
 import type { SnapMode, SnapSettings } from '../../sketch/snapping'
-import type { SketchControlRef, SketchEditTool } from '../../store/types'
+import type { OpenProfileEndpoint, SketchControlRef, SketchEditTool } from '../../store/types'
 import { filletFeatureFromPoint, filletFeatureFromRadius, filletRadiusFromPoint, previewOffsetFeatures, resizeBackdropFromReference, resizeFeatureFromReference, rotateBackdropFromReference, rotateFeatureFromReference, useProjectStore } from '../../store/projectStore'
 import {
   buildArcSegmentFromThreePoints,
@@ -75,7 +75,7 @@ import {
   worldToCanvas,
 } from './viewTransform'
 import type { CanvasPoint, SketchViewState, ViewTransform } from './viewTransform'
-import { findSketchInsertTarget, isLoopCloseCandidate, projectPointOntoLine, resolveOffsetPreview } from './draftGeometry'
+import { findSketchInsertTarget, isLoopCloseCandidate, nearestPointOnSegmentWithT, projectPointOntoLine, resolveOffsetPreview } from './draftGeometry'
 import {
   distance2,
   featureFullyInsideRect,
@@ -111,6 +111,7 @@ import { useAxisLock, lockModeGuideColor } from '../../sketch/useAxisLock'
 const NODE_HIT_RADIUS = 9
 const HANDLE_HIT_RADIUS = 7
 const POLYGON_CLOSE_RADIUS = 12
+const OPEN_ENDPOINT_JOIN_HIT_RADIUS = 14
 const MIN_SKETCH_ZOOM = 0.02
 
 interface PendingPreviewPoint {
@@ -126,6 +127,17 @@ interface SketchEditPreviewPoint {
 interface PendingSketchFillet {
   anchorIndex: number
   corner: Point
+}
+
+interface OpenEndpointHit {
+  featureId: string
+  endpoint: OpenProfileEndpoint
+  anchor: Point
+}
+
+interface SegmentHit {
+  segmentIndex: number
+  point: Point
 }
 
 export interface SketchCanvasHandle {
@@ -321,7 +333,10 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     cancelHistoryTransaction,
     moveFeatureControl,
     insertFeaturePoint,
+    joinOpenFeatureEndpoints,
     deleteFeaturePoint,
+    deleteFeatureSegment,
+    disconnectFeaturePoint,
     filletFeaturePoint,
     moveTabControl,
     moveClampControl,
@@ -700,8 +715,16 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       if (feature && sketchEditTool === 'add_point') {
         pendingSketchFilletRef.current = null
         if (pendingSketchExtensionRef.current) {
+          const sourceEndpoint = endpointFromSketchExtension(pendingSketchExtensionRef.current.kind)
+          const targetEndpoint = findOpenEndpointHit(livePoint, vt, {
+            exclude: {
+              featureId: feature.id,
+              endpoint: sourceEndpoint,
+              anchor: pendingSketchExtensionRef.current.anchor,
+            },
+          })
           const lockedSnapped = applyLock(snapped, pendingSketchExtensionRef.current.anchor)
-          sketchEditPreviewRef.current = { point: lockedSnapped, mode: 'add_point' }
+          sketchEditPreviewRef.current = { point: targetEndpoint?.anchor ?? lockedSnapped, mode: 'add_point' }
         } else {
           const endpoint = findOpenProfileExtensionEndpoint(feature.sketch.profile, livePoint, vt)
           if (endpoint) {
@@ -711,6 +734,27 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
             sketchEditPreviewRef.current = target ? { point: target.point, mode: 'add_point' } : null
           }
         }
+        scheduleDraw()
+        return
+      }
+
+      if (feature && sketchEditTool === 'delete_segment') {
+        pendingSketchExtensionRef.current = null
+        pendingSketchFilletRef.current = null
+        const target = findSketchSegmentHit(feature.sketch.profile, livePoint, vt)
+        sketchEditPreviewRef.current = target ? { point: target.point, mode: 'delete_segment' } : null
+        scheduleDraw()
+        return
+      }
+
+      if (feature && sketchEditTool === 'disconnect') {
+        pendingSketchExtensionRef.current = null
+        pendingSketchFilletRef.current = null
+        const control = hitEditableControl(worldToCanvas(livePoint, vt), { includeSegments: false })
+        sketchEditPreviewRef.current =
+          control?.kind === 'anchor'
+            ? { point: anchorPointForIndex(feature.sketch.profile, control.index), mode: 'disconnect' }
+            : null
         scheduleDraw()
         return
       }
@@ -1787,6 +1831,100 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     )
   }
 
+  function openEndpointAnchor(feature: SketchFeature, endpoint: OpenProfileEndpoint): Point {
+    return endpoint === 'start'
+      ? feature.sketch.profile.start
+      : anchorPointForIndex(feature.sketch.profile, feature.sketch.profile.segments.length)
+  }
+
+  function endpointFromSketchExtension(kind: PendingSketchExtension['kind']): OpenProfileEndpoint {
+    return kind === 'extend_start' ? 'start' : 'end'
+  }
+
+  function openEndpointForAnchorControl(feature: SketchFeature, control: SketchControlRef): OpenProfileEndpoint | null {
+    if (control.kind !== 'anchor' || feature.sketch.profile.closed || feature.sketch.profile.segments.length === 0) {
+      return null
+    }
+
+    const lastAnchorIndex = profileVertices(feature.sketch.profile).length - 1
+    if (control.index === 0) {
+      return 'start'
+    }
+    if (control.index === lastAnchorIndex) {
+      return 'end'
+    }
+    return null
+  }
+
+  function findOpenEndpointHit(
+    rawPoint: Point,
+    vt: ViewTransform,
+    options?: {
+      featureIds?: Set<string>
+      exclude?: OpenEndpointHit | null
+    },
+  ): OpenEndpointHit | null {
+    const project = projectRef.current
+    const rawCanvas = worldToCanvas(rawPoint, vt)
+    let best: OpenEndpointHit | null = null
+    let bestDistance = OPEN_ENDPOINT_JOIN_HIT_RADIUS * OPEN_ENDPOINT_JOIN_HIT_RADIUS
+
+    for (let index = project.features.length - 1; index >= 0; index -= 1) {
+      const feature = project.features[index]
+      if (
+        !feature
+        || !feature.visible
+        || feature.locked
+        || feature.sketch.profile.closed
+        || feature.sketch.profile.segments.length === 0
+        || (options?.featureIds && !options.featureIds.has(feature.id))
+      ) {
+        continue
+      }
+
+      for (const endpoint of ['start', 'end'] as const) {
+        if (
+          options?.exclude
+          && options.exclude.featureId === feature.id
+          && options.exclude.endpoint === endpoint
+        ) {
+          continue
+        }
+
+        const anchor = openEndpointAnchor(feature, endpoint)
+        const anchorCanvas = worldToCanvas(anchor, vt)
+        const distance = distance2(rawCanvas, anchorCanvas)
+        if (distance < bestDistance) {
+          bestDistance = distance
+          best = { featureId: feature.id, endpoint, anchor }
+        }
+      }
+    }
+
+    return best
+  }
+
+  function findSketchSegmentHit(profile: SketchFeature['sketch']['profile'], rawPoint: Point, vt: ViewTransform): SegmentHit | null {
+    let best: SegmentHit | null = null
+    let bestDistance = NODE_HIT_RADIUS * NODE_HIT_RADIUS
+
+    for (let index = 0; index < profile.segments.length; index += 1) {
+      const segment = profile.segments[index]
+      if (segment.type === 'circle') {
+        continue
+      }
+
+      const start = anchorPointForIndex(profile, index)
+      const candidate = nearestPointOnSegmentWithT(rawPoint, start, segment, vt)
+      if (candidate.distanceSqPx < bestDistance) {
+        bestDistance = candidate.distanceSqPx
+        best = { segmentIndex: index, point: candidate.point }
+      }
+    }
+
+    return best
+  }
+
   function editableClamp(): Clamp | null {
     const selection = selectionRef.current
     const project = projectRef.current
@@ -2277,11 +2415,36 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       if (feature && sketchEditTool === 'delete_point') {
         pendingSketchExtensionRef.current = null
         pendingSketchFilletRef.current = null
-          const control = hitEditableControl(point, { includeSegments: false })
-          sketchEditPreviewRef.current =
-            control?.kind === 'anchor'
-              ? { point: anchorPointForIndex(feature.sketch.profile, control.index), mode: 'delete_point' }
-              : null
+        const control = hitEditableControl(point, { includeSegments: false })
+        sketchEditPreviewRef.current =
+          control?.kind === 'anchor'
+            ? { point: anchorPointForIndex(feature.sketch.profile, control.index), mode: 'delete_point' }
+            : null
+        scheduleDraw()
+        setHoveredEditControl(null)
+        hoverFeature(null)
+        return
+      }
+
+      if (feature && sketchEditTool === 'delete_segment') {
+        pendingSketchExtensionRef.current = null
+        pendingSketchFilletRef.current = null
+        const target = findSketchSegmentHit(feature.sketch.profile, world, vt)
+        sketchEditPreviewRef.current = target ? { point: target.point, mode: 'delete_segment' } : null
+        scheduleDraw()
+        setHoveredEditControl(null)
+        hoverFeature(null)
+        return
+      }
+
+      if (feature && sketchEditTool === 'disconnect') {
+        pendingSketchExtensionRef.current = null
+        pendingSketchFilletRef.current = null
+        const control = hitEditableControl(point, { includeSegments: false })
+        sketchEditPreviewRef.current =
+          control?.kind === 'anchor'
+            ? { point: anchorPointForIndex(feature.sketch.profile, control.index), mode: 'disconnect' }
+            : null
         scheduleDraw()
         setHoveredEditControl(null)
         hoverFeature(null)
@@ -2338,6 +2501,49 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     dragStartWorldRef.current = null
     setActiveControl(null)
     commitHistoryTransaction()
+  }
+
+  function tryJoinDraggedOpenEndpoint(): boolean {
+    const canvas = canvasRef.current
+    const rawPoint = livePointerWorldRef.current
+    const selection = selectionRef.current
+    const feature = editableFeature()
+    if (
+      !canvas
+      || !rawPoint
+      || !feature
+      || !isDraggingNodeRef.current
+      || selection.mode !== 'sketch_edit'
+      || selection.selectedNode?.type !== 'feature'
+      || !selection.selectedFeatureId
+      || !selection.activeControl
+    ) {
+      return false
+    }
+
+    const sourceEndpoint = openEndpointForAnchorControl(feature, selection.activeControl)
+    if (!sourceEndpoint) {
+      return false
+    }
+
+    const vt = computeViewTransform(projectRef.current.stock, canvas.width, canvas.height, viewStateRef.current)
+    const targetEndpoint = findOpenEndpointHit(rawPoint, vt, {
+      exclude: {
+        featureId: selection.selectedFeatureId,
+        endpoint: sourceEndpoint,
+        anchor: openEndpointAnchor(feature, sourceEndpoint),
+      },
+    })
+    if (!targetEndpoint) {
+      return false
+    }
+
+    return joinOpenFeatureEndpoints(
+      selection.selectedFeatureId,
+      sourceEndpoint,
+      targetEndpoint.featureId,
+      targetEndpoint.endpoint,
+    )
   }
 
   function stopPan() {
@@ -2405,6 +2611,10 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       }
       marqueeStartRef.current = null
       marqueeCurrentRef.current = null
+      scheduleDraw()
+    }
+    if (tryJoinDraggedOpenEndpoint()) {
+      suppressClickRef.current = true
       scheduleDraw()
     }
     stopNodeDrag()
@@ -2536,6 +2746,29 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         const feature = editableFeature()
         if (feature && selection.sketchEditTool === 'add_point') {
           if (pendingSketchExtensionRef.current) {
+            const sourceEndpoint = endpointFromSketchExtension(pendingSketchExtensionRef.current.kind)
+            const targetEndpoint = findOpenEndpointHit(world, vt, {
+              exclude: {
+                featureId: selection.selectedFeatureId,
+                endpoint: sourceEndpoint,
+                anchor: pendingSketchExtensionRef.current.anchor,
+              },
+            })
+            if (targetEndpoint) {
+              const joined = joinOpenFeatureEndpoints(
+                selection.selectedFeatureId,
+                sourceEndpoint,
+                targetEndpoint.featureId,
+                targetEndpoint.endpoint,
+              )
+              if (joined) {
+                pendingSketchExtensionRef.current = null
+                sketchEditPreviewRef.current = null
+                scheduleDraw()
+              }
+              return
+            }
+
             if (!pickedPoint) {
               return
             }
@@ -2573,6 +2806,26 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           const control = hitEditableControl(point, { includeSegments: false })
           if (control?.kind === 'anchor') {
             deleteFeaturePoint(selection.selectedFeatureId, control.index)
+          }
+          return
+        }
+
+        if (feature && selection.sketchEditTool === 'delete_segment') {
+          const target = findSketchSegmentHit(feature.sketch.profile, world, vt)
+          if (target) {
+            deleteFeatureSegment(selection.selectedFeatureId, target.segmentIndex)
+            sketchEditPreviewRef.current = null
+            scheduleDraw()
+          }
+          return
+        }
+
+        if (feature && selection.sketchEditTool === 'disconnect') {
+          const control = hitEditableControl(point, { includeSegments: false })
+          if (control?.kind === 'anchor') {
+            disconnectFeaturePoint(selection.selectedFeatureId, control.index)
+            sketchEditPreviewRef.current = null
+            scheduleDraw()
           }
           return
         }
@@ -4380,6 +4633,10 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
               ? 'Add Point active. Click a segment to insert a point, or click an open-path end first to start an extension. Press '
               : selection.sketchEditTool === 'delete_point'
                 ? 'Delete Point active. Click anchors to remove them. Press '
+                : selection.sketchEditTool === 'delete_segment'
+                  ? 'Delete Segment active. Click a segment to remove it. Press '
+                  : selection.sketchEditTool === 'disconnect'
+                    ? 'Disconnect active. Click an anchor to split the path there. Press '
                 : selection.sketchEditTool === 'fillet'
                 ? pendingSketchFilletRef.current
                     ? 'Fillet active. Click a second point to define the corner round, or press Tab to type the radius. Press '

--- a/src/components/canvas/scenePrimitives.ts
+++ b/src/components/canvas/scenePrimitives.ts
@@ -197,15 +197,16 @@ export function drawSketchControls(
 
 export function drawSketchEditPreviewPoint(
   ctx: CanvasRenderingContext2D,
-  preview: { point: Point; mode: 'add_point' | 'delete_point' | 'fillet' },
+  preview: { point: Point; mode: 'add_point' | 'delete_point' | 'delete_segment' | 'disconnect' | 'fillet' },
   vt: ViewTransform,
 ): void {
   const { cx, cy } = worldToCanvas(preview.point, vt)
   ctx.beginPath()
   ctx.arc(cx, cy, NODE_RADIUS + 2, 0, Math.PI * 2)
-  ctx.fillStyle = preview.mode === 'delete_point' ? '#d66c6c' : '#5daeea'
+  const destructive = preview.mode === 'delete_point' || preview.mode === 'delete_segment'
+  ctx.fillStyle = destructive ? '#d66c6c' : preview.mode === 'disconnect' ? '#d9945e' : '#5daeea'
   ctx.fill()
-  ctx.strokeStyle = preview.mode === 'delete_point' ? '#efb0b0' : '#a9d2f5'
+  ctx.strokeStyle = destructive ? '#efb0b0' : preview.mode === 'disconnect' ? '#f1c59d' : '#a9d2f5'
   ctx.lineWidth = 2
   ctx.stroke()
 }

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -420,6 +420,8 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
     handleDistributeSelectedFeatures,
     handleSketchEditAddPoint: () => toggleSketchEditTool('add_point'),
     handleSketchEditDeletePoint: () => toggleSketchEditTool('delete_point'),
+    handleSketchEditDeleteSegment: () => toggleSketchEditTool('delete_segment'),
+    handleSketchEditDisconnect: () => toggleSketchEditTool('disconnect'),
     handleSketchEditFillet: () => toggleSketchEditTool('fillet'),
     handleFeatureConstraint: () => {
       if (pendingConstraint) {
@@ -942,6 +944,8 @@ function SketchEditActions({
   tooltipSide,
   onAddPoint,
   onDeletePoint,
+  onDeleteSegment,
+  onDisconnect,
   onFillet,
 }: {
   enabled: boolean
@@ -949,6 +953,8 @@ function SketchEditActions({
   tooltipSide?: 'bottom' | 'right'
   onAddPoint: () => void
   onDeletePoint: () => void
+  onDeleteSegment: () => void
+  onDisconnect: () => void
   onFillet: () => void
 }) {
   if (!enabled) return null
@@ -968,6 +974,20 @@ function SketchEditActions({
         active={activeTool === 'delete_point'}
         tooltipSide={tooltipSide}
         onClick={onDeletePoint}
+      />
+      <ToolbarActionButton
+        icon="segment-delete"
+        label={activeTool === 'delete_segment' ? 'Cancel delete segment' : 'Delete segment'}
+        active={activeTool === 'delete_segment'}
+        tooltipSide={tooltipSide}
+        onClick={onDeleteSegment}
+      />
+      <ToolbarActionButton
+        icon="disconnect"
+        label={activeTool === 'disconnect' ? 'Cancel disconnect' : 'Disconnect point'}
+        active={activeTool === 'disconnect'}
+        tooltipSide={tooltipSide}
+        onClick={onDisconnect}
       />
       <ToolbarActionButton
         icon="fillet"
@@ -1259,6 +1279,8 @@ export function CreationToolbar({
           tooltipSide={layout === 'vertical' ? 'right' : 'bottom'}
           onAddPoint={toolbar.handleSketchEditAddPoint}
           onDeletePoint={toolbar.handleSketchEditDeletePoint}
+          onDeleteSegment={toolbar.handleSketchEditDeleteSegment}
+          onDisconnect={toolbar.handleSketchEditDisconnect}
           onFillet={toolbar.handleSketchEditFillet}
         />
         <BackdropEditActions
@@ -1378,6 +1400,8 @@ export function Toolbar({
           activeTool={toolbar.sketchEditTool}
           onAddPoint={toolbar.handleSketchEditAddPoint}
           onDeletePoint={toolbar.handleSketchEditDeletePoint}
+          onDeleteSegment={toolbar.handleSketchEditDeleteSegment}
+          onDisconnect={toolbar.handleSketchEditDisconnect}
           onFillet={toolbar.handleSketchEditFillet}
         />
         <BackdropEditActions

--- a/src/store/openProfileJoin.test.ts
+++ b/src/store/openProfileJoin.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit tests for open-profile joining.
+ *
+ * Run with: npx tsx src/store/openProfileJoin.test.ts
+ */
+
+import { newProject, polygonProfile, profileVertices, type Point, type SketchFeature, type SketchProfile } from '../types/project'
+import type { OpenProfileEndpoint } from './types'
+import { joinOpenProfiles, useProjectStore } from './projectStore'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function pointsApprox(left: Point, right: Point, epsilon = 1e-9): boolean {
+  return Math.abs(left.x - right.x) <= epsilon && Math.abs(left.y - right.y) <= epsilon
+}
+
+function openPolyline(points: Point[]): SketchProfile {
+  const start = points[0] ?? { x: 0, y: 0 }
+  return {
+    start,
+    segments: points.slice(1).map((point) => ({ type: 'line' as const, to: point })),
+    closed: false,
+  }
+}
+
+function makeFeature(id: string, points: Point[]): SketchFeature {
+  return {
+    id,
+    name: id,
+    kind: 'polygon',
+    folderId: null,
+    sketch: {
+      profile: openPolyline(points),
+      origin: { x: 0, y: 0 },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+    operation: 'add',
+    z_top: 5,
+    z_bottom: 0,
+    visible: true,
+    locked: false,
+  }
+}
+
+function endpoint(profile: SketchProfile, which: OpenProfileEndpoint): Point {
+  const vertices = profileVertices(profile)
+  return which === 'start' ? vertices[0] : vertices[vertices.length - 1]
+}
+
+function testJoinOpenProfilesOrientsSelectedEndpointsTogether(): void {
+  console.log('Testing open profile join orientation...')
+  const upper = openPolyline([{ x: 0, y: 0 }, { x: 10, y: 0 }])
+  const lower = openPolyline([{ x: 0, y: 10 }, { x: 10, y: 10 }])
+  const joined = joinOpenProfiles(upper, 'start', lower, 'start')
+
+  if (!joined) throw new Error('Assertion failed: expected joined open profile')
+  assert(!joined.closed, 'one endpoint join should leave the profile open')
+  assert(pointsApprox(endpoint(joined, 'start'), { x: 10, y: 0 }), 'joined path should start at unjoined upper endpoint')
+  assert(pointsApprox(endpoint(joined, 'end'), { x: 10, y: 10 }), 'joined path should end at unjoined lower endpoint')
+  assert(joined.segments.length === 3, `expected two source lines plus one bridge, got ${joined.segments.length}`)
+}
+
+function testStoreJoinAbsorbsFeatureThenClosesPath(): void {
+  console.log('Testing store open join absorbs and closes...')
+  const upper = makeFeature('upper', [{ x: 0, y: 0 }, { x: 10, y: 0 }])
+  const lower = makeFeature('lower', [{ x: 0, y: 10 }, { x: 10, y: 10 }])
+  const project = {
+    ...newProject('open join', 'mm'),
+    features: [upper, lower],
+    featureTree: [
+      { type: 'feature' as const, featureId: upper.id },
+      { type: 'feature' as const, featureId: lower.id },
+    ],
+  }
+
+  const store = useProjectStore.getState()
+  store.loadProject(project)
+  store.enterSketchEdit(upper.id)
+
+  assert(store.joinOpenFeatureEndpoints(upper.id, 'start', lower.id, 'start'), 'expected first join to succeed')
+  let state = useProjectStore.getState()
+  assert(state.project.features.length === 1, `expected lower feature to be absorbed, got ${state.project.features.length} features`)
+  assert(state.project.features[0].id === upper.id, 'expected upper feature to remain active')
+  assert(!state.project.features[0].sketch.profile.closed, 'first join should leave a still-open feature')
+
+  assert(store.joinOpenFeatureEndpoints(upper.id, 'start', upper.id, 'end'), 'expected same-feature endpoint join to close')
+  state = useProjectStore.getState()
+  const profile = state.project.features[0].sketch.profile
+  assert(profile.closed, 'same-feature endpoint join should close the profile')
+  assert(pointsApprox(profile.segments[profile.segments.length - 1].to, profile.start), 'closed profile should end at its start point')
+}
+
+function testJoinDuringHistoryTransactionCommitsAsOneUndoStep(): void {
+  console.log('Testing open join respects active history transaction...')
+  const upper = makeFeature('upper', [{ x: 0, y: 0 }, { x: 10, y: 0 }])
+  const lower = makeFeature('lower', [{ x: 0, y: 10 }, { x: 10, y: 10 }])
+  const project = {
+    ...newProject('open join transaction', 'mm'),
+    features: [upper, lower],
+    featureTree: [
+      { type: 'feature' as const, featureId: upper.id },
+      { type: 'feature' as const, featureId: lower.id },
+    ],
+  }
+
+  const store = useProjectStore.getState()
+  store.loadProject(project)
+  store.enterSketchEdit(upper.id)
+  store.beginHistoryTransaction()
+
+  assert(store.joinOpenFeatureEndpoints(upper.id, 'start', lower.id, 'start'), 'expected transaction join to succeed')
+  assert(useProjectStore.getState().history.past.length === 0, 'join should not push history while transaction is open')
+
+  store.commitHistoryTransaction()
+  assert(useProjectStore.getState().history.past.length === 1, 'transaction should commit one undo step')
+}
+
+function testDeleteSegmentOpensClosedProfile(): void {
+  console.log('Testing segment delete opens a closed profile...')
+  const square = makeFeature('square', [{ x: 0, y: 0 }, { x: 10, y: 0 }])
+  square.sketch.profile = polygonProfile([
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+    { x: 0, y: 10 },
+  ])
+  const project = {
+    ...newProject('delete segment', 'mm'),
+    features: [square],
+    featureTree: [{ type: 'feature' as const, featureId: square.id }],
+  }
+
+  const store = useProjectStore.getState()
+  store.loadProject(project)
+  store.enterSketchEdit(square.id)
+  store.deleteFeatureSegment(square.id, 1)
+
+  const profile = useProjectStore.getState().project.features[0].sketch.profile
+  assert(!profile.closed, 'deleted segment should leave profile open')
+  assert(pointsApprox(profile.start, { x: 10, y: 10 }), 'open profile should start after deleted segment')
+  assert(pointsApprox(profile.segments[profile.segments.length - 1].to, { x: 10, y: 0 }), 'open profile should end before deleted segment')
+}
+
+function testDeleteSegmentSplitsOpenProfile(): void {
+  console.log('Testing segment delete splits an open profile...')
+  const path = makeFeature('path', [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 20, y: 0 },
+    { x: 30, y: 0 },
+  ])
+  const project = {
+    ...newProject('delete open segment', 'mm'),
+    features: [path],
+    featureTree: [{ type: 'feature' as const, featureId: path.id }],
+  }
+
+  const store = useProjectStore.getState()
+  store.loadProject(project)
+  store.enterSketchEdit(path.id)
+  store.deleteFeatureSegment(path.id, 1)
+
+  const features = useProjectStore.getState().project.features
+  assert(features.length === 2, `expected split delete to create two features, got ${features.length}`)
+  assert(pointsApprox(features[0].sketch.profile.start, { x: 0, y: 0 }), 'first split should keep original start')
+  assert(pointsApprox(features[0].sketch.profile.segments[0].to, { x: 10, y: 0 }), 'first split should end before deleted segment')
+  assert(pointsApprox(features[1].sketch.profile.start, { x: 20, y: 0 }), 'second split should start after deleted segment')
+  assert(pointsApprox(features[1].sketch.profile.segments[0].to, { x: 30, y: 0 }), 'second split should keep trailing segment')
+}
+
+function testDisconnectClosedProfileDuplicatesAnchor(): void {
+  console.log('Testing disconnect opens a closed profile at an anchor...')
+  const square = makeFeature('square', [{ x: 0, y: 0 }, { x: 10, y: 0 }])
+  square.sketch.profile = polygonProfile([
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+    { x: 0, y: 10 },
+  ])
+  const project = {
+    ...newProject('disconnect closed', 'mm'),
+    features: [square],
+    featureTree: [{ type: 'feature' as const, featureId: square.id }],
+  }
+
+  const store = useProjectStore.getState()
+  store.loadProject(project)
+  store.enterSketchEdit(square.id)
+  store.disconnectFeaturePoint(square.id, 1)
+
+  const profile = useProjectStore.getState().project.features[0].sketch.profile
+  assert(!profile.closed, 'disconnect should leave profile open')
+  assert(pointsApprox(profile.start, { x: 10, y: 0 }), 'disconnect should start at selected anchor')
+  assert(pointsApprox(profile.segments[profile.segments.length - 1].to, profile.start), 'disconnect should duplicate selected anchor at path end')
+}
+
+function testDisconnectSplitsOpenProfile(): void {
+  console.log('Testing disconnect splits an open profile...')
+  const path = makeFeature('path', [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 20, y: 0 },
+  ])
+  const project = {
+    ...newProject('disconnect open', 'mm'),
+    features: [path],
+    featureTree: [{ type: 'feature' as const, featureId: path.id }],
+  }
+
+  const store = useProjectStore.getState()
+  store.loadProject(project)
+  store.enterSketchEdit(path.id)
+  store.disconnectFeaturePoint(path.id, 1)
+
+  const features = useProjectStore.getState().project.features
+  assert(features.length === 2, `expected disconnect to create two features, got ${features.length}`)
+  assert(pointsApprox(features[0].sketch.profile.start, { x: 0, y: 0 }), 'first split should keep original start')
+  assert(pointsApprox(features[0].sketch.profile.segments[0].to, { x: 10, y: 0 }), 'first split should end at duplicated anchor')
+  assert(pointsApprox(features[1].sketch.profile.start, { x: 10, y: 0 }), 'second split should start at duplicated anchor')
+  assert(pointsApprox(features[1].sketch.profile.segments[0].to, { x: 20, y: 0 }), 'second split should keep trailing segment')
+}
+
+testJoinOpenProfilesOrientsSelectedEndpointsTogether()
+testStoreJoinAbsorbsFeatureThenClosesPath()
+testJoinDuringHistoryTransactionCommitsAsOneUndoStep()
+testDeleteSegmentOpensClosedProfile()
+testDeleteSegmentSplitsOpenProfile()
+testDisconnectClosedProfileDuplicatesAnchor()
+testDisconnectSplitsOpenProfile()
+
+console.log('open profile edit tests passed')

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -70,6 +70,7 @@ import type {
   Tab,
   Tool,
 } from '../types/project'
+import type { OpenProfileEndpoint } from './types'
 import { convertProjectUnits } from '../utils/units'
 import { convertLength } from '../utils/units'
 import {
@@ -308,6 +309,126 @@ function extendOpenProfileAtEnd(profile: SketchProfile, point: Point): SketchPro
     ...profile,
     segments: nextSegments,
   }
+}
+
+function reverseOpenProfile(profile: SketchProfile): SketchProfile {
+  const anchors = [profile.start, ...profile.segments.map((segment) => segment.to)]
+  const lastAnchor = anchors[anchors.length - 1] ?? profile.start
+  const segments: Segment[] = []
+
+  for (let index = profile.segments.length - 1; index >= 0; index -= 1) {
+    const segment = profile.segments[index]
+    const previousAnchor = anchors[index]
+    if (!segment || !previousAnchor) {
+      continue
+    }
+
+    if (segment.type === 'line') {
+      segments.push({ type: 'line', to: clonePoint(previousAnchor) })
+      continue
+    }
+
+    if (segment.type === 'bezier') {
+      segments.push({
+        type: 'bezier',
+        control1: clonePoint(segment.control2),
+        control2: clonePoint(segment.control1),
+        to: clonePoint(previousAnchor),
+      })
+      continue
+    }
+
+    if (segment.type === 'arc') {
+      segments.push({
+        type: 'arc',
+        center: clonePoint(segment.center),
+        clockwise: !segment.clockwise,
+        to: clonePoint(previousAnchor),
+      })
+    }
+  }
+
+  return {
+    ...profile,
+    start: clonePoint(lastAnchor),
+    segments,
+    closed: false,
+  }
+}
+
+function endPointForOpenProfile(profile: SketchProfile): Point {
+  return anchorPointForIndex(profile, profile.segments.length)
+}
+
+function orientOpenProfileTowardEndpoint(profile: SketchProfile, endpoint: OpenProfileEndpoint): SketchProfile {
+  return endpoint === 'end'
+    ? {
+        ...profile,
+        start: clonePoint(profile.start),
+        segments: profile.segments.map(cloneSegment),
+        closed: false,
+      }
+    : reverseOpenProfile(profile)
+}
+
+function orientOpenProfileFromEndpoint(profile: SketchProfile, endpoint: OpenProfileEndpoint): SketchProfile {
+  return endpoint === 'start'
+    ? {
+        ...profile,
+        start: clonePoint(profile.start),
+        segments: profile.segments.map(cloneSegment),
+        closed: false,
+      }
+    : reverseOpenProfile(profile)
+}
+
+function closeOpenProfile(profile: SketchProfile): SketchProfile | null {
+  if (profile.closed || profile.segments.length === 0) {
+    return null
+  }
+
+  const endPoint = endPointForOpenProfile(profile)
+  const segments = profile.segments.map(cloneSegment)
+  if (!pointsEqual(endPoint, profile.start)) {
+    segments.push({ type: 'line', to: clonePoint(profile.start) })
+  }
+
+  return normalizeEditableProfileClosure({
+    ...profile,
+    start: clonePoint(profile.start),
+    segments,
+    closed: true,
+  })
+}
+
+export function joinOpenProfiles(
+  profile: SketchProfile,
+  endpoint: OpenProfileEndpoint,
+  targetProfile: SketchProfile,
+  targetEndpoint: OpenProfileEndpoint,
+): SketchProfile | null {
+  if (profile.closed || targetProfile.closed || profile.segments.length === 0 || targetProfile.segments.length === 0) {
+    return null
+  }
+
+  const leading = orientOpenProfileTowardEndpoint(profile, endpoint)
+  const trailing = orientOpenProfileFromEndpoint(targetProfile, targetEndpoint)
+  const leadingEnd = endPointForOpenProfile(leading)
+  const trailingStart = trailing.start
+  const segments = leading.segments.map(cloneSegment)
+
+  if (!pointsEqual(leadingEnd, trailingStart)) {
+    segments.push({ type: 'line', to: clonePoint(trailingStart) })
+  }
+
+  segments.push(...trailing.segments.map(cloneSegment))
+
+  return normalizeEditableProfileClosure({
+    ...profile,
+    start: clonePoint(leading.start),
+    segments,
+    closed: false,
+  })
 }
 
 function buildBridgeSegment(
@@ -550,6 +671,112 @@ function deleteAnchorFromProfile(profile: SketchProfile, anchorIndex: number): S
     ...profile,
     segments: nextSegments,
     closed: false,
+  }
+}
+
+interface ProfileBreakResult {
+  profile: SketchProfile
+  splitProfile: SketchProfile | null
+}
+
+function profileFromOpenSegments(start: Point, segments: Segment[]): SketchProfile | null {
+  if (segments.length === 0) {
+    return null
+  }
+
+  return {
+    start: clonePoint(start),
+    segments: segments.map(cloneSegment),
+    closed: false,
+  }
+}
+
+function deleteSegmentFromProfile(profile: SketchProfile, segmentIndex: number): ProfileBreakResult | null {
+  if (segmentIndex < 0 || segmentIndex >= profile.segments.length || profile.segments.length <= 1) {
+    return null
+  }
+
+  const segment = profile.segments[segmentIndex]
+  if (!segment || segment.type === 'circle') {
+    return null
+  }
+
+  if (profile.closed) {
+    const nextSegments: Segment[] = []
+    for (let offset = 1; offset < profile.segments.length; offset += 1) {
+      const nextSegment = profile.segments[(segmentIndex + offset) % profile.segments.length]
+      if (nextSegment) {
+        nextSegments.push(cloneSegment(nextSegment))
+      }
+    }
+
+    return {
+      profile: {
+        ...profile,
+        start: clonePoint(segment.to),
+        segments: nextSegments,
+        closed: false,
+      },
+      splitProfile: null,
+    }
+  }
+
+  const leading = profileFromOpenSegments(profile.start, profile.segments.slice(0, segmentIndex))
+  const trailing = profileFromOpenSegments(segment.to, profile.segments.slice(segmentIndex + 1))
+  const primaryProfile = leading ?? trailing
+  if (!primaryProfile) {
+    return null
+  }
+
+  return {
+    profile: primaryProfile,
+    splitProfile: leading && trailing ? trailing : null,
+  }
+}
+
+function disconnectProfileAtAnchor(profile: SketchProfile, anchorIndex: number): ProfileBreakResult | null {
+  const anchors = profileVertices(profile)
+  if (anchorIndex < 0 || anchorIndex >= anchors.length || profile.segments.length === 0) {
+    return null
+  }
+
+  if (profile.segments.length === 1 && profile.segments[0].type === 'circle') {
+    return null
+  }
+
+  if (profile.closed) {
+    const nextSegments: Segment[] = []
+    for (let offset = 0; offset < profile.segments.length; offset += 1) {
+      const segment = profile.segments[(anchorIndex + offset) % profile.segments.length]
+      if (segment) {
+        nextSegments.push(cloneSegment(segment))
+      }
+    }
+
+    return {
+      profile: {
+        ...profile,
+        start: clonePoint(anchors[anchorIndex]),
+        segments: nextSegments,
+        closed: false,
+      },
+      splitProfile: null,
+    }
+  }
+
+  if (anchorIndex === 0 || anchorIndex === anchors.length - 1) {
+    return null
+  }
+
+  const leading = profileFromOpenSegments(profile.start, profile.segments.slice(0, anchorIndex))
+  const trailing = profileFromOpenSegments(anchors[anchorIndex], profile.segments.slice(anchorIndex))
+  if (!leading || !trailing) {
+    return null
+  }
+
+  return {
+    profile: leading,
+    splitProfile: trailing,
   }
 }
 
@@ -2633,6 +2860,80 @@ function withAutoDirty(rawSet: SetFn): SetFn {
 
 export const useProjectStore = create<ProjectStore>((rawSet, get) => {
   const set = withAutoDirty(rawSet)
+  const applyProfileBreak = (
+    featureId: string,
+    resolveBreak: (profile: SketchProfile) => ProfileBreakResult | null,
+  ) => set((s) => {
+    const feature = s.project.features.find((entry) => entry.id === featureId) ?? null
+    if (!feature || feature.locked) {
+      return {}
+    }
+
+    const result = resolveBreak(feature.sketch.profile)
+    if (!result) {
+      return {}
+    }
+
+    const splitFeature = result.splitProfile
+      ? createDerivedFeature(
+          s.project,
+          feature,
+          result.splitProfile,
+          feature.operation,
+          uniqueName(`${normalizeDerivedFeatureNameStem(feature.name)} Split`, s.project.features.map((entry) => entry.name)),
+        )
+      : null
+
+    const baseFeatures = s.project.features.map((entry) => {
+      if (entry.id !== featureId) {
+        return entry
+      }
+
+      return {
+        ...entry,
+        kind: ['text', 'stl'].includes(entry.kind) ? entry.kind : inferFeatureKind(result.profile),
+        sketch: {
+          ...entry.sketch,
+          profile: result.profile,
+        },
+      }
+    })
+    const createdGroups: DerivedFeatureGroup[] = splitFeature ? [{ sourceId: featureId, features: [splitFeature] }] : []
+    let nextProject = syncFeatureTreeProject({
+      ...s.project,
+      features: splitFeature
+        ? insertDerivedFeaturesAfterSources(baseFeatures, createdGroups, new Set())
+        : baseFeatures,
+      featureTree: splitFeature
+        ? insertDerivedFeatureTreeEntries(s.project.featureTree, baseFeatures, createdGroups, new Set())
+        : s.project.featureTree,
+      meta: { ...s.project.meta, modified: new Date().toISOString() },
+    })
+
+    nextProject = syncStockFromSourceFeature(nextProject, featureId)
+    if (projectsEqual(nextProject, s.project)) {
+      return {}
+    }
+
+    return {
+      project: nextProject,
+      selection: {
+        ...s.selection,
+        selectedFeatureId: featureId,
+        selectedFeatureIds: [featureId],
+        selectedNode: { type: 'feature' as const, featureId },
+        activeControl: null,
+      },
+      history: s.history.transactionStart
+        ? s.history
+        : {
+            past: [...s.history.past, cloneProject(s.project)].slice(-100),
+            future: [],
+            transactionStart: null,
+          },
+    }
+  })
+
   return {
   project: normalizeProject(newProject()),
   creationTarget: 'feature',
@@ -5588,6 +5889,116 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
       }
     }),
 
+  joinOpenFeatureEndpoints: (featureId, endpoint, targetFeatureId, targetEndpoint) => {
+    let didJoin = false
+    set((s) => {
+      const feature = s.project.features.find((entry) => entry.id === featureId) ?? null
+      const targetFeature = s.project.features.find((entry) => entry.id === targetFeatureId) ?? null
+      if (
+        !feature
+        || !targetFeature
+        || feature.locked
+        || targetFeature.locked
+        || feature.sketch.profile.closed
+        || targetFeature.sketch.profile.closed
+      ) {
+        return {}
+      }
+
+      const nextProfile =
+        featureId === targetFeatureId
+          ? endpoint === targetEndpoint
+            ? null
+            : closeOpenProfile(feature.sketch.profile)
+          : joinOpenProfiles(feature.sketch.profile, endpoint, targetFeature.sketch.profile, targetEndpoint)
+      if (!nextProfile) {
+        return {}
+      }
+
+      const removedFeatureIds = new Set(featureId === targetFeatureId ? [] : [targetFeatureId])
+      let nextProject = syncFeatureTreeProject({
+        ...s.project,
+        features: s.project.features
+          .filter((entry) => !removedFeatureIds.has(entry.id))
+          .map((entry) => {
+            if (entry.id === featureId) {
+              return {
+                ...entry,
+                kind: ['text', 'stl'].includes(entry.kind) ? entry.kind : inferFeatureKind(nextProfile),
+                sketch: {
+                  ...entry.sketch,
+                  profile: nextProfile,
+                  constraints: entry.sketch.constraints.map((constraint) => {
+                    const refId = constraint.reference_feature_id ?? constraint.segment_ids[0]
+                    if (constraint.type === 'fixed_distance' && refId && removedFeatureIds.has(refId)) {
+                      return {
+                        ...constraint,
+                        is_invalid: true,
+                        error_message: 'Reference feature was joined into another feature',
+                      }
+                    }
+                    return constraint
+                  }),
+                },
+              }
+            }
+
+            if (removedFeatureIds.size === 0 || entry.sketch.constraints.every((constraint) => constraint.type !== 'fixed_distance')) {
+              return entry
+            }
+
+            const constraints = entry.sketch.constraints.map((constraint) => {
+              const refId = constraint.reference_feature_id ?? constraint.segment_ids[0]
+              if (constraint.type === 'fixed_distance' && refId && removedFeatureIds.has(refId)) {
+                return {
+                  ...constraint,
+                  is_invalid: true,
+                  error_message: 'Reference feature was joined into another feature',
+                }
+              }
+              return constraint
+            })
+
+            return {
+              ...entry,
+              sketch: {
+                ...entry.sketch,
+                constraints,
+              },
+            }
+          }),
+        featureTree: s.project.featureTree.filter((entry) => !(entry.type === 'feature' && removedFeatureIds.has(entry.featureId))),
+        meta: { ...s.project.meta, modified: new Date().toISOString() },
+      })
+
+      nextProject = syncStockFromSourceFeature(nextProject, featureId)
+      if (projectsEqual(nextProject, s.project)) {
+        return {}
+      }
+
+      didJoin = true
+      return {
+        project: nextProject,
+        selection: {
+          ...s.selection,
+          selectedFeatureId: featureId,
+          selectedFeatureIds: [featureId],
+          selectedNode: { type: 'feature', featureId },
+          activeControl: null,
+        },
+        history: s.history.transactionStart
+          ? s.history
+          : {
+              past: [...s.history.past, cloneProject(s.project)].slice(-100),
+              future: [],
+              transactionStart: null,
+            },
+      }
+    })
+
+    return didJoin
+  },
+
   deleteFeaturePoint: (featureId, anchorIndex) =>
     set((s) => {
       let changed = false
@@ -5636,6 +6047,12 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         },
       }
     }),
+
+  deleteFeatureSegment: (featureId, segmentIndex) =>
+    applyProfileBreak(featureId, (profile) => deleteSegmentFromProfile(profile, segmentIndex)),
+
+  disconnectFeaturePoint: (featureId, anchorIndex) =>
+    applyProfileBreak(featureId, (profile) => disconnectProfileAtAnchor(profile, anchorIndex)),
 
   filletFeaturePoint: (featureId, anchorIndex, radius) =>
     set((s) => {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -55,7 +55,8 @@ export interface SketchControlRef {
   t?: number
 }
 
-export type SketchEditTool = 'add_point' | 'delete_point' | 'fillet'
+export type SketchEditTool = 'add_point' | 'delete_point' | 'delete_segment' | 'disconnect' | 'fillet'
+export type OpenProfileEndpoint = 'start' | 'end'
 
 export type FeatureAlignment =
   | 'left'
@@ -327,7 +328,15 @@ export interface ProjectStore {
   setActiveControl: (control: SketchControlRef | null) => void
   moveFeatureControl: (featureId: string, control: SketchControlRef, point: Point) => void
   insertFeaturePoint: (featureId: string, target: SketchInsertTarget) => void
+  joinOpenFeatureEndpoints: (
+    featureId: string,
+    endpoint: OpenProfileEndpoint,
+    targetFeatureId: string,
+    targetEndpoint: OpenProfileEndpoint,
+  ) => boolean
   deleteFeaturePoint: (featureId: string, anchorIndex: number) => void
+  deleteFeatureSegment: (featureId: string, segmentIndex: number) => void
+  disconnectFeaturePoint: (featureId: string, anchorIndex: number) => void
   filletFeaturePoint: (featureId: string, anchorIndex: number, radius: number) => void
   moveClampControl: (clampId: string, control: SketchControlRef, point: Point) => void
 


### PR DESCRIPTION
## Summary
- add automatic open-profile joining while extending or dragging endpoints
- add sketch edit tools for deleting segments and disconnecting anchors
- add toolbar icons and focused store tests for open profile edits

## Verification
- npx tsx src/store/openProfileJoin.test.ts
- npm run build