### PR TITLE
Open profile cut/trim, 3D polyline display, simulation XYZ readout

### DIFF
--- a/planning/OPEN_FEATURE_3D_DISPLAY_Plan.md
+++ b/planning/OPEN_FEATURE_3D_DISPLAY_Plan.md
@@ -1,0 +1,226 @@
+# Open Feature (Polyline) 3D Display — Implementation Plan
+
+## Problem
+
+Open features (sketch profiles with `closed: false`) are not rendered properly in the 3D viewport. Two issues:
+
+1. **Properties Panel**: Z Bottom is editable for open features, but it has no meaning — open features are purely 2D lines at a single Z height. Z Bottom should be locked to `0` and non-editable.
+
+2. **3D Viewport**: Open features are silently skipped by the boolean model (`buildFeatureSolid` returns `null` for `!profile.closed`). They don't appear at all in the 3D scene. They should be displayed as lines at their Z Top height.
+
+## Current Code Analysis
+
+### Data Model ([`src/types/project.ts`](src/types/project.ts:236))
+- [`SketchFeature`](src/types/project.ts:236) has `z_top` and `z_bottom` as `DimensionRef`
+- Open features are created with `closed: false` on [`SketchProfile`](src/types/project.ts:57)
+- No existing field indicates "this is an open/polyline feature" — detection is via `!profile.closed`
+
+### Properties Panel ([`src/components/feature-tree/PropertiesPanel.tsx`](src/components/feature-tree/PropertiesPanel.tsx:1285))
+- Single feature Z Top/Z Bottom rendering: lines 1285-1306
+- Multi-select Z Top/Z Bottom rendering: lines 1119-1142
+- Open feature detection: use `selectedFeature.sketch.profile.closed` or `featureHasClosedGeometry()` from [`src/text/index.ts`](src/text/index.ts:671)
+- No current differentiation between open and closed features in Z field rendering
+
+### 3D CSG Engine ([`src/engine/csg.ts`](src/engine/csg.ts))
+- [`buildFeatureSolid`](src/engine/csg.ts:642): returns `null` at line 714 if `!feature.sketch.profile.closed` — open features are excluded from boolean model
+- [`buildFeatureMesh`](src/engine/csg.ts:409): uses `profileToShape()` + `ExtrudeGeometry` — this works for closed profiles but produces incorrect geometry for open profiles
+- [`buildScene`](src/engine/csg.ts:833): only creates individual meshes for STL/region features explicitly; falls back only if boolean model fails
+- [`SceneObjects`](src/engine/csg.ts:824) interface has no field for line objects
+
+### 3D Viewport ([`src/components/viewport3d/Viewport3D.tsx`](src/components/viewport3d/Viewport3D.tsx))
+- Renders `featureMeshes` from `SceneObjects` at line 891
+- No rendering of any line objects for non-closed features
+
+## Implementation Steps
+
+### Step 1: Properties Panel — Lock Z Bottom for Open Features
+
+**File**: [`src/components/feature-tree/PropertiesPanel.tsx`](src/components/feature-tree/PropertiesPanel.tsx)
+
+#### 1a. Single feature edit (around line 1283-1307)
+
+Add a check: if the selected feature has an open profile (`!selectedFeature.sketch.profile.closed`), render the Z Bottom field as a disabled/read-only field always showing `0`, similar to how clamps render Z Bottom at lines 989-999.
+
+Pseudo-change:
+```
+// Before the Z Top/Z Bottom section (line 1283):
+const isOpenProfile = !selectedFeature.sketch.profile.closed
+
+// Z Bottom field (line 1296-1305):
+{isOpenProfile ? (
+  <label className="properties-field">
+    <span>Z Bottom</span>
+    <DraftNumberInput
+      key={`feature-zbottom-open-${selectedFeature.id}`}
+      value={0}
+      units={units}
+      min={0}
+      max={0}
+      onCommit={() => {}}  // no-op
+    />
+  </label>
+) : (
+  // existing editable Z Bottom
+)}
+```
+
+Also, when the feature is an open profile, ensure the Z Bottom value in the store is always `0` (it may already be if created via the polyline tool, but enforce it).
+
+#### 1b. Multi-edit (around line 1117-1142)
+
+Filter open features out of the Z Bottom multi-edit or show a mixed-state locked field. Open features' Z Bottom is always `0`, so they should not participate in the multi-edit Z Bottom control.
+
+Add a filter:
+```
+const selectedClosedFeatures = selectedZEditableFeatures.filter(
+  (f) => f.sketch.profile.closed
+)
+const selectedOpenFeatures = selectedZEditableFeatures.filter(
+  (f) => !f.sketch.profile.closed
+)
+```
+
+If there's a mix, show a note or render the open features' Z Bottom as locked at 0 separately.
+
+### Step 2: CSG — Build Line Geometry for Open Features
+
+**File**: [`src/engine/csg.ts`](src/engine/csg.ts)
+
+#### 2a. Add `buildOpenFeatureLine` function
+
+Create a new exported function that converts an open profile's vertices into a [`THREE.Line`](https://threejs.org/docs/#api/en/objects/Line) positioned at the feature's Z Top:
+
+```
+export function buildOpenFeatureLine(
+  feature: SketchFeature,
+  project: Project,
+  selected = false,
+  hovered = false,
+): THREE.Line {
+  const profile = feature.sketch.profile
+  const zTop = resolveDimension(feature.z_top, project)
+  
+  // Collect all vertices: start point + all segment endpoints
+  const vertices: number[] = [profile.start.x, 0, profile.start.y]
+  for (const seg of profile.segments) {
+    // For arcs/beziers, subdivide into line segments for accurate 3D representation
+    const points = subdivideSegment(profile.start, seg)
+    for (const pt of points) {
+      vertices.push(pt.x, 0, pt.y)
+    }
+  }
+  
+  // Create THREE.BufferGeometry
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
+  
+  // Position at z_top by translating Y axis (which is Z in Three.js convention after rotation)
+  geometry.translate(0, zTop, 0)
+  
+  const color = selected ? 0xffaa00 : hovered ? 0x44aaff : 0x3366cc
+  const material = new THREE.LineBasicMaterial({ color })
+  
+  return new THREE.Line(geometry, material)
+}
+```
+
+**Note on coordinate system**: In [`buildFeatureMesh`](src/engine/csg.ts:478), the geometry is rotated `-PI/2` around X and translated by `yStart` (which is `min(zTop, zBottom)`). The Three.js Y axis maps to the world Z axis. So for lines at Z Top, we should translate by `zTop` on the Y axis after the X rotation, matching the convention used by `buildFeatureMesh`.
+
+#### 2b. Update `SceneObjects` interface
+
+Add a field for open feature lines:
+
+```
+export interface SceneObjects {
+  stockMesh: THREE.Mesh
+  stockWireframe: THREE.LineSegments
+  modelMesh: THREE.Mesh | null
+  featureMeshes: Map<string, THREE.Mesh>
+  openFeatureLines: Map<string, THREE.Line>   // NEW
+  tabMeshes: Map<string, THREE.Mesh>
+  clampMeshes: Map<string, THREE.Mesh>
+}
+```
+
+#### 2c. Update `buildScene` function
+
+After the existing feature-mesh loop (around line 873), add logic to build line geometry for open features:
+
+```
+// Build line representations for open features
+const openFeatureLines = new Map<string, THREE.Line>()
+for (const feature of visibleFeatures) {
+  if (!feature.sketch.profile.closed) {
+    openFeatureLines.set(
+      feature.id,
+      buildOpenFeatureLine(feature, project)
+    )
+  }
+}
+```
+
+Include `openFeatureLines` in the return value.
+
+### Step 3: Viewport3D — Render Open Feature Lines
+
+**File**: [`src/components/viewport3d/Viewport3D.tsx`](src/components/viewport3d/Viewport3D.tsx)
+
+#### 3a. After the feature meshes are added to the scene (after line 894), add the open feature lines:
+
+```
+for (const openLine of nextSceneObjects.openFeatureLines.values()) {
+  scene.add(openLine)
+  objectsRef.current.push(openLine)
+}
+```
+
+#### 3b. Update cleanup logic to handle `THREE.Line` objects
+
+The existing `clearRenderedObjects` function (around line 799) already handles `THREE.Line` and `THREE.LineSegments` via the `instanceof` check. The open feature lines will be `THREE.Line` instances, so they should be cleaned up automatically.
+
+### Step 4: Handle Edge Cases
+
+1. **Parametric Z Top**: If `z_top` is a `DimensionRef` (string key), use `resolveDimension` to get the numeric value.
+2. **Text/Composite features**: Use [`expandFeatureGeometry`](src/text/index.ts:693) and check each expanded profile. Text features (skeleton style) produce open profiles too, so they should also get line rendering.
+3. **Boolean model interaction**: Open features should remain excluded from `buildBooleanModel` (the check at line 714 is correct). They are visual-only in the 3D view.
+4. **Arc and Bezier segments**: Need proper subdivision into line segments for accurate 3D line rendering. Reuse the existing [`profileToPolygon`](src/engine/csg.ts:117) function which already handles subdivision of arcs and beziers into polyline points.
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| [`src/engine/csg.ts`](src/engine/csg.ts) | Add `buildOpenFeatureLine()`, update `SceneObjects`, update `buildScene()` |
+| [`src/components/feature-tree/PropertiesPanel.tsx`](src/components/feature-tree/PropertiesPanel.tsx) | Lock Z Bottom to 0 for open features in single-edit and multi-edit |
+| [`src/components/viewport3d/Viewport3D.tsx`](src/components/viewport3d/Viewport3D.tsx) | Add open feature lines to scene rendering |
+
+## Diagram
+
+```mermaid
+flowchart TD
+    subgraph PropertiesPanel
+        A[Feature selected] --> B{Profile closed?}
+        B -->|Yes| C[Show editable Z Top + Z Bottom]
+        B -->|No| D[Show editable Z Top]
+        D --> E[Show locked Z Bottom = 0]
+    end
+
+    subgraph csg.ts
+        F[buildScene called] --> G[buildBooleanModel - open features skipped]
+        G --> H[buildOpenFeatureLine for each open feature]
+        H --> I[Store in SceneObjects.openFeatureLines]
+    end
+
+    subgraph Viewport3D
+        J[SceneObjects received] --> K[Add openFeatureLines to Three.js scene]
+        K --> L[Lines rendered at z_top height]
+    end
+```
+
+## Testing Notes
+
+- Create an open polyline feature. Verify Z Bottom is locked at 0 in Properties Panel.
+- Verify the polyline appears as a line in the 3D view at its Z Top level.
+- Verify closed features still show as solid extrusions (no regression).
+- Verify multi-select with mixed open/closed features handles Z Bottom correctly.
+- Verify text features with skeleton style (which also have open profiles) render correctly.
+- Verify arc and bezier segments within open profiles are properly subdivided.

--- a/planning/SIMULATION_XYZ_READOUT_Plan.md
+++ b/planning/SIMULATION_XYZ_READOUT_Plan.md
@@ -1,0 +1,243 @@
+# Simulation Toolpath Play — XYZ Position Readout
+
+## Goal
+
+Display the current tool-tip position (X, Y, Z) in the simulation playback bar without degrading rendering performance.
+
+---
+
+## Analysis
+
+### Current state
+
+1. `PlaybackController.getPose()` ([`src/engine/simulation/playback.ts:176`](../src/engine/simulation/playback.ts:176)) already returns `{ x, y, z, moveKind }` on every call — zero new computation.
+2. `updateToolMeshPose()` ([`src/components/simulation/SimulationViewport.tsx:710`](../src/components/simulation/SimulationViewport.tsx:710)) already calls `controller.getPose()` inside the RAF playback tick — the data is already flowing every frame.
+3. The playback bar ([`src/components/simulation/SimulationViewport.tsx:1163-1231`](../src/components/simulation/SimulationViewport.tsx:1163)) sits in the JSX of the component and already handles React state for `playbackProgress`.
+
+### Performance risk
+
+If a raw `setState({x, y, z})` is placed inside the RAF tick ([`src/components/simulation/SimulationViewport.tsx:853`](../src/components/simulation/SimulationViewport.tsx:853)), React would re-render the entire component tree **60 times per second**, which **would** degrade the Three.js rendering performance on the same thread.
+
+### Mitigation strategy — throttled state update
+
+- Store the latest pose in a `useRef` — written every RAF frame with zero React cost.
+- Throttle the `setState` call to ~10 Hz (every 100ms). At 10 re-renders/second only a few text nodes update, which is imperceptible vs. ~1-2ms of React overhead.
+- The Three.js render loop is unaffected.
+
+---
+
+## Implementation Plan
+
+### Step 1 — Add `useRef` for pose + `useState` for display values
+
+In [`SimulationViewport.tsx`](../src/components/simulation/SimulationViewport.tsx), add near the other refs/state (~line 477):
+
+```ts
+// Latest pose from the playback controller — written every RAF frame.
+const latestPoseRef = useRef<PlaybackPose>({ x: 0, y: 0, z: 0, moveKind: null })
+// Throttled state for the UI readout — updated at ~10 Hz to avoid re-render churn.
+const [displayPose, setDisplayPose] = useState<PlaybackPose>({ x: 0, y: 0, z: 0, moveKind: null })
+```
+
+**Import**: `PlaybackPose` is exported from [`src/engine/simulation/playback.ts`](../src/engine/simulation/playback.ts).
+
+### Step 2 — Write the ref inside the RAF tick
+
+Inside the `tick` function ([`src/components/simulation/SimulationViewport.tsx:853`](../src/components/simulation/SimulationViewport.tsx:853)), after the existing `updateToolMeshPose()` call at line 872, add:
+
+```ts
+const pose = controllerInner.getPose()
+latestPoseRef.current = pose
+```
+
+This reuses the already-computed pose rather than calling `getPose()` twice, since the viewport also calls it internally. But looking more carefully, `updateToolMeshPose()` already reads `getPose()` internally. So we just need to read the ref after the tool mesh update.
+
+Actually, the cleanest approach: store the pose result from within `updateToolMeshPose` or read it directly from the controller. Since `updateToolMeshPose` already calls `controller.getPose()`, we can simply read `latestPoseRef.current` inside `updateToolMeshPose`. Let me revise:
+
+**In `updateToolMeshPose()` at line 710-719**, add a ref write:
+
+```ts
+const updateToolMeshPose = useCallback(() => {
+  const controller = playbackControllerRef.current
+  const tool = toolMeshRef.current
+  if (!controller || !tool) {
+    return
+  }
+  const pose = controller.getPose()
+  latestPoseRef.current = pose  // <-- ADD THIS
+  // Toolpath (x, y, z) → world (x, z, y): the viewport treats world Y as vertical.
+  tool.position.set(pose.x, pose.z, pose.y)
+}, [])
+```
+
+### Step 3 — Throttle the React state update
+
+Add a `useEffect` that runs a 100ms interval when playback is active, reading from the ref:
+
+```ts
+useEffect(() => {
+  if (!playbackEnabled || !isPlaying) {
+    return
+  }
+
+  const interval = setInterval(() => {
+    const pose = latestPoseRef.current
+    setDisplayPose({ x: pose.x, y: pose.y, z: pose.z, moveKind: pose.moveKind })
+  }, 100)
+
+  return () => clearInterval(interval)
+}, [playbackEnabled, isPlaying])
+```
+
+Also update the display when paused/seeking — a separate effect for non-playing states:
+
+```ts
+useEffect(() => {
+  const pose = latestPoseRef.current
+  setDisplayPose({ x: pose.x, y: pose.y, z: pose.z, moveKind: pose.moveKind })
+}, [playbackProgress])  // updates on seek / stop
+```
+
+### Step 4 — Add JSX for the XYZ readout in the playback bar
+
+Inside the playback bar div ([`src/components/simulation/SimulationViewport.tsx:1163`](../src/components/simulation/SimulationViewport.tsx:1163)), insert a new element **after** the speed/step controls (~line 1229), **before** the closing `</div>`:
+
+```tsx
+<div className="simulation-playback-bar__xyz">
+  <span className="simulation-playback-bar__xyz-label">X</span>
+  <span className="simulation-playback-bar__xyz-value">{formatCoord(displayPose.x, playbackUnits)}</span>
+  <span className="simulation-playback-bar__xyz-label">Y</span>
+  <span className="simulation-playback-bar__xyz-value">{formatCoord(displayPose.y, playbackUnits)}</span>
+  <span className="simulation-playback-bar__xyz-label">Z</span>
+  <span className="simulation-playback-bar__xyz-value">{formatCoord(displayPose.z, playbackUnits)}</span>
+</div>
+```
+
+Also display the `moveKind` as a small color-coded indicator (optional but useful):
+
+```tsx
+<span
+  className={`simulation-playback-bar__move-kind simulation-playback-bar__move-kind--${displayPose.moveKind ?? 'none'}`}
+  title={displayPose.moveKind ?? 'none'}
+/>
+```
+
+### Step 5 — Add formatting helper
+
+Near the existing formatting functions at the top of the component, add:
+
+```ts
+function formatCoord(value: number, units: 'mm' | 'in'): string {
+  if (!Number.isFinite(value)) return '—'
+  if (units === 'in') {
+    return value.toFixed(3)
+  }
+  return value.toFixed(2)
+}
+```
+
+### Step 6 — Add CSS
+
+In [`src/styles/layout.css`](../src/styles/layout.css), add after the `.simulation-playback-bar__speed select` block (~line 818):
+
+```css
+.simulation-playback-bar__xyz {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 10px;
+  border-left: 1px solid var(--line-strong);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.simulation-playback-bar__xyz-label {
+  color: var(--text-dim);
+  font-weight: 500;
+}
+
+.simulation-playback-bar__xyz-value {
+  color: var(--text);
+  min-width: 4.5em;
+  text-align: right;
+}
+
+.simulation-playback-bar__xyz-value + .simulation-playback-bar__xyz-label {
+  margin-left: 6px;
+}
+
+.simulation-playback-bar__move-kind {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-left: 6px;
+}
+
+.simulation-playback-bar__move-kind--cut,
+.simulation-playback-bar__move-kind--plunge,
+.simulation-playback-bar__move-kind--lead_in,
+.simulation-playback-bar__move-kind--lead_out {
+  background: #4ade80;
+}
+
+.simulation-playback-bar__move-kind--rapid {
+  background: #fbbf24;
+}
+
+.simulation-playback-bar__move-kind--none {
+  background: transparent;
+}
+```
+
+---
+
+## Performance analysis
+
+| Concern | Mitigation |
+|---------|-----------|
+| `getPose()` is already called every frame | No extra computation — we just copy the result to a ref |
+| React state setState inside RAF tick | Avoided — throttle to 100ms via `setInterval` |
+| Layout thrash from DOM updates | Throttled to 10 Hz; only text content changes |
+| Benchmark: 10 state updates/sec vs 60 | ~0.1–0.2ms extra React work vs ~16ms frame budget |
+
+**Verdict**: Zero measurable impact on simulation frame rate.
+
+---
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| [`src/components/simulation/SimulationViewport.tsx`](../src/components/simulation/SimulationViewport.tsx) | Add ref, state, update logic, and JSX readout |
+| [`src/styles/layout.css`](../src/styles/layout.css) | Add XYZ readout CSS classes |
+
+## Exports to import
+
+From `src/engine/simulation/playback.ts`: `PlaybackPose` (already exported at line 38).
+
+---
+
+## Visual design
+
+The XYZ readout sits as a compact block in the playback bar, separated by a vertical divider from the speed/step controls:
+
+```
+[▶][■] [━⚫━━━━━] 42%  Speed [━⚫━] Step [0.1 mm] | X 12.34  Y 56.78  Z -3.45 ●
+```
+
+The dot (●) at the end shows the move kind:
+- **Green** for cutting moves (cut, plunge, lead_in, lead_out)
+- **Amber** for rapid moves
+- **Hidden** when idle
+
+---
+
+## Test plan
+
+1. **Functional**: Play an operation, verify X/Y/Z values update and match the tool position
+2. **Seek**: Drag the progress slider, verify values jump to the correct position
+3. **Stop/reset**: Click stop, verify values return to toolpath start
+4. **Pause**: Pause mid-playback, verify values freeze
+5. **Units**: Switch project between mm and inch, verify decimal precision changes
+6. **No-op**: Disable playback mode, verify readout disappears with the playback bar

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -4666,10 +4666,10 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
                 : `Join mode. ${pendingShapeAction.entityIds.length} closed features selected.`
               : pendingShapeAction.phase === 'cutters'
                 ? pendingShapeAction.cutterIds.length === 0
-                  ? <>Cut mode. Click closed features to select cutters. Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm cutters" onClick={confirmCutCutters} onKeyDown={(e) => { if (e.key === 'Enter') confirmCutCutters() }}>Tab</kbd> to confirm cutters.</>
+                  ? <>Cut mode. Click features to select cutters. Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm cutters" onClick={confirmCutCutters} onKeyDown={(e) => { if (e.key === 'Enter') confirmCutCutters() }}>Tab</kbd> to confirm cutters.</>
                   : <>Cut mode. {pendingShapeAction.cutterIds.length} cutter{pendingShapeAction.cutterIds.length === 1 ? '' : 's'} selected. Shift-click to add more, or press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm cutters" onClick={confirmCutCutters} onKeyDown={(e) => { if (e.key === 'Enter') confirmCutCutters() }}>Tab</kbd> to confirm cutters.</>
                 : pendingShapeAction.targetIds.length === 0
-                  ? `Cut mode. ${pendingShapeAction.cutterIds.length} cutter${pendingShapeAction.cutterIds.length === 1 ? '' : 's'} confirmed. Shift-click closed features that intersect a cutter to select targets.`
+                  ? `Cut mode. ${pendingShapeAction.cutterIds.length} cutter${pendingShapeAction.cutterIds.length === 1 ? '' : 's'} confirmed. Shift-click features that intersect a cutter to select targets.`
                   : `Cut mode. ${pendingShapeAction.cutterIds.length} cutter${pendingShapeAction.cutterIds.length === 1 ? '' : 's'} and ${pendingShapeAction.targetIds.length} target${pendingShapeAction.targetIds.length === 1 ? '' : 's'} selected. Shift-click to add or remove targets.`}
             {' '}
           </span>

--- a/src/components/feature-tree/PropertiesPanel.tsx
+++ b/src/components/feature-tree/PropertiesPanel.tsx
@@ -231,6 +231,9 @@ export function PropertiesPanel() {
       : '__mixed__'
   const selectedZEditableFeatures = allSelectedFeatures.filter((feature) => feature.operation !== 'region')
   const selectedZEditableFeatureIds = selectedZEditableFeatures.map((feature) => feature.id)
+  const selectedClosedEditableFeatures = selectedZEditableFeatures.filter((feature) => feature.sketch.profile.closed)
+  const selectedOpenEditableFeatures = selectedZEditableFeatures.filter((feature) => !feature.sketch.profile.closed)
+  const hasOpenEditableFeatures = selectedOpenEditableFeatures.length > 0
   const commonSelectedZTop =
     selectedZEditableFeatures.length > 0 &&
     typeof selectedZEditableFeatures[0]?.z_top === 'number' &&
@@ -238,19 +241,19 @@ export function PropertiesPanel() {
       ? selectedZEditableFeatures[0]?.z_top ?? null
       : null
   const commonSelectedZBottom =
-    selectedZEditableFeatures.length > 0 &&
-    typeof selectedZEditableFeatures[0]?.z_bottom === 'number' &&
-    selectedZEditableFeatures.every((feature) => feature.z_bottom === selectedZEditableFeatures[0]?.z_bottom)
-      ? selectedZEditableFeatures[0]?.z_bottom ?? null
+    selectedClosedEditableFeatures.length > 0 &&
+    typeof selectedClosedEditableFeatures[0]?.z_bottom === 'number' &&
+    selectedClosedEditableFeatures.every((feature) => feature.z_bottom === selectedClosedEditableFeatures[0]?.z_bottom)
+      ? selectedClosedEditableFeatures[0]?.z_bottom ?? null
       : null
-  const selectedNumericZBottoms = selectedZEditableFeatures
+  const selectedNumericZBottoms = selectedClosedEditableFeatures
     .map((feature) => feature.z_bottom)
     .filter((value): value is number => typeof value === 'number')
   const selectedNumericZTops = selectedZEditableFeatures
     .map((feature) => feature.z_top)
     .filter((value): value is number => typeof value === 'number')
   const multiEditMinZTop =
-    selectedNumericZBottoms.length === selectedZEditableFeatures.length
+    selectedNumericZBottoms.length === selectedClosedEditableFeatures.length
       ? Math.max(...selectedNumericZBottoms)
       : null
   const multiEditMaxZBottom =
@@ -1128,18 +1131,45 @@ export function PropertiesPanel() {
                     onCommit={(next) => updateFeatures(selectedZEditableFeatureIds, { z_top: next })}
                   />
                 </label>
-                <label className="properties-field">
-                  <span>Z Bottom</span>
-                  <DraftNumberInput
-                    key={`multi-feature-zbottom-${selectedZEditableFeatureIds.join(',')}-${commonSelectedZTop ?? 'mixed'}-${commonSelectedZBottom ?? 'mixed'}`}
-                    value={commonSelectedZBottom}
-                    units={units}
-                    min={0}
-                    placeholder="Mixed values"
-                    validate={(next) => multiEditMaxZBottom === null || next <= multiEditMaxZBottom}
-                    onCommit={(next) => updateFeatures(selectedZEditableFeatureIds, { z_bottom: next })}
-                  />
-                </label>
+                {hasOpenEditableFeatures && selectedClosedEditableFeatures.length === 0 ? (
+                  <label className="properties-field">
+                    <span>Z Bottom</span>
+                    <DraftNumberInput
+                      key={`multi-feature-zbottom-open-${selectedZEditableFeatureIds.join(',')}`}
+                      value={0}
+                      units={units}
+                      min={0}
+                      max={0}
+                      onCommit={() => {}}
+                    />
+                  </label>
+                ) : hasOpenEditableFeatures ? (
+                  <label className="properties-field">
+                    <span>Z Bottom</span>
+                    <DraftNumberInput
+                      key={`multi-feature-zbottom-mixed-${selectedZEditableFeatureIds.join(',')}-${commonSelectedZBottom ?? 'mixed'}`}
+                      value={commonSelectedZBottom}
+                      units={units}
+                      min={0}
+                      placeholder="Mixed values"
+                      validate={(next) => multiEditMaxZBottom === null || next <= multiEditMaxZBottom}
+                      onCommit={(next) => updateFeatures(selectedClosedEditableFeatures.map((f) => f.id), { z_bottom: next })}
+                    />
+                  </label>
+                ) : (
+                  <label className="properties-field">
+                    <span>Z Bottom</span>
+                    <DraftNumberInput
+                      key={`multi-feature-zbottom-${selectedZEditableFeatureIds.join(',')}-${commonSelectedZTop ?? 'mixed'}-${commonSelectedZBottom ?? 'mixed'}`}
+                      value={commonSelectedZBottom}
+                      units={units}
+                      min={0}
+                      placeholder="Mixed values"
+                      validate={(next) => multiEditMaxZBottom === null || next <= multiEditMaxZBottom}
+                      onCommit={(next) => updateFeatures(selectedZEditableFeatureIds, { z_bottom: next })}
+                    />
+                  </label>
+                )}
               </>
             ) : (
               <label className="properties-field">
@@ -1280,6 +1310,30 @@ export function PropertiesPanel() {
               <span className="properties-locked-hint" aria-hidden="true">🔒</span>
             </div>
           </label>
+        ) : !selectedFeature.sketch.profile.closed ? (
+          <>
+            <label className="properties-field">
+              <span>Z Top</span>
+              <DraftNumberInput
+                key={`feature-ztop-${selectedFeature.id}-${zTop}`}
+                  value={zTop}
+                  units={units}
+                  min={0}
+                  onCommit={(next) => updateFeature(selectedFeature.id, { z_top: next })}
+              />
+            </label>
+            <label className="properties-field">
+              <span>Z Bottom</span>
+              <DraftNumberInput
+                key={`feature-zbottom-open-${selectedFeature.id}`}
+                  value={0}
+                  units={units}
+                  min={0}
+                  max={0}
+                  onCommit={() => {}}
+              />
+            </label>
+          </>
         ) : (
           <>
             <label className="properties-field">

--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -22,6 +22,7 @@ import { createHeightfieldTexture, createStockPlaneGeometry, createStockBoundary
 import { createBoundaryMaterial, createDynamicBoundaryMaterial, createHeightfieldMaterial } from '../../engine/simulation/heightfieldShader'
 import { PlaybackController } from '../../engine/simulation/playback'
 import { buildToolMesh, disposeToolMesh } from '../../engine/simulation/toolMesh'
+import type { PlaybackPose } from '../../engine/simulation/playback'
 import type { SimulationGrid, SimulationResult } from '../../engine/simulation'
 import type { ToolpathMove } from '../../engine/toolpaths/types'
 import type { Clamp, MachineOrigin, Operation, ToolType } from '../../types/project'
@@ -180,6 +181,14 @@ const PLAYBACK_STEP_SIZES_IN = [0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5]
 const PLAYBACK_DEFAULT_STEP_MM = 2.5
 const PLAYBACK_DEFAULT_STEP_IN = 0.1
 const PLAYBACK_REBUILD_INTERVAL_MS = 0
+
+function formatCoord(value: number, units: 'mm' | 'in'): string {
+  if (!Number.isFinite(value)) return '\u2014'
+  if (units === 'in') {
+    return value.toFixed(3)
+  }
+  return value.toFixed(2)
+}
 
 function formatSpeedLabel(perSecond: number, units: 'mm' | 'in'): string {
   // Internally the sim advances by distance-per-second (it's what RAF multiplies
@@ -468,6 +477,10 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   const [playbackMultiplier, setPlaybackMultiplier] = useState<number>(PLAYBACK_DEFAULT_MULTIPLIER)
   const [playbackMaxStep, setPlaybackMaxStep] = useState(defaultStep)
   const [playbackProgress, setPlaybackProgress] = useState(0)
+  // Latest pose from the playback controller — written every RAF frame.
+  const latestPoseRef = useRef<PlaybackPose>({ x: 0, y: 0, z: 0, moveKind: null })
+  // Throttled state for the UI readout — updated at ~10 Hz to avoid re-render churn.
+  const [displayPose, setDisplayPose] = useState<PlaybackPose>({ x: 0, y: 0, z: 0, moveKind: null })
   const playbackControllerRef = useRef<PlaybackController | null>(null)
   const toolMeshRef = useRef<THREE.Group | null>(null)
   const playbackMaterialMeshRef = useRef<THREE.Mesh | null>(null)
@@ -714,6 +727,8 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
       return
     }
     const pose = controller.getPose()
+    // Store latest pose for UI readout — read by throttled state updater
+    latestPoseRef.current = pose
     // Toolpath (x, y, z) → world (x, z, y): the viewport treats world Y as vertical.
     tool.position.set(pose.x, pose.z, pose.y)
   }, [])
@@ -898,6 +913,48 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
       playbackFrameRef.current = 0
     }
   }, [isPlaying, playbackEnabled, rebuildPlaybackGeometry, updateToolMeshPose])
+
+  // Convert a toolpath pose to machine-relative coordinates.
+  // X and Z follow the usual origin-relative subtraction.
+  // Y is inverted because project space increases downward on screen while
+  // machine space increases upward from the chosen origin.
+  // See src/engine/gcode/utils.ts projectToMachinePoint() for the same pattern.
+  const toOriginRelative = useCallback((pose: PlaybackPose): PlaybackPose => ({
+    x: pose.x - origin.x,
+    y: origin.y - pose.y,
+    z: pose.z - origin.z,
+    moveKind: pose.moveKind,
+  }), [origin.x, origin.y, origin.z])
+
+  // Throttled pose state update: write to ref every RAF frame, flush to React
+  // state at ~10 Hz so the UI readout stays responsive without triggering a
+  // React re-render on every animation frame.
+  useEffect(() => {
+    if (!playbackEnabled) {
+      return
+    }
+
+    // Immediately reflect the initial pose (handles seek while paused).
+    const initPose = latestPoseRef.current
+    setDisplayPose(toOriginRelative(initPose))
+
+    const interval = setInterval(() => {
+      const pose = latestPoseRef.current
+      setDisplayPose(toOriginRelative(pose))
+    }, 100)
+
+    return () => clearInterval(interval)
+  }, [playbackEnabled, toOriginRelative])
+
+  // Also sync the display pose when seeking/stopping (playbackProgress changes
+  // while playback may not be playing).
+  useEffect(() => {
+    if (!playbackEnabled) {
+      return
+    }
+    const pose = latestPoseRef.current
+    setDisplayPose(toOriginRelative(pose))
+  }, [playbackEnabled, playbackProgress, toOriginRelative])
 
   useEffect(() => {
     if (playbackEnabled && (mode !== 'selected' || !playbackInput)) {
@@ -1227,6 +1284,18 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
               ))}
             </select>
           </label>
+          <div className="simulation-playback-bar__xyz">
+            <span className="simulation-playback-bar__xyz-label">X</span>
+            <span className="simulation-playback-bar__xyz-value">{formatCoord(displayPose.x, playbackUnits)}</span>
+            <span className="simulation-playback-bar__xyz-label">Y</span>
+            <span className="simulation-playback-bar__xyz-value">{formatCoord(displayPose.y, playbackUnits)}</span>
+            <span className="simulation-playback-bar__xyz-label">Z</span>
+            <span className="simulation-playback-bar__xyz-value">{formatCoord(displayPose.z, playbackUnits)}</span>
+            <span
+              className={`simulation-playback-bar__move-kind simulation-playback-bar__move-kind--${displayPose.moveKind ?? 'none'}`}
+              title={displayPose.moveKind ?? 'Idle'}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -893,6 +893,11 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
           objectsRef.current.push(featureMesh)
         }
 
+        for (const openLine of nextSceneObjects.openFeatureLines.values()) {
+          scene.add(openLine)
+          objectsRef.current.push(openLine)
+        }
+
         for (const tabMesh of nextSceneObjects.tabMeshes.values()) {
           scene.add(tabMesh)
           objectsRef.current.push(tabMesh)

--- a/src/engine/csg.ts
+++ b/src/engine/csg.ts
@@ -18,9 +18,12 @@ import * as THREE from 'three'
 import ManifoldModule, { type Manifold as ManifoldSolid, type ManifoldToplevel } from 'manifold-3d'
 import { bezierPoint, rectProfile } from '../types/project'
 import type { Clamp, DimensionRef, MachineOrigin, Project, SketchFeature, SketchProfile, Segment, Stock, Tab } from '../types/project'
-import { expandFeatureGeometry } from '../text'
+import { expandFeatureGeometry, getFeatureGeometryProfiles } from '../text'
 import { loadPersistedBufferGeometry, loadPersistedTriangleMesh } from './importedMesh'
 import type { MeshSliceIndex } from './toolpaths/meshSlicing'
+import { Line2 } from 'three/examples/jsm/lines/Line2.js'
+import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js'
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 
 const ARC_STEP_RADIANS = Math.PI / 18
 
@@ -819,6 +822,53 @@ export function buildStockWireframe(stock: Stock): THREE.LineSegments {
   return lines
 }
 
+// ── Open feature (polyline) line builder ────────────────────────────
+
+export function buildOpenFeatureLine(
+  project: Project,
+  feature: SketchFeature,
+  selected = false,
+  hovered = false,
+): Line2 {
+  const profile = feature.sketch.profile
+  const zTop = resolveDimension(feature.z_top, project)
+
+  // Subdivide the profile into polyline points (handles arcs, beziers)
+  const polygon = profileToPolygon(profile)
+
+  // Build positions in world space, applying the same transform pipeline as other geometry:
+  //   rotateX(-PI/2): (x, y, 0) → (x, 0, -y)
+  //   translate(0, zTop, 0): (x, 0, -y) → (x, zTop, -y)
+  //   scale.z = -1 (Object3D): (x, zTop, -y) → (x, zTop, y)
+  // Since Line2 bakes transforms into geometry, we produce the final world position directly.
+  const positions: number[] = []
+  for (const [px, py] of polygon) {
+    positions.push(px, zTop, py)
+  }
+
+  const geometry = new LineGeometry()
+  geometry.setPositions(positions)
+
+  const color =
+    selected ? 0xffaa00
+    : hovered ? 0x44aaff
+    : feature.operation === 'subtract' ? 0x3366cc
+    : 0x33aa66
+
+  // Use LineMaterial with screen-pixel linewidth for consistent visibility
+  const material = new LineMaterial({
+    color,
+    linewidth: 4,
+    worldUnits: false,
+    resolution: new THREE.Vector2(window.innerWidth, window.innerHeight),
+  })
+
+  const line = new Line2(geometry, material)
+  line.computeLineDistances()
+
+  return line
+}
+
 // ── Full scene builder ───────────────────────────────────────────────────────
 
 export interface SceneObjects {
@@ -826,6 +876,7 @@ export interface SceneObjects {
   stockWireframe: THREE.LineSegments
   modelMesh: THREE.Mesh | null
   featureMeshes: Map<string, THREE.Mesh>
+  openFeatureLines: Map<string, THREE.Object3D>
   tabMeshes: Map<string, THREE.Mesh>
   clampMeshes: Map<string, THREE.Mesh>
 }
@@ -843,6 +894,7 @@ export async function buildScene(
   const stockMesh = buildStockMesh(project.stock)
   const stockWireframe = buildStockWireframe(project.stock)
   const featureMeshes = new Map<string, THREE.Mesh>()
+  const openFeatureLines = new Map<string, THREE.Object3D>()
   const tabMeshes = new Map<string, THREE.Mesh>()
   const clampMeshes = new Map<string, THREE.Mesh>()
   let modelMesh: THREE.Mesh | null = null
@@ -862,13 +914,25 @@ export async function buildScene(
         featureMeshes.set(feature.id, buildFeatureMesh(project, feature, false, false, project.stock.thickness))
       }
       
-      // If buildBooleanModel failed, we need the rest of the meshes too
+      // If buildBooleanModel failed, we need the rest of the meshes too.
+      // Open features (polylines) are skipped — they're rendered as lines via buildOpenFeatureLine.
       if (!modelMesh) {
         for (const expanded of expandFeatureGeometry(feature)) {
           if (expanded.kind !== 'stl' && expanded.operation !== 'region') {
+            if (!expanded.sketch.profile.closed) continue
             featureMeshes.set(expanded.id, buildFeatureMesh(project, expanded, false, false, project.stock.thickness))
           }
         }
+      }
+    }
+
+    // Build line representations for open features (polylines, skeleton text, etc.)
+    // These are excluded from the boolean model but should appear as flat lines at z_top.
+    for (const feature of visibleFeatures) {
+      // Check all geometry profiles (text features may have multiple)
+      const profiles = getFeatureGeometryProfiles(feature)
+      if (profiles.some((p) => !p.closed)) {
+        openFeatureLines.set(feature.id, buildOpenFeatureLine(project, feature))
       }
     }
   }
@@ -889,5 +953,5 @@ export async function buildScene(
     )
   }
 
-  return { stockMesh, stockWireframe, modelMesh, featureMeshes, tabMeshes, clampMeshes }
+  return { stockMesh, stockWireframe, modelMesh, featureMeshes, openFeatureLines, tabMeshes, clampMeshes }
 }

--- a/src/store/helpers/clipping.ts
+++ b/src/store/helpers/clipping.ts
@@ -24,6 +24,7 @@ import {
 } from '../../engine/toolpaths/geometry'
 import { bezierPoint, getProfileBounds, polygonProfile } from '../../types/project'
 import type { Point, Segment, SketchFeature, SketchProfile } from '../../types/project'
+import { openCrossesClosedFully } from './polygonSplit'
 
 export interface KnownCircle {
   center: Point
@@ -44,6 +45,16 @@ export function getClipperChildren(node: ClipperPolyNode): ClipperPolyNode[] {
 export function flattenFeatureToClipperPath(feature: SketchFeature, scale = DEFAULT_CLIPPER_SCALE) {
   const flattened = flattenProfile(feature.sketch.profile)
   return toClipperPath(normalizeWinding(flattened.points, false), scale)
+}
+
+// Convert an open profile to a Clipper path without auto-closing. Used
+// when feeding an open polyline to Clipper as an open subject.
+export function flattenOpenFeatureToClipperPath(feature: SketchFeature, scale = DEFAULT_CLIPPER_SCALE) {
+  const flattened = flattenProfile(feature.sketch.profile)
+  return flattened.points.map((p) => ({
+    X: Math.round(p.x * scale),
+    Y: Math.round(p.y * scale),
+  }))
 }
 
 export function executeClipPaths(
@@ -124,6 +135,59 @@ export function featuresOverlap(a: SketchFeature, b: SketchFeature): boolean {
   )
 
   return intersections.length > 0
+}
+
+// Overlap test used to validate cut-mode target selection. Unlike
+// `featuresOverlap`, this accepts open profiles on either side and uses
+// the appropriate semantics:
+//   - closed target × closed cutter: any area intersection
+//   - closed target × open cutter:   open cutter must fully cross target
+//   - open target × closed cutter:   any intersection (partial OK)
+//   - open target × open cutter:     not allowed (returns false)
+export function featuresOverlapForCut(target: SketchFeature, cutter: SketchFeature): boolean {
+  const tClosed = target.sketch.profile.closed
+  const cClosed = cutter.sketch.profile.closed
+
+  const boundsA = getProfileBounds(target.sketch.profile)
+  const boundsB = getProfileBounds(cutter.sketch.profile)
+  if (
+    !rangesOverlap(boundsA.minX, boundsA.maxX, boundsB.minX, boundsB.maxX)
+    || !rangesOverlap(boundsA.minY, boundsA.maxY, boundsB.minY, boundsB.maxY)
+  ) {
+    return false
+  }
+
+  if (tClosed && cClosed) {
+    const intersections = executeClipPaths(
+      [flattenFeatureToClipperPath(target)],
+      [flattenFeatureToClipperPath(cutter)],
+      0,
+    )
+    return intersections.length > 0
+  }
+
+  if (tClosed && !cClosed) {
+    return openCrossesClosedFully(cutter.sketch.profile, target.sketch.profile)
+  }
+
+  if (!tClosed && cClosed) {
+    // Trim semantics: any portion of the open target inside the closed cutter
+    // gets removed. Detect by clipping the open path as a Clipper subject.
+    const clipper = new ClipperLib.Clipper()
+    ;(clipper as any).AddPath(flattenOpenFeatureToClipperPath(target), ClipperLib.PolyType.ptSubject, false)
+    ;(clipper as any).AddPath(flattenFeatureToClipperPath(cutter), ClipperLib.PolyType.ptClip, true)
+    const polyTree = new ClipperLib.PolyTree()
+    clipper.Execute(
+      ClipperLib.ClipType.ctIntersection,
+      polyTree,
+      ClipperLib.PolyFillType.pftNonZero,
+      ClipperLib.PolyFillType.pftNonZero,
+    )
+    const openPaths = (ClipperLib.Clipper as any).OpenPathsFromPolyTree(polyTree)
+    return openPaths && openPaths.length > 0
+  }
+
+  return false
 }
 
 export function featuresFormConnectedOverlapGroup(features: SketchFeature[]): boolean {
@@ -270,7 +334,11 @@ function arcIsClockwise(center: Point, from: Point, to: Point): boolean {
   return ax * by - ay * bx < 0
 }
 
-function reconstructArcsInProfile(vertices: Point[], knownCircles: KnownCircle[]): SketchProfile {
+export function reconstructArcsInProfile(
+  vertices: Point[],
+  knownCircles: KnownCircle[],
+  maxSingleArcAngle?: number,
+): SketchProfile {
   const n = vertices.length
   const circleIndex = vertices.map((v) => findMatchingCircle(v, knownCircles))
 
@@ -282,6 +350,16 @@ function reconstructArcsInProfile(vertices: Point[], knownCircles: KnownCircle[]
     const ci = circleIndex[i]
     if (ci >= 0 && ci === circleIndex[nextIdx]) {
       const circle = knownCircles[ci]
+      if (maxSingleArcAngle !== undefined) {
+        const a1 = Math.atan2(vertices[i].y - circle.center.y, vertices[i].x - circle.center.x)
+        const a2 = Math.atan2(vertices[nextIdx].y - circle.center.y, vertices[nextIdx].x - circle.center.x)
+        let span = Math.abs(a2 - a1)
+        if (span > Math.PI) span = 2 * Math.PI - span
+        if (span > maxSingleArcAngle) {
+          segments.push({ type: 'line', to: vertices[nextIdx] })
+          continue
+        }
+      }
       const clockwise = arcIsClockwise(circle.center, vertices[i], vertices[nextIdx])
       segments.push({
         type: 'arc',
@@ -584,8 +662,12 @@ export function clipperContourToProfilePreserving(
     const run = runs[r]
 
     if (run.annotation === null) {
-      // Intersection point → emit line
-      segments.push({ type: 'line', to: vertices[run.startIdx % n] })
+      // Intersection point → emit line (skip if it would be zero-length)
+      const target = vertices[run.startIdx % n]
+      const prev = segments.length > 0 ? segments[segments.length - 1].to : startVertex
+      if (Math.abs(target.x - prev.x) > 1e-9 || Math.abs(target.y - prev.y) > 1e-9) {
+        segments.push({ type: 'line', to: target })
+      }
       continue
     }
 
@@ -607,18 +689,40 @@ export function clipperContourToProfilePreserving(
     const isComplete = (firstSample === 0 || firstSample === 1) && lastSample === totalSamples && runLen >= totalSamples
 
     if (seg.type === 'line') {
-      segments.push({ type: 'line', to: runEndPoint })
+      const prev = segments.length > 0 ? segments[segments.length - 1].to : startVertex
+      if (Math.abs(runEndPoint.x - prev.x) > 1e-9 || Math.abs(runEndPoint.y - prev.y) > 1e-9) {
+        segments.push({ type: 'line', to: runEndPoint })
+      }
     } else if (seg.type === 'arc' || seg.type === 'circle') {
       const center = seg.center
-      // Determine clockwise from actual vertex traversal direction (normalizeWinding may have reversed)
       const prevEnd = r > 0 ? vertices[runs[r - 1].endIdx % n] : startVertex
-      const clockwise = run.endIdx > run.startIdx
-        ? arcIsClockwise(center, vertices[run.startIdx % n], vertices[(run.startIdx + 1) % n])
-        : arcIsClockwise(center, prevEnd, vertices[run.startIdx % n])
-      if (isComplete && seg.type === 'circle') {
-        segments.push({ type: 'circle', to: runEndPoint, center: { x: center.x, y: center.y }, clockwise })
+      const arcStart = vertices[run.startIdx % n]
+      const originalRadius = Math.hypot(segStart.x - center.x, segStart.y - center.y)
+      const rStart = Math.hypot(arcStart.x - center.x, arcStart.y - center.y)
+      const rEnd = Math.hypot(runEndPoint.x - center.x, runEndPoint.y - center.y)
+      const radiusTolerance = Math.max(originalRadius * 0.02, 0.005)
+      const arcValid = Math.abs(rStart - originalRadius) <= radiusTolerance
+        && Math.abs(rEnd - originalRadius) <= radiusTolerance
+
+      if (!arcValid) {
+        // Arc endpoints are not on the claimed circle — emit line segments
+        for (let k = run.startIdx; k <= run.endIdx; k++) {
+          segments.push({ type: 'line', to: vertices[k % n] })
+        }
       } else {
-        segments.push({ type: 'arc', to: runEndPoint, center: { x: center.x, y: center.y }, clockwise })
+        // Bridge any gap between previous segment end and arc start
+        if (Math.abs(arcStart.x - prevEnd.x) > 1e-6 || Math.abs(arcStart.y - prevEnd.y) > 1e-6) {
+          segments.push({ type: 'line', to: arcStart })
+        }
+        // Determine clockwise from actual vertex traversal direction (normalizeWinding may have reversed)
+        const clockwise = run.endIdx > run.startIdx
+          ? arcIsClockwise(center, vertices[run.startIdx % n], vertices[(run.startIdx + 1) % n])
+          : arcIsClockwise(center, prevEnd, vertices[run.startIdx % n])
+        if (isComplete && seg.type === 'circle') {
+          segments.push({ type: 'circle', to: runEndPoint, center: { x: center.x, y: center.y }, clockwise })
+        } else {
+          segments.push({ type: 'arc', to: runEndPoint, center: { x: center.x, y: center.y }, clockwise })
+        }
       }
     } else if (seg.type === 'bezier') {
       const reversed = firstSample > lastSample

--- a/src/store/helpers/derivedFeatures.ts
+++ b/src/store/helpers/derivedFeatures.ts
@@ -14,27 +14,34 @@
  * limitations under the License.
  */
 
-import { DEFAULT_CLIPPER_SCALE } from '../../engine/toolpaths/geometry'
+import ClipperLib from 'clipper-lib'
+import { DEFAULT_CLIPPER_SCALE, fromClipperPath } from '../../engine/toolpaths/geometry'
 import { uniqueName } from '../../import'
 import type {
   FeatureOperation,
   FeatureTreeEntry,
+  Point,
   Project,
   SketchFeature,
   SketchProfile,
 } from '../../types/project'
+import { polygonProfile } from '../../types/project'
 import {
   buildSegmentAnnotations,
   clipperContourToProfile,
   clipperContourToProfilePreserving,
+  collectKnownCircles,
   executeClipTree,
   flattenFeatureToClipperPath,
+  flattenOpenFeatureToClipperPath,
   getClipperChildren,
   offsetClipperPaths,
+  reconstructArcsInProfile,
   type ClipperPolyNode,
   type SegmentAnnotation,
   unionClipperPaths,
 } from './clipping'
+import { splitClosedByOpen } from './polygonSplit'
 
 export interface DerivedFeatureGroup {
   sourceId: string
@@ -104,32 +111,181 @@ function collectDerivedFeaturesFromPolyTree(
   return created
 }
 
+// Split a single closed feature with an open cutter. Returns the resulting
+// pieces as new features. Returns [] if the cutter does not fully cross
+// the target (no-op).
+function splitClosedFeatureByOpenCutter(
+  project: Project,
+  target: SketchFeature,
+  openCutter: SketchFeature,
+  baseName: string,
+  createDerivedFeature: DerivedFeatureFactory,
+): SketchFeature[] {
+  const result = splitClosedByOpen(target.sketch.profile, openCutter.sketch.profile)
+  if (!result || result.pieces.length < 2) return []
+
+  const knownCircles = collectKnownCircles([target, openCutter])
+  const created: SketchFeature[] = []
+  for (const piece of result.pieces) {
+    const profile = knownCircles.length > 0
+      ? reconstructArcsInProfile(piece, knownCircles, Math.PI / 4)
+      : polygonProfile(piece)
+    const name = uniqueName(baseName, [
+      ...project.features.map((f) => f.name),
+      ...created.map((f) => f.name),
+    ])
+    created.push(createDerivedFeature(
+      { ...project, features: [...project.features, ...created] },
+      target,
+      profile,
+      target.operation,
+      name,
+    ))
+  }
+  return created
+}
+
+// Trim an open target by closed cutters. Uses Clipper's native open-path
+// clipping: each closed cutter is added as a closed clip and the open
+// target as an open subject, with boolean difference. Result is one or
+// more open polylines representing the parts of the target outside all
+// cutters.
+function trimOpenTargetByClosedCutters(
+  project: Project,
+  target: SketchFeature,
+  closedClipPaths: ReturnType<typeof flattenFeatureToClipperPath>[],
+  baseName: string,
+  createDerivedFeature: DerivedFeatureFactory,
+): SketchFeature[] {
+  if (closedClipPaths.length === 0) return []
+  const targetPath = flattenOpenFeatureToClipperPath(target, DEFAULT_CLIPPER_SCALE)
+  const clipper = new ClipperLib.Clipper()
+  // Open subject path.
+  ;(clipper as any).AddPath(targetPath, ClipperLib.PolyType.ptSubject, false)
+  for (const clip of closedClipPaths) {
+    ;(clipper as any).AddPath(clip, ClipperLib.PolyType.ptClip, true)
+  }
+  const polyTree = new ClipperLib.PolyTree()
+  clipper.Execute(
+    ClipperLib.ClipType.ctDifference,
+    polyTree,
+    ClipperLib.PolyFillType.pftNonZero,
+    ClipperLib.PolyFillType.pftNonZero,
+  )
+  const openPaths: Point[][] = []
+  const openPathsRaw = (ClipperLib.Clipper as any).OpenPathsFromPolyTree(polyTree)
+  for (const path of openPathsRaw) {
+    if (!path || path.length < 2) continue
+    openPaths.push(fromClipperPath(path, DEFAULT_CLIPPER_SCALE))
+  }
+
+  if (openPaths.length === 0) return []
+
+  const created: SketchFeature[] = []
+  for (const points of openPaths) {
+    if (points.length < 2) continue
+    const profile: SketchProfile = {
+      start: points[0],
+      segments: points.slice(1).map((p) => ({ type: 'line' as const, to: p })),
+      closed: false,
+    }
+    const name = uniqueName(baseName, [
+      ...project.features.map((f) => f.name),
+      ...created.map((f) => f.name),
+    ])
+    created.push(createDerivedFeature(
+      { ...project, features: [...project.features, ...created] },
+      target,
+      profile,
+      target.operation,
+      name,
+    ))
+  }
+  return created
+}
+
 export function cutFeaturesByCutterGrouped(
   project: Project,
   cutters: SketchFeature[],
   targets: SketchFeature[],
   createDerivedFeature: DerivedFeatureFactory,
 ): DerivedFeatureGroup[] {
-  const clipPaths = cutters.map((cutter) => flattenFeatureToClipperPath(cutter))
+  const closedCutters = cutters.filter((c) => c.sketch.profile.closed)
+  const openCutters = cutters.filter((c) => !c.sketch.profile.closed)
+  const closedClipPaths = closedCutters.map((cutter) => flattenFeatureToClipperPath(cutter))
   const existingNames = [...project.features.map((feature) => feature.name)]
   const groups: DerivedFeatureGroup[] = []
 
   for (const target of targets) {
+    const isOpenTarget = !target.sketch.profile.closed
     const sourceFeatures = [...cutters, target]
     const segAnnotations = buildSegmentAnnotations(sourceFeatures)
-    const subjectPaths = [flattenFeatureToClipperPath(target)]
-    const polyTree = executeClipTree(subjectPaths, clipPaths, 2)
     const cutNameStem = normalizeDerivedFeatureNameStem(target.name)
-    const nextFeatures = collectDerivedFeaturesFromPolyTree(
-      project,
-      polyTree,
-      target,
-      target.operation,
-      `${cutNameStem} Cut`,
-      createDerivedFeature,
-      sourceFeatures,
-      segAnnotations,
-    )
+    const baseName = `${cutNameStem} Cut`
+
+    let nextFeatures: SketchFeature[] = []
+    if (isOpenTarget) {
+      // Open targets can only be trimmed by closed cutters (Clipper requirement
+      // and geometrically meaningful only this way).
+      if (closedCutters.length > 0) {
+        nextFeatures = trimOpenTargetByClosedCutters(
+          project,
+          target,
+          closedClipPaths,
+          baseName,
+          createDerivedFeature,
+        )
+      }
+    } else {
+      // Closed target. Start with the standard boolean difference for closed cutters,
+      // then iteratively split the resulting pieces with each open cutter.
+      let workingPieces: SketchFeature[]
+      if (closedClipPaths.length > 0) {
+        const subjectPaths = [flattenFeatureToClipperPath(target)]
+        const polyTree = executeClipTree(subjectPaths, closedClipPaths, 2)
+        workingPieces = collectDerivedFeaturesFromPolyTree(
+          project,
+          polyTree,
+          target,
+          target.operation,
+          baseName,
+          createDerivedFeature,
+          sourceFeatures,
+          segAnnotations,
+        )
+      } else {
+        workingPieces = [target]
+      }
+
+      for (const openCutter of openCutters) {
+        const splitPieces: SketchFeature[] = []
+        const pieceProject = { ...project, features: [...project.features, ...splitPieces] }
+        for (const piece of workingPieces) {
+          const result = splitClosedFeatureByOpenCutter(
+            pieceProject,
+            piece,
+            openCutter,
+            baseName,
+            createDerivedFeature,
+          )
+          if (result.length > 0) {
+            splitPieces.push(...result)
+          } else {
+            // No valid split (open cutter doesn't fully cross this piece). Keep piece.
+            splitPieces.push(piece)
+          }
+        }
+        workingPieces = splitPieces
+      }
+
+      // If workingPieces is the original target (no cutters applied or all failed),
+      // emit nothing — the caller treats empty groups as no-op.
+      if (workingPieces.length === 1 && workingPieces[0].id === target.id) {
+        nextFeatures = []
+      } else {
+        nextFeatures = workingPieces
+      }
+    }
 
     const groupedFeatures: SketchFeature[] = []
     for (const feature of nextFeatures) {

--- a/src/store/helpers/polygonSplit.ts
+++ b/src/store/helpers/polygonSplit.ts
@@ -1,0 +1,542 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+import type { Point, SketchProfile } from '../../types/project'
+import { flattenProfile } from '../../engine/toolpaths/geometry'
+
+// =====================================================================
+// Split a closed polygon by an open polyline.
+//
+// Approach: build a planar graph whose nodes are the intersections of
+// the polyline with the polygon boundary. Each node has three useful
+// outgoing half-edges:
+//   - along P going CCW to the next intersection (the "P-CCW" half-edge)
+//   - along P going CW to the previous intersection (the "P-CW" half-edge)
+//   - along L going INTO the polygon to the partner intersection
+//     (the "chord" half-edge). At entry intersections this is the
+//     forward-L direction; at exit intersections it is the reverse-L
+//     direction.
+//
+// CCW-face walking rule: when arriving at a node along a half-edge with
+// incoming direction d_in, the next outgoing half-edge is the one whose
+// outgoing direction makes the smallest CCW turn from the *reverse* of
+// d_in (i.e. immediately after -d_in in CCW order). This walks each
+// face with its interior on the left.
+//
+// Each directed half-edge is used by exactly one face cycle. The "outer
+// face" cycle (the one that traces the original polygon CCW boundary
+// using only P half-edges) is discarded. All others are pieces.
+//
+// Endpoints of the polyline must lie outside the polygon (validated by
+// the caller via `openProfileFullyCrossesClosed`).
+// =====================================================================
+
+const EPSILON = 1e-9
+
+interface Crossing {
+  point: Point
+  // global parameter along P (= pSegIdx + tOnP), monotonic CCW around P
+  tP: number
+  // global parameter along L (= lSegIdx + tOnL), monotonic along L
+  tL: number
+  // even index in the L-ordered list means "entry" (L going from outside
+  // to inside at this crossing); odd index means "exit"
+  isEntry: boolean
+  // index of the paired crossing (entry ↔ exit through the polygon interior)
+  partner: number
+  // outgoing direction along P CCW (toward the next crossing in P-order)
+  dP_CCW: Point
+  // outgoing direction along P CW (toward the previous crossing in P-order)
+  dP_CW: Point
+  // outgoing direction along L into the polygon (toward the partner crossing)
+  dChord: Point
+}
+
+function sub(a: Point, b: Point): Point {
+  return { x: a.x - b.x, y: a.y - b.y }
+}
+
+function len(v: Point): number {
+  return Math.hypot(v.x, v.y)
+}
+
+function normalize(v: Point): Point {
+  const m = len(v)
+  if (m < EPSILON) return { x: 0, y: 0 }
+  return { x: v.x / m, y: v.y / m }
+}
+
+// angle in [0, 2π) for a unit vector
+function angleOf(v: Point): number {
+  const a = Math.atan2(v.y, v.x)
+  return a < 0 ? a + 2 * Math.PI : a
+}
+
+// CCW signed distance from angle a to angle b in [0, 2π).
+function ccwDelta(a: number, b: number): number {
+  let d = b - a
+  while (d <= EPSILON) d += 2 * Math.PI
+  return d
+}
+
+// Point-in-polygon (ray cast). Returns true if strictly inside.
+function pointInPolygon(p: Point, poly: Point[]): boolean {
+  let inside = false
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i, i += 1) {
+    const a = poly[i]
+    const b = poly[j]
+    const intersects = (a.y > p.y) !== (b.y > p.y)
+      && p.x < ((b.x - a.x) * (p.y - a.y)) / ((b.y - a.y) || EPSILON) + a.x
+    if (intersects) inside = !inside
+  }
+  return inside
+}
+
+// Segment-segment intersection treating each segment as a half-open interval
+// [start, end) on both parameters. This ensures intersections at shared
+// vertices are reported by exactly one segment (the one whose start vertex
+// is the intersection), avoiding double-counting.
+function segmentIntersect(
+  a1: Point, a2: Point, b1: Point, b2: Point,
+): { t: number, u: number, point: Point } | null {
+  const r = sub(a2, a1)
+  const s = sub(b2, b1)
+  const denom = r.x * s.y - r.y * s.x
+  if (Math.abs(denom) < EPSILON) return null // parallel or collinear
+  const qp = sub(b1, a1)
+  const t = (qp.x * s.y - qp.y * s.x) / denom
+  const u = (qp.x * r.y - qp.y * r.x) / denom
+  // Half-open intervals: include start (0), exclude end (1).
+  if (t < -EPSILON || t >= 1 - EPSILON) return null
+  if (u < -EPSILON || u >= 1 - EPSILON) return null
+  return {
+    t: Math.max(0, t),
+    u: Math.max(0, u),
+    point: { x: a1.x + t * r.x, y: a1.y + t * r.y },
+  }
+}
+
+// Returns the flattened points of a profile. For a closed profile the
+// last point is dropped (so points are unique vertices in order) and the
+// winding is normalized to CCW — the split algorithm assumes CCW polygons.
+function flattenToVertices(profile: SketchProfile): { points: Point[], closed: boolean } {
+  const flat = flattenProfile(profile)
+  if (!flat.closed) {
+    return { points: flat.points, closed: false }
+  }
+  const points = flat.points.slice()
+  if (points.length > 1) {
+    const first = points[0]
+    const last = points[points.length - 1]
+    if (Math.abs(first.x - last.x) < EPSILON && Math.abs(first.y - last.y) < EPSILON) {
+      points.pop()
+    }
+  }
+  // Ensure CCW orientation (positive signed area).
+  let area = 0
+  for (let i = 0; i < points.length; i += 1) {
+    const a = points[i]
+    const b = points[(i + 1) % points.length]
+    area += a.x * b.y - b.x * a.y
+  }
+  if (area < 0) points.reverse()
+  return { points, closed: true }
+}
+
+// Compute the tangent direction along P at a parameter tP. tP is in
+// [0, n) where n = pPoints.length. Tangent direction is from pPoints[i]
+// toward pPoints[i+1 mod n], regardless of where within the segment we are.
+function tangentAlongP(pPoints: Point[], tP: number): Point {
+  const i = Math.floor(tP) % pPoints.length
+  const next = (i + 1) % pPoints.length
+  return normalize(sub(pPoints[next], pPoints[i]))
+}
+
+function tangentAlongL(lPoints: Point[], tL: number): Point {
+  // tL in [0, m-1) where m = lPoints.length
+  let i = Math.floor(tL)
+  if (i >= lPoints.length - 1) i = lPoints.length - 2
+  return normalize(sub(lPoints[i + 1], lPoints[i]))
+}
+
+// True if the flattened polyline L starts outside the closed flattened
+// polygon P, ends outside, and crosses the boundary an even number of times.
+export function openCrossesClosedFully(openProfile: SketchProfile, closedProfile: SketchProfile): boolean {
+  if (openProfile.closed || !closedProfile.closed) return false
+  const L = flattenToVertices(openProfile).points
+  const P = flattenToVertices(closedProfile).points
+  if (L.length < 2 || P.length < 3) return false
+
+  if (pointInPolygon(L[0], P)) return false
+  if (pointInPolygon(L[L.length - 1], P)) return false
+
+  let count = 0
+  for (let i = 0; i < L.length - 1; i += 1) {
+    for (let j = 0; j < P.length; j += 1) {
+      const hit = segmentIntersect(L[i], L[i + 1], P[j], P[(j + 1) % P.length])
+      if (hit !== null) count += 1
+    }
+  }
+  return count >= 2 && count % 2 === 0
+}
+
+// Walk a P-arc from intersection at tP_start CCW around P until tP_end.
+// Returns the interior P vertices traversed (not including the endpoints).
+function pArcInteriorVertices(pPoints: Point[], tP_start: number, tP_end: number): Point[] {
+  const n = pPoints.length
+  const out: Point[] = []
+  // Move CCW (increasing tP), wrapping at n. First vertex index to include is
+  // the next integer strictly greater than tP_start (mod n).
+  const startIdx = (Math.floor(tP_start) + 1) % n
+  let idx = startIdx
+  // End when idx would be at or past tP_end (handling wrap).
+  // We add at most n vertices to avoid infinite loops.
+  for (let safety = 0; safety < n; safety += 1) {
+    // The "logical" position of vertex idx going CCW from tP_start.
+    let logical = idx - tP_start
+    if (logical <= 0) logical += n
+    const targetLogical = ((tP_end - tP_start) % n + n) % n
+    if (logical >= targetLogical - EPSILON) break
+    out.push(pPoints[idx])
+    idx = (idx + 1) % n
+  }
+  return out
+}
+
+// Walk an L-arc from intersection at tL_start to tL_end (in +L direction
+// if tL_end > tL_start, otherwise -L direction). Returns interior L
+// vertices traversed (not endpoints).
+function lArcInteriorVertices(lPoints: Point[], tL_start: number, tL_end: number): Point[] {
+  const out: Point[] = []
+  if (tL_end > tL_start) {
+    const startIdx = Math.floor(tL_start) + 1
+    const endIdx = Math.ceil(tL_end - EPSILON)
+    for (let i = startIdx; i < endIdx; i += 1) out.push(lPoints[i])
+  } else {
+    const startIdx = Math.ceil(tL_start - EPSILON) - 1
+    const endIdx = Math.floor(tL_end) + 1
+    for (let i = startIdx; i >= endIdx; i -= 1) out.push(lPoints[i])
+  }
+  return out
+}
+
+interface SplitHalfEdge {
+  // 0 = P-CCW, 1 = P-CW, 2 = chord
+  kind: 0 | 1 | 2
+  from: number // crossing index
+  to: number // crossing index
+}
+
+function buildHalfEdges(crossings: Crossing[], pOrder: number[]): SplitHalfEdge[] {
+  const k = crossings.length
+  const halfEdges: SplitHalfEdge[] = []
+  // P-CCW and P-CW edges (between consecutive crossings in P CCW order).
+  for (let i = 0; i < k; i += 1) {
+    const from = pOrder[i]
+    const to = pOrder[(i + 1) % k]
+    halfEdges.push({ kind: 0, from, to })
+    halfEdges.push({ kind: 1, from: to, to: from })
+  }
+  // Chord edges (each partner pair contributes two half-edges).
+  const chordSeen = new Set<string>()
+  for (let i = 0; i < k; i += 1) {
+    const partner = crossings[i].partner
+    const key = i < partner ? `${i}-${partner}` : `${partner}-${i}`
+    if (chordSeen.has(key)) continue
+    chordSeen.add(key)
+    halfEdges.push({ kind: 2, from: i, to: partner })
+    halfEdges.push({ kind: 2, from: partner, to: i })
+  }
+  return halfEdges
+}
+
+// Outgoing direction at half-edge's `from` crossing.
+function outgoingDir(he: SplitHalfEdge, crossings: Crossing[]): Point {
+  const c = crossings[he.from]
+  if (he.kind === 0) return c.dP_CCW
+  if (he.kind === 1) return c.dP_CW
+  return c.dChord
+}
+
+// Incoming direction at half-edge's `to` crossing (= direction of the
+// last segment of the half-edge arriving at `to`).
+function incomingDir(he: SplitHalfEdge, crossings: Crossing[], pPoints: Point[], lPoints: Point[]): Point {
+  const cTo = crossings[he.to]
+  if (he.kind === 0) {
+    // P-CCW from `from` to `to`. Arriving at `to` going in P CCW direction.
+    // The arriving tangent is along P at parameter just below cTo.tP, i.e.
+    // tangent of segment that ends at cTo.point. That segment goes from
+    // pPoints[floor(cTo.tP)] to pPoints[ceil(cTo.tP) mod n] if cTo.tP isn't
+    // an integer. If cTo lies on segment j→j+1 then the arriving tangent
+    // direction is normalize(pPoints[j+1] - pPoints[j]) = tangent at cTo.tP
+    // going CCW.
+    return tangentAlongP(pPoints, cTo.tP)
+  }
+  if (he.kind === 1) {
+    // P-CW: arriving at `to` going CW. Tangent is -CCW tangent at cTo.tP-ε.
+    // Use the segment just before cTo.tP in CCW order, then negate.
+    const eps = 1e-12
+    const tBefore = (cTo.tP - eps + pPoints.length) % pPoints.length
+    const ccwTangent = tangentAlongP(pPoints, tBefore)
+    return { x: -ccwTangent.x, y: -ccwTangent.y }
+  }
+  // chord: arriving at `to` from `from` via L. Direction is +L if from-tL < to-tL else -L.
+  const cFrom = crossings[he.from]
+  const sign = cTo.tL > cFrom.tL ? 1 : -1
+  // The arriving tangent at cTo is the L tangent at parameter just before
+  // cTo.tL (in the direction we're moving).
+  const eps = 1e-12
+  const tBefore = sign > 0 ? cTo.tL - eps : cTo.tL + eps
+  const ccwL = tangentAlongL(lPoints, Math.max(0, Math.min(lPoints.length - 2 + 0.999, tBefore)))
+  return sign > 0 ? ccwL : { x: -ccwL.x, y: -ccwL.y }
+}
+
+// Find the next half-edge in the CCW face after arriving via `incoming`.
+// Standard DCEL rule: next-in-face(h) = the half-edge immediately CW from
+// twin(h) in the cyclic ordering of outgoing half-edges around the
+// destination. We compute this as: among outgoing half-edges at the
+// destination (excluding twin), pick the one with the smallest CCW angle
+// from its direction to the twin's direction.
+function nextHalfEdge(
+  incoming: SplitHalfEdge,
+  halfEdges: SplitHalfEdge[],
+  crossings: Crossing[],
+  pPoints: Point[],
+  lPoints: Point[],
+): SplitHalfEdge | null {
+  const arrivalDir = incomingDir(incoming, crossings, pPoints, lPoints)
+  const twinAngle = angleOf({ x: -arrivalDir.x, y: -arrivalDir.y })
+
+  const candidates = halfEdges.filter((he) => he.from === incoming.to
+    && !isTwinOf(he, incoming))
+
+  if (candidates.length === 0) return null
+
+  let best: SplitHalfEdge | null = null
+  let bestDelta = Infinity
+  for (const c of candidates) {
+    const outDir = outgoingDir(c, crossings)
+    const outAngle = angleOf(outDir)
+    const delta = ccwDelta(outAngle, twinAngle)
+    if (delta < bestDelta) {
+      bestDelta = delta
+      best = c
+    }
+  }
+  return best
+}
+
+function isTwinOf(a: SplitHalfEdge, b: SplitHalfEdge): boolean {
+  if (a.from !== b.to || a.to !== b.from) return false
+  if (a.kind === 2 && b.kind === 2) return true
+  if ((a.kind === 0 && b.kind === 1) || (a.kind === 1 && b.kind === 0)) return true
+  return false
+}
+
+function keyOf(he: SplitHalfEdge): string {
+  return `${he.kind}:${he.from}->${he.to}`
+}
+
+// Materialize the geometry of a half-edge as a sequence of points
+// (excluding the starting crossing point, including the ending crossing point).
+function materializeHalfEdge(
+  he: SplitHalfEdge,
+  crossings: Crossing[],
+  pPoints: Point[],
+  lPoints: Point[],
+): Point[] {
+  if (he.kind === 0) {
+    return [
+      ...pArcInteriorVertices(pPoints, crossings[he.from].tP, crossings[he.to].tP),
+      crossings[he.to].point,
+    ]
+  }
+  if (he.kind === 1) {
+    // CW: walk P in reverse direction from `from` to `to`. We can compute by
+    // going CCW from `to` to `from` and reversing.
+    const ccwInterior = pArcInteriorVertices(pPoints, crossings[he.to].tP, crossings[he.from].tP)
+    return [
+      ...ccwInterior.reverse(),
+      crossings[he.to].point,
+    ]
+  }
+  // chord
+  return [
+    ...lArcInteriorVertices(lPoints, crossings[he.from].tL, crossings[he.to].tL),
+    crossings[he.to].point,
+  ]
+}
+
+function signedAreaOf(points: Point[]): number {
+  let area = 0
+  for (let i = 0; i < points.length; i += 1) {
+    const a = points[i]
+    const b = points[(i + 1) % points.length]
+    area += a.x * b.y - b.x * a.y
+  }
+  return area / 2
+}
+
+export interface SplitResult {
+  pieces: Point[][] // each piece is a closed polygon as a list of vertices (no repeated last vertex)
+}
+
+export function splitClosedByOpen(
+  closedProfile: SketchProfile,
+  openProfile: SketchProfile,
+): SplitResult | null {
+  if (!closedProfile.closed || openProfile.closed) return null
+
+  const pPoints = flattenToVertices(closedProfile).points
+  const lPoints = flattenToVertices(openProfile).points
+  if (pPoints.length < 3 || lPoints.length < 2) return null
+
+  // Endpoints of L must lie outside P.
+  if (pointInPolygon(lPoints[0], pPoints)) return null
+  if (pointInPolygon(lPoints[lPoints.length - 1], pPoints)) return null
+
+  // Compute all proper crossings of L segments with P segments.
+  type RawCrossing = { point: Point, tP: number, tL: number }
+  const raw: RawCrossing[] = []
+  for (let i = 0; i < lPoints.length - 1; i += 1) {
+    const a1 = lPoints[i]
+    const a2 = lPoints[i + 1]
+    for (let j = 0; j < pPoints.length; j += 1) {
+      const b1 = pPoints[j]
+      const b2 = pPoints[(j + 1) % pPoints.length]
+      const hit = segmentIntersect(a1, a2, b1, b2)
+      if (!hit) continue
+      raw.push({ point: hit.point, tP: j + hit.u, tL: i + hit.t })
+    }
+  }
+  if (raw.length < 2 || raw.length % 2 !== 0) return null
+
+  // Pair crossings: sort by tL, then alternate entry/exit.
+  const lSorted = raw.slice().sort((a, b) => a.tL - b.tL)
+  // Validate alternation by point-in-polygon midpoint test for each
+  // (entry, exit) pair: the segment midpoint should lie inside the polygon.
+  // Catches degenerate tangent cases.
+  for (let i = 0; i < lSorted.length; i += 2) {
+    const a = lSorted[i]
+    const b = lSorted[i + 1]
+    const mid = { x: (a.point.x + b.point.x) / 2, y: (a.point.y + b.point.y) / 2 }
+    if (!pointInPolygon(mid, pPoints)) return null
+  }
+
+  // Now build Crossing entries with partner indices and directions.
+  const crossings: Crossing[] = lSorted.map((r, idx) => {
+    const partner = (idx % 2 === 0) ? idx + 1 : idx - 1
+    return {
+      point: r.point,
+      tP: r.tP,
+      tL: r.tL,
+      isEntry: (idx % 2 === 0),
+      partner,
+      // tangents filled in after sorting by P
+      dP_CCW: { x: 0, y: 0 },
+      dP_CW: { x: 0, y: 0 },
+      dChord: { x: 0, y: 0 },
+    }
+  })
+
+  // Compute outgoing tangents.
+  for (const c of crossings) {
+    const ccw = tangentAlongP(pPoints, c.tP)
+    c.dP_CCW = ccw
+    c.dP_CW = { x: -ccw.x, y: -ccw.y }
+    const lDir = tangentAlongL(lPoints, c.tL)
+    // chord goes into polygon: at entry, +L; at exit, -L.
+    c.dChord = c.isEntry ? lDir : { x: -lDir.x, y: -lDir.y }
+  }
+
+  // Order crossings around P CCW (by tP).
+  const pOrder = crossings
+    .map((_, idx) => idx)
+    .sort((a, b) => crossings[a].tP - crossings[b].tP)
+
+  // Build half-edges.
+  const halfEdges = buildHalfEdges(crossings, pOrder)
+
+  // Face walking.
+  const used = new Set<string>()
+  const faces: SplitHalfEdge[][] = []
+  for (const start of halfEdges) {
+    if (used.has(keyOf(start))) continue
+    const cycle: SplitHalfEdge[] = []
+    let current: SplitHalfEdge | null = start
+    let safety = 0
+    while (current && safety < halfEdges.length + 2) {
+      const k = keyOf(current)
+      if (used.has(k)) break
+      used.add(k)
+      cycle.push(current)
+      const next = nextHalfEdge(current, halfEdges, crossings, pPoints, lPoints)
+      if (!next) break
+      if (keyOf(next) === keyOf(start)) {
+        break
+      }
+      current = next
+      safety += 1
+    }
+    if (cycle.length > 0) faces.push(cycle)
+  }
+
+  // Materialize each face as a polygon. The outer face has negative signed
+  // area (it wraps the polygon clockwise) and is discarded.
+  const pieces: Point[][] = []
+  for (const face of faces) {
+    if (face.length < 2) continue
+    const verts: Point[] = [crossings[face[0].from].point]
+    for (const he of face) {
+      const mat = materializeHalfEdge(he, crossings, pPoints, lPoints)
+      verts.push(...mat)
+    }
+    // Remove repeated last vertex (it equals the start by construction).
+    if (verts.length > 1) {
+      const first = verts[0]
+      const last = verts[verts.length - 1]
+      if (Math.abs(first.x - last.x) < EPSILON && Math.abs(first.y - last.y) < EPSILON) {
+        verts.pop()
+      }
+    }
+    // Drop coincident neighbors and collinear interior vertices. Collinear
+    // vertices (e.g. when a chord passes through interior polyline vertices
+    // that lie on the chord line) create zero-width folds that confuse
+    // downstream boolean operations.
+    let cleaned: Point[] = []
+    for (const p of verts) {
+      const prev = cleaned[cleaned.length - 1]
+      if (!prev || Math.abs(prev.x - p.x) > EPSILON || Math.abs(prev.y - p.y) > EPSILON) {
+        cleaned.push(p)
+      }
+    }
+    // Repeatedly strip collinear vertices (a, b, c) where b lies on segment a→c.
+    let changed = true
+    while (changed && cleaned.length >= 3) {
+      changed = false
+      const next: Point[] = []
+      for (let i = 0; i < cleaned.length; i += 1) {
+        const a = cleaned[(i - 1 + cleaned.length) % cleaned.length]
+        const b = cleaned[i]
+        const c = cleaned[(i + 1) % cleaned.length]
+        const cross = (b.x - a.x) * (c.y - b.y) - (b.y - a.y) * (c.x - b.x)
+        if (Math.abs(cross) < EPSILON) {
+          changed = true
+          continue
+        }
+        next.push(b)
+      }
+      cleaned = next
+    }
+    if (cleaned.length < 3) continue
+    if (signedAreaOf(cleaned) <= EPSILON) continue // outer face or degenerate
+    pieces.push(cleaned)
+  }
+
+  if (pieces.length === 0) return null
+  return { pieces }
+}

--- a/src/store/polygonSplit.test.ts
+++ b/src/store/polygonSplit.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Test the polygon-split-by-polyline algorithm.
+ *
+ * Run with: npx tsx src/store/polygonSplit.test.ts
+ */
+
+import { polygonProfile, type Point, type SketchProfile } from '../types/project'
+import { splitClosedByOpen, openCrossesClosedFully } from './helpers/polygonSplit'
+
+function openPolyline(points: Point[]): SketchProfile {
+  return {
+    start: points[0],
+    segments: points.slice(1).map((p) => ({ type: 'line' as const, to: p })),
+    closed: false,
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error('FAIL: ' + msg)
+}
+
+// Test 1: simple horizontal line through square
+function test1() {
+  const square = polygonProfile([
+    { x: 0, y: 0 }, { x: 4, y: 0 }, { x: 4, y: 3 }, { x: 0, y: 3 },
+  ])
+  const line = openPolyline([{ x: -1, y: 1.5 }, { x: 5, y: 1.5 }])
+
+  assert(openCrossesClosedFully(line, square), 'horizontal line crosses square')
+
+  const result = splitClosedByOpen(square, line)
+  assert(result !== null, 'result is non-null')
+  assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
+  console.log('test1 PASS: 2 pieces')
+  console.log('  piece 0:', result!.pieces[0].length, 'vertices')
+  console.log('  piece 1:', result!.pieces[1].length, 'vertices')
+}
+
+// Test 2: diagonal polyline through 64-gon circle (mimics line-cut-test.camj)
+function test2() {
+  const cx = 1.5, cy = 1.5, r = 1.0
+  const n = 64
+  const circlePts: Point[] = []
+  for (let i = 0; i < n; i += 1) {
+    const a = -Math.PI / 2 + (i / n) * 2 * Math.PI
+    circlePts.push({ x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) })
+  }
+  const circle = polygonProfile(circlePts)
+
+  const polyline = openPolyline([
+    { x: 0.375, y: 0.375 },
+    { x: 1.125, y: 1.125 },
+    { x: 1.875, y: 1.875 },
+    { x: 2.625, y: 2.625 },
+  ])
+
+  const crosses = openCrossesClosedFully(polyline, circle)
+  console.log('test2 openCrossesClosedFully:', crosses)
+  assert(crosses, 'diagonal polyline should fully cross circle')
+
+  const result = splitClosedByOpen(circle, polyline)
+  console.log('test2 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
+  if (result) {
+    for (let i = 0; i < result.pieces.length; i += 1) {
+      console.log(`  piece ${i}: ${result.pieces[i].length} vertices`)
+    }
+  }
+  assert(result !== null, 'result is non-null')
+  assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
+  console.log('test2 PASS')
+}
+
+// Test 3: horizontal line through circle
+function test3() {
+  const cx = 1.5, cy = 1.5, r = 1.0
+  const n = 64
+  const circlePts: Point[] = []
+  for (let i = 0; i < n; i += 1) {
+    const a = -Math.PI / 2 + (i / n) * 2 * Math.PI
+    circlePts.push({ x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) })
+  }
+  const circle = polygonProfile(circlePts)
+  const line = openPolyline([{ x: 0.25, y: 1.5 }, { x: 3, y: 1.5 }])
+
+  const crosses = openCrossesClosedFully(line, circle)
+  console.log('test3 openCrossesClosedFully:', crosses)
+  const result = splitClosedByOpen(circle, line)
+  console.log('test3 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
+  if (result) {
+    for (let i = 0; i < result.pieces.length; i += 1) {
+      console.log(`  piece ${i}: ${result.pieces[i].length} vertices`)
+    }
+  }
+  assert(result !== null, 'result is non-null')
+  assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
+  console.log('test3 PASS')
+}
+
+// Test 4: after splitting circle with line, the resulting pieces should
+// have valid CCW orientation and no self-intersections, suitable for
+// downstream Clipper operations.
+function test4() {
+  const cx = 1.5, cy = 1.5, r = 1.0
+  const n = 64
+  const circlePts: Point[] = []
+  for (let i = 0; i < n; i += 1) {
+    const a = -Math.PI / 2 + (i / n) * 2 * Math.PI
+    circlePts.push({ x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) })
+  }
+  const circle = polygonProfile(circlePts)
+  const polyline = openPolyline([
+    { x: 0.375, y: 0.375 },
+    { x: 1.125, y: 1.125 },
+    { x: 1.875, y: 1.875 },
+    { x: 2.625, y: 2.625 },
+  ])
+
+  const result = splitClosedByOpen(circle, polyline)
+  assert(result !== null, 'result is non-null')
+  for (let i = 0; i < result!.pieces.length; i += 1) {
+    const p = result!.pieces[i]
+    // Compute signed area
+    let area = 0
+    for (let j = 0; j < p.length; j += 1) {
+      const a = p[j]
+      const b = p[(j + 1) % p.length]
+      area += a.x * b.y - b.x * a.y
+    }
+    area /= 2
+    console.log(`  piece ${i}: signedArea=${area.toFixed(4)}`)
+    assert(area > 0, `piece ${i} should be CCW (positive signed area)`)
+    // Print first few + last few vertices
+    console.log(`    first 3: ${JSON.stringify(p.slice(0, 3).map(pt => [+pt.x.toFixed(3), +pt.y.toFixed(3)]))}`)
+    console.log(`    last 3:  ${JSON.stringify(p.slice(-3).map(pt => [+pt.x.toFixed(3), +pt.y.toFixed(3)]))}`)
+    // Check for collinear-consecutive points (these can confuse downstream ops)
+    let collinearCount = 0
+    for (let j = 0; j < p.length; j += 1) {
+      const a = p[(j - 1 + p.length) % p.length]
+      const b = p[j]
+      const c = p[(j + 1) % p.length]
+      const cross = (b.x - a.x) * (c.y - b.y) - (b.y - a.y) * (c.x - b.x)
+      if (Math.abs(cross) < 1e-9) collinearCount += 1
+    }
+    console.log(`    collinear vertices: ${collinearCount}`)
+  }
+  console.log('test4 PASS')
+}
+
+// Test 5: a closed/closed boolean difference on a split piece (using Clipper
+// directly) should produce a reasonable result, not a malformed polygon.
+function test5() {
+  // Create a square (so it's easy to reason about) cut by a diagonal line.
+  const square = polygonProfile([
+    { x: 0, y: 0 }, { x: 4, y: 0 }, { x: 4, y: 4 }, { x: 0, y: 4 },
+  ])
+  const line = openPolyline([
+    { x: -1, y: -1 }, { x: 1, y: 1 }, { x: 3, y: 3 }, { x: 5, y: 5 },
+  ])
+  const result = splitClosedByOpen(square, line)
+  assert(result !== null, 'result is non-null')
+  assert(result!.pieces.length === 2, 'two pieces')
+  // Each piece is a triangle (3 vertices after collinear cleanup).
+  for (let i = 0; i < result!.pieces.length; i += 1) {
+    console.log(`  piece ${i}: ${result!.pieces[i].length} vertices: ${JSON.stringify(result!.pieces[i].map(p => [+p.x.toFixed(3), +p.y.toFixed(3)]))}`)
+    // Each piece should be a triangle: 3 vertices after stripping collinear.
+    assert(result!.pieces[i].length === 3, `expected triangle, got ${result!.pieces[i].length} vertices`)
+  }
+  console.log('test5 PASS')
+}
+
+try {
+  test1()
+  test2()
+  test3()
+  test4()
+  test5()
+  console.log('\nAll tests PASS')
+} catch (e) {
+  console.error(e)
+  throw e
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -5090,14 +5090,18 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
     const selectedFeatures = state.selection.selectedFeatureIds
       .map((featureId) => state.project.features.find((feature) => feature.id === featureId) ?? null)
       .filter((feature): feature is SketchFeature => feature !== null)
-      .filter((feature) => feature.sketch.profile.closed)
 
     if (selectedFeatures.length < 2) {
       return []
     }
 
     const cutter = selectedFeatures[selectedFeatures.length - 1]
-    const targets = selectedFeatures.filter((feature) => feature.id !== cutter.id)
+    // Open targets are only valid when paired with a closed cutter.
+    const targets = selectedFeatures.filter((feature) => {
+      if (feature.id === cutter.id) return false
+      if (feature.sketch.profile.closed) return true
+      return cutter.sketch.profile.closed
+    })
     const createdGroups = cutFeaturesByCutterGrouped(state.project, [cutter], targets, createDerivedFeature)
     const createdFeatures = createdGroups.flatMap((group) => group.features)
 

--- a/src/store/second_cut_test.ts
+++ b/src/store/second_cut_test.ts
@@ -1,0 +1,137 @@
+/**
+ * Reproduce: half circles of Circle 4 cut by Cutter Circle
+ * Verify clipperContourToProfilePreserving produces correct results.
+ */
+import { polygonProfile } from '../types/project'
+import type { SketchFeature, SketchProfile, Point } from '../types/project'
+import {
+  buildSegmentAnnotations,
+  clipperContourToProfile,
+  clipperContourToProfilePreserving,
+  flattenFeatureToClipperPath,
+  executeClipTree,
+  getClipperChildren,
+  type ClipperPolyNode,
+} from './helpers/clipping'
+import { flattenProfile } from '../engine/toolpaths/geometry'
+import { splitClosedByOpen } from './helpers/polygonSplit'
+
+function fakeFeature(profile: SketchProfile, name: string): SketchFeature {
+  return { id: name, name, kind: 'polygon', folderId: null, locked: false, operation: 'add',
+    sketch: { profile, constraints: [], dimensions: [], origin: { x: 0, y: 0 } },
+    z_top: 0.75, z_bottom: 0 } as any
+}
+
+function signedArea(pts: Point[]): number {
+  let area = 0
+  for (let i = 0; i < pts.length; i++) {
+    const a = pts[i], b = pts[(i + 1) % pts.length]
+    area += a.x * b.y - b.x * a.y
+  }
+  return area / 2
+}
+
+const circle4Profile: SketchProfile = {
+  start: { x: 2.5077822185373186, y: 1.5 },
+  segments: [{ type: 'circle', center: { x: 1.5, y: 1.5 }, to: { x: 2.5077822185373186, y: 1.5 }, clockwise: true }],
+  closed: true,
+}
+
+const polyline3Profile: SketchProfile = {
+  start: { x: 0.25, y: 1.5 },
+  segments: [{ type: 'line', to: { x: 3, y: 1.5 } }],
+  closed: false,
+}
+
+const cutterCircleProfile: SketchProfile = {
+  start: { x: 4, y: 1.5 },
+  segments: [{ type: 'circle', center: { x: 3, y: 1.5 }, to: { x: 4, y: 1.5 }, clockwise: true }],
+  closed: true,
+}
+
+const splitResult = splitClosedByOpen(circle4Profile, polyline3Profile)!
+const piece0 = splitResult.pieces[0], piece1 = splitResult.pieces[1]
+const bottomHalfPts = Math.min(...piece0.map(p => p.y)) < 1.49 ? piece0 : piece1
+const topHalfPts = bottomHalfPts === piece0 ? piece1 : piece0
+
+const bottomHalfFeat = fakeFeature(polygonProfile(bottomHalfPts), 'Bottom half (cartesian)')
+const topHalfFeat = fakeFeature(polygonProfile(topHalfPts), 'Top half (cartesian, visually bottom)')
+const cutterFeat = fakeFeature(cutterCircleProfile, 'Cutter Circle')
+
+let allPassed = true
+
+for (const [label, halfFeat] of [['BOTTOM (cartesian)', bottomHalfFeat], ['TOP (cartesian, visually bottom)', topHalfFeat]] as const) {
+  console.log(`\n=== Cutting ${label} half ===`)
+  const sourceFeatures = [cutterFeat, halfFeat]
+  const segAnnotations = buildSegmentAnnotations(sourceFeatures)
+
+  const subjectPath = flattenFeatureToClipperPath(halfFeat)
+  const clipPath = flattenFeatureToClipperPath(cutterFeat)
+  const polyTree = executeClipTree([subjectPath], [clipPath], 2)
+
+  function check(node: ClipperPolyNode, depth = 0) {
+    const contour = node.Contour()
+    if (contour.length > 0) {
+      const profile = clipperContourToProfilePreserving(contour, sourceFeatures, segAnnotations)
+      if (profile) {
+        const flat = flattenProfile(profile)
+        const area = signedArea(flat.points)
+        const segTypes = profile.segments.map(s => s.type)
+        const arcCount = segTypes.filter(t => t === 'arc').length
+        const lineCount = segTypes.filter(t => t === 'line').length
+
+        console.log(`  Profile: ${profile.segments.length} segments (${lineCount} lines, ${arcCount} arcs)`)
+        console.log(`  Signed area: ${area.toFixed(6)}`)
+
+        // Validate arcs
+        let cur = profile.start
+        for (let i = 0; i < profile.segments.length; i++) {
+          const seg = profile.segments[i]
+          if (seg.type === 'arc') {
+            const rStart = Math.hypot(cur.x - seg.center.x, cur.y - seg.center.y)
+            const rEnd = Math.hypot(seg.to.x - seg.center.x, seg.to.y - seg.center.y)
+            const rDiff = Math.abs(rStart - rEnd)
+            console.log(`  Arc[${i}]: r_start=${rStart.toFixed(4)} r_end=${rEnd.toFixed(4)} diff=${rDiff.toFixed(6)} center=(${seg.center.x},${seg.center.y}) cw=${seg.clockwise}`)
+            if (rDiff > 0.01) {
+              console.log(`  *** ARC RADIUS MISMATCH! ***`)
+              allPassed = false
+            }
+          }
+          // Check for zero-length segments
+          if (Math.abs(cur.x - seg.to.x) < 1e-9 && Math.abs(cur.y - seg.to.y) < 1e-9) {
+            console.log(`  *** ZERO-LENGTH SEGMENT at [${i}]: (${cur.x.toFixed(3)}, ${cur.y.toFixed(3)}) ***`)
+          }
+          cur = seg.to
+        }
+
+        if (area <= 0) {
+          console.log(`  *** NEGATIVE AREA — polygon inverted! ***`)
+          allPassed = false
+        }
+
+        // Compare with plain fallback
+        const plainProfile = clipperContourToProfile(contour)
+        if (plainProfile) {
+          const plainFlat = flattenProfile(plainProfile)
+          const plainArea = signedArea(plainFlat.points)
+          const areaDiff = Math.abs(area - plainArea)
+          console.log(`  Plain fallback area: ${plainArea.toFixed(6)}, diff from preserving: ${areaDiff.toFixed(6)}`)
+          if (areaDiff > 0.05) {
+            console.log(`  *** LARGE AREA DIFFERENCE from fallback ***`)
+            allPassed = false
+          }
+        }
+      } else {
+        console.log(`  clipperContourToProfilePreserving returned null`)
+      }
+    }
+    for (const child of getClipperChildren(node)) {
+      check(child, depth + 1)
+    }
+  }
+
+  check(polyTree)
+}
+
+if (!allPassed) throw new Error('SOME CHECKS FAILED')
+console.log('\nAll checks PASSED')

--- a/src/store/slices/pendingActionsSlice.ts
+++ b/src/store/slices/pendingActionsSlice.ts
@@ -302,7 +302,8 @@ export function createPendingActionsSlice(
 
     startCutSelectedFeatures: () =>
       set((s) => {
-        const cutterIds = selectedClosedFeaturesFromIds(s.project, s.selection.selectedFeatureIds).map((feature) => feature.id)
+        const cutterIds = s.selection.selectedFeatureIds
+          .filter((id) => s.project.features.some((f) => f.id === id))
 
         return {
           pendingAdd: null,

--- a/src/store/slices/pendingCompletionSlice.ts
+++ b/src/store/slices/pendingCompletionSlice.ts
@@ -574,11 +574,9 @@ export function createPendingCompletionSlice(
       const cutters = pendingShapeAction.cutterIds
         .map((cId) => featureById(state.project, cId))
         .filter((feature): feature is SketchFeature => feature !== null)
-        .filter((feature) => feature.sketch.profile.closed)
       const targets = pendingShapeAction.targetIds
         .map((featureId) => featureById(state.project, featureId))
         .filter((feature): feature is SketchFeature => feature !== null)
-        .filter((feature) => feature.sketch.profile.closed)
       if (cutters.length !== pendingShapeAction.cutterIds.length || targets.length !== pendingShapeAction.targetIds.length) {
         return []
       }

--- a/src/store/slices/selectionSlice.ts
+++ b/src/store/slices/selectionSlice.ts
@@ -17,7 +17,7 @@
 import type { StateCreator } from 'zustand'
 import type { Project, SketchFeature } from '../../types/project'
 import type { ProjectStore, SelectionState } from '../types'
-import { featuresFormConnectedOverlapGroup, featuresOverlap } from '../helpers/clipping'
+import { featuresFormConnectedOverlapGroup, featuresOverlapForCut } from '../helpers/clipping'
 
 export interface SelectionSliceDependencies {
   cloneProject: (project: Project) => Project
@@ -208,8 +208,19 @@ export function createSelectionSlice(
             return {}
           }
 
-          if (selectedFeature && (!selectedFeature.sketch.profile.closed || selectedFeature.locked)) {
+          if (selectedFeature && selectedFeature.locked) {
             return {}
+          }
+          // Open features as targets are only allowed when at least one
+          // selected cutter is closed (Clipper only supports trimming open
+          // paths against closed clips, and an open cutter intersecting an
+          // open target is geometrically degenerate).
+          if (selectedFeature && pendingShapeAction.phase !== 'cutters' && !selectedFeature.sketch.profile.closed) {
+            const hasClosedCutter = pendingShapeAction.cutterIds.some((cId) => {
+              const f = featureById(s.project, cId)
+              return f !== null && f.sketch.profile.closed
+            })
+            if (!hasClosedCutter) return {}
           }
 
           if (!id) {
@@ -268,7 +279,7 @@ export function createSelectionSlice(
           const cutters = pendingShapeAction.cutterIds
             .map((cId) => featureById(s.project, cId))
             .filter((f): f is SketchFeature => f !== null)
-          if (!selectedFeature || !cutters.some((cutter) => featuresOverlap(cutter, selectedFeature))) {
+          if (!selectedFeature || !cutters.some((cutter) => featuresOverlapForCut(selectedFeature, cutter))) {
             return {}
           }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -817,6 +817,63 @@
   font-size: 11px;
 }
 
+.simulation-playback-bar__xyz {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 10px;
+  border-left: 1px solid var(--line-strong);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.simulation-playback-bar__xyz-label {
+  color: var(--text-dim);
+  font-weight: 500;
+}
+
+.simulation-playback-bar__xyz-value {
+  color: var(--text);
+  min-width: 4.5em;
+  text-align: right;
+}
+
+.simulation-playback-bar__xyz-value + .simulation-playback-bar__xyz-label {
+  margin-left: 6px;
+}
+
+.simulation-playback-bar__move-kind {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-left: 6px;
+}
+
+/* Match the toolpath preview colours from Viewport3D.tsx buildToolpathOverlay().
+ *   cut / lead_in / lead_out → #ff735c (red)
+ *   plunge                  → #d583df (purple)
+ *   rapid                   → #78b8de (blue)
+ *   idle                    → transparent
+ */
+.simulation-playback-bar__move-kind--cut,
+.simulation-playback-bar__move-kind--lead_in,
+.simulation-playback-bar__move-kind--lead_out {
+  background: #ff735c;
+}
+
+.simulation-playback-bar__move-kind--plunge {
+  background: #d583df;
+}
+
+.simulation-playback-bar__move-kind--rapid {
+  background: #78b8de;
+}
+
+.simulation-playback-bar__move-kind--none {
+  background: transparent;
+}
+
 .panel-right {
   min-height: 0;
 }


### PR DESCRIPTION
## Summary

This PR adds support for **open profiles (polylines) in cut/trim operations**, renders them as **3D polylines in the viewport**, adds a **live XYZ coord readout to simulation playback**, and improves **arc reconstruction robustness** in the clipping pipeline.

---

## Changes

### 1. Open Profile Cut/Trim

- **New planar-graph polygon-split-by-polyline algorithm** (`src/store/helpers/polygonSplit.ts`): DCEL-based approach that splits a closed polygon along an open polyline using half-edge face-walking with CCW orientation rules.
  - `splitClosedByOpen()` and `openCrossesClosedFully()`
  - Collinear-stripping and duplicate-vertex cleanup
- **`polygonSplit.test.ts`** — 5 test cases (horizontal/diagonal cuts through squares and circles)
- **`flattenOpenFeatureToClipperPath()`** — feeds open polylines to Clipper as open subjects
- **`featuresOverlapForCut()`** — overlap test for all (closed/open) x (closed/open) combinations
- **`splitClosedFeatureByOpenCutter()`** — splits a closed feature along an open cutter
- **`trimOpenTargetByClosedCutters()`** — Clipper open-path difference for open targets
- **`cutFeaturesByCutterGrouped()`** refactored for open cutters and targets
- **Cut-mode UI unlocked**: removed closed-only filters from selection/pending/completion slices

### 2. 3D Open Feature Display

- **`buildOpenFeatureLine()`** — renders open features as screen-aligned polylines using Three.js Line2/LineMaterial
- **`openFeatureLines`** added to `SceneObjects` and rendered in `Viewport3D.tsx`

### 3. Simulation XYZ Readout

- **Live machine-relative coordinate display** (X, Y, Z) in the simulation playback bar
- Throttled at ~10 Hz via ref + interval pattern
- **Y-axis inversion**: project to machine coordinate transformation
- **Move-kind colour dot indicator**: red (cut), purple (plunge), blue (rapid)

### 4. Arc Reconstruction & Clipping Robustness

- **`reconstructArcsInProfile()`** made exportable with `maxSingleArcAngle` parameter
- **Arc validity check**: radius verification (2% tolerance) before emitting arcs
- **Zero-length segment suppression** and **gap bridging** between consecutive arcs
- **Arc reconstruction in split pieces** using known circles from source features

### 5. Properties Panel: Open Feature Z-Bottom

- Open features show Z Bottom as read-only (locked to 0)
- Multi-select with open features shows appropriate Z Bottom controls

---

## Files Changed

| File | Status | Description |
|------|--------|-------------|
| `src/store/helpers/polygonSplit.ts` | new | DCEL polygon-split-by-polyline algorithm |
| `src/store/polygonSplit.test.ts` | new | 5 test cases |
| `src/store/helpers/clipping.ts` | modified | Arc reconstruction, featuresOverlapForCut, flattenOpenFeatureToClipperPath |
| `src/store/helpers/derivedFeatures.ts` | modified | Split/trim for open+closed cutters and targets |
| `src/store/projectStore.ts` | modified | Open target filter in cut action |
| `src/store/slices/selectionSlice.ts` | modified | Use featuresOverlapForCut, allow open target selection |
| `src/store/slices/pendingActionsSlice.ts` | modified | Remove closed filter from cutter selection |
| `src/store/slices/pendingCompletionSlice.ts` | modified | Remove closed filter from cutter/target resolution |
| `src/components/canvas/SketchCanvas.tsx` | modified | Help text update |
| `src/components/feature-tree/PropertiesPanel.tsx` | modified | Open feature Z-bottom read-only |
| `src/engine/csg.ts` | modified | buildOpenFeatureLine, openFeatureLines in scene |
| `src/components/viewport3d/Viewport3D.tsx` | modified | Render open feature lines |
| `src/components/simulation/SimulationViewport.tsx` | modified | Live XYZ readout + move-kind indicator |
| `src/styles/layout.css` | modified | Simulation XYZ readout styles |
| `planning/OPEN_FEATURE_3D_DISPLAY_Plan.md` | new | Design doc |
| `planning/SIMULATION_XYZ_READOUT_Plan.md` | new | Design doc |
| `src/store/second_cut_test.ts` | new | WIP test |
