### PR TITLE
Tablet UX: shell mode, pointer events, workflow panels, toolbar split, and polish

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # PureCutCNC — Foundational Architecture & Standards (ARCHITECTURE.md)
 
-This document is the primary source of truth for the architectural vision, coding standards, and operational constraints of the PureCutCNC project. It takes absolute precedence over general defaults. Always refer to this file and the `planning/` directory for detailed design and implementation context.
+This document is the primary source of truth for the architectural vision, coding standards, and operational constraints of the PureCutCNC project. It takes absolute precedence over general defaults. Always refer to this file and the `planning/` directory for detailed design and implementation context. For tablet UI/UX-specific architecture and design decisions, see [`planning/TABLET_UX_COMBINED_PLAN.md`](planning/TABLET_UX_COMBINED_PLAN.md).
 
 ## 1. Project Vision & Purpose
 PureCutCNC is a web-based, parametric 2.5D CAM application designed for CNC enthusiasts. 
@@ -34,6 +34,7 @@ Defined in `src/types/project.ts`:
 - `src/components/canvas/`: Complex 2D interaction logic, snapping, and viewport transformations.
 - `src/import/`: DXF and SVG parsers that normalize external geometry into the `.camj` format.
 - `src/text/`: Logic for converting text and fonts into machinable geometry.
+- `src/styles/tablet.css`: Tablet-optimized styles for touch/mobile-friendly UI (see [`planning/TABLET_UX_COMBINED_PLAN.md`](planning/TABLET_UX_COMBINED_PLAN.md) for the full tablet UX design).
 
 ## 5. Icon System
 

--- a/planning/TABLET_UI_UX_REFRESH_PLAN.md
+++ b/planning/TABLET_UI_UX_REFRESH_PLAN.md
@@ -1,0 +1,620 @@
+# Tablet UI/UX Refresh Plan
+
+## Status
+
+`[x]` Superseded. This document is retained as strategic background only. Its architectural
+direction has been merged into the combined implementation plan, which is now the source of
+truth for tablet work.
+
+Current plan: [TABLET_UX_COMBINED_PLAN.md](TABLET_UX_COMBINED_PLAN.md)
+
+## Goal
+
+Make PureCutCNC usable on 10-inch tablets first, with a credible compact-tablet path for
+7-8 inch devices. The product should feel like a CNC workbench: dense, precise, and
+task-focused, but not a shrunken desktop app.
+
+The core change is not "make buttons bigger." The app needs a tablet shell with deliberate
+command surfaces, drawers, touch gestures, and non-keyboard editing flows.
+
+## Target Devices
+
+### Primary Target: 10-inch Tablet
+
+- Landscape is the main supported orientation.
+- CSS viewport target: roughly `900px` to `1199px` wide, `650px+` tall, coarse pointer.
+- Expected hardware: iPad 10-inch class, Android 10-inch class, Surface-style touch tablet.
+- Required workflows: sketch, edit, define CAM operations, preview, simulate, export.
+
+### Secondary Target: 7-8 inch Tablet
+
+- Landscape only for full editing.
+- CSS viewport target: roughly `740px` to `899px` wide, coarse pointer.
+- This should use a more focused shell: canvas first, every panel as a drawer or sheet.
+- The goal is "usable for focused edits," not full desktop-equivalent productivity.
+
+### Phones
+
+- Continue blocking phone-sized touch layouts for now.
+- If we later support phones, that should be a separate read-only/review mode, not this plan.
+
+### Desktop
+
+- Desktop may adopt the same command architecture if it improves clarity.
+- Large desktop can still show docked left and right panels.
+- Laptop desktop should benefit from the tablet work by reducing toolbar wrapping and chrome.
+
+## Current Problems
+
+### Shell And Layout
+
+- The desktop three-column layout is compressed onto tablet instead of switching modes.
+- The right CAM panel is intended to become a drawer, but the drawer opener is not reliable:
+  `.tablet-drawer-toggle` is set to `display: inline-flex` inside a media query, then later
+  reset to `display: none` with equal specificity.
+- Layout preferences such as workspace layout and toolbar orientation are desktop controls,
+  but they remain visible in the workspace header on constrained layouts.
+- The status bar, legends, tab headers, and side panels permanently consume space that the
+  canvas needs.
+
+### Toolbar
+
+- `Toolbar` combines project/file/history/view/snap/creation/edit/alignment/backdrop actions
+  into one wrapping strip.
+- On tablet this wraps unpredictably and takes vertical space from the canvas.
+- Existing `GlobalToolbar` and `CreationToolbar` already point toward the right split, but
+  the shell does not consistently select that model for tablet.
+- Snap controls occupy seven persistent buttons. These should be a popover on tablet.
+
+### Panels
+
+- The left project tree and properties panel are stacked in a resizable split.
+- This works on a large desktop but is cramped on tablet.
+- CAM operations and tool library are a right dock on desktop and should be a discoverable
+  drawer on tablet.
+- There is no clear tablet mental model for "where do I edit this thing?"
+
+### Interaction
+
+- Several core operations still depend on mouse and keyboard patterns: hover, Tab, Esc,
+  right-click, double-click, Shift/Ctrl multi-select, and HTML drag-and-drop.
+- Sketch, 3D, and simulation navigation need touch-native gestures.
+- Stylus input should behave as precise drawing/edit input, not as generic finger navigation.
+
+## Design Principles
+
+1. **Canvas first.** The stock/canvas/preview is the primary workspace. Persistent chrome must
+   justify its space.
+2. **Modes should be visible.** Sketching, selecting, editing, CAM, simulation, and export
+   need obvious entry and exit points.
+3. **Commands should be contextual.** Creation and edit tools should live near the canvas and
+   appear when useful, not compete with file actions.
+4. **No hover-only or keyboard-only paths.** Every primary command must have a touch path.
+5. **Drawers over compressed sidebars.** Tablet panels should overlay or slide, not crush the
+   workspace.
+6. **Keep precision.** Touch UI must not make the CAD/CAM workflow feel vague. Numeric entry,
+   snapping, constraints, and exact dimensions remain first-class.
+7. **Desktop should not be sacred.** If the tablet shell clarifies the product, apply the same
+   architecture to desktop with larger/docked variants.
+
+## Proposed Product Model
+
+### App Regions
+
+The app should be organized around stable regions:
+
+- **Top command bar:** project name, save state, file actions, undo/redo, workspace view tabs,
+  zoom controls, export/open operations entry.
+- **Left tool rail:** sketch creation, feature/region target toggle, selection/edit commands,
+  and contextual tools for the active mode.
+- **Canvas stage:** sketch/3D/simulation surface with lightweight overlay controls.
+- **Left drawer:** Project Tree and Properties, shown as tabs or a sheet depending on width.
+- **Right drawer:** Operations and Tools, with a persistent and discoverable opener.
+- **Bottom strip:** compact status, coordinate/readout, active command confirmation/cancel,
+  and optional warnings. This replaces the current always-on full status row on tablet.
+
+### Tablet Navigation Model
+
+On tablet, a user should be able to answer these questions immediately:
+
+- What am I editing? Shown in the active context header or bottom strip.
+- What can I do now? Shown in the left tool rail and active command strip.
+- Where are operations? Persistent `Operations` button with count, not a hidden `CAM` button.
+- How do I close a panel? Obvious close button, scrim tap, and optional edge handle.
+- How do I enter exact values? Tap dimension label or a visible numeric chip, not Tab.
+
+## Breakpoint Strategy
+
+Use layout classes from JS, not only scattered CSS media queries. Suggested shell modes:
+
+```ts
+type ShellMode =
+  | 'desktop-wide'
+  | 'desktop-compact'
+  | 'tablet'
+  | 'tablet-compact'
+  | 'unsupported-phone'
+```
+
+Suggested detection inputs:
+
+- `window.innerWidth`
+- `window.innerHeight`
+- `matchMedia('(pointer: coarse)')`
+- `matchMedia('(hover: none)')`
+- optional user override for testing
+
+Suggested behavior:
+
+| Mode | Conditions | Shell |
+| --- | --- | --- |
+| `desktop-wide` | `>= 1400px`, pointer fine | docked left, center, right; split toolbar optional |
+| `desktop-compact` | `1100-1399px`, pointer fine | docked or collapsible side panels; split toolbar preferred |
+| `tablet` | `900-1199px`, pointer coarse | left tool rail, drawers for tree/properties/CAM, compact top bar |
+| `tablet-compact` | `740-899px`, pointer coarse | canvas-first focus mode, bottom tool sheet, all panels drawers |
+| `unsupported-phone` | `< 740px`, pointer coarse | blocked or read-only fallback |
+
+Avoid `max-width: 960px` as the only tablet trigger. A 10-inch tablet can be wider than that,
+and a desktop browser can be narrower than that.
+
+## Phased Work
+
+### Phase 0 - UX Inventory And Shell Contract
+
+**Goal:** Define the workflows and layout contract before changing UI.
+
+**Work:**
+
+- Inventory the primary workflows:
+  - create project
+  - import geometry
+  - create/edit sketch feature
+  - exact dimension entry
+  - create region
+  - create tabs/clamps
+  - create CAM operation
+  - preview toolpath
+  - simulate
+  - export G-code
+- Document every command that currently depends on hover, keyboard, right-click, double-click,
+  modifier keys, or drag-and-drop.
+- Add a shell mode helper, initially read-only, that reports `desktop-wide`,
+  `desktop-compact`, `tablet`, `tablet-compact`, or `unsupported-phone`.
+- Add a temporary debug readout behind `import.meta.env.DEV` so shell mode can be verified on
+  real devices.
+- Create a screenshot matrix for:
+  - 1440x900 desktop
+  - 1280x800 laptop
+  - 1024x768 10-inch tablet landscape
+  - 820x1180 tablet portrait, informational only
+  - 800x600 compact tablet landscape
+
+**Files likely touched:**
+
+- `src/App.tsx`
+- `src/components/layout/AppShell.tsx`
+- `src/styles/tablet.css`
+- optional new `src/components/layout/useShellMode.ts`
+
+**Acceptance:**
+
+- No visual redesign yet.
+- The app can reliably identify tablet and compact-tablet modes.
+- We have a written command inventory for touch-blocked workflows.
+
+### Phase 1 - Tablet Shell Foundation
+
+**Goal:** Stop compressing the desktop app onto tablet.
+
+**Work:**
+
+- Refactor `AppShell` around named regions:
+  - top command bar
+  - left command rail
+  - center stage
+  - left drawer/sheet
+  - right drawer/sheet
+  - bottom status/action strip
+- Fix the tablet right drawer opener. Replace hidden `CAM` with a persistent
+  `Operations` control that includes the operation count when available.
+- On tablet, remove workspace layout and toolbar orientation controls from the workspace
+  header. These are desktop configuration controls.
+- Make the right drawer usable and discoverable:
+  - clear `Operations` / `Tools` tabs
+  - close button
+  - scrim tap
+  - optional right-edge reopen handle
+- Keep desktop behavior mostly intact during this phase, but route tablet through the new
+  shell regions.
+
+**Files likely touched:**
+
+- `src/components/layout/AppShell.tsx`
+- `src/App.tsx`
+- `src/styles/layout.css`
+- `src/styles/tablet.css`
+
+**Acceptance for 10-inch tablet:**
+
+- There is an obvious way to open Operations.
+- Closing Operations leaves an obvious way to reopen it.
+- Canvas is not squeezed by a right dock.
+- Workspace layout/orientation controls are not visible in tablet mode.
+
+### Phase 2 - Command Bar And Tool Rail Redesign
+
+**Goal:** Replace the one-strip toolbar with purpose-built command surfaces.
+
+**Work:**
+
+- Split toolbar architecture into:
+  - `TopCommandBar`
+  - `ToolRail`
+  - `CommandPopover`
+  - optional `CommandSheet` for compact tablet
+- Top command bar contains:
+  - project name
+  - save state
+  - New/Open/Import/Save
+  - Undo/Redo
+  - workspace tabs: Sketch, 3D, Simulation
+  - Zoom/Fit
+  - Operations entry
+- Left tool rail contains:
+  - selection tool
+  - feature/region target toggle
+  - rectangle/circle/ellipse/polygon/spline/composite/text
+  - selected-feature transform actions
+  - sketch-edit tools when in edit mode
+- Move snap modes into a popover:
+  - top-level snap enabled button
+  - grid/point/line/midpoint/center/perpendicular inside popover
+  - active snap mode indicator on the snap button
+- Move alignment/distribution into contextual popovers shown only when multi-selection makes
+  them valid.
+- On compact tablet, use a bottom `CommandSheet` instead of a permanent left rail if the rail
+  would leave too little canvas.
+
+**Files likely touched:**
+
+- `src/components/layout/Toolbar.tsx`
+- new `src/components/layout/TopCommandBar.tsx`
+- new `src/components/layout/ToolRail.tsx`
+- new `src/components/layout/CommandPopover.tsx`
+- `src/styles/layout.css`
+- `src/styles/tablet.css`
+
+**Acceptance:**
+
+- At 1024x768 tablet landscape, the top bar is one row.
+- Creation and edit tools do not wrap.
+- Snap controls do not permanently occupy seven button widths.
+- Desktop can optionally use the same split toolbar if it improves laptop layout.
+
+### Phase 3 - Panel System Refresh
+
+**Goal:** Make project structure, properties, operations, and tools accessible without
+permanent side-panel pressure.
+
+**Work:**
+
+- Replace tablet left stacked split with a drawer containing tabs:
+  - Project
+  - Properties
+- Add explicit open buttons:
+  - `Project` or tree icon for the left drawer
+  - `Properties` shown when a selection exists
+  - `Operations` with count for the right drawer
+- In tablet mode, opening a tree row should expose relevant actions without requiring the
+  properties panel to always be visible.
+- In CAM drawer:
+  - keep Operations and Tools tabs
+  - make Add/Export persistent in the drawer header
+  - ensure row actions are 44px hit targets
+  - keep selected operation properties in the same drawer, either below the list or as a
+    secondary detail sheet
+- In desktop mode, decide whether to keep current docked panels or adopt the same drawer
+  model with dock/undock capability.
+
+**Files likely touched:**
+
+- `src/components/layout/AppShell.tsx`
+- `src/components/feature-tree/FeatureTree.tsx`
+- `src/components/feature-tree/PropertiesPanel.tsx`
+- `src/components/cam/CAMPanel.tsx`
+- `src/styles/layout.css`
+- `src/styles/tablet.css`
+
+**Acceptance:**
+
+- On 10-inch tablet, the canvas can be used with no side panels open.
+- The user can still open Project, Properties, Operations, and Tools with one tap.
+- The Operations drawer is self-contained enough to create and edit an operation.
+
+### Phase 4 - Touch Editing Reachability
+
+**Goal:** Remove mouse and keyboard dependencies from sketch and tree editing.
+
+**Work:**
+
+- Migrate sketch canvas interaction from mouse events to pointer events.
+- Define pointer semantics:
+  - mouse keeps desktop behavior
+  - finger uses touch gestures and larger hit targets
+  - pen uses precise draw/select/edit behavior
+- Add explicit multi-select mode:
+  - visible toggle in tool rail or bottom strip
+  - stays on until turned off
+  - supports tap-to-add/remove selection
+- Replace hover-plus-Tab dimension entry:
+  - tap a dimension label or selected segment to show a numeric chip
+  - chip opens the existing dimension input
+  - keep keyboard Tab as desktop shortcut
+- Replace right-click and double-click-only paths:
+  - visible More buttons in rows
+  - explicit Edit actions for selected features/tabs/clamps
+  - optional long-press context menu as secondary, not primary
+- Add drag-and-drop fallbacks:
+  - Move up/down buttons for feature rows
+  - Move up/down buttons for CAM operations
+
+**Files likely touched:**
+
+- `src/components/canvas/SketchCanvas.tsx`
+- `src/components/feature-tree/FeatureTree.tsx`
+- `src/components/cam/CAMPanel.tsx`
+- `src/store/projectStore.ts`
+- `src/store/slices/selectionSlice.ts`
+- `src/styles/layout.css`
+- `src/styles/tablet.css`
+
+**Acceptance:**
+
+- A tablet user can create and dimension a rectangle without a keyboard.
+- A tablet user can edit a selected feature without double-clicking.
+- A tablet user can multi-select without Shift/Ctrl.
+- A tablet user can reorder features and operations without drag-and-drop.
+
+### Phase 5 - Canvas, 3D, And Simulation Gestures
+
+**Goal:** Make every viewport navigable on touch.
+
+**Work:**
+
+- Sketch canvas:
+  - one finger: active tool input or selection
+  - two fingers: pan
+  - pinch: zoom around midpoint
+  - optional two-finger tap: zoom to model or undo only if tested and intentional
+- 3D viewport:
+  - one finger: orbit
+  - two fingers: pan
+  - pinch: zoom
+  - double tap or fit button: zoom to model
+- Simulation viewport:
+  - match 3D gestures
+  - make playback controls touch-sized and avoid covering the model
+- Do not rely on `touchAction = 'none'` without matching pointer handlers. Use it only on
+  active gesture regions.
+- Add gesture conflict rules for stylus:
+  - pen contact edits/selects
+  - finger gesture navigates
+  - simultaneous pen plus finger should not corrupt active sketch state
+
+**Files likely touched:**
+
+- `src/components/canvas/SketchCanvas.tsx`
+- `src/components/viewport3d/Viewport3D.tsx`
+- `src/components/simulation/SimulationViewport.tsx`
+- `src/components/canvas/viewTransform.ts`
+- `src/styles/layout.css`
+
+**Acceptance:**
+
+- 3D and simulation can be panned, zoomed, and rotated without mouse wheel or modifier keys.
+- Sketch canvas can be zoomed and panned without exiting the active tool unexpectedly.
+- Gestures are tested on real tablet hardware, not only desktop emulation.
+
+### Phase 6 - Tablet Workflow Polish
+
+**Goal:** Make the common CAD/CAM flow feel coherent, not just technically reachable.
+
+**Work:**
+
+- Add an active command strip:
+  - current tool or operation
+  - primary confirmation action
+  - cancel action
+  - numeric entry shortcut when available
+- Make selection state obvious:
+  - selected feature name
+  - selected operation name
+  - lock/visibility status
+- Improve operation creation flow:
+  - target selection is clear
+  - tool selection is accessible in drawer
+  - warnings are visible but not permanently blocking canvas
+- Make import workflow tablet-friendly:
+  - import dialog touch targets
+  - post-import "fit to model" and "create operation" affordances
+- Review all dialogs for 10-inch and compact tablet dimensions.
+
+**Files likely touched:**
+
+- `src/components/layout/AppShell.tsx`
+- `src/components/project/ImportGeometryDialog.tsx`
+- `src/components/project/NewProjectDialog.tsx`
+- `src/components/project/TextToolDialog.tsx`
+- `src/components/export/ExportDialog.tsx`
+- `src/components/cam/CAMPanel.tsx`
+- `src/styles/dialog.css`
+- `src/styles/tablet.css`
+
+**Acceptance:**
+
+- The end-to-end path from sketch to G-code export can be completed on a 10-inch tablet.
+- Dialogs fit without clipped controls.
+- The user always has a visible way to confirm or cancel an active command.
+
+### Phase 7 - Compact Tablet Mode
+
+**Goal:** Support 7-8 inch tablets without pretending they are desktops.
+
+**Work:**
+
+- Add `tablet-compact` shell mode.
+- Use a canvas-first focus layout:
+  - top bar reduced to project/view/operations
+  - no permanent left panel
+  - tools in a bottom sheet or collapsible rail
+  - Project/Properties/Operations all drawers or full-height sheets
+- Reduce simultaneous panel count:
+  - only one drawer/sheet open at a time
+  - opening Operations closes Project/Properties
+  - active command strip remains available
+- Define portrait behavior:
+  - either show rotate-device hint for full editing
+  - or allow review/simple selection only
+
+**Acceptance:**
+
+- At 800x600 landscape, the user can select, inspect, make small edits, and open Operations.
+- Full CAM editing is possible, but not optimized.
+- No view relies on horizontal scrolling for primary controls.
+
+### Phase 8 - Desktop Harmonization
+
+**Goal:** Avoid maintaining two unrelated apps.
+
+**Work:**
+
+- Decide which tablet shell improvements become desktop defaults:
+  - split top command bar and tool rail
+  - snap popover
+  - Operations opener with count
+  - dockable drawers instead of fixed right panel
+- Remove or simplify old preferences if they are now redundant:
+  - toolbar orientation
+  - workspace layout presets
+- Keep desktop-specific advantages:
+  - keyboard shortcuts
+  - hover tooltips
+  - right-click context menus as enhancements
+  - docked multi-panel layouts for wide displays
+
+**Acceptance:**
+
+- Desktop is not worse than before on a full-size MacBook Pro.
+- Laptop desktop gains vertical space and avoids toolbar wrapping.
+- Tablet and desktop share component architecture.
+
+### Phase 9 - QA, Rollout, And Regression Protection
+
+**Goal:** Make tablet support testable and maintainable.
+
+**Work:**
+
+- Add a manual test script in `planning/` or `docs/` for:
+  - 10-inch tablet landscape
+  - compact tablet landscape
+  - desktop full-size
+  - laptop desktop
+- Add Playwright or screenshot checks if the project already has a path for browser tests.
+  If not, document a repeatable Chrome DevTools screenshot workflow.
+- Add smoke tests for shell mode helper.
+- Add CSS regression checks where practical:
+  - top bar does not wrap at 1024x768 tablet
+  - Operations opener visible when right drawer hidden
+  - side panels hidden/drawer in tablet mode
+- Run `npm run build` before merging each implementation PR.
+
+**Acceptance:**
+
+- Every phase has before/after screenshots.
+- Tablet work cannot regress into a hidden Operations drawer again.
+- Build passes before every merge.
+
+## Suggested PR Breakdown
+
+1. **PR 1: Shell mode helper and drawer opener fix**
+   - Add shell mode detection.
+   - Fix hidden tablet drawer opener.
+   - Rename/reposition opener to `Operations`.
+   - No broad visual redesign yet.
+
+2. **PR 2: Top command bar and tool rail**
+   - Introduce split command surfaces.
+   - Tablet uses split layout.
+   - Desktop can keep existing combined toolbar behind a transition flag if needed.
+
+3. **PR 3: Tablet panel drawers**
+   - Left Project/Properties drawer.
+   - Right Operations/Tools drawer cleanup.
+   - Remove tablet-visible desktop layout controls.
+
+4. **PR 4: Touch editing reachability**
+   - Pointer event migration.
+   - Multi-select mode.
+   - Dimension entry touch path.
+   - More/Edit buttons audited.
+
+5. **PR 5: Touch gestures**
+   - Sketch pan/zoom.
+   - 3D orbit/pan/pinch.
+   - Simulation pan/pinch.
+
+6. **PR 6: Compact tablet mode**
+   - Bottom command sheet.
+   - Single drawer/sheet policy.
+   - 7-8 inch landscape pass.
+
+7. **PR 7: Desktop harmonization**
+   - Apply the improved command architecture to desktop where appropriate.
+   - Remove redundant shell controls if they no longer carry their weight.
+
+## Non-Goals For This Plan
+
+- Phone editing support.
+- A new visual brand or marketing-style redesign.
+- Replacing the CAD/CAM engine or data model.
+- Introducing a UI component library.
+- Rewriting Zustand state architecture.
+
+## Engineering Notes
+
+- All project mutations still go through `src/store/projectStore.ts`.
+- Keep React components typed; do not introduce `any`.
+- Prefer component-level shell state over global store state unless the state is part of the
+  project data or must persist across sessions.
+- Use CSS variables for tablet dimensions:
+  - `--touch-target: 44px`
+  - `--tool-rail-width`
+  - `--drawer-width`
+  - `--bottom-strip-height`
+- Avoid making tablet behavior depend on CSS order alone. Shell mode should be explicit in
+  the DOM, for example `data-shell-mode="tablet"`.
+- Keep keyboard shortcuts on desktop, but never make them the only path.
+
+## Open Decisions
+
+- Should 10-inch tablet portrait be supported for editing, or show a rotate-device prompt?
+- Should desktop adopt the tool rail by default, or keep it as an optional layout at first?
+- Should left Project/Properties be a drawer, a bottom sheet, or dockable tabs on 10-inch
+  tablets?
+- Should compact tablet support CAM operation editing, or only operation review and export?
+- Should shell mode be user-overridable from settings for testing and accessibility?
+
+## Definition Of Done
+
+Tablet support is done when all of these are true on a real 10-inch tablet:
+
+- The app opens into a usable canvas-first layout.
+- The Operations panel is discoverable, opens, closes, and reopens.
+- Sketch tools are reachable without toolbar wrapping.
+- Exact dimension entry works without a hardware keyboard.
+- Multi-select works without modifier keys.
+- Feature/tree/CAM row actions work without right-click.
+- Reordering works without drag-and-drop.
+- Sketch, 3D, and simulation can be navigated with touch gestures.
+- Export can be completed without switching to desktop.
+- Desktop full-size layout remains professional and at least as efficient as before.

--- a/planning/TABLET_UX_COMBINED_PLAN.md
+++ b/planning/TABLET_UX_COMBINED_PLAN.md
@@ -241,6 +241,234 @@ In `handlePointerDown` when `pointerType === 'touch'` and a control is hit:
 
 ---
 
+## PR 2.5 — Refactor Canvas Workflows Into Reusable Panels
+
+**Goal:** Pause feature expansion and turn the successful Cut popup experiment into a
+reusable interaction pattern before continuing with toolbar and drawer work.
+
+The Cut flow showed that the same explicit, draggable workflow panel works better on both
+tablet and desktop than the old banner text plus `Tab` / `Enter` / `Esc` hints. We should
+promote this into a shared canvas workflow surface and then migrate similar multi-step
+operations onto it deliberately.
+
+### 2.5a. Workflow panel pattern ✓
+
+Create a reusable canvas-overlay panel for active workflows.
+
+Expected behavior:
+- Draggable by a compact handle/header.
+- Clamped inside the canvas viewport.
+- Works with mouse, touch, and pen.
+- Does not steal the canvas as the primary interaction surface.
+- Returns focus to the canvas when opened, when closed, and after panel actions.
+- Clears transient canvas click/pan suppression state after panel actions so the next sketch
+  selection works on the first click/tap.
+- Uses intent labels (`Next`, `Confirm`, `Cancel`, `Dimension`, `Select targets`) rather than
+  visible keyboard-key labels.
+- Keyboard shortcuts may remain as secondary desktop accelerators, but they are no longer the
+  primary visible workflow UI.
+
+Candidate component/API:
+```tsx
+<CanvasWorkflowPanel
+  title="Cut"
+  step="Select targets"
+  position={position}
+  onPositionChange={setPosition}
+  onRequestCanvasFocus={focusCanvasForWorkflow}
+  actions={...}
+>
+  ...
+</CanvasWorkflowPanel>
+```
+
+Supporting hook:
+```ts
+useCanvasWorkflowPanel({
+  open,
+  phaseKey,
+  containerRef,
+  canvasRef,
+  clearTransientCanvasState,
+})
+```
+
+Do not leave Cut-specific drag/focus code embedded directly in `SketchCanvas` after this
+refactor. `SketchCanvas` should decide *which* workflow is active; reusable workflow panel
+code should handle movement, focus handoff, and overlay mechanics.
+
+### 2.5b. Cut as the reference implementation ✓
+
+Current Cut pilot behavior to preserve:
+- Panel appears for Cut on desktop and tablet.
+- Header is compact: title only (`Cut`) plus drag grip.
+- Current phase appears in the body: `Select cutters` or `Select targets`.
+- Body copy uses input-neutral language: `Select features...`, not `Tap...`.
+- `Keep originals` stays in the panel body.
+- `Next`, `Confirm`, and `Cancel` stay in the panel action row.
+- `Next` is disabled until at least one cutter is selected.
+- `Confirm` is disabled until at least one target is selected.
+- Multi-select remains in the existing selection command surface, visually selected during
+  Cut/Join because multi-select is automatic; it should not be a dead control inside the
+  workflow panel.
+
+Cut-specific acceptance:
+- Open Cut, select a cutter, press `Next`, then select the first target with one click/tap.
+- Open Cut and select additional cutters without first clicking/tapping the canvas just to
+  recover focus.
+- Toggle `Keep originals`, then select geometry with one click/tap.
+- Drag the panel away from geometry; it remains inside the canvas.
+- Desktop mouse and tablet touch follow the same visible flow.
+
+### 2.5c. Migration order after Cut
+
+After Cut is refactored into the reusable panel pattern, migrate workflows in this order:
+1. ✓ Join closed features.
+2. ✓ Move / Copy.
+3. ✓ Rotate / Resize / Mirror.
+4. ✓ Offset.
+5. Composite / polygon / spline drawing command controls.
+6. Sketch edit apply/cancel/dimension controls.
+
+For each migration:
+- Remove keyboard-key text from the primary visible flow.
+- Keep shortcuts operational where they already exist.
+- Add panel actions only when they map to a real state transition.
+- Keep the canvas focus contract: after any panel action, the next geometry click/tap must be
+  handled by the canvas immediately.
+- Verify desktop and tablet together. This pattern is now cross-device, not tablet-only.
+
+### 2.5d. Design constraints
+
+- Panels should be compact. Default width target: about 300px, responsive down to available
+  canvas width.
+- No nested cards.
+- Action rows should be stable: button sizes should not reflow wildly as workflow state
+  changes.
+- Use concise phase labels and put longer guidance in the body.
+- Prefer one active workflow panel at a time.
+- If a workflow needs global selection state, reflect that state in the existing command
+  surface rather than duplicating confusing controls inside the workflow panel.
+
+### 2.5e. Exact entry requires an explicit preview reference
+
+The old desktop `Tab` model depended on hover state: move the mouse in the intended
+direction, press `Tab`, then type the distance along that live vector. A standalone
+`Dimension` button is not equivalent. On desktop it can be pressed before the pointer has
+defined a direction; on tablet there is no hover preview at all, so the user can be asked
+to type a distance without knowing which direction or snap result will be used.
+
+Rule: exact entry is never a free-standing command. It must operate on an existing,
+visible, frozen preview reference.
+
+Move / Copy target flow should become:
+1. Select the source/from point.
+2. Select or preview the target direction.
+3. Show a visible guide from source to preview target, a target marker, the measured
+   distance, and the active snap result.
+4. Click/tap the canvas target to freeze the reference point and enter exact distance
+   editing immediately.
+5. Prefill the distance field from the frozen source-to-reference vector.
+6. `Confirm` commits that prefilled distance as-is, or the user can edit the value first.
+7. `Cancel` exits the move/copy workflow. A separate `Back`/`Change reference` action may be
+   added if testing shows users need to re-pick the reference without cancelling.
+
+Tablet-specific behavior:
+- The first tap after the source point should set a preview/reference point instead of
+  blindly committing the move/copy.
+- After that tap, the workflow panel opens distance entry prefilled from the selected point.
+- The canvas must show the resolved snap mode near the preview target or in the workflow
+  panel, for example `Snap: Grid`, `Snap: Point`, `Snap: Midpoint`, `Snap: Center`,
+  `Snap: Line`, `Snap: Perpendicular`, or `Snap: Free`.
+
+Desktop behavior may stay faster, but it should use the same model internally:
+- Hover updates the preview reference.
+- Clicking freezes the hovered/snapped reference and opens the same prefilled distance
+  entry. This avoids depending on hover after the pointer moves toward a panel button.
+- Pressing `Tab` can remain as a desktop shortcut that freezes the current hover reference
+  and opens the same prefilled distance entry.
+
+Apply the same rule to shape drawing and sketch edit dimensions:
+- A typed length/angle should be based on the current visible preview segment.
+- Tablet users need a visible preview point/segment and snap indicator before typing exact
+  values.
+- Do not migrate more dimension-heavy workflows until this reference/preview contract is
+  implemented.
+
+### 2.5f. Feature creation workflow panels
+
+Feature creation (rect, circle, ellipse, line, arc, polygon, spline, composite) must use the
+same workflow panel pattern as Cut/Join/Move/Transform/Offset. This is the only way for
+tablet users to enter precise dimensions, and it gives desktop users a visual alternative to
+the `Tab`-to-type shortcut.
+
+Universal focus contract — applies to both desktop and tablet:
+1. **Canvas phase:** the user taps/clicks points on the canvas. The canvas holds focus. The
+   workflow panel is visible but passive, showing the current step and offering action buttons.
+2. **Numeric entry phase:** the user taps a panel action (e.g. `Dimensions`, `Radius`,
+   `Angle`). Focus moves to the first input field inside the panel. The user types values and
+   tabs between fields within the panel.
+3. **Confirm:** the user taps `Confirm` or presses `Enter`. The feature is applied (or the
+   step advances), and focus returns to the canvas immediately via `focusCanvasAfterAction()`.
+4. **Cancel:** the user taps `Cancel` or presses `Escape`. Input is discarded, focus returns
+   to the canvas, and the user is back in the spatial-click phase.
+
+The panel never holds focus after an action completes. Every button tap and every
+`Enter`/`Escape` in a panel input ends with the canvas receiving focus. This is enforced by
+`useCanvasWorkflowPanel` — the same hook already used by Cut, Join, Move, Transform, and
+Offset.
+
+Desktop retains existing keyboard shortcuts (`Tab` to open dimension entry, `Enter` to
+confirm, `Escape` to cancel) as accelerators. These shortcuts trigger the same state
+transitions as the panel buttons — they are not a separate code path.
+
+Feature creation migration order:
+1. ✓ Rectangle (width × height after first point).
+2. ✓ Circle (radius after center point).
+3. ✓ Ellipse (radii after center point).
+4. Line / Arc / Spline segment dimension entry.
+5. Polygon (side count, radius).
+6. Composite drawing controls.
+
+Tab and Clamp creation also migrated to the workflow panel (same anchor-based pattern as
+rect/circle/ellipse).
+
+For each feature type:
+- The panel shows the current creation step (e.g. `Click first corner`, `Click second corner
+  or enter dimensions`).
+- Numeric entry buttons are only enabled when a visible preview reference exists (per 2.5e).
+- After confirming dimensions, the feature is created and the tool either resets for the next
+  feature or exits, matching current behavior.
+- The `sketch-dim-input` inline overlays on the canvas are replaced by input fields inside
+  the workflow panel. This removes the split between "canvas overlay inputs" and "panel
+  inputs" and gives a single consistent surface for numeric entry.
+
+Dialog focus restoration: ✓
+- Modal dialogs (New Project, Import Geometry, Export, Text Tool) use
+  `useRestoreCanvasFocus()` to return focus to the canvas on close. Implemented and separate
+  from the workflow panel focus contract.
+
+### Files likely modified
+- `src/components/canvas/CanvasWorkflowPanel.tsx` — reusable overlay component
+- `src/components/canvas/useCanvasWorkflowPanel.ts` — drag/focus helper hook
+- `src/components/canvas/SketchCanvas.tsx` — consume workflow panel for all creation flows
+- `src/utils/useRestoreCanvasFocus.ts` — modal dialog focus restoration hook
+- `src/styles/canvas-workflow.css` or `src/styles/tablet.css` — shared panel styles
+
+### Verification
+- `npm run build`
+- Desktop Cut flow: no keyboard required, no double-click/two-click focus recovery.
+- Tablet Cut flow: same behavior with touch.
+- Desktop feature creation: click points or use panel dimensions — both work.
+- Tablet feature creation: tap first point, tap Dimensions, type values, confirm — canvas
+  receives focus immediately and is ready for the next interaction.
+- Drag panel with mouse and touch.
+- Existing keyboard shortcuts still work as accelerators.
+- Modal dialogs (New Project, Import, Export, Text) restore canvas focus on close.
+- No duplicated or contradictory visible controls.
+
+---
+
 ## PR 3 — Toolbar split + left drawer + command surfaces
 
 **Goal:** Replace the wrapping one-strip toolbar with purpose-built command surfaces and

--- a/planning/TABLET_UX_COMBINED_PLAN.md
+++ b/planning/TABLET_UX_COMBINED_PLAN.md
@@ -1,0 +1,458 @@
+# Tablet UX — Combined Implementation Plan
+
+## Context
+
+The app is non-functional on iPad — the sketch canvas doesn't respond to touch at all. CSS responsive foundations exist (right panel drawer, 44px touch targets, status bar wrapping — Phase 1/PR #53), and Phase 2A added Edit/More buttons and clickable kbd chips. But core interactions are still mouse+keyboard only.
+
+Two prior plans exist:
+- **[TABLET_UX_Implementation_Plan.md](TABLET_UX_Implementation_Plan.md)** — incremental bug inventory, items 2B-2E remain
+- **[TABLET_UI_UX_REFRESH_PLAN.md](TABLET_UI_UX_REFRESH_PLAN.md)** — holistic redesign from Codex (shell modes, toolbar split, 9 phases)
+
+This plan synthesizes both. It adopts the Codex plan's architectural ideas (shell mode
+system, toolbar split, canvas-first principle) but sequences them pragmatically into 4 PRs
+instead of 7, with implementation-level detail.
+
+This revision also incorporates a review pass:
+- Operations discoverability must land immediately, not as late polish.
+- Pointer conversion and gestures should not be bundled into one high-risk mega-change.
+- Touch controls should be named by user intent, not by keyboard shortcuts.
+- 7-8" tablets and desktop harmonization can be implemented later, but their architectural
+  constraints must influence the shell from PR 1.
+
+**Target:** iPad-class tablets (10"+), landscape primary, 1024px+ width.
+**Secondary target:** 7-8" tablets, landscape, canvas-first compact shell.
+**User decisions:** Left panel -> collapsible drawer. Keyboard shortcuts -> touch command
+surfaces. Phased PRs. Desktop can change if the tablet architecture is better.
+
+---
+
+## Cross-Cutting UX Rules
+
+These rules apply to every PR:
+
+- The canvas must remain the primary surface on tablet.
+- The Operations drawer must always have a visible opener when closed.
+- Keyboard shortcuts can remain, but they cannot be the only path for primary actions.
+- Tablet buttons should use intent labels/icons: `Dimension`, `Line`, `Arc`, `Spline`,
+  `Confirm`, `Cancel`, `Lock X/Y`, not raw keyboard labels like `Tab`, `L`, `A`, `S`.
+- Double-click, right-click, hover, modifier keys, and drag-and-drop are desktop
+  enhancements only.
+- A 7-8" compact shell is not implemented first, but new components must be able to move
+  from a left rail into a bottom command sheet later.
+- Desktop should not be protected from improvement. If the split command model is clearer,
+  laptop/desktop can adopt it in a later phase.
+
+---
+
+## PR 1 — Shell mode + drawer discoverability + basic pointer conversion
+
+**Goal:** The app knows what shell mode it is in, the Operations drawer is discoverable, and
+the sketch canvas receives pointer events on touch. This PR should be small enough to review
+without also introducing full gesture behavior.
+
+### 1a. Shell mode system
+
+**New file:** `src/components/layout/useShellMode.ts`
+
+Adopting from the Codex plan — a single source of truth for device class, replacing scattered media queries:
+
+```ts
+type ShellMode = 'desktop-wide' | 'desktop-compact' | 'tablet' | 'tablet-compact'
+```
+
+Detection inputs: `window.innerWidth`, `matchMedia('(pointer: coarse)')`, `matchMedia('(hover: none)')`. Returns a reactive value (re-evaluates on resize). Sets `data-shell-mode` attribute on the app shell root, enabling CSS to target `[data-shell-mode="tablet"]` instead of fragile `@media` combinations.
+
+Breakpoints (from Codex plan, adjusted):
+| Mode | Width | Pointer |
+|------|-------|---------|
+| `desktop-wide` | ≥1400px | fine |
+| `desktop-compact` | 1100-1399px | fine |
+| `tablet` | ≥900px | coarse |
+| `tablet-compact` | 740-899px | coarse |
+
+Phone (<740px coarse) remains blocked by existing `main.tsx` check. Keep the compact-tablet
+mode even if it initially maps to the same UI as `tablet`; this prevents 10" assumptions
+from leaking into the shell API.
+
+Add dev-mode debug readout (`import.meta.env.DEV` only) showing current shell mode.
+
+### 1b. Set shell mode on the app shell
+
+**File:** `src/components/layout/AppShell.tsx`
+
+- Consume `useShellMode`.
+- Set `data-shell-mode` on `.app-shell`.
+- Use shell mode to drive tablet behavior instead of only CSS media queries.
+- Keep existing media queries as fallback during migration.
+
+### 1c. Operations drawer discoverability
+
+**Files:** `src/components/layout/AppShell.tsx`, `src/styles/tablet.css`
+
+Fix the current right drawer opener immediately:
+- The existing `.tablet-drawer-toggle` rule is hidden by a later equal-specificity
+  `display: none`; correct the CSS order/specificity.
+- Rename the opener from `CAM` to `Operations`.
+- Include operation count when available, e.g. `Operations 4`.
+- Keep the opener visible whenever the right panel is hidden in tablet/tablet-compact modes.
+- Put the opener in a predictable top command area or workspace header, not at the end of a
+  wrapping toolbar.
+- Keep close button, scrim tap, and `Escape` close behavior.
+
+This is not polish. If the drawer can close and cannot obviously reopen, the app is broken.
+
+### 1d. Basic pointer event migration in SketchCanvas.tsx
+
+**File:** `src/components/canvas/SketchCanvas.tsx`
+
+The canvas (line 3964-3974) uses `onMouseDown`, `onMouseUp`, `onMouseLeave` — these don't fire on touch. `onClick`, `onDoubleClick`, `onContextMenu` already work on touch.
+
+Changes:
+- **`onMouseDown` → `onPointerDown`**: Rename `handleMouseDown` (line 2107) → `handlePointerDown`, param type → `React.PointerEvent<HTMLCanvasElement>`. All `event.button`/`event.shiftKey` checks remain valid. Add `setPointerCapture(event.pointerId)` for touch drags.
+- **`onMouseUp` → `onPointerUp`**: Rename `handleMouseUp` (line 2566) → `handlePointerUp`, add `releasePointerCapture`. Add `onPointerCancel` wired to same handler.
+- **`onMouseLeave` → `onPointerLeave`**: Rename `handleMouseLeave` (line 2636) → `handlePointerLeave`.
+- **Import**: Update `type { MouseEvent }` (line 18) to include `PointerEvent`.
+- Keep `onClick`, `onDoubleClick`, `onKeyDown`, `onContextMenu` unchanged.
+
+Important constraint: do not rely on `onDoubleClick` or `onContextMenu` as primary tablet
+interaction. This PR can keep them for compatibility, but later PRs must add visible touch
+alternatives.
+
+### 1e. Minimal touch panning
+
+Currently pan requires Shift+click or middle/right button (line 2125-2126). For touch in `handlePointerDown`:
+- When `event.pointerType === 'touch'` and no pending operation active, start panning immediately if no control/feature/clamp/tab is hit. Matches CAD tablet convention — tap selects, drag on empty pans.
+- When a feature IS hit, proceed with normal logic.
+
+### 1f. CSS foundation
+
+**File:** `src/styles/layout.css` — Add `touch-action: none` to `.sketch-canvas`
+**File:** `src/styles/tablet.css` — Migrate existing `@media (pointer: coarse)` rules to also support `[data-shell-mode="tablet"]` / `[data-shell-mode="tablet-compact"]` selectors (keep media queries as fallback for now, add attribute selectors as progressive enhancement).
+
+### Files modified
+- `src/components/canvas/SketchCanvas.tsx` — pointer events and minimal touch pan
+- `src/components/layout/useShellMode.ts` — **new**, shell mode detection
+- `src/components/layout/AppShell.tsx` — consume `useShellMode`, set `data-shell-mode` attribute
+- `src/components/layout/Toolbar.tsx` if needed for opener placement
+- `src/styles/layout.css` — `touch-action: none` on canvas
+- `src/styles/tablet.css` — drawer opener fix and attribute selector support alongside media queries
+
+### Verification
+- iPad Safari: tap features to select, single-finger drag on empty pans
+- Operations button visible when the right drawer is closed
+- Operations drawer opens, closes, and reopens
+- Apple Pencil: precise pointer, no accidental pan when touching a feature/control
+- Desktop mouse: zero regression
+
+---
+
+## PR 2 — Sketch touch gestures + tablet command bar
+
+**Goal:** Sketching and editing are actually usable on touch. Add pinch/pan gestures,
+long-press as a secondary context-menu path, and a touch command bar with intent-based
+actions.
+
+### 2a. Pinch-to-zoom + two-finger pan
+
+**New file:** `src/sketch/useCanvasGestures.ts`
+
+Hook that:
+- Tracks active touch pointers in `Map<number, {x, y}>`
+- On two active pointers: computes center + distance, calculates delta for zoom (calls
+  existing `setViewState`) and delta-center for pan
+- Exposes `isGestureActive` ref so `handlePointerDown` skips single-pointer logic when the
+  second finger lands
+- Only tracks `pointerType === 'touch'` — mouse and pen pass through
+- Attaches near the existing native `pointermove` listener (line 1804)
+
+### 2b. Long-press context menu
+
+In `handlePointerDown` for touch: start 500ms timer. If finger doesn't move >10px and
+doesn't lift, open the same context menu as right-click. Cancel on move/up.
+
+Long-press is a secondary path. Primary tablet actions must still be visible buttons.
+
+### 2c. Floating tablet command bar
+
+**Files:** `src/components/canvas/SketchCanvas.tsx` (JSX), `src/styles/tablet.css`
+
+Context-sensitive floating bar, bottom-right of canvas, visible only in tablet shell modes.
+Use the same callbacks already wired to existing `<kbd>` banner chips where possible, but do
+not expose keyboard names as the primary UI.
+
+Buttons by context:
+| Context | Buttons |
+|---------|---------|
+| Composite drawing | **Line** / **Arc** / **Spline** mode buttons, **Undo point** |
+| Polygon/spline drawing | **Undo point** |
+| Any pending op | **Confirm**, **Cancel** |
+| Sketch edit mode | **Dimension** when a node/segment is armed |
+| Spatial operation (move/transform/drag) | **Axis lock** cycle button with X/Y state |
+| Feature selection | **Multi-select** toggle |
+
+Keyboard hints can appear in tooltips or secondary labels on desktop, but the visible tablet
+commands should describe intent.
+
+### 2d. Multi-select mode
+
+Local `multiSelectMode` boolean in SketchCanvas. When true, taps in `handleClick` act as if `event.shiftKey` were true. Toggle in floating action bar. Auto-enabled during shape actions (Join/Cut).
+
+Update banner text: "Shift-click" → "Tap" when in tablet shell mode.
+
+### 2e. Axis lock toggle
+
+**File:** `src/sketch/useAxisLock.ts`
+
+Export `cycleLock` from the hook (the function `cycleLockMode` at line 78 already exists but the hook doesn't expose an imperative trigger):
+```ts
+const cycleLock = useCallback(() => {
+  lockModeRef.current = cycleLockMode(lockModeRef.current)
+  onLockChangeRef.current?.()
+}, [])
+```
+
+Wire to action bar button. Display current mode with `lockModeGuideColor` coloring.
+
+### 2f. Tap-to-arm nodes (sketch edit hover replacement)
+
+Banner says "Hover a node and press Tab" — hover doesn't exist on touch.
+
+In `handlePointerDown` when `pointerType === 'touch'` and a control is hit:
+- Don't immediately start drag. Record potential drag start.
+- In `handleCanvasPointerMove`: if move >5px, begin drag normally.
+- In `handlePointerUp`: if <5px (no drag), treat as "tap-to-arm" — set `hoveredEditControl`, making Tab action bar button active.
+
+### Files modified
+- `src/components/canvas/SketchCanvas.tsx` — gesture integration, command bar JSX, multi-select, tap-to-arm
+- `src/sketch/useCanvasGestures.ts` — **new**, pinch-to-zoom + two-finger pan
+- `src/sketch/useAxisLock.ts` — expose `cycleLock`
+- `src/styles/tablet.css` — command bar styles
+
+### Verification
+- Action bar buttons work for all pending operations
+- Composite Line/Arc/Spline switch drawing modes
+- Multi-select toggle: enable, tap features, accumulate selection
+- Axis lock: during move, tap button, verify constraint + guide color
+- Tap-to-arm: in sketch edit, tap node (don't drag), Tab button activates, tap it, dimension input opens
+- Two-finger pinch zooms around midpoint
+- Two-finger pan moves the sketch view
+- Long-press opens context menu, but all primary context actions are also reachable via buttons
+- Desktop: no regression
+
+---
+
+## PR 3 — Toolbar split + left drawer + command surfaces
+
+**Goal:** Replace the wrapping one-strip toolbar with purpose-built command surfaces and
+move left-side chrome into a tablet drawer.
+
+### 3a. Top command bar
+
+**New file:** `src/components/layout/TopCommandBar.tsx`
+
+Contains: project name, save state, New/Open/Import/Save, Undo/Redo, workspace view tabs (Sketch/3D/Simulation), Zoom/Fit, Operations opener (with count).
+
+On tablet: single non-wrapping row. Tight spacing, icon-only where possible, text labels for view tabs.
+
+### 3b. Tool rail
+
+**New file:** `src/components/layout/ToolRail.tsx`
+
+Contains: selection tool, feature/region target toggle, creation tools (rect/circle/ellipse/polygon/spline/composite/text), edit tools (move/rotate/resize/mirror/offset/fillet/join/cut), alignment/distribution (shown only on multi-select).
+
+On tablet: vertical left rail (48px wide) for 10" class layouts. The component must also be
+able to render as a bottom command sheet later for 7-8" compact tablets.
+
+On desktop: keep the current combined toolbar initially, but build `ToolRail` without
+tablet-only assumptions so desktop can adopt it later.
+
+### 3c. Snap popover
+
+**New file:** `src/components/layout/SnapPopover.tsx`
+
+Replace 7 persistent snap buttons with: one snap-enabled toggle button + popover showing grid/point/line/midpoint/center/perpendicular options. Active snap mode indicator on the toggle button.
+
+### 3d. Wire into AppShell
+
+**File:** `src/components/layout/AppShell.tsx`
+
+In tablet shell modes, render `TopCommandBar` + `ToolRail` instead of the combined `Toolbar`. Desktop keeps current combined toolbar (can adopt split layout later in harmonization phase).
+
+### 3e. Left panel drawer
+
+**Files:** `src/components/layout/AppShell.tsx`, `src/styles/tablet.css`
+
+Mirror the existing right panel drawer pattern:
+- `leftDrawerOpen` state
+- `data-left-open` attribute on `.app-shell`
+- Left scrim element
+- Tree/Project toggle button in the top command bar
+- Close button inside left panel header
+
+CSS: `.panel-left` becomes `position: fixed; inset: 0 auto 0 0; width: min(300px, 85vw);
+transform: translateX(-100%)` in tablet modes. Grid drops the left panel column; center
+fills the available width except for the tool rail.
+
+The drawer should expose Project and Properties either as:
+- the current stacked split for this PR, or
+- tabbed Project / Properties if the stacked split is too cramped.
+
+### 3f. Remove tablet-visible desktop controls
+
+On tablet, hide workspace layout controls (lcr/lc/c/cr buttons) and toolbar orientation controls — these are desktop configuration that doesn't apply when the shell mode drives layout.
+
+### Files modified
+- `src/components/layout/TopCommandBar.tsx` — **new**
+- `src/components/layout/ToolRail.tsx` — **new**
+- `src/components/layout/SnapPopover.tsx` — **new**
+- `src/components/layout/AppShell.tsx` — conditional rendering by shell mode
+- `src/components/feature-tree/FeatureTree.tsx` if drawer header/action wiring needs it
+- `src/styles/tablet.css` — top bar, tool rail, snap popover styles
+- `src/styles/layout.css` — grid adjustments for tool rail column
+
+### Verification
+- iPad 1024x768: top bar is one non-wrapping row
+- Creation and edit tools don't wrap (they're in the vertical rail)
+- Snap controls: one button, popover shows all options
+- Left drawer: hidden by default, toggle opens, scrim closes, Project/Properties are usable
+- Desktop: existing toolbar unchanged
+- All tool selections, snap modes, file operations work
+
+---
+
+## PR 4 — Reorder controls + 3D/simulation gestures + workflow polish
+
+**Goal:** Remaining desktop-only patterns get touch alternatives, all viewports are
+navigable by touch, and the end-to-end tablet workflow is credible.
+
+### 4a. Reorder controls
+
+**Files:** `src/components/feature-tree/FeatureTree.tsx`, `src/components/cam/CAMPanel.tsx`
+
+Move Up / Move Down buttons on feature rows and CAM operation rows. Visible in tablet shell mode, hidden on desktop. Keep HTML drag-and-drop as desktop enhancement.
+
+### 4b. Dialog audit
+
+Review all dialogs for 10" tablet dimensions:
+- `src/components/project/ImportGeometryDialog.tsx`
+- `src/components/project/NewProjectDialog.tsx`
+- `src/components/project/TextToolDialog.tsx`
+- `src/components/export/ExportDialog.tsx`
+
+Ensure touch targets, no clipping, scrollable content areas.
+
+### 4c. 3D and simulation touch gestures
+
+**Files:** `src/components/viewport3d/Viewport3D.tsx`,
+`src/components/simulation/SimulationViewport.tsx`
+
+Implement explicit touch gestures:
+- One finger: orbit in 3D/simulation.
+- Two fingers: pan.
+- Pinch: zoom.
+- Fit button remains available as a visible recovery action.
+- Pen input should behave as precise pointer input, not camera orbit.
+
+Do not treat sketch gestures as sufficient for 3D/simulation. These viewports have their own
+camera state and need their own acceptance tests.
+
+### 4d. Operations drawer polish
+
+Operations discoverability lands in PR 1. This PR polishes the drawer:
+- operation count badge styling
+- active operation summary
+- warning visibility
+- Add/Export placement in drawer header
+- row action hit targets
+
+### 4e. Status bar compact mode
+
+On tablet, status bar auto-collapses to a single-line readout. Tap to expand full status. Saves ~20px vertical space.
+
+### 4f. Compact tablet and desktop check
+
+No full compact-tablet implementation yet, but this PR should verify:
+- at 800x600 landscape, the app does not have unrecoverable hidden controls
+- the new command surfaces can be moved into a bottom sheet later
+- desktop MacBook layout remains at least as usable as before
+
+### Files modified
+- `src/components/feature-tree/FeatureTree.tsx` — reorder buttons
+- `src/components/cam/CAMPanel.tsx` — reorder buttons, operations badge
+- `src/components/viewport3d/Viewport3D.tsx` — touch gestures
+- `src/components/simulation/SimulationViewport.tsx` — touch gestures
+- Dialog files — touch target audit
+- `src/components/layout/AppShell.tsx` — drawer polish/status strip if needed
+- `src/styles/tablet.css` — reorder buttons, status bar compact, operations badge
+
+### Verification
+- Reorder: move up/down buttons work on tablet
+- Dialogs: all fit and usable at 1024x768
+- Operations button: labeled, shows count, always visible
+- 3D: one-finger orbit, two-finger pan, pinch zoom
+- Simulation: one-finger orbit, two-finger pan, pinch zoom
+- 800x600 landscape smoke pass: no unrecoverable controls
+- Desktop full-size MacBook screenshot: no major regression
+- End-to-end: create project → draw features → set dimensions → create operation → simulate → export G-code — all completable on iPad without keyboard
+
+---
+
+## Critique of both source plans
+
+### Codex plan — what we're adopting
+- Shell mode system (PR 1) — much better than scattered media queries
+- Toolbar split (PR 3) — the wrapping toolbar is a real usability issue
+- Snap popover — 7 buttons to 1 is a clear win
+- Operations discoverability — "Operations" with count > hidden "CAM" button
+- Canvas-first principle — guides every layout decision
+
+### Codex plan — what we're deferring
+- **Full Phase 0 inventory** — keep a lightweight command inventory inside each PR instead
+  of making it a standalone phase.
+- **Full compact tablet implementation** — premature until 10" is solid, but the shell API
+  must include `tablet-compact` from PR 1.
+- **Desktop harmonization rollout** — better as a follow-up project, but components should
+  be desktop-ready from the start.
+- **Standalone QA phase** — testing should be embedded in each PR, with screenshots and real
+  tablet checks as acceptance criteria.
+- **CommandSheet implementation** — deferred until compact tablet support, but `ToolRail`
+  should be designed so it can become a sheet.
+
+### Codex plan — critique
+- 9 phases is too many sequential dependencies — delays the most impactful fix (pointer events)
+- A standalone Phase 0 can become process overhead, but skipping all inventory is also risky.
+  Each PR should include a small command/dependency audit for the surface it touches.
+- Desktop harmonization should be a separate rollout decision, but not a separate
+  architecture. New command components should be reusable on desktop.
+- Some phases are underspecified on implementation (e.g., "migrate sketch canvas to pointer
+  events" without addressing the mouse/click/doubleclick question).
+
+### Original incremental plan — what changed
+- Added shell mode system (was missing entirely)
+- Added toolbar split as PR 3 (was not addressed)
+- Moved left drawer into PR 3 with the command-surface work, where it fits the new shell
+  layout.
+- Moved Operations discoverability to PR 1 because hidden/reopenable panels are a blocker.
+- Kept pointer event migration strategy (concrete and correct)
+- Kept floating action bar design, but changed visible labels from keyboard shortcuts to
+  intent-based tablet commands.
+- Kept `useCanvasGestures` hook, but split it into PR 2 to reduce PR 1 risk.
+
+---
+
+## Alignment with existing planning docs
+
+Updates `planning/TABLET_UX_Implementation_Plan.md`:
+- **Phase 2B** (pointer events) → PR 1 (1d-1e) + PR 2 (2a-2f)
+- **Phase 2C** (3D/sim gestures) → PR 4 (4c)
+- **Phase 2D** (reorder) → PR 4 (4a)
+- **Phase 2E** (toolbar/chrome) → PR 1 (Operations opener) + PR 3 (toolbar split,
+  left drawer) + PR 4 (status bar compact)
+
+## Not covered (future)
+- Full compact tablet (7-8") UI — after 10" is solid, but `tablet-compact` shell mode exists
+  from PR 1.
+- Desktop harmonization rollout — separate project, but new command components are designed
+  to be reused.
+- Canvas dimension label tap-targets
+- Portrait mode support

--- a/planning/TABLET_UX_COMBINED_PLAN.md
+++ b/planning/TABLET_UX_COMBINED_PLAN.md
@@ -327,8 +327,9 @@ After Cut is refactored into the reusable panel pattern, migrate workflows in th
 2. ✓ Move / Copy.
 3. ✓ Rotate / Resize / Mirror.
 4. ✓ Offset.
-5. Composite / polygon / spline drawing command controls.
-6. Sketch edit apply/cancel/dimension controls.
+5. ✓ Composite / polygon / spline drawing command controls.
+6. ✓ Sketch edit apply/cancel/dimension controls.
+7. ✓ Constraint creation (anchor → reference → distance entry).
 
 For each migration:
 - Remove keyboard-key text from the primary visible flow.
@@ -395,7 +396,7 @@ Apply the same rule to shape drawing and sketch edit dimensions:
 - Do not migrate more dimension-heavy workflows until this reference/preview contract is
   implemented.
 
-### 2.5f. Feature creation workflow panels
+### 2.5f. Feature creation workflow panels ✓
 
 Feature creation (rect, circle, ellipse, line, arc, polygon, spline, composite) must use the
 same workflow panel pattern as Cut/Join/Move/Transform/Offset. This is the only way for
@@ -426,9 +427,9 @@ Feature creation migration order:
 1. ✓ Rectangle (width × height after first point).
 2. ✓ Circle (radius after center point).
 3. ✓ Ellipse (radii after center point).
-4. Line / Arc / Spline segment dimension entry.
-5. Polygon (side count, radius).
-6. Composite drawing controls.
+4. ✓ Line / Arc / Spline segment dimension entry.
+5. ✓ Polygon (side count, radius).
+6. ✓ Composite drawing controls.
 
 Tab and Clamp creation also migrated to the workflow panel (same anchor-based pattern as
 rect/circle/ellipse).
@@ -466,6 +467,86 @@ Dialog focus restoration: ✓
 - Existing keyboard shortcuts still work as accelerators.
 - Modal dialogs (New Project, Import, Export, Text) restore canvas focus on close.
 - No duplicated or contradictory visible controls.
+
+### 2.5g. Composite arc dimension entry modes
+
+The composite shape supports three segment modes (line, arc, spline), each with different
+dimension entry fields. The arc mode has a two-phase click workflow (endpoint then curvature
+point), but dimension entry collapses this into fewer steps.
+
+**Line mode:** Length + Angle — polar coordinates from the last point. Same as polygon/spline.
+
+**Arc mode, entering from scratch (no pendingArcEnd):** Length + Angle + Radius — all three
+fields shown together. Length and angle define the arc endpoint (same as line), and radius
+defines the arc curvature. On confirm, the system:
+1. Computes the endpoint from length + angle relative to the last point.
+2. Adds it as `pendingArcEnd` via `addPendingCompositePoint`.
+3. Computes the arc through-point from the radius using the sagitta formula on the chord
+   between the last point and the new endpoint.
+4. Adds the through-point via `addPendingCompositePoint` to complete the arc segment.
+This means the user defines a full arc in one dimension entry step rather than two clicks.
+
+**Arc mode, endpoint already placed (has pendingArcEnd):** Radius only — the arc endpoint
+was already clicked, so only the curvature remains. The through-point is computed from the
+chord (lastPoint → pendingArcEnd) and the entered radius, placed on the perpendicular
+bisector of the chord at sagitta distance.
+
+**Spline mode:** Length + Angle — same as line mode. The spline curvature is computed
+automatically from the sequence of control points.
+
+The sagitta formula: given chord half-length `h` and radius `r` (must be ≥ h), the sagitta
+(bulge distance from chord midpoint to arc midpoint) is `s = r - sqrt(r² - h²)`. The
+through-point is placed at `chordMidpoint + s * perpendicular`. The perpendicular direction
+defaults based on the cursor position when dimension entry was triggered, stored as
+`arcClockwise` on the dimension edit state.
+
+### 2.5h. Edit mode workflow panel + click-to-edit dimensions ✓
+
+The edit mode currently renders Apply, Cancel, Dimension, and Lock buttons in the tablet
+command bar. The Lock button only appears during drag but is impractical to tap while
+dragging. These controls should migrate into a CanvasWorkflowPanel for consistency with
+creation workflows.
+
+**Workflow panel for edit mode:**
+- Shows when `selection.mode === 'sketch_edit'` (not during creation).
+- Always shows Apply and Cancel buttons.
+- Shows axis Lock toggle when dragging a node.
+- Dimension entry is triggered by tapping a segment or anchor on the canvas, not by a
+  separate Dimension button. This eliminates the `armedForDimension` flag and Tab-key
+  cycling through segments.
+
+**Click-to-edit segment dimensions:**
+When the user clicks/taps a segment in edit mode, the workflow panel shows dimension input
+fields appropriate to the segment type:
+- **Line segment:** Length + Angle (polar from the segment's start anchor).
+- **Arc segment:** Radius (of the arc).
+- **Bezier segment:** Length + Angle (chord from start to end anchor).
+Confirm applies the dimension change. Cancel discards it. This replaces the desktop-only
+Tab-to-cycle-dimensions workflow with a visual, click-based approach that works on both
+platforms.
+
+**Add-point bug on tablet (open feature extension):**
+`handlePointerLeave` clears `pendingSketchExtensionRef` when the pointer leaves the canvas.
+On touch devices, `pointerleave` fires after every finger lift (touch → pointerup →
+pointerleave → click). This means the first tap successfully sets the extension endpoint,
+but `pointerleave` clears it before the second tap's click handler runs. Fix:
+`handlePointerLeave` must not clear `pendingSketchExtensionRef` — it should only be cleared
+by explicit cancellation or successful extension.
+
+### 2.5i. Constraint creation workflow panel ✓
+
+The constraint creation flow (press C → pick anchor → pick reference → enter distance) was
+previously rendered as a `sketch-place-banner` with a floating positioned input. Converted to
+a `CanvasWorkflowPanel` with three phases:
+- **Pick anchor point:** summary text guiding user to tap a snap point on the feature.
+- **Pick reference point:** summary text guiding user to tap a snap point on another feature.
+- **Set distance:** Distance input field with Confirm/Cancel buttons.
+
+The existing `constraintEdit` inline input (click-on-constraint-label to edit its value)
+remains as a positioned overlay since it needs to appear at the constraint's screen location.
+
+Also: starting a node drag now auto-cancels any active dimension edit fields to prevent stale
+inputs from remaining visible while the user interacts with geometry directly.
 
 ---
 

--- a/planning/TABLET_UX_Implementation_Plan.md
+++ b/planning/TABLET_UX_Implementation_Plan.md
@@ -1,5 +1,12 @@
 # Tablet UX Implementation Plan
 
+## Obsolete
+
+`[x]` Superseded. This document is retained as historical context and a bug inventory only.
+Do not use it as the implementation source of truth.
+
+Current plan: [TABLET_UX_COMBINED_PLAN.md](TABLET_UX_COMBINED_PLAN.md)
+
 ## Context
 
 This plan is based on a code review of the current shell, responsive CSS, and input handling.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -984,6 +984,14 @@ function App() {
         rightTab={rightTab}
         onRightTabChange={setRightTab}
         statusBarExtras={collapsedDepthLegend}
+        onZoomToModel={handleZoomToModel}
+        onZoomWindow={handleZoomWindow}
+        zoomWindowActive={zoomWindowActive}
+        onImportComplete={handleImportComplete}
+        snapSettings={snapSettings}
+        activeSnapMode={activeSnapMode}
+        onToggleSnapEnabled={handleToggleSnapEnabled}
+        onToggleSnapMode={handleToggleSnapMode}
       />
       
       {showExportDialog && (

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -33,6 +33,7 @@ import type {
 import { featureHasClosedGeometry } from '../../text'
 import { convertToolUnits, formatLength, parseLengthInput } from '../../utils/units'
 import { Icon } from '../Icon'
+import { isTabletMode, useShellMode } from '../layout/useShellMode'
 import { PanelSplit } from './PanelSplit'
 
 interface CAMPanelProps {
@@ -728,9 +729,12 @@ export function CAMPanel({
     operationId: string
     text: string
   } | null>(null)
+  const shellMode = useShellMode()
+  const tabletShell = isTabletMode(shellMode)
   const [dragOperationId, setDragOperationId] = useState<string | null>(null)
   const addOperationMenuRef = useRef<HTMLDivElement>(null)
   const dragOverOperationId = useRef<string | null>(null)
+  const gripDragRef = useRef<{ operationId: string; lastSwapY: number; pointerId: number } | null>(null)
   const {
     project,
     selection,
@@ -1103,6 +1107,16 @@ export function CAMPanel({
     dragOverOperationId.current = null
   }
 
+  function handleMoveOperation(operationId: string, direction: -1 | 1) {
+    const ids = project.operations.map((op) => op.id)
+    const index = ids.indexOf(operationId)
+    const swapIndex = index + direction
+    if (index === -1 || swapIndex < 0 || swapIndex >= ids.length) return
+    const nextIds = [...ids]
+    ;[nextIds[index], nextIds[swapIndex]] = [nextIds[swapIndex], nextIds[index]]
+    reorderOperations(nextIds)
+  }
+
   function handleApplySelectionToOperation() {
     if (!selectedOperation) {
       return
@@ -1276,6 +1290,53 @@ export function CAMPanel({
                           onDrop={handleOperationDrop}
                         >
                           <span className={generatingOperationIds?.has(operation.id) ? 'tree-branch tree-branch--generating' : 'tree-branch'} aria-hidden="true" />
+                          {tabletShell && project.operations.length > 1 ? (
+                            <button
+                              className="tree-action-btn tree-drag-grip"
+                              type="button"
+                              title="Drag to reorder"
+                              aria-label="Drag to reorder"
+                              onPointerDown={(e) => {
+                                if (e.pointerType !== 'touch') return
+                                e.preventDefault()
+                                e.stopPropagation()
+                                e.currentTarget.setPointerCapture(e.pointerId)
+                                gripDragRef.current = { operationId: operation.id, lastSwapY: e.clientY, pointerId: e.pointerId }
+                              }}
+                              onPointerMove={(e) => {
+                                const state = gripDragRef.current
+                                if (!state || state.pointerId !== e.pointerId) return
+                                e.preventDefault()
+                                const delta = e.clientY - state.lastSwapY
+                                const threshold = 36
+                                if (delta > threshold) {
+                                  handleMoveOperation(state.operationId, 1)
+                                  state.lastSwapY = e.clientY
+                                } else if (delta < -threshold) {
+                                  handleMoveOperation(state.operationId, -1)
+                                  state.lastSwapY = e.clientY
+                                }
+                              }}
+                              onPointerUp={(e) => {
+                                gripDragRef.current = null
+                                if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+                                  e.currentTarget.releasePointerCapture(e.pointerId)
+                                }
+                              }}
+                              onPointerCancel={(e) => {
+                                gripDragRef.current = null
+                                if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+                                  e.currentTarget.releasePointerCapture(e.pointerId)
+                                }
+                              }}
+                            >
+                              <svg viewBox="0 0 14 14" width="12" height="12" focusable="false" aria-hidden="true" style={{ display: 'block' }}>
+                                <circle cx="5" cy="3.5" r="1.2" fill="currentColor" /><circle cx="9" cy="3.5" r="1.2" fill="currentColor" />
+                                <circle cx="5" cy="7" r="1.2" fill="currentColor" /><circle cx="9" cy="7" r="1.2" fill="currentColor" />
+                                <circle cx="5" cy="10.5" r="1.2" fill="currentColor" /><circle cx="9" cy="10.5" r="1.2" fill="currentColor" />
+                              </svg>
+                            </button>
+                          ) : null}
                           <span className="tree-label">
                             {operation.name}
                           </span>
@@ -1320,7 +1381,7 @@ export function CAMPanel({
                                 handleDeleteOperation(operation.id)
                               }}
                             >
-                              ✕
+                              <Icon id="trash" />
                             </button>
                           </span>
                         </div>

--- a/src/components/cam/PanelSplit.tsx
+++ b/src/components/cam/PanelSplit.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 interface PanelSplitProps {
   children: [React.ReactNode, React.ReactNode]
@@ -52,21 +52,16 @@ export function PanelSplit({
   })
 
   const containerRef = useRef<HTMLDivElement>(null)
+  const activePointerRef = useRef<number | null>(null)
 
-  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    e.currentTarget.setPointerCapture(e.pointerId)
-  }, [])
-
-  const handlePointerMove = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!e.currentTarget.hasPointerCapture(e.pointerId)) return
+  const resizeAt = useCallback(
+    (clientY: number) => {
       const container = containerRef.current
       if (!container) return
 
       const rect = container.getBoundingClientRect()
       const totalHeight = rect.height
-      const offsetY = e.clientY - rect.top
+      const offsetY = clientY - rect.top
 
       const minRatio = minFirst / totalHeight
       const maxRatio = 1 - minSecond / totalHeight
@@ -79,6 +74,47 @@ export function PanelSplit({
     },
     [minFirst, minSecond, storageKey],
   )
+
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    activePointerRef.current = e.pointerId
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId)
+    } catch {
+      // Window-level pointer tracking below keeps resizing working if capture is unavailable.
+    }
+  }, [])
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (activePointerRef.current !== e.pointerId && !e.currentTarget.hasPointerCapture(e.pointerId)) return
+      resizeAt(e.clientY)
+    },
+    [resizeAt],
+  )
+
+  useEffect(() => {
+    function handleWindowPointerMove(event: PointerEvent) {
+      if (activePointerRef.current !== event.pointerId) return
+      event.preventDefault()
+      resizeAt(event.clientY)
+    }
+
+    function handleWindowPointerEnd(event: PointerEvent) {
+      if (activePointerRef.current === event.pointerId) {
+        activePointerRef.current = null
+      }
+    }
+
+    window.addEventListener('pointermove', handleWindowPointerMove, { passive: false })
+    window.addEventListener('pointerup', handleWindowPointerEnd)
+    window.addEventListener('pointercancel', handleWindowPointerEnd)
+    return () => {
+      window.removeEventListener('pointermove', handleWindowPointerMove)
+      window.removeEventListener('pointerup', handleWindowPointerEnd)
+      window.removeEventListener('pointercancel', handleWindowPointerEnd)
+    }
+  }, [resizeAt])
 
   const classes = ['panel-split', className].filter(Boolean).join(' ')
 

--- a/src/components/canvas/CanvasWorkflowPanel.tsx
+++ b/src/components/canvas/CanvasWorkflowPanel.tsx
@@ -1,0 +1,56 @@
+import type { HTMLAttributes, ReactNode, RefObject } from 'react'
+import type { CanvasWorkflowPanelPosition } from './useCanvasWorkflowPanel'
+
+interface CanvasWorkflowPanelProps {
+  title: string
+  step?: ReactNode
+  children: ReactNode
+  actions: ReactNode
+  position: CanvasWorkflowPanelPosition
+  panelRef: RefObject<HTMLDivElement | null>
+  handleProps: HTMLAttributes<HTMLDivElement>
+  actionRowProps?: HTMLAttributes<HTMLDivElement>
+  className?: string
+  moveLabel?: string
+}
+
+export function CanvasWorkflowPanel({
+  title,
+  step,
+  children,
+  actions,
+  position,
+  panelRef,
+  handleProps,
+  actionRowProps,
+  className = '',
+  moveLabel = 'Move workflow controls',
+}: CanvasWorkflowPanelProps) {
+  const panelClassName = ['canvas-workflow-panel', className].filter(Boolean).join(' ')
+
+  return (
+    <div
+      ref={panelRef}
+      className={panelClassName}
+      style={{ left: position.x, top: position.y }}
+    >
+      <div
+        className="canvas-workflow-panel__handle"
+        role="button"
+        tabIndex={0}
+        aria-label={moveLabel}
+        {...handleProps}
+      >
+        <span className="canvas-workflow-panel__grip" aria-hidden="true" />
+        <span className="canvas-workflow-panel__title">{title}</span>
+      </div>
+      <div className="canvas-workflow-panel__body">
+        {step ? <div className="canvas-workflow-panel__step">{step}</div> : null}
+        {children}
+      </div>
+      <div className="canvas-workflow-panel__actions" {...actionRowProps}>
+        {actions}
+      </div>
+    </div>
+  )
+}

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -15,7 +15,7 @@
  */
 
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
-import type { KeyboardEvent, MouseEvent, WheelEvent } from 'react'
+import type { KeyboardEvent, MouseEvent, PointerEvent as ReactPointerEvent, WheelEvent } from 'react'
 import type { ToolpathResult } from '../../engine/toolpaths/types'
 import { ToolpathVisibilityPanel, type ToolpathVisibility } from '../ToolpathVisibilityPanel'
 import type { SnapMode, SnapSettings } from '../../sketch/snapping'
@@ -107,6 +107,7 @@ import {
 import type { Clamp, Point, SketchFeature, Tab } from '../../types/project'
 import { formatLength, parseLengthInput } from '../../utils/units'
 import { useAxisLock, lockModeGuideColor } from '../../sketch/useAxisLock'
+import { useCanvasGestures } from '../../sketch/useCanvasGestures'
 
 const NODE_HIT_RADIUS = 9
 const HANDLE_HIT_RADIUS = 7
@@ -254,6 +255,8 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const isPanningRef = useRef(false)
   const didPanRef = useRef(false)
   const lastPanPointRef = useRef<CanvasPoint | null>(null)
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const longPressStartRef = useRef<{ cx: number; cy: number; clientX: number; clientY: number } | null>(null)
   const marqueeStartRef = useRef<CanvasPoint | null>(null)
   const marqueeCurrentRef = useRef<CanvasPoint | null>(null)
   const zoomWindowStartRef = useRef<CanvasPoint | null>(null)
@@ -1796,6 +1799,15 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     }
 
     function handleNativePointerMove(event: PointerEvent) {
+      if (longPressTimerRef.current && longPressStartRef.current) {
+        const dx = event.clientX - longPressStartRef.current.clientX
+        const dy = event.clientY - longPressStartRef.current.clientY
+        if (dx * dx + dy * dy > 100) {
+          clearTimeout(longPressTimerRef.current)
+          longPressTimerRef.current = null
+          longPressStartRef.current = null
+        }
+      }
       const coalesced = typeof event.getCoalescedEvents === 'function' ? event.getCoalescedEvents() : []
       const sourceEvent = coalesced.length > 0 ? coalesced[coalesced.length - 1] : event
       handleCanvasPointerMove(canvasCoordinates(sourceEvent))
@@ -1822,6 +1834,25 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       canvas.removeEventListener('wheel', handleNativeWheel)
     }
   }, [zoomWindowActive])
+
+  const { isGestureActive: isGestureActiveRef } = useCanvasGestures({
+    getCanvas: () => canvasRef.current,
+    getViewState: () => viewStateRef.current,
+    setViewState: (updater) => setViewState(updater),
+    getBaseTransform: () => {
+      const canvas = canvasRef.current
+      if (!canvas) return { scale: 1, offsetX: 0, offsetY: 0 }
+      const base = computeBaseViewTransform(projectRef.current.stock, canvas.width, canvas.height)
+      return { scale: base.scale, offsetX: base.offsetX, offsetY: base.offsetY }
+    },
+    canvasToWorld: (cx, cy) => {
+      const canvas = canvasRef.current
+      if (!canvas) return { x: 0, y: 0 }
+      const vt = computeViewTransform(projectRef.current.stock, canvas.width, canvas.height, viewStateRef.current)
+      return canvasToWorld(cx, cy, vt)
+    },
+    minZoom: MIN_SKETCH_ZOOM,
+  })
 
   function canvasCoordinates(event: Pick<MouseEvent<HTMLCanvasElement> | WheelEvent<HTMLCanvasElement> | globalThis.WheelEvent, 'clientX' | 'clientY'>): CanvasPoint {
     const rect = canvasRef.current!.getBoundingClientRect()
@@ -2104,7 +2135,39 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     return bestControl
   }
 
-  function handleMouseDown(event: MouseEvent<HTMLCanvasElement>) {
+  function handlePointerDown(event: ReactPointerEvent<HTMLCanvasElement>) {
+    if (isGestureActiveRef.current) return
+
+    if (event.pointerType === 'touch') {
+      event.currentTarget.setPointerCapture(event.pointerId)
+    }
+
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current)
+      longPressTimerRef.current = null
+    }
+
+    if (event.pointerType === 'touch' && event.button === 0) {
+      const startCx = event.clientX
+      const startCy = event.clientY
+      const rect = canvasRef.current?.getBoundingClientRect()
+      longPressStartRef.current = {
+        cx: rect ? startCx - rect.left : startCx,
+        cy: rect ? startCy - rect.top : startCy,
+        clientX: startCx,
+        clientY: startCy,
+      }
+      longPressTimerRef.current = setTimeout(() => {
+        longPressTimerRef.current = null
+        if (longPressStartRef.current) {
+          triggerContextMenuAt(longPressStartRef.current.clientX, longPressStartRef.current.clientY)
+          suppressClickRef.current = true
+          stopPan()
+          longPressStartRef.current = null
+        }
+      }, 500)
+    }
+
     const project = projectRef.current
     const selection = selectionRef.current
     const pendingOffset = pendingOffsetRef.current
@@ -2123,6 +2186,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     }
 
     const shiftStartsPan = event.button === 0 && event.shiftKey && !pendingShapeAction
+    const isTouch = event.pointerType === 'touch'
     if (event.button === 1 || event.button === 2 || shiftStartsPan) {
       isPanningRef.current = true
       didPanRef.current = false
@@ -2151,6 +2215,13 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     const hitTabId = findHitTabId(world, project.tabs)
     const hitFeatureId = findHitFeatureId(world, project.features, vt)
     if (!control && !hitClampId && !hitTabId && !hitFeatureId) {
+      if (isTouch) {
+        isPanningRef.current = true
+        didPanRef.current = false
+        lastPanPointRef.current = point
+        setHoveredEditControl(null)
+        return
+      }
       marqueeStartRef.current = point
       marqueeCurrentRef.current = point
       setHoveredEditControl(null)
@@ -2563,7 +2634,17 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     lastPanPointRef.current = null
   }
 
-  function handleMouseUp() {
+  function handlePointerUp(event?: ReactPointerEvent<HTMLCanvasElement>) {
+    if (event?.pointerType === 'touch') {
+      try { event.currentTarget.releasePointerCapture(event.pointerId) } catch { /* already released */ }
+    }
+
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current)
+      longPressTimerRef.current = null
+    }
+    longPressStartRef.current = null
+
     const canvas = canvasRef.current
     const project = projectRef.current
     const selection = selectionRef.current
@@ -2633,7 +2714,13 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     stopPan()
   }
 
-  function handleMouseLeave() {
+  function handlePointerLeave() {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current)
+      longPressTimerRef.current = null
+    }
+    longPressStartRef.current = null
+
     const pendingAdd = pendingAddRef.current
     const pendingMove = pendingMoveRef.current
     const pendingTransform = pendingTransformRef.current
@@ -3133,69 +3220,51 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     if (hitId) enterSketchEdit(hitId)
   }
 
-  function handleContextMenu(event: MouseEvent<HTMLCanvasElement>) {
-    event.preventDefault()
-
-    if (zoomWindowActive) {
-      return
-    }
-
-    if (didPanRef.current) {
-      didPanRef.current = false
-      return
-    }
-
-    const project = projectRef.current
-    const selection = selectionRef.current
-    const pendingAdd = pendingAddRef.current
-    const pendingMove = pendingMoveRef.current
-    const pendingTransform = pendingTransformRef.current
-    const pendingOffset = pendingOffsetRef.current
-    if (pendingAdd) {
-      return
-    }
-
-    if (pendingMove) {
-      return
-    }
-
-    if (pendingTransform) {
-      return
-    }
-
-    if (pendingOffset) {
-      return
-    }
+  function triggerContextMenuAt(clientX: number, clientY: number) {
+    if (zoomWindowActive) return
+    if (pendingAddRef.current || pendingMoveRef.current || pendingTransformRef.current || pendingOffsetRef.current) return
 
     const canvas = canvasRef.current
     if (!canvas) return
 
-    const point = canvasCoordinates(event)
+    const rect = canvas.getBoundingClientRect()
+    const point: CanvasPoint = { cx: clientX - rect.left, cy: clientY - rect.top }
+    const project = projectRef.current
+    const selection = selectionRef.current
     const vt = computeViewTransform(project.stock, canvas.width, canvas.height, viewStateRef.current)
     const world = canvasToWorld(point.cx, point.cy, vt)
     const hitClampId = findHitClampId(world, project.clamps)
     if (hitClampId) {
       selectClamp(hitClampId)
-      onClampContextMenu?.(hitClampId, event.clientX, event.clientY)
+      onClampContextMenu?.(hitClampId, clientX, clientY)
       return
     }
 
     const hitTabId = findHitTabId(world, project.tabs)
     if (hitTabId) {
       selectTab(hitTabId)
-      onTabContextMenu?.(hitTabId, event.clientX, event.clientY)
+      onTabContextMenu?.(hitTabId, clientX, clientY)
       return
     }
 
     const hitId = findHitFeatureId(world, project.features, vt)
-    if (!hitId) {
-      return
-    }
+    if (!hitId) return
 
     if (!selection.selectedFeatureIds.includes(hitId)) {
       selectFeature(hitId)
     }
-    onFeatureContextMenu?.(hitId, event.clientX, event.clientY)
+    onFeatureContextMenu?.(hitId, clientX, clientY)
+  }
+
+  function handleContextMenu(event: MouseEvent<HTMLCanvasElement>) {
+    event.preventDefault()
+
+    if (didPanRef.current) {
+      didPanRef.current = false
+      return
+    }
+
+    triggerContextMenuAt(event.clientX, event.clientY)
   }
 
   function applyEditDimStep(stepIndex: number, steps: EditDimStep[], featureId: string, units: 'mm' | 'inch') {
@@ -3964,9 +4033,10 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       <canvas
         ref={canvasRef}
         className={`sketch-canvas ${pendingAdd || pendingMove || pendingTransform || pendingOffset || pendingShapeAction ? 'sketch-canvas--placing' : ''}`}
-        onMouseDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseLeave}
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onPointerLeave={handlePointerLeave}
         onClick={handleClick}
         onDoubleClick={handleDoubleClick}
         onKeyDown={handleKeyDown}

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -519,6 +519,15 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     clearTransientCanvasState,
   })
 
+  const placementPanelActive = !!pendingAdd && !creationPanelShape
+  const placementWorkflowPanel = useCanvasWorkflowPanel({
+    open: placementPanelActive,
+    phaseKey: pendingAdd?.shape ?? 'place',
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+
   const editModeActive = selection.mode === 'sketch_edit' && !pendingAdd
   const editDimEditActive = editModeActive && !!dimensionEdit
   const editWorkflowPanel = useCanvasWorkflowPanel({
@@ -5256,17 +5265,23 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           ) : null}
         </CanvasWorkflowPanel>
       )}
-      {pendingAdd && !creationPanelShape && (
-        <div className="sketch-place-banner">
-          <div>
-            {pendingAdd.shape === 'origin'
+      {placementPanelActive && (
+        <CanvasWorkflowPanel
+          title={pendingAdd!.shape === 'origin' ? 'Place Origin' : 'Place Text'}
+          step={
+            pendingAdd!.shape === 'origin'
               ? 'Click the sketch to place machine X0 Y0. Z remains manual in Properties.'
-              : pendingAdd.shape === 'text'
-                ? 'Move the mouse to preview the text, then click to place it.'
-                : null}
-            {' '}Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingAdd} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingAdd() }}>Esc</kbd> to cancel.
-          </div>
-        </div>
+              : 'Tap the sketch to place the text.'
+          }
+          position={placementWorkflowPanel.position}
+          panelRef={placementWorkflowPanel.panelRef}
+          handleProps={placementWorkflowPanel.handleProps}
+          actions={
+            <button type="button" className="tablet-cmd-btn tablet-cmd-btn--cancel" onClick={cancelPendingAdd}>Cancel</button>
+          }
+        >
+          {null}
+        </CanvasWorkflowPanel>
       )}
       {pendingConstraint && (
         <CanvasWorkflowPanel

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -108,6 +108,9 @@ import type { Clamp, Point, SketchFeature, Tab } from '../../types/project'
 import { formatLength, parseLengthInput } from '../../utils/units'
 import { useAxisLock, lockModeGuideColor } from '../../sketch/useAxisLock'
 import { useCanvasGestures } from '../../sketch/useCanvasGestures'
+import { useShellMode, isTabletMode } from '../layout/useShellMode'
+import { CanvasWorkflowPanel } from './CanvasWorkflowPanel'
+import { useCanvasWorkflowPanel } from './useCanvasWorkflowPanel'
 
 const NODE_HIT_RADIUS = 9
 const HANDLE_HIT_RADIUS = 7
@@ -252,6 +255,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const containerRef = useRef<HTMLDivElement>(null)
   const isDraggingNodeRef = useRef(false)
   const dragStartWorldRef = useRef<Point | null>(null)
+  const touchDragPendingRef = useRef<{ control: SketchControlRef; world: Point; canvasPoint: CanvasPoint } | null>(null)
   const isPanningRef = useRef(false)
   const didPanRef = useRef(false)
   const lastPanPointRef = useRef<CanvasPoint | null>(null)
@@ -307,6 +311,11 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const constraintEditInputRef = useRef<HTMLInputElement>(null)
   // Stores label hit areas for click detection: { featureId, constraintId, cx, cy, halfW, halfH }
   const constraintLabelRectsRef = useRef<Array<{ featureId: string; constraintId: string; cx: number; cy: number; halfW: number; halfH: number }>>([])
+
+  const shellMode = useShellMode()
+  const isTablet = isTabletMode(shellMode)
+  const [multiSelectMode, setMultiSelectMode] = useState(false)
+  const [armedForDimension, setArmedForDimension] = useState(false)
 
   const {
     project,
@@ -380,7 +389,26 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     cancelPendingConstraint,
     updateConstraintValue,
   } = useProjectStore()
-  const copyCountPromptActive = pendingMove?.mode === 'copy' && !!pendingMove.fromPoint && !!pendingMove.toPoint
+  const moveDistanceEditActive =
+    !!pendingMove
+    && !!pendingMove.fromPoint
+    && !!pendingMove.toPoint
+    && (operationDimEdit?.kind === 'move' || operationDimEdit?.kind === 'copy')
+  const copyCountPromptActive = pendingMove?.mode === 'copy' && !!pendingMove.fromPoint && !!pendingMove.toPoint && !moveDistanceEditActive
+  const transformScaleEditActive =
+    !!pendingTransform
+    && pendingTransform.mode === 'resize'
+    && !!pendingTransform.referenceStart
+    && !!pendingTransform.referenceEnd
+    && operationDimEdit?.kind === 'scale'
+  const transformRotateEditActive =
+    !!pendingTransform
+    && pendingTransform.mode === 'rotate'
+    && !!pendingTransform.referenceStart
+    && !!pendingTransform.referenceEnd
+    && operationDimEdit?.kind === 'rotate'
+  const transformExactEditActive = transformScaleEditActive || transformRotateEditActive
+  const offsetDistanceEditActive = !!pendingOffset && operationDimEdit?.kind === 'offset'
   const rotateCopyCountPromptActive = !!pendingRotateCopyPoint
   const projectRef = useRef(project)
   const selectionRef = useRef(selection)
@@ -421,8 +449,56 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
   // Axis lock — active whenever a move, node drag, sketch-edit drag, constraint pick, or feature creation is in progress
   const isDraggingAny = !!pendingMove || !!pendingAdd || !!pendingConstraint || isDraggingNodeRef.current || selection.sketchEditTool === 'add_point'
+  const showCutFlowPanel = pendingShapeAction?.kind === 'cut'
+  const cutFlowPanelPhase = pendingShapeAction?.kind === 'cut' ? pendingShapeAction.phase : null
   const scheduleDrawRef = useRef<() => void>(() => {})
-  const { lockModeRef, applyLock } = useAxisLock(isDraggingAny, () => scheduleDrawRef.current())
+  const { lockModeRef, applyLock, cycleLock } = useAxisLock(isDraggingAny, () => scheduleDrawRef.current())
+  const cutWorkflowPanel = useCanvasWorkflowPanel({
+    open: showCutFlowPanel,
+    phaseKey: cutFlowPanelPhase,
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+  const showJoinFlowPanel = pendingShapeAction?.kind === 'join'
+  const joinWorkflowPanel = useCanvasWorkflowPanel({
+    open: !!showJoinFlowPanel,
+    phaseKey: 'join',
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+  const moveWorkflowPanel = useCanvasWorkflowPanel({
+    open: !!pendingMove,
+    phaseKey: pendingMove?.fromPoint ? (moveDistanceEditActive ? 'distance' : pendingMove.toPoint ? 'count' : 'to') : 'from',
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+  const transformWorkflowPanel = useCanvasWorkflowPanel({
+    open: !!pendingTransform,
+    phaseKey: transformExactEditActive ? 'exact' : pendingTransform?.referenceEnd ? 'commit' : (pendingTransform?.referenceStart ? 'end' : 'start'),
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+  const offsetWorkflowPanel = useCanvasWorkflowPanel({
+    open: !!pendingOffset,
+    phaseKey: offsetDistanceEditActive ? 'distance' : 'offset',
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+  const creationPanelShape = pendingAdd && (pendingAdd.shape === 'rect' || pendingAdd.shape === 'circle' || pendingAdd.shape === 'ellipse' || pendingAdd.shape === 'tab' || pendingAdd.shape === 'clamp') ? pendingAdd.shape : null
+  const creationPanelHasAnchor = creationPanelShape && pendingAdd && 'anchor' in pendingAdd && !!pendingAdd.anchor
+  const creationDimEditActive = !!creationPanelHasAnchor && !!dimensionEdit
+  const creationWorkflowPanel = useCanvasWorkflowPanel({
+    open: !!creationPanelShape,
+    phaseKey: creationDimEditActive ? 'dimensions' : creationPanelHasAnchor ? 'place' : 'anchor',
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
 
   function updateActiveSnap(nextSnap: ResolvedSnap | null) {
     activeSnapRef.current = nextSnap?.mode ? nextSnap : null
@@ -464,7 +540,202 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       return
     }
     hoveredEditControlRef.current = nextControl
+    if (!nextControl) setArmedForDimension(false)
     scheduleDraw()
+  }
+
+  function clearTransientCanvasState() {
+    suppressClickRef.current = false
+    didPanRef.current = false
+    stopPan()
+    marqueeStartRef.current = null
+    marqueeCurrentRef.current = null
+    touchDragPendingRef.current = null
+    livePointerWorldRef.current = null
+  }
+
+  function confirmCutCuttersFromTabletPanel() {
+    confirmCutCutters()
+    cutWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function completeCutFromTabletPanel() {
+    completePendingShapeAction()
+    cutWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function cancelCutFromTabletPanel() {
+    cancelPendingShapeAction()
+    cutWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function completeJoinFromPanel() {
+    completePendingShapeAction()
+    joinWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function cancelJoinFromPanel() {
+    cancelPendingShapeAction()
+    joinWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function cancelMoveFromPanel() {
+    cancelPendingMove()
+    setPendingMovePreviewPointRef(null)
+    setCopyCountDraft('1')
+    setOperationDimEdit(null)
+    moveWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function beginMoveDistanceEntry(referencePoint: Point) {
+    const pendingMove = pendingMoveRef.current
+    if (!pendingMove?.fromPoint) return
+    const dx = referencePoint.x - pendingMove.fromPoint.x
+    const dy = referencePoint.y - pendingMove.fromPoint.y
+    const distance = Math.hypot(dx, dy)
+    setPendingMoveTo(referencePoint)
+    setPendingMovePreviewPointRef({ point: referencePoint, session: pendingMove.session })
+    setOperationDimEdit({
+      kind: pendingMove.mode,
+      distance: formatLength(distance, projectRef.current.meta.units),
+    })
+  }
+
+  function beginMoveDistanceEntryFromPreview() {
+    const pendingMove = pendingMoveRef.current
+    if (!pendingMove?.fromPoint) return
+    const previewPoint =
+      pendingMovePreviewPointRef.current?.session === pendingMove.session
+        ? pendingMovePreviewPointRef.current.point
+        : pendingMove.fromPoint
+    beginMoveDistanceEntry(previewPoint)
+    moveWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function commitMoveDistanceEditFromPanel() {
+    const currentEdit = operationDimEditRef.current
+    if (!currentEdit || (currentEdit.kind !== 'move' && currentEdit.kind !== 'copy')) return
+    const pendingMove = pendingMoveRef.current
+    if (!pendingMove?.fromPoint) return
+    const distance = parseLengthInput(currentEdit.distance, projectRef.current.meta.units)
+    if (distance === null) return
+    const referencePoint = pendingMove.toPoint ?? pendingMovePreviewPointRef.current?.point ?? pendingMove.fromPoint
+    const toPoint = computeMoveDistancePreviewPoint(pendingMove.fromPoint, referencePoint, distance)
+    if (currentEdit.kind === 'move') {
+      completePendingMove(toPoint)
+      setPendingMovePreviewPointRef(null)
+    } else {
+      setPendingMoveTo(toPoint)
+      setPendingMovePreviewPointRef({ point: toPoint, session: pendingMove.session })
+      setCopyCountDraft('1')
+    }
+    setOperationDimEdit(null)
+    moveWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function cancelTransformFromPanel() {
+    cancelPendingTransform()
+    setPendingTransformPreviewPointRef(null)
+    setPendingRotateCopyPoint(null)
+    setRotateCopyCountDraft('1')
+    setOperationDimEdit(null)
+    transformWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function triggerDimensionFromTransformPanel() {
+    triggerDimensionEdit()
+    transformWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function commitTransformExactEditFromPanel() {
+    const currentEdit = operationDimEditRef.current
+    const pendingTransform = pendingTransformRef.current
+    if (!currentEdit || !pendingTransform?.referenceStart || !pendingTransform.referenceEnd) return
+
+    if (currentEdit.kind === 'scale') {
+      if (pendingTransform.mode !== 'resize') return
+      const factor = Number(currentEdit.factor)
+      if (!Number.isFinite(factor) || factor <= 0) return
+      const previewPoint = computeScalePreviewPoint(
+        pendingTransform.referenceStart,
+        pendingTransform.referenceEnd,
+        factor,
+      )
+      completePendingTransform(previewPoint)
+      setPendingTransformPreviewPointRef(null)
+      setOperationDimEdit(null)
+      transformWorkflowPanel.focusCanvasAfterAction()
+      return
+    }
+
+    if (currentEdit.kind === 'rotate') {
+      if (pendingTransform.mode !== 'rotate') return
+      const angleDegrees = Number(currentEdit.angle)
+      if (!Number.isFinite(angleDegrees)) return
+      const previewPoint = computeRotatePreviewPoint(
+        pendingTransform.referenceStart,
+        pendingTransform.referenceEnd,
+        angleDegrees,
+      )
+      if (pendingTransform.keepOriginals) {
+        setPendingRotateCopyPoint(previewPoint)
+      } else {
+        completePendingTransform(previewPoint)
+        setPendingTransformPreviewPointRef(null)
+      }
+      setOperationDimEdit(null)
+      transformWorkflowPanel.focusCanvasAfterAction()
+    }
+  }
+
+  function cancelOffsetFromPanel() {
+    cancelPendingOffset()
+    setPendingOffsetPreviewPointRef(null)
+    setPendingOffsetRawPreviewPointRef(null)
+    setOperationDimEdit(null)
+    offsetWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function triggerDimensionFromOffsetPanel() {
+    triggerDimensionEdit()
+    offsetWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function commitOffsetDistanceEditFromPanel() {
+    const currentEdit = operationDimEditRef.current
+    if (!currentEdit || currentEdit.kind !== 'offset') return
+    const distance = parseLengthInput(currentEdit.distance, projectRef.current.meta.units)
+    if (distance === null) return
+    completePendingOffset(distance)
+    setPendingOffsetPreviewPointRef(null)
+    setPendingOffsetRawPreviewPointRef(null)
+    setOperationDimEdit(null)
+    offsetWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function triggerDimensionFromCreationPanel() {
+    triggerDimensionEdit()
+  }
+
+  function commitCreationDimensionEdit() {
+    const edit = dimensionEditRef.current
+    if (!edit) return
+    const pt = computeDimensionEditPreviewPoint(edit, projectRef.current.meta.units)
+    placePendingAddAt(pt)
+    setPendingPreviewPointRef(null)
+    setDimensionEdit(null)
+    creationWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function cancelCreationDimensionEdit() {
+    setDimensionEdit(null)
+    creationWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function cancelCreationFromPanel() {
+    cancelPendingAdd()
+    setDimensionEdit(null)
+    creationWorkflowPanel.focusCanvasAfterAction()
   }
 
   function isActiveSnapPoint(point: Point | null | undefined): boolean {
@@ -694,6 +965,18 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     }
 
     if (pendingMove) {
+      const moveEdit = operationDimEditRef.current
+      if ((moveEdit?.kind === 'move' || moveEdit?.kind === 'copy') && pendingMove.fromPoint) {
+        const distance = parseLengthInput(moveEdit.distance, project.meta.units)
+        const referencePoint = pendingMove.toPoint ?? pendingMovePreviewPointRef.current?.point ?? snapped
+        setPendingMovePreviewPointRef({
+          point: distance !== null
+            ? computeMoveDistancePreviewPoint(pendingMove.fromPoint, referencePoint, distance)
+            : referencePoint,
+          session: pendingMove.session,
+        })
+        return
+      }
       setPendingMovePreviewPointRef({ point: snapped, session: pendingMove.session })
       return
     }
@@ -1681,7 +1964,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     setPendingMovePreviewPointRef({
       point: computeMoveDistancePreviewPoint(
         pendingMove.fromPoint,
-        pendingMovePreviewPointRef.current?.point ?? pendingMove.fromPoint,
+        pendingMove.toPoint ?? pendingMovePreviewPointRef.current?.point ?? pendingMove.fromPoint,
         distance,
       ),
       session: pendingMove.session,
@@ -2250,6 +2533,11 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       }
     }
 
+    if (isTouch && selection.mode === 'sketch_edit' && !selection.sketchEditTool) {
+      touchDragPendingRef.current = { control: nextControl, world, canvasPoint: point }
+      return
+    }
+
     beginHistoryTransaction()
     setActiveControl(nextControl)
     isDraggingNodeRef.current = true
@@ -2267,6 +2555,17 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     const canvas = canvasRef.current
     if (!canvas) return
 
+    if (isGestureActiveRef.current) {
+      if (isPanningRef.current) stopPan()
+      touchDragPendingRef.current = null
+      if (longPressTimerRef.current) {
+        clearTimeout(longPressTimerRef.current)
+        longPressTimerRef.current = null
+      }
+      longPressStartRef.current = null
+      return
+    }
+
     const project = projectRef.current
     const selection = selectionRef.current
     const pendingAdd = pendingAddRef.current
@@ -2278,6 +2577,23 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     const world = canvasToWorld(point.cx, point.cy, vt)
     livePointerWorldRef.current = world
     const sketchEditTool = selection.sketchEditTool
+
+    if (touchDragPendingRef.current) {
+      const pending = touchDragPendingRef.current
+      const dx = point.cx - pending.canvasPoint.cx
+      const dy = point.cy - pending.canvasPoint.cy
+      if (dx * dx + dy * dy > 25) {
+        touchDragPendingRef.current = null
+        beginHistoryTransaction()
+        setActiveControl(pending.control)
+        isDraggingNodeRef.current = true
+        dragStartWorldRef.current = pending.world
+        if (pending.control.kind === 'segment' && selection.selectedFeatureId) {
+          moveFeatureControl(selection.selectedFeatureId, pending.control, world)
+        }
+      }
+      return
+    }
 
     if (isPanningRef.current && lastPanPointRef.current) {
       sketchEditPreviewRef.current = null
@@ -2383,17 +2699,18 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       const moveEdit = operationDimEditRef.current
       if ((moveEdit?.kind === 'move' || moveEdit?.kind === 'copy') && pendingMove.fromPoint) {
         const distance = parseLengthInput(moveEdit.distance, project.meta.units)
-        if (distance !== null) {
-          const direction = unitDirection(pendingMove.fromPoint, snapped)
-          setPendingMovePreviewPointRef({
-            point: {
-              x: pendingMove.fromPoint.x + direction.x * Math.abs(distance),
-              y: pendingMove.fromPoint.y + direction.y * Math.abs(distance),
-            },
-            session: pendingMove.session,
-          })
-          return
-        }
+        const referencePoint = pendingMove.toPoint ?? pendingMovePreviewPointRef.current?.point ?? snapped
+        const direction = unitDirection(pendingMove.fromPoint, referencePoint)
+        setPendingMovePreviewPointRef({
+          point: distance !== null
+            ? {
+                x: pendingMove.fromPoint.x + direction.x * Math.abs(distance),
+                y: pendingMove.fromPoint.y + direction.y * Math.abs(distance),
+              }
+            : referencePoint,
+          session: pendingMove.session,
+        })
+        return
       }
       const lockedSnapped = pendingMove.fromPoint ? applyLock(snapped, pendingMove.fromPoint) : snapped
       setPendingMovePreviewPointRef({ point: lockedSnapped, session: pendingMove.session })
@@ -2645,6 +2962,14 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     }
     longPressStartRef.current = null
 
+    if (touchDragPendingRef.current) {
+      const pending = touchDragPendingRef.current
+      touchDragPendingRef.current = null
+      setHoveredEditControl(pending.control)
+      setArmedForDimension(true)
+      return
+    }
+
     const canvas = canvasRef.current
     const project = projectRef.current
     const selection = selectionRef.current
@@ -2720,6 +3045,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       longPressTimerRef.current = null
     }
     longPressStartRef.current = null
+    touchDragPendingRef.current = null
 
     const pendingAdd = pendingAddRef.current
     const pendingMove = pendingMoveRef.current
@@ -2789,6 +3115,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     const pendingMove = pendingMoveRef.current
     const pendingTransform = pendingTransformRef.current
     const pendingOffset = pendingOffsetRef.current
+    const pendingShapeAction = pendingShapeActionRef.current
     const viewState = viewStateRef.current
     const dimensionEdit = dimensionEditRef.current
     if (isDraggingNodeRef.current) return
@@ -3042,13 +3369,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         setPendingMovePreviewPointRef({ point: snapped, session: pendingMove.session })
       } else if (!pendingMove.toPoint) {
         const lockedSnapped = applyLock(snapped, pendingMove.fromPoint)
-        setPendingMoveTo(lockedSnapped)
-        setPendingMovePreviewPointRef({ point: lockedSnapped, session: pendingMove.session })
-        setCopyCountDraft('1')
-        if (pendingMove.mode === 'move') {
-          completePendingMove(lockedSnapped)
-          setPendingMovePreviewPointRef(null)
-        }
+        beginMoveDistanceEntry(lockedSnapped)
       }
       return
     }
@@ -3138,11 +3459,12 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     }
 
     const hitId = findHitFeatureId(world, project.features, vt)
+    const additive = event.metaKey || event.ctrlKey || event.shiftKey || multiSelectMode || !!pendingShapeAction
     if (hitId) {
-      selectFeature(hitId, event.metaKey || event.ctrlKey || event.shiftKey)
+      selectFeature(hitId, additive)
     } else if (project.backdrop?.visible && hitBackdrop(world, project.backdrop)) {
       selectBackdrop()
-    } else if (!(event.metaKey || event.ctrlKey || event.shiftKey)) {
+    } else if (!additive) {
       selectFeature(null)
     }
   }
@@ -3408,9 +3730,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
     if (pendingMove?.fromPoint && !pendingMove.toPoint) {
       const previewPoint = pendingMovePreviewPointRef.current?.point ?? pendingMove.fromPoint
-      const dx = previewPoint.x - pendingMove.fromPoint.x
-      const dy = previewPoint.y - pendingMove.fromPoint.y
-      setOperationDimEdit({ kind: pendingMove.mode, distance: formatLength(Math.hypot(dx, dy), units) })
+      beginMoveDistanceEntry(previewPoint)
       return
     }
 
@@ -3645,15 +3965,8 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     if (event.key === 'Tab' && pendingMove && pendingMove.fromPoint && !pendingMove.toPoint) {
       event.preventDefault()
       const currentEdit = operationDimEditRef.current
-      const units = projectRef.current.meta.units
       if (!currentEdit) {
-        const previewPoint = pendingMovePreviewPointRef.current?.point ?? pendingMove.fromPoint
-        const dx = previewPoint.x - pendingMove.fromPoint.x
-        const dy = previewPoint.y - pendingMove.fromPoint.y
-        setOperationDimEdit({
-          kind: pendingMove.mode,
-          distance: formatLength(Math.hypot(dx, dy), units),
-        })
+        beginMoveDistanceEntryFromPreview()
       } else if (currentEdit.kind === 'move' || currentEdit.kind === 'copy') {
         setOperationDimEdit(null)
         canvasRef.current?.focus({ preventScroll: true })
@@ -4084,7 +4397,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           className="sketch-toolpath-vis"
         />
       )}
-      {dimensionEdit && pendingAdd && (() => {
+      {dimensionEdit && pendingAdd && !creationPanelShape && (() => {
         const canvas = canvasRef.current
         if (!canvas) return null
         const vt = computeViewTransform(project.stock, canvas.width, canvas.height, viewState)
@@ -4457,261 +4770,6 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           onFocus={(e) => e.currentTarget.select()}
         />
       )}
-      {operationDimEdit && (() => {
-        const canvas = canvasRef.current
-        if (!canvas) return null
-        const vt = computeViewTransform(project.stock, canvas.width, canvas.height, viewState)
-
-        if ((operationDimEdit.kind === 'move' || operationDimEdit.kind === 'copy') && pendingMove?.fromPoint) {
-          const edit = operationDimEdit
-          const units = project.meta.units
-          const distance = parseLengthInput(edit.distance, units)
-          const previewPoint =
-            distance !== null
-              ? computeMoveDistancePreviewPoint(
-                  pendingMove.fromPoint,
-                  pendingMovePreviewPointRef.current?.point ?? pendingMove.fromPoint,
-                  distance,
-                )
-              : pendingMovePreviewPointRef.current?.point ?? pendingMove.fromPoint
-
-          const fromC = worldToCanvas(pendingMove.fromPoint, vt)
-          const toC = worldToCanvas(previewPoint, vt)
-          const layout = computeLinearInputLabel(fromC, toC, 14)
-
-          function commitMoveDistanceEdit() {
-            const currentEdit = operationDimEditRef.current
-            if (!currentEdit || (currentEdit.kind !== 'move' && currentEdit.kind !== 'copy')) return
-            const pm = pendingMoveRef.current
-            if (!pm || !pm.fromPoint) return
-            const units = projectRef.current.meta.units
-            const distance = parseLengthInput(currentEdit.distance, units)
-            if (distance === null) return
-            const toPoint = computeMoveDistancePreviewPoint(
-              pm.fromPoint,
-              pendingMovePreviewPointRef.current?.point ?? pm.fromPoint,
-              distance,
-            )
-            if (currentEdit.kind === 'move') {
-              completePendingMove(toPoint)
-              setPendingMovePreviewPointRef(null)
-            } else {
-              setPendingMoveTo(toPoint)
-              setPendingMovePreviewPointRef({ point: toPoint, session: pm.session })
-              setCopyCountDraft('1')
-            }
-            setOperationDimEdit(null)
-          }
-
-          return (
-            <input
-              ref={widthInputRef}
-              className="sketch-dim-input"
-              style={{ left: layout.labelX, top: layout.labelY, transform: `translate(-50%, -50%) rotate(${layout.angle}rad)` }}
-              value={edit.distance}
-              onChange={(e) => setOperationDimEdit({ ...edit, distance: e.target.value })}
-              onFocus={(e) => e.currentTarget.select()}
-              onKeyDown={(e) => {
-                e.stopPropagation()
-                if (e.key === 'Enter') {
-                  e.preventDefault()
-                  commitMoveDistanceEdit()
-                } else if (e.key === 'Escape') {
-                  e.preventDefault()
-                  cancelPendingMove()
-                  setPendingMovePreviewPointRef(null)
-                  setCopyCountDraft('1')
-                  setOperationDimEdit(null)
-                } else if (e.key === 'Tab') {
-                  e.preventDefault()
-                  setOperationDimEdit(null)
-                  canvasRef.current?.focus({ preventScroll: true })
-                }
-              }}
-            />
-          )
-        }
-
-        if (operationDimEdit.kind === 'scale' && pendingTransform?.mode === 'resize' && pendingTransform.referenceStart && pendingTransform.referenceEnd) {
-          const factor = Number(operationDimEdit.factor)
-          const previewPoint =
-            Number.isFinite(factor) && factor > 0
-              ? computeScalePreviewPoint(
-                  pendingTransform.referenceStart,
-                  pendingTransform.referenceEnd,
-                  factor,
-                )
-              : pendingTransformPreviewPointRef.current?.point ?? pendingTransform.referenceEnd
-          const fromC = worldToCanvas(pendingTransform.referenceStart, vt)
-          const toC = worldToCanvas(previewPoint, vt)
-          const layout = computeLinearInputLabel(fromC, toC, 14)
-
-          return (
-            <input
-              ref={widthInputRef}
-              className="sketch-dim-input"
-              style={{ left: layout.labelX, top: layout.labelY, transform: `translate(-50%, -50%) rotate(${layout.angle}rad)` }}
-              value={operationDimEdit.factor}
-              onChange={(e) => setOperationDimEdit({ kind: 'scale', factor: e.target.value })}
-              onFocus={(e) => e.currentTarget.select()}
-              onKeyDown={(e) => {
-                e.stopPropagation()
-                if (e.key === 'Enter') {
-                  e.preventDefault()
-                  const edit = operationDimEditRef.current
-                  if (!edit || edit.kind !== 'scale') return
-                  const pt = pendingTransformRef.current
-                  if (!pt || pt.mode !== 'resize' || !pt.referenceStart || !pt.referenceEnd) return
-                  const factor = Number(edit.factor)
-                  if (!Number.isFinite(factor) || factor <= 0) return
-                  const previewPoint = computeScalePreviewPoint(
-                    pt.referenceStart,
-                    pt.referenceEnd,
-                    factor,
-                  )
-                  completePendingTransform(previewPoint)
-                  setPendingTransformPreviewPointRef(null)
-                  setOperationDimEdit(null)
-                } else if (e.key === 'Escape') {
-                  e.preventDefault()
-                  cancelPendingTransform()
-                  setPendingTransformPreviewPointRef(null)
-                  setOperationDimEdit(null)
-                } else if (e.key === 'Tab') {
-                  e.preventDefault()
-                  setOperationDimEdit(null)
-                  canvasRef.current?.focus({ preventScroll: true })
-                }
-              }}
-            />
-          )
-        }
-
-        if (operationDimEdit.kind === 'rotate' && pendingTransform?.mode === 'rotate' && pendingTransform.referenceStart && pendingTransform.referenceEnd) {
-          const angleDegrees = Number(operationDimEdit.angle)
-          const previewPoint =
-            Number.isFinite(angleDegrees)
-              ? computeRotatePreviewPoint(
-                  pendingTransform.referenceStart,
-                  pendingTransform.referenceEnd,
-                  angleDegrees,
-                )
-              : pendingTransformPreviewPointRef.current?.point ?? pendingTransform.referenceEnd
-          const originC = worldToCanvas(pendingTransform.referenceStart, vt)
-          const previewC = worldToCanvas(previewPoint, vt)
-          const layout = computeLinearInputLabel(originC, previewC, 22)
-
-          return (
-            <input
-              ref={widthInputRef}
-              className="sketch-dim-input"
-              style={{ left: layout.labelX, top: layout.labelY, transform: `translate(-50%, -50%) rotate(${layout.angle}rad)` }}
-              value={operationDimEdit.angle}
-              onChange={(e) => setOperationDimEdit({ kind: 'rotate', angle: e.target.value })}
-              onFocus={(e) => e.currentTarget.select()}
-              onKeyDown={(e) => {
-                e.stopPropagation()
-                if (e.key === 'Enter') {
-                  e.preventDefault()
-                  const edit = operationDimEditRef.current
-                  if (!edit || edit.kind !== 'rotate') return
-                  const pt = pendingTransformRef.current
-                  if (!pt || pt.mode !== 'rotate' || !pt.referenceStart || !pt.referenceEnd) return
-                  const angleDegrees = Number(edit.angle)
-                  if (!Number.isFinite(angleDegrees)) return
-                  const previewPoint = computeRotatePreviewPoint(
-                    pt.referenceStart,
-                    pt.referenceEnd,
-                    angleDegrees,
-                  )
-                  if (pt.keepOriginals) {
-                    setPendingRotateCopyPoint(previewPoint)
-                  } else {
-                    completePendingTransform(previewPoint)
-                    setPendingTransformPreviewPointRef(null)
-                  }
-                  setOperationDimEdit(null)
-                } else if (e.key === 'Escape') {
-                  e.preventDefault()
-                  cancelPendingTransform()
-                  setPendingTransformPreviewPointRef(null)
-                  setOperationDimEdit(null)
-                } else if (e.key === 'Tab') {
-                  e.preventDefault()
-                  setOperationDimEdit(null)
-                  canvasRef.current?.focus({ preventScroll: true })
-                }
-              }}
-            />
-          )
-        }
-
-        if (operationDimEdit.kind === 'offset' && pendingOffset) {
-          const currentOffsetRawPreviewPoint =
-            pendingOffsetRawPreviewPointRef.current?.session === pendingOffset.session
-              ? pendingOffsetRawPreviewPointRef.current.point
-              : null
-          const currentOffsetPreviewPoint =
-            pendingOffsetPreviewPointRef.current?.session === pendingOffset.session
-              ? pendingOffsetPreviewPointRef.current.point
-              : null
-          const features = pendingOffset.entityIds
-            .map((featureId) => project.features.find((entry) => entry.id === featureId) ?? null)
-            .filter((feature): feature is SketchFeature => feature !== null)
-            .filter((feature) => feature.sketch.profile.closed)
-          const rawOffsetPoint = currentOffsetRawPreviewPoint ?? livePointerWorldRef.current ?? activeSnapRef.current?.rawPoint ?? null
-          const snappedOffsetPoint = currentOffsetPreviewPoint ?? activeSnapRef.current?.point ?? rawOffsetPoint
-          const previewInput =
-            features.length > 0 && rawOffsetPoint && snappedOffsetPoint
-              ? resolveOffsetPreview(features, rawOffsetPoint, snappedOffsetPoint, activeSnapRef.current?.mode ?? null, vt)
-              : null
-          const labelAnchor = previewInput?.nearestPoint ?? snappedOffsetPoint
-          const labelTarget = snappedOffsetPoint ?? previewInput?.nearestPoint
-          if (!labelAnchor || !labelTarget) return null
-
-          const fromC = worldToCanvas(labelAnchor, vt)
-          const toC = worldToCanvas(labelTarget, vt)
-          const layout = computeLinearInputLabel(fromC, toC, 14)
-
-          return (
-            <input
-              ref={widthInputRef}
-              className="sketch-dim-input"
-              style={{ left: layout.labelX, top: layout.labelY, transform: `translate(-50%, -50%) rotate(${layout.angle}rad)` }}
-              value={operationDimEdit.distance}
-              onChange={(e) => setOperationDimEdit({ kind: 'offset', distance: e.target.value })}
-              onFocus={(e) => e.currentTarget.select()}
-              onKeyDown={(e) => {
-                e.stopPropagation()
-                if (e.key === 'Enter') {
-                  e.preventDefault()
-                  const edit = operationDimEditRef.current
-                  if (!edit || edit.kind !== 'offset') return
-                  const units = projectRef.current.meta.units
-                  const dist = parseLengthInput(edit.distance, units)
-                  if (dist === null) return
-                  completePendingOffset(dist)
-                  setPendingOffsetPreviewPointRef(null)
-                  setPendingOffsetRawPreviewPointRef(null)
-                  setOperationDimEdit(null)
-                } else if (e.key === 'Escape') {
-                  e.preventDefault()
-                  cancelPendingOffset()
-                  setPendingOffsetPreviewPointRef(null)
-                  setPendingOffsetRawPreviewPointRef(null)
-                  setOperationDimEdit(null)
-                } else if (e.key === 'Tab') {
-                  e.preventDefault()
-                  setOperationDimEdit(null)
-                  canvasRef.current?.focus({ preventScroll: true })
-                }
-              }}
-            />
-          )
-        }
-
-        return null
-      })()}
       {selection.mode === 'sketch_edit' && (
         <div className="sketch-edit-banner">
           <div>
@@ -4727,7 +4785,9 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
                 ? pendingSketchFilletRef.current
                     ? 'Fillet active. Click a second point to define the corner round, or press Tab to type the radius. Press '
                     : 'Fillet active. Click a line-line corner to start. Press '
-                  : 'Drag nodes or straight segments to reshape. Hover a node and press Tab to type length/angle. Press '}
+                  : isTablet
+                    ? 'Drag nodes or straight segments to reshape. Tap a node then use Dimension to type length/angle. Press '
+                    : 'Drag nodes or straight segments to reshape. Hover a node and press Tab to type length/angle. Press '}
             <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Apply" onClick={() => { stopNodeDrag(); applySketchEdit() }} onKeyDown={(e) => { if (e.key === 'Enter') { stopNodeDrag(); applySketchEdit() } }}>Enter</kbd> to apply or <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={() => { stopNodeDrag(); cancelSketchEdit() }} onKeyDown={(e) => { if (e.key === 'Enter') { stopNodeDrag(); cancelSketchEdit() } }}>Esc</kbd> to cancel.
           </div>
           {editingFeatureHasSelfIntersection ? (
@@ -4739,47 +4799,319 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         </div>
       )}
       {pendingOffset && (
-        <div className="sketch-place-banner">
-          <>Move the mouse to preview the offset. Inside creates an inward offset, outside creates an outward offset. Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Type exact distance" onClick={triggerDimensionEdit} onKeyDown={(e) => { if (e.key === 'Enter') triggerDimensionEdit() }}>Tab</kbd> to type exact distance, click to commit, or press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingOffset} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingOffset() }}>Esc</kbd> to cancel.</>
-        </div>
+        <CanvasWorkflowPanel
+          title="Offset"
+          step={offsetDistanceEditActive ? 'Set distance' : 'Preview distance'}
+          position={offsetWorkflowPanel.position}
+          panelRef={offsetWorkflowPanel.panelRef}
+          handleProps={offsetWorkflowPanel.handleProps}
+          actionRowProps={offsetWorkflowPanel.actionRowProps}
+          className="canvas-workflow-panel--offset"
+          moveLabel="Move offset controls"
+          actions={(
+            <>
+              {offsetDistanceEditActive ? (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn tablet-cmd-btn--confirm"
+                  onClick={commitOffsetDistanceEditFromPanel}
+                >Confirm</button>
+              ) : (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn"
+                  onClick={triggerDimensionFromOffsetPanel}
+                >Distance</button>
+              )}
+              <button
+                type="button"
+                className="tablet-cmd-btn tablet-cmd-btn--cancel"
+                onClick={cancelOffsetFromPanel}
+              >Cancel</button>
+            </>
+          )}
+        >
+          {offsetDistanceEditActive && operationDimEdit?.kind === 'offset' ? (
+            <div className="canvas-workflow-panel__meta">
+              <label className="canvas-workflow-panel__field">
+                <span>Distance</span>
+                <input
+                  ref={widthInputRef}
+                  className="canvas-workflow-panel__count-input"
+                  type="text"
+                  inputMode="decimal"
+                  value={operationDimEdit.distance}
+                  onChange={(event) => setOperationDimEdit({ kind: 'offset', distance: event.target.value })}
+                  onFocus={(event) => event.currentTarget.select()}
+                  onKeyDown={(event) => {
+                    event.stopPropagation()
+                    if (event.key === 'Enter') {
+                      event.preventDefault()
+                      commitOffsetDistanceEditFromPanel()
+                    } else if (event.key === 'Escape') {
+                      event.preventDefault()
+                      cancelOffsetFromPanel()
+                    }
+                  }}
+                  autoFocus
+                />
+              </label>
+            </div>
+          ) : (
+            <div className="canvas-workflow-panel__summary">
+              Move inside or outside the feature to preview. Click to commit.
+            </div>
+          )}
+        </CanvasWorkflowPanel>
       )}
-      {pendingShapeAction && (
-        <div className="sketch-place-banner">
-          <span>
-            {pendingShapeAction.kind === 'join'
-              ? pendingShapeAction.entityIds.length < 2
-                ? 'Join mode. Shift-click closed features to select at least two.'
-                : `Join mode. ${pendingShapeAction.entityIds.length} closed features selected.`
-              : pendingShapeAction.phase === 'cutters'
-                ? pendingShapeAction.cutterIds.length === 0
-                  ? <>Cut mode. Click features to select cutters. Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm cutters" onClick={confirmCutCutters} onKeyDown={(e) => { if (e.key === 'Enter') confirmCutCutters() }}>Tab</kbd> to confirm cutters.</>
-                  : <>Cut mode. {pendingShapeAction.cutterIds.length} cutter{pendingShapeAction.cutterIds.length === 1 ? '' : 's'} selected. Shift-click to add more, or press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm cutters" onClick={confirmCutCutters} onKeyDown={(e) => { if (e.key === 'Enter') confirmCutCutters() }}>Tab</kbd> to confirm cutters.</>
-                : pendingShapeAction.targetIds.length === 0
-                  ? `Cut mode. ${pendingShapeAction.cutterIds.length} cutter${pendingShapeAction.cutterIds.length === 1 ? '' : 's'} confirmed. Shift-click features that intersect a cutter to select targets.`
-                  : `Cut mode. ${pendingShapeAction.cutterIds.length} cutter${pendingShapeAction.cutterIds.length === 1 ? '' : 's'} and ${pendingShapeAction.targetIds.length} target${pendingShapeAction.targetIds.length === 1 ? '' : 's'} selected. Shift-click to add or remove targets.`}
-            {' '}
-          </span>
-          <label className="sketch-place-toggle">
-            <input
-              type="checkbox"
-              checked={pendingShapeAction.keepOriginals}
-              onChange={(event) => setPendingShapeActionKeepOriginals(event.target.checked)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') {
-                  event.preventDefault()
-                  completePendingShapeAction()
-                } else if (event.key === 'Escape') {
-                  event.preventDefault()
-                  cancelPendingShapeAction()
-                }
-              }}
-            />
-            <span>Keep originals</span>
-          </label>
-          <span>Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm" onClick={completePendingShapeAction} onKeyDown={(e) => { if (e.key === 'Enter') completePendingShapeAction() }}>Enter</kbd> to confirm or <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingShapeAction} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingShapeAction() }}>Esc</kbd> to cancel.</span>
-        </div>
+      {showJoinFlowPanel && pendingShapeAction?.kind === 'join' && (
+        <CanvasWorkflowPanel
+          title="Join"
+          step="Select features"
+          position={joinWorkflowPanel.position}
+          panelRef={joinWorkflowPanel.panelRef}
+          handleProps={joinWorkflowPanel.handleProps}
+          actionRowProps={joinWorkflowPanel.actionRowProps}
+          className="canvas-workflow-panel--join"
+          moveLabel="Move join controls"
+          actions={(
+            <>
+              <button
+                type="button"
+                className="tablet-cmd-btn tablet-cmd-btn--confirm"
+                disabled={pendingShapeAction.entityIds.length < 2}
+                onClick={completeJoinFromPanel}
+              >Confirm</button>
+              <button
+                type="button"
+                className="tablet-cmd-btn tablet-cmd-btn--cancel"
+                onClick={cancelJoinFromPanel}
+              >Cancel</button>
+            </>
+          )}
+        >
+          <div className="canvas-workflow-panel__summary">
+            {pendingShapeAction.entityIds.length < 2
+              ? 'Select at least two closed features.'
+              : `${pendingShapeAction.entityIds.length} closed features selected.`}
+          </div>
+          <div className="canvas-workflow-panel__meta">
+            <label className="canvas-workflow-panel__check">
+              <input
+                type="checkbox"
+                checked={pendingShapeAction.keepOriginals}
+                onChange={(event) => {
+                  setPendingShapeActionKeepOriginals(event.target.checked)
+                  joinWorkflowPanel.focusCanvasAfterAction()
+                }}
+              />
+              <span>Keep originals</span>
+            </label>
+          </div>
+        </CanvasWorkflowPanel>
       )}
-      {pendingAdd && (
+      {showCutFlowPanel && pendingShapeAction?.kind === 'cut' && (
+        <CanvasWorkflowPanel
+          title="Cut"
+          step={pendingShapeAction.phase === 'cutters' ? 'Select cutters' : 'Select targets'}
+          position={cutWorkflowPanel.position}
+          panelRef={cutWorkflowPanel.panelRef}
+          handleProps={cutWorkflowPanel.handleProps}
+          actionRowProps={cutWorkflowPanel.actionRowProps}
+          className="canvas-workflow-panel--cut"
+          moveLabel="Move cut controls"
+          actions={(
+            <>
+              {pendingShapeAction.phase === 'cutters' ? (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn tablet-cmd-btn--confirm"
+                  disabled={pendingShapeAction.cutterIds.length === 0}
+                  onClick={confirmCutCuttersFromTabletPanel}
+                >Next</button>
+              ) : (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn tablet-cmd-btn--confirm"
+                  disabled={pendingShapeAction.targetIds.length === 0}
+                  onClick={completeCutFromTabletPanel}
+                >Confirm</button>
+              )}
+              <button
+                type="button"
+                className="tablet-cmd-btn tablet-cmd-btn--cancel"
+                onClick={cancelCutFromTabletPanel}
+              >Cancel</button>
+            </>
+          )}
+        >
+          <div className="canvas-workflow-panel__summary">
+            {pendingShapeAction.phase === 'cutters'
+              ? pendingShapeAction.cutterIds.length === 0
+                ? 'Select features to mark cutters.'
+                : `${pendingShapeAction.cutterIds.length} cutter${pendingShapeAction.cutterIds.length === 1 ? '' : 's'} selected.`
+              : pendingShapeAction.targetIds.length === 0
+                ? `${pendingShapeAction.cutterIds.length} cutter${pendingShapeAction.cutterIds.length === 1 ? '' : 's'} locked. Select target features.`
+                : `${pendingShapeAction.targetIds.length} target${pendingShapeAction.targetIds.length === 1 ? '' : 's'} selected.`}
+          </div>
+          <div className="canvas-workflow-panel__meta">
+            <label className="canvas-workflow-panel__check">
+              <input
+                type="checkbox"
+                checked={pendingShapeAction.keepOriginals}
+                onChange={(event) => {
+                  setPendingShapeActionKeepOriginals(event.target.checked)
+                  cutWorkflowPanel.focusCanvasAfterAction()
+                }}
+              />
+              <span>Keep originals</span>
+            </label>
+          </div>
+        </CanvasWorkflowPanel>
+      )}
+      {creationPanelShape && pendingAdd && (
+        <CanvasWorkflowPanel
+          title={
+            creationPanelShape === 'rect' ? 'Rectangle'
+            : creationPanelShape === 'circle' ? 'Circle'
+            : creationPanelShape === 'ellipse' ? 'Ellipse'
+            : creationPanelShape === 'tab' ? 'Tab'
+            : 'Clamp'
+          }
+          step={
+            creationDimEditActive ? 'Enter dimensions'
+            : creationPanelHasAnchor
+              ? (creationPanelShape === 'circle'
+                ? 'Click to set radius or enter dimensions'
+                : creationPanelShape === 'ellipse'
+                  ? 'Click to set radii or enter dimensions'
+                  : 'Click opposite corner or enter dimensions')
+              : (creationPanelShape === 'circle' || creationPanelShape === 'ellipse')
+                ? 'Click center point'
+                : 'Click first corner'
+          }
+          position={creationWorkflowPanel.position}
+          panelRef={creationWorkflowPanel.panelRef}
+          handleProps={creationWorkflowPanel.handleProps}
+          actionRowProps={creationWorkflowPanel.actionRowProps}
+          className="canvas-workflow-panel--creation"
+          moveLabel="Move creation controls"
+          actions={(
+            <>
+              {creationDimEditActive && (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn tablet-cmd-btn--confirm"
+                  onClick={commitCreationDimensionEdit}
+                >Confirm</button>
+              )}
+              {creationPanelHasAnchor && !creationDimEditActive && (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn"
+                  onClick={triggerDimensionFromCreationPanel}
+                >Dimensions</button>
+              )}
+              <button
+                type="button"
+                className="tablet-cmd-btn tablet-cmd-btn--cancel"
+                onClick={cancelCreationFromPanel}
+              >Cancel</button>
+            </>
+          )}
+        >
+          {creationDimEditActive && dimensionEdit && (
+            <div className="canvas-workflow-panel__meta">
+              {dimensionEdit.shape === 'circle' ? (
+                <label className="canvas-workflow-panel__field">
+                  <span>Radius</span>
+                  <input
+                    ref={radiusInputRef}
+                    className="canvas-workflow-panel__count-input canvas-workflow-panel__distance-input"
+                    type="text"
+                    inputMode="decimal"
+                    value={dimensionEdit.radius}
+                    onChange={(e) => setDimensionEdit((prev) => prev ? { ...prev, radius: e.target.value } : null)}
+                    onFocus={(e) => e.currentTarget.select()}
+                    onKeyDown={(e) => {
+                      e.stopPropagation()
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        commitCreationDimensionEdit()
+                      } else if (e.key === 'Escape') {
+                        e.preventDefault()
+                        cancelCreationDimensionEdit()
+                      }
+                    }}
+                    autoFocus
+                  />
+                </label>
+              ) : (
+                <>
+                  <label className="canvas-workflow-panel__field">
+                    <span>Width</span>
+                    <input
+                      ref={widthInputRef}
+                      className="canvas-workflow-panel__count-input canvas-workflow-panel__distance-input"
+                      type="text"
+                      inputMode="decimal"
+                      value={dimensionEdit.width}
+                      onChange={(e) => setDimensionEdit((prev) => prev ? { ...prev, width: e.target.value } : null)}
+                      onFocus={(e) => e.currentTarget.select()}
+                      onKeyDown={(e) => {
+                        e.stopPropagation()
+                        if (e.key === 'Enter') {
+                          e.preventDefault()
+                          commitCreationDimensionEdit()
+                        } else if (e.key === 'Escape') {
+                          e.preventDefault()
+                          cancelCreationDimensionEdit()
+                        } else if (e.key === 'Tab') {
+                          e.preventDefault()
+                          heightInputRef.current?.focus({ preventScroll: true })
+                        }
+                      }}
+                      autoFocus
+                    />
+                  </label>
+                  <label className="canvas-workflow-panel__field">
+                    <span>Height</span>
+                    <input
+                      ref={heightInputRef}
+                      className="canvas-workflow-panel__count-input canvas-workflow-panel__distance-input"
+                      type="text"
+                      inputMode="decimal"
+                      value={dimensionEdit.height}
+                      onChange={(e) => setDimensionEdit((prev) => prev ? { ...prev, height: e.target.value } : null)}
+                      onFocus={(e) => e.currentTarget.select()}
+                      onKeyDown={(e) => {
+                        e.stopPropagation()
+                        if (e.key === 'Enter') {
+                          e.preventDefault()
+                          commitCreationDimensionEdit()
+                        } else if (e.key === 'Escape') {
+                          e.preventDefault()
+                          cancelCreationDimensionEdit()
+                        } else if (e.key === 'Tab') {
+                          e.preventDefault()
+                          widthInputRef.current?.focus({ preventScroll: true })
+                        }
+                      }}
+                    />
+                  </label>
+                </>
+              )}
+            </div>
+          )}
+          {pendingDraftHasSelfIntersection ? (
+            <div className="sketch-banner-warning">This profile self-intersects. 3D/CAM results may be invalid.</div>
+          ) : null}
+          {pendingDraftExceedsStock ? (
+            <div className="sketch-banner-warning">This profile extends outside the stock boundary.</div>
+          ) : null}
+        </CanvasWorkflowPanel>
+      )}
+      {pendingAdd && !creationPanelShape && (
         <div className="sketch-place-banner">
           <div>
             {pendingAdd.shape === 'polygon' || pendingAdd.shape === 'spline'
@@ -4815,18 +5147,32 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
                 : pendingAdd.shape === 'circle'
                   ? 'Click the sketch to set the circle center, then click again to set the radius.'
                     : !pendingAdd.start
-                      ? 'Click to place the first composite point. Press L for line, A for arc, or S for spline.'
+                      ? isTablet
+                        ? 'Tap to place the first composite point. Use Line / Arc / Spline buttons to switch modes.'
+                        : 'Click to place the first composite point. Press L for line, A for arc, or S for spline.'
                       : pendingAdd.currentMode === 'arc'
                           ? pendingAdd.pendingArcEnd
-                            ? 'Click a third point on the arc to define curvature. Press Tab to type position, Backspace to undo.'
-                            : 'Click to place the arc end point, then click again to define the arc. Press Tab to type position, L or S to switch modes.'
+                            ? isTablet
+                              ? 'Tap a third point on the arc to define curvature. Use Dimension to type position, Undo to go back.'
+                              : 'Click a third point on the arc to define curvature. Press Tab to type position, Backspace to undo.'
+                            : isTablet
+                              ? 'Tap to place the arc end point, then tap again to define the arc. Use Dimension to type position, or switch modes above.'
+                              : 'Click to place the arc end point, then click again to define the arc. Press Tab to type position, L or S to switch modes.'
                           : pendingAdd.currentMode === 'spline'
                             ? creationTarget === 'region'
-                              ? 'Click to add a spline segment endpoint. Press Tab to type length/angle. Click the first point to close the region.'
-                              : 'Click to add a spline segment endpoint. Press Tab to type length/angle. Click the first point to close, or press Enter to finish open.'
+                              ? isTablet
+                                ? 'Tap to add a spline segment endpoint. Use Dimension to type length/angle. Tap the first point to close the region.'
+                                : 'Click to add a spline segment endpoint. Press Tab to type length/angle. Click the first point to close the region.'
+                              : isTablet
+                                ? 'Tap to add a spline segment endpoint. Use Dimension to type length/angle. Tap the first point to close, or use Finish.'
+                                : 'Click to add a spline segment endpoint. Press Tab to type length/angle. Click the first point to close, or press Enter to finish open.'
                             : creationTarget === 'region'
-                              ? 'Click to add connected line segments. Press Tab to type length/angle. Click the first point to close the region.'
-                              : 'Click to add connected line segments. Press Tab to type length/angle. Click the first point to close, or press Enter to finish open.'}
+                              ? isTablet
+                                ? 'Tap to add connected line segments. Use Dimension to type length/angle. Tap the first point to close the region.'
+                                : 'Click to add connected line segments. Press Tab to type length/angle. Click the first point to close the region.'
+                              : isTablet
+                                ? 'Tap to add connected line segments. Use Dimension to type length/angle. Tap the first point to close, or use Finish.'
+                                : 'Click to add connected line segments. Press Tab to type length/angle. Click the first point to close, or press Enter to finish open.'}
             {(() => {
               const canType =
                 ((pendingAdd.shape === 'rect' || pendingAdd.shape === 'circle' || pendingAdd.shape === 'ellipse' || pendingAdd.shape === 'tab' || pendingAdd.shape === 'clamp') && !!pendingAdd.anchor)
@@ -4860,126 +5206,363 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         </div>
       )}
       {pendingMove && (
-        <div className="sketch-place-banner">
-          {pendingMove.mode === 'copy' && pendingMove.fromPoint && pendingMove.toPoint ? (
+        <CanvasWorkflowPanel
+          title={pendingMove.mode === 'copy' ? 'Copy' : 'Move'}
+          step={moveDistanceEditActive
+            ? 'Set distance'
+            : !pendingMove.fromPoint
+              ? 'Select from point'
+              : !pendingMove.toPoint
+                ? 'Select target point'
+                : pendingMove.mode === 'copy'
+                  ? 'Set copy count'
+                  : undefined}
+          position={moveWorkflowPanel.position}
+          panelRef={moveWorkflowPanel.panelRef}
+          handleProps={moveWorkflowPanel.handleProps}
+          actionRowProps={moveWorkflowPanel.actionRowProps}
+          className="canvas-workflow-panel--move"
+          moveLabel={`Move ${pendingMove.mode} controls`}
+          actions={(
             <>
-              <span>Copies</span>
-              <input
-                ref={copyCountInputRef}
-                className="sketch-place-count"
-                type="text"
-                inputMode="numeric"
-                value={copyCountDraft}
-                onChange={(event) => setCopyCountDraft(event.target.value.replace(/[^\d]/g, ''))}
-                onFocus={(event) => event.currentTarget.select()}
-                onKeyDown={(event) => {
-                  event.stopPropagation()
-                  if (event.key === 'Enter') {
-                    const nextCount = Math.max(1, Math.floor(Number(copyCountDraft) || 1))
-                    completePendingMove(pendingMove.toPoint!, nextCount)
+              {moveDistanceEditActive && (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn tablet-cmd-btn--confirm"
+                  onClick={commitMoveDistanceEditFromPanel}
+                >Confirm</button>
+              )}
+              {!moveDistanceEditActive && pendingMove.mode === 'copy' && pendingMove.fromPoint && pendingMove.toPoint && (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn tablet-cmd-btn--confirm"
+                  onClick={() => {
+                    const n = Math.max(1, Math.floor(Number(copyCountDraft) || 1))
+                    completePendingMove(pendingMove.toPoint!, n)
                     setPendingMovePreviewPointRef(null)
                     setCopyCountDraft('1')
-                  } else if (event.key === 'Escape') {
-                    event.preventDefault()
-                    cancelPendingMove()
-                    setPendingMovePreviewPointRef(null)
-                    setCopyCountDraft('1')
-                  }
-                }}
-                autoFocus
-              />
-              <span>Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm" onClick={() => { const n = Math.max(1, Math.floor(Number(copyCountDraft) || 1)); completePendingMove(pendingMove.toPoint!, n); setPendingMovePreviewPointRef(null); setCopyCountDraft('1') }} onKeyDown={(e) => { if (e.key === 'Enter') { const n = Math.max(1, Math.floor(Number(copyCountDraft) || 1)); completePendingMove(pendingMove.toPoint!, n); setPendingMovePreviewPointRef(null); setCopyCountDraft('1') } }}>Enter</kbd> to confirm, <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={() => { cancelPendingMove(); setPendingMovePreviewPointRef(null); setCopyCountDraft('1') }} onKeyDown={(e) => { if (e.key === 'Enter') { cancelPendingMove(); setPendingMovePreviewPointRef(null); setCopyCountDraft('1') } }}>Esc</kbd> to cancel.</span>
+                    moveWorkflowPanel.focusCanvasAfterAction()
+                  }}
+                >Confirm</button>
+              )}
+              <button
+                type="button"
+                className="tablet-cmd-btn tablet-cmd-btn--cancel"
+                onClick={cancelMoveFromPanel}
+              >Cancel</button>
+            </>
+          )}
+        >
+          {pendingMove.fromPoint && !pendingMove.toPoint && (
+            <div className="canvas-workflow-panel__summary">
+              Select a target point to set the direction and default distance.
+            </div>
+          )}
+          {moveDistanceEditActive && (operationDimEdit?.kind === 'move' || operationDimEdit?.kind === 'copy') && (
+            <div className="canvas-workflow-panel__meta">
+              <label className="canvas-workflow-panel__field">
+                <span>Distance</span>
+                <input
+                  ref={widthInputRef}
+                  className="canvas-workflow-panel__count-input canvas-workflow-panel__distance-input"
+                  type="text"
+                  inputMode="decimal"
+                  value={operationDimEdit.distance}
+                  onChange={(event) => setOperationDimEdit({ ...operationDimEdit, distance: event.target.value })}
+                  onFocus={(event) => event.currentTarget.select()}
+                  onKeyDown={(event) => {
+                    event.stopPropagation()
+                    if (event.key === 'Enter') {
+                      event.preventDefault()
+                      commitMoveDistanceEditFromPanel()
+                    } else if (event.key === 'Escape') {
+                      event.preventDefault()
+                      cancelMoveFromPanel()
+                    }
+                  }}
+                  autoFocus
+                />
+              </label>
+            </div>
+          )}
+          {!moveDistanceEditActive && pendingMove.mode === 'copy' && pendingMove.fromPoint && pendingMove.toPoint && (
+            <div className="canvas-workflow-panel__meta">
+              <label className="canvas-workflow-panel__field">
+                <span>Copies</span>
+                <input
+                  ref={copyCountInputRef}
+                  className="canvas-workflow-panel__count-input"
+                  type="text"
+                  inputMode="numeric"
+                  value={copyCountDraft}
+                  onChange={(event) => setCopyCountDraft(event.target.value.replace(/[^\d]/g, ''))}
+                  onFocus={(event) => event.currentTarget.select()}
+                  onKeyDown={(event) => {
+                    event.stopPropagation()
+                    if (event.key === 'Enter') {
+                      const nextCount = Math.max(1, Math.floor(Number(copyCountDraft) || 1))
+                      completePendingMove(pendingMove.toPoint!, nextCount)
+                      setPendingMovePreviewPointRef(null)
+                      setCopyCountDraft('1')
+                      moveWorkflowPanel.focusCanvasAfterAction()
+                    } else if (event.key === 'Escape') {
+                      event.preventDefault()
+                      cancelMoveFromPanel()
+                    }
+                  }}
+                  autoFocus
+                />
+              </label>
+            </div>
+          )}
+        </CanvasWorkflowPanel>
+      )}
+      {pendingTransform && (
+        <CanvasWorkflowPanel
+          title={pendingTransform.mode === 'resize' ? 'Resize' : pendingTransform.mode === 'mirror' ? 'Mirror' : 'Rotate'}
+          step={transformExactEditActive
+            ? transformScaleEditActive ? 'Set scale' : 'Set angle'
+            : rotateCopyCountPromptActive
+            ? 'Set copy count'
+            : pendingTransform.mode === 'resize'
+              ? !pendingTransform.referenceStart
+                ? 'Select first reference'
+                : !pendingTransform.referenceEnd
+                  ? 'Select second reference'
+                  : 'Scale to commit'
+              : pendingTransform.mode === 'mirror'
+                ? !pendingTransform.referenceStart
+                  ? 'Select first line point'
+                  : 'Select second line point'
+                : !pendingTransform.referenceStart
+                  ? 'Select origin'
+                  : !pendingTransform.referenceEnd
+                    ? 'Select reference direction'
+                    : 'Rotate to commit'}
+          position={transformWorkflowPanel.position}
+          panelRef={transformWorkflowPanel.panelRef}
+          handleProps={transformWorkflowPanel.handleProps}
+          actionRowProps={transformWorkflowPanel.actionRowProps}
+          className="canvas-workflow-panel--transform"
+          moveLabel={`Move ${pendingTransform.mode} controls`}
+          actions={(
+            <>
+              {transformExactEditActive && (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn tablet-cmd-btn--confirm"
+                  onClick={commitTransformExactEditFromPanel}
+                >Confirm</button>
+              )}
+              {!transformExactEditActive && !rotateCopyCountPromptActive
+                && ((pendingTransform.mode === 'resize' && pendingTransform.referenceStart && pendingTransform.referenceEnd)
+                  || (pendingTransform.mode === 'rotate' && pendingTransform.referenceStart && pendingTransform.referenceEnd)) && (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn"
+                  onClick={triggerDimensionFromTransformPanel}
+                >{pendingTransform.mode === 'resize' ? 'Scale' : 'Angle'}</button>
+              )}
+              {!transformExactEditActive && rotateCopyCountPromptActive && (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn tablet-cmd-btn--confirm"
+                  onClick={() => {
+                    const n = Math.max(1, Math.floor(Number(rotateCopyCountDraft) || 1))
+                    completePendingTransform(pendingRotateCopyPoint!, n)
+                    setPendingTransformPreviewPointRef(null)
+                    setPendingRotateCopyPoint(null)
+                    setRotateCopyCountDraft('1')
+                    transformWorkflowPanel.focusCanvasAfterAction()
+                  }}
+                >Confirm</button>
+              )}
+              <button
+                type="button"
+                className="tablet-cmd-btn tablet-cmd-btn--cancel"
+                onClick={cancelTransformFromPanel}
+              >Cancel</button>
+            </>
+          )}
+        >
+          {transformExactEditActive && (operationDimEdit?.kind === 'scale' || operationDimEdit?.kind === 'rotate') ? (
+            <div className="canvas-workflow-panel__meta">
+              <label className="canvas-workflow-panel__field">
+                <span>{operationDimEdit.kind === 'scale' ? 'Scale' : 'Angle'}</span>
+                <input
+                  ref={widthInputRef}
+                  className="canvas-workflow-panel__count-input"
+                  type="text"
+                  inputMode="decimal"
+                  value={operationDimEdit.kind === 'scale' ? operationDimEdit.factor : operationDimEdit.angle}
+                  onChange={(event) => {
+                    if (operationDimEdit.kind === 'scale') {
+                      setOperationDimEdit({ kind: 'scale', factor: event.target.value })
+                    } else {
+                      setOperationDimEdit({ kind: 'rotate', angle: event.target.value })
+                    }
+                  }}
+                  onFocus={(event) => event.currentTarget.select()}
+                  onKeyDown={(event) => {
+                    event.stopPropagation()
+                    if (event.key === 'Enter') {
+                      event.preventDefault()
+                      commitTransformExactEditFromPanel()
+                    } else if (event.key === 'Escape') {
+                      event.preventDefault()
+                      cancelTransformFromPanel()
+                    }
+                  }}
+                  autoFocus
+                />
+              </label>
+            </div>
+          ) : rotateCopyCountPromptActive ? (
+            <>
+              <div className="canvas-workflow-panel__meta">
+                <label className="canvas-workflow-panel__field">
+                  <span>Copies</span>
+                  <input
+                    ref={rotateCopyCountInputRef}
+                    className="canvas-workflow-panel__count-input"
+                    type="text"
+                    inputMode="numeric"
+                    value={rotateCopyCountDraft}
+                    onChange={(event) => setRotateCopyCountDraft(event.target.value.replace(/[^\d]/g, ''))}
+                    onFocus={(event) => event.currentTarget.select()}
+                    onKeyDown={(event) => {
+                      event.stopPropagation()
+                      if (event.key === 'Enter') {
+                        const n = Math.max(1, Math.floor(Number(rotateCopyCountDraft) || 1))
+                        completePendingTransform(pendingRotateCopyPoint!, n)
+                        setPendingTransformPreviewPointRef(null)
+                        setPendingRotateCopyPoint(null)
+                        setRotateCopyCountDraft('1')
+                        transformWorkflowPanel.focusCanvasAfterAction()
+                      } else if (event.key === 'Escape') {
+                        event.preventDefault()
+                        cancelTransformFromPanel()
+                      }
+                    }}
+                    autoFocus
+                  />
+                </label>
+              </div>
             </>
           ) : (
             <>
-              <span>{pendingMove.fromPoint
-                ? pendingMove.mode === 'copy'
-                  ? 'Click the copy to point, then enter the copy count.'
-                  : 'Click the destination point to complete the move.'
-                : pendingMove.mode === 'copy'
-                  ? 'Click the copy from point, then click the copy to point.'
-                  : 'Click the move from point, then click the move to point.'}</span>
-              {pendingMove.fromPoint && !pendingMove.toPoint && (
-                <> Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Type exact distance" onClick={triggerDimensionEdit} onKeyDown={(e) => { if (e.key === 'Enter') triggerDimensionEdit() }}>Tab</kbd> to type exact distance.</>)}
-              {' '}Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingMove} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingMove() }}>Esc</kbd> to cancel.
+              {((pendingTransform.mode === 'resize' && pendingTransform.referenceStart && pendingTransform.referenceEnd)
+                || (pendingTransform.mode === 'rotate' && pendingTransform.referenceStart && pendingTransform.referenceEnd)
+                || (pendingTransform.mode === 'mirror' && pendingTransform.referenceStart)) && (
+                <div className="canvas-workflow-panel__summary">
+                  {pendingTransform.mode === 'resize'
+                    ? 'Move along the reference line to preview, then click to commit.'
+                    : pendingTransform.mode === 'mirror'
+                      ? 'Move to preview, then click the second mirror line point.'
+                      : pendingTransform.keepOriginals
+                        ? 'Move to preview the rotated copy, then click to set angle.'
+                        : 'Move to preview, then click to commit.'}
+                </div>
+              )}
+              {((pendingTransform.mode === 'rotate' && pendingTransform.referenceStart && pendingTransform.referenceEnd)
+                || (pendingTransform.mode === 'mirror' && pendingTransform.referenceStart)) && (
+                <div className="canvas-workflow-panel__meta">
+                  <label className="canvas-workflow-panel__check">
+                    <input
+                      type="checkbox"
+                      checked={pendingTransform.keepOriginals}
+                      onChange={(event) => {
+                        setPendingTransformKeepOriginals(event.target.checked)
+                        transformWorkflowPanel.focusCanvasAfterAction()
+                      }}
+                    />
+                    <span>Keep originals</span>
+                  </label>
+                </div>
+              )}
             </>
           )}
-        </div>
+        </CanvasWorkflowPanel>
       )}
-      {pendingTransform && !rotateCopyCountPromptActive && (
-        <div className="sketch-place-banner">
-          <span>{pendingTransform.mode === 'resize'
-            ? !pendingTransform.referenceStart
-              ? 'Click the first resize reference point.'
-              : !pendingTransform.referenceEnd
-                ? 'Click the second resize reference point.'
-                : 'Move along the reference line to preview the resized feature, then click to commit.'
-            : pendingTransform.mode === 'mirror'
-              ? !pendingTransform.referenceStart
-                ? 'Click the first mirror line point.'
-                : 'Move to preview the mirrored feature, then click the second mirror line point to commit.'
-              : !pendingTransform.referenceStart
-                ? 'Click the rotation origin.'
-                : !pendingTransform.referenceEnd
-                  ? 'Click the reference direction point.'
-                  : pendingTransform.keepOriginals
-                    ? 'Move to preview the rotated copy, then click to set angle.'
-                    : 'Move to preview the rotated feature, then click to commit.'}</span>
-          {((pendingTransform.mode === 'rotate' && pendingTransform.referenceStart && pendingTransform.referenceEnd)
-            || (pendingTransform.mode === 'mirror' && pendingTransform.referenceStart)) && (
-            <label className="sketch-place-toggle">
-              <input
-                type="checkbox"
-                checked={pendingTransform.keepOriginals}
-                onChange={(event) => setPendingTransformKeepOriginals(event.target.checked)}
-                onKeyDown={(event) => {
-                  if (event.key === 'Escape') {
-                    event.preventDefault()
-                    cancelPendingTransform()
-                    setPendingTransformPreviewPointRef(null)
-                  }
-                }}
-              />
-              <span>Keep originals</span>
-            </label>
+      {isTablet && (
+        <div className="tablet-command-bar">
+          {/* Composite drawing: mode switch + undo point */}
+          {pendingAdd?.shape === 'composite' && pendingAdd.start && !pendingAdd.closed && (
+            <>
+              <button
+                type="button"
+                className={`tablet-cmd-btn ${pendingAdd.currentMode === 'line' ? 'tablet-cmd-btn--active' : ''}`}
+                onClick={() => setPendingCompositeMode('line')}
+              >Line</button>
+              <button
+                type="button"
+                className={`tablet-cmd-btn ${pendingAdd.currentMode === 'arc' ? 'tablet-cmd-btn--active' : ''}`}
+                onClick={() => setPendingCompositeMode('arc')}
+              >Arc</button>
+              <button
+                type="button"
+                className={`tablet-cmd-btn ${pendingAdd.currentMode === 'spline' ? 'tablet-cmd-btn--active' : ''}`}
+                onClick={() => setPendingCompositeMode('spline')}
+              >Spline</button>
+              <button type="button" className="tablet-cmd-btn" onClick={undoPendingCompositeStep}>Undo</button>
+            </>
           )}
-          {((pendingTransform.mode === 'resize' && pendingTransform.referenceStart && pendingTransform.referenceEnd)
-            || (pendingTransform.mode === 'rotate' && pendingTransform.referenceStart && pendingTransform.referenceEnd)) && (
-            <> Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title={pendingTransform.mode === 'resize' ? 'Type scale factor' : 'Type exact angle'} onClick={triggerDimensionEdit} onKeyDown={(e) => { if (e.key === 'Enter') triggerDimensionEdit() }}>Tab</kbd> to type {pendingTransform.mode === 'resize' ? 'scale factor' : 'exact angle'}.</>
+          {/* Polygon/spline drawing: undo point */}
+          {(pendingAdd?.shape === 'polygon' || pendingAdd?.shape === 'spline') && pendingAdd.points.length > 0 && (
+            <button type="button" className="tablet-cmd-btn" onClick={undoPendingPolygonPoint}>Undo</button>
           )}
-          {' '}Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={() => { cancelPendingTransform(); setPendingTransformPreviewPointRef(null) }} onKeyDown={(e) => { if (e.key === 'Enter') { cancelPendingTransform(); setPendingTransformPreviewPointRef(null) } }}>Esc</kbd> to cancel.
-        </div>
-      )}
-      {rotateCopyCountPromptActive && pendingTransform && (
-        <div className="sketch-place-banner">
-          <span>Copies</span>
-          <input
-            ref={rotateCopyCountInputRef}
-            className="sketch-place-count"
-            type="text"
-            inputMode="numeric"
-            value={rotateCopyCountDraft}
-            onChange={(event) => setRotateCopyCountDraft(event.target.value.replace(/[^\d]/g, ''))}
-            onFocus={(event) => event.currentTarget.select()}
-            onKeyDown={(event) => {
-              event.stopPropagation()
-              if (event.key === 'Enter') {
-                const n = Math.max(1, Math.floor(Number(rotateCopyCountDraft) || 1))
-                completePendingTransform(pendingRotateCopyPoint!, n)
-                setPendingTransformPreviewPointRef(null)
-                setPendingRotateCopyPoint(null)
-                setRotateCopyCountDraft('1')
-              } else if (event.key === 'Escape') {
-                event.preventDefault()
-                cancelPendingTransform()
-                setPendingTransformPreviewPointRef(null)
-                setPendingRotateCopyPoint(null)
-                setRotateCopyCountDraft('1')
-              }
-            }}
-            autoFocus
-          />
-          <span>Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Confirm" onClick={() => { const n = Math.max(1, Math.floor(Number(rotateCopyCountDraft) || 1)); completePendingTransform(pendingRotateCopyPoint!, n); setPendingTransformPreviewPointRef(null); setPendingRotateCopyPoint(null); setRotateCopyCountDraft('1') }} onKeyDown={(e) => { if (e.key === 'Enter') { const n = Math.max(1, Math.floor(Number(rotateCopyCountDraft) || 1)); completePendingTransform(pendingRotateCopyPoint!, n); setPendingTransformPreviewPointRef(null); setPendingRotateCopyPoint(null); setRotateCopyCountDraft('1') } }}>Enter</kbd> to confirm, <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={() => { cancelPendingTransform(); setPendingTransformPreviewPointRef(null); setPendingRotateCopyPoint(null); setRotateCopyCountDraft('1') }} onKeyDown={(e) => { if (e.key === 'Enter') { cancelPendingTransform(); setPendingTransformPreviewPointRef(null); setPendingRotateCopyPoint(null); setRotateCopyCountDraft('1') } }}>Esc</kbd> to cancel.</span>
+          {/* Pending add: confirm + cancel (Move/Transform/Offset/Join/Cut now use workflow panels) */}
+          {pendingAdd && (
+            <>
+              {(pendingAdd.shape === 'composite' && pendingAdd.segments.length >= 1 && !pendingAdd.pendingArcEnd && creationTarget !== 'region') && (
+                <button type="button" className="tablet-cmd-btn tablet-cmd-btn--confirm" onClick={completePendingOpenComposite}>Finish</button>
+              )}
+              <button
+                type="button"
+                className="tablet-cmd-btn tablet-cmd-btn--cancel"
+                onClick={cancelPendingAdd}
+              >Cancel</button>
+            </>
+          )}
+          {/* Sketch edit mode: apply + cancel + dimension */}
+          {selection.mode === 'sketch_edit' && !pendingAdd && (
+            <>
+              {armedForDimension && (
+                <button type="button" className="tablet-cmd-btn" onClick={() => { triggerDimensionEdit(); setArmedForDimension(false) }}>Dimension</button>
+              )}
+              <button type="button" className="tablet-cmd-btn tablet-cmd-btn--confirm" onClick={() => { stopNodeDrag(); applySketchEdit() }}>Apply</button>
+              <button type="button" className="tablet-cmd-btn tablet-cmd-btn--cancel" onClick={() => { stopNodeDrag(); cancelSketchEdit() }}>Cancel</button>
+            </>
+          )}
+          {/* Dimension input: button for pending shapes */}
+          {pendingAdd && !pendingShapeAction && (() => {
+            const canType =
+              ((pendingAdd.shape === 'rect' || pendingAdd.shape === 'circle' || pendingAdd.shape === 'ellipse' || pendingAdd.shape === 'tab' || pendingAdd.shape === 'clamp') && !!pendingAdd.anchor)
+              || ((pendingAdd.shape === 'polygon' || pendingAdd.shape === 'spline') && pendingAdd.points.length >= 1)
+              || (pendingAdd.shape === 'composite' && !!pendingAdd.start && !pendingAdd.closed)
+            return canType ? (
+              <button type="button" className="tablet-cmd-btn" onClick={triggerDimensionEdit}>Dimension</button>
+            ) : null
+          })()}
+          {/* Axis lock during drag operations */}
+          {isDraggingAny && (
+            <button
+              type="button"
+              className="tablet-cmd-btn"
+              style={{ borderColor: lockModeGuideColor(lockModeRef.current) }}
+              onClick={cycleLock}
+            >{lockModeRef.current === 'none' ? 'Lock' : lockModeRef.current === 'x' ? 'Lock X' : 'Lock Y'}</button>
+          )}
+          {/* Multi-select toggle */}
+          {selection.mode === 'feature' && !pendingAdd && !pendingMove && !pendingTransform && !pendingOffset && (
+            <button
+              type="button"
+              className={`tablet-cmd-btn ${(multiSelectMode || !!pendingShapeAction) ? 'tablet-cmd-btn--active' : ''}`}
+              disabled={!!pendingShapeAction}
+              title={pendingShapeAction ? 'Multi-select is automatic for Join and Cut' : 'Toggle multi-select'}
+              onClick={() => setMultiSelectMode((prev) => !prev)}
+            >Multi</button>
+          )}
         </div>
       )}
     </div>

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -1018,7 +1018,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
   useEffect(() => {
     scheduleDraw()
-  }, [project, selection, pendingAdd, pendingMove, pendingTransform, pendingOffset, viewState, backdropImage, stlImageRevision, toolpaths, selectedOperationId, collidingClampIds, snapSettings, copyCountDraft, dimensionEdit])
+  }, [project, selection, pendingAdd, pendingMove, pendingTransform, pendingOffset, viewState, backdropImage, stlImageRevision, toolpaths, selectedOperationId, collidingClampIds, snapSettings, copyCountDraft, dimensionEdit, toolpathVisibility])
 
   useEffect(() => {
     sketchEditPreviewRef.current = null

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -448,11 +448,11 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   constraintEditRef.current = constraintEdit
 
   // Axis lock — active whenever a move, node drag, sketch-edit drag, constraint pick, or feature creation is in progress
-  const isDraggingAny = !!pendingMove || !!pendingAdd || !!pendingConstraint || isDraggingNodeRef.current || selection.sketchEditTool === 'add_point'
+
   const showCutFlowPanel = pendingShapeAction?.kind === 'cut'
   const cutFlowPanelPhase = pendingShapeAction?.kind === 'cut' ? pendingShapeAction.phase : null
   const scheduleDrawRef = useRef<() => void>(() => {})
-  const { lockModeRef, applyLock, cycleLock } = useAxisLock(isDraggingAny, () => scheduleDrawRef.current())
+  const { lockModeRef, lockMode, applyLock, cycleLock, reset: resetLock } = useAxisLock(() => scheduleDrawRef.current())
   const cutWorkflowPanel = useCanvasWorkflowPanel({
     open: showCutFlowPanel,
     phaseKey: cutFlowPanelPhase,
@@ -489,12 +489,41 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     canvasRef,
     clearTransientCanvasState,
   })
-  const creationPanelShape = pendingAdd && (pendingAdd.shape === 'rect' || pendingAdd.shape === 'circle' || pendingAdd.shape === 'ellipse' || pendingAdd.shape === 'tab' || pendingAdd.shape === 'clamp') ? pendingAdd.shape : null
+  const constraintDistanceReady = !!pendingConstraint && !!pendingConstraint.anchor && !!pendingConstraint.reference
+  const constraintWorkflowPanel = useCanvasWorkflowPanel({
+    open: !!pendingConstraint,
+    phaseKey: constraintDistanceReady ? 'distance' : pendingConstraint?.anchor ? 'reference' : 'anchor',
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+  const creationPanelShape = pendingAdd && (
+    pendingAdd.shape === 'rect' || pendingAdd.shape === 'circle' || pendingAdd.shape === 'ellipse'
+    || pendingAdd.shape === 'tab' || pendingAdd.shape === 'clamp'
+    || pendingAdd.shape === 'polygon' || pendingAdd.shape === 'spline' || pendingAdd.shape === 'composite'
+  ) ? pendingAdd.shape : null
   const creationPanelHasAnchor = creationPanelShape && pendingAdd && 'anchor' in pendingAdd && !!pendingAdd.anchor
-  const creationDimEditActive = !!creationPanelHasAnchor && !!dimensionEdit
+  const creationPanelHasPoints = creationPanelShape && pendingAdd && 'points' in pendingAdd && pendingAdd.points.length > 0
+  const creationPanelHasStart = creationPanelShape === 'composite' && pendingAdd?.shape === 'composite' && !!pendingAdd.start
+  const creationCanDimEdit = creationPanelHasAnchor || creationPanelHasPoints || (creationPanelHasStart && pendingAdd?.shape === 'composite' && !pendingAdd.closed)
+  const creationDimEditActive = !!creationCanDimEdit && !!dimensionEdit
   const creationWorkflowPanel = useCanvasWorkflowPanel({
     open: !!creationPanelShape,
-    phaseKey: creationDimEditActive ? 'dimensions' : creationPanelHasAnchor ? 'place' : 'anchor',
+    phaseKey: creationDimEditActive ? 'dimensions'
+      : creationPanelHasAnchor ? 'place'
+      : creationPanelHasPoints ? 'adding'
+      : creationPanelHasStart ? 'drawing'
+      : 'start',
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+
+  const editModeActive = selection.mode === 'sketch_edit' && !pendingAdd
+  const editDimEditActive = editModeActive && !!dimensionEdit
+  const editWorkflowPanel = useCanvasWorkflowPanel({
+    open: editModeActive,
+    phaseKey: editDimEditActive ? 'dimensions' : 'editing',
     containerRef,
     canvasRef,
     clearTransientCanvasState,
@@ -696,6 +725,21 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     offsetWorkflowPanel.focusCanvasAfterAction()
   }
 
+  function commitConstraintFromPanel() {
+    const parsed = parseLengthInput(constraintDistanceInput ?? '', projectRef.current.meta.units)
+    if (parsed != null && parsed >= 0) {
+      commitConstraintDistance(parsed)
+      setConstraintDistanceInput(null)
+    }
+    constraintWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function cancelConstraintFromPanel() {
+    cancelPendingConstraint()
+    setConstraintDistanceInput(null)
+    constraintWorkflowPanel.focusCanvasAfterAction()
+  }
+
   function triggerDimensionFromOffsetPanel() {
     triggerDimensionEdit()
     offsetWorkflowPanel.focusCanvasAfterAction()
@@ -721,10 +765,59 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     const edit = dimensionEditRef.current
     if (!edit) return
     const pt = computeDimensionEditPreviewPoint(edit, projectRef.current.meta.units)
-    placePendingAddAt(pt)
-    setPendingPreviewPointRef(null)
-    setDimensionEdit(null)
-    creationWorkflowPanel.focusCanvasAfterAction()
+    const pendingAdd = pendingAddRef.current
+    if ((edit.shape === 'polygon' || edit.shape === 'spline') && (pendingAdd?.shape === 'polygon' || pendingAdd?.shape === 'spline')) {
+      addPendingPolygonPoint(pt)
+      setPendingPreviewPointRef({ point: pt, session: pendingAdd.session })
+      setDimensionEdit(null)
+      creationWorkflowPanel.focusCanvasAfterAction()
+    } else if (pendingAdd?.shape === 'composite') {
+      if (pendingAdd.currentMode === 'arc' && !pendingAdd.pendingArcEnd && edit.radius) {
+        const units = projectRef.current.meta.units
+        const r = parseLengthInput(edit.radius, units)
+        if (r != null && r > 0) {
+          addPendingCompositePoint(pt)
+          const arcStart = edit.anchor
+          const arcEnd = pt
+          const midX = (arcStart.x + arcEnd.x) / 2
+          const midY = (arcStart.y + arcEnd.y) / 2
+          const chordDx = arcEnd.x - arcStart.x
+          const chordDy = arcEnd.y - arcStart.y
+          const halfChord = Math.hypot(chordDx, chordDy) / 2
+          if (halfChord > 1e-9 && r >= halfChord) {
+            const chordLen = halfChord * 2
+            const perpX = -chordDy / chordLen
+            const perpY = chordDx / chordLen
+            const sagitta = r - Math.sqrt(r * r - halfChord * halfChord)
+            const throughPt = { x: midX + sagitta * perpX, y: midY + sagitta * perpY }
+            addPendingCompositePoint(throughPt)
+            setPendingPreviewPointRef({ point: arcEnd, session: pendingAdd.session })
+          } else {
+            setPendingPreviewPointRef({ point: pt, session: pendingAdd.session })
+          }
+          setDimensionEdit(null)
+          creationWorkflowPanel.focusCanvasAfterAction()
+          return
+        }
+      }
+      if (edit.arcStart && edit.arcEnd) {
+        addPendingCompositePoint(pt)
+        const arcEnd = edit.arcEnd
+        setPendingPreviewPointRef({ point: arcEnd, session: pendingAdd.session })
+        setDimensionEdit(null)
+        creationWorkflowPanel.focusCanvasAfterAction()
+      } else {
+        addPendingCompositePoint(pt)
+        setPendingPreviewPointRef({ point: pt, session: pendingAdd.session })
+        setDimensionEdit(null)
+        creationWorkflowPanel.focusCanvasAfterAction()
+      }
+    } else {
+      placePendingAddAt(pt)
+      setPendingPreviewPointRef(null)
+      setDimensionEdit(null)
+      creationWorkflowPanel.focusCanvasAfterAction()
+    }
   }
 
   function cancelCreationDimensionEdit() {
@@ -736,6 +829,56 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     cancelPendingAdd()
     setDimensionEdit(null)
     creationWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function undoFromCreationPanel() {
+    const pendingAdd = pendingAddRef.current
+    if (pendingAdd?.shape === 'polygon' || pendingAdd?.shape === 'spline') {
+      undoPendingPolygonPoint()
+    } else if (pendingAdd?.shape === 'composite') {
+      undoPendingCompositeStep()
+    }
+    creationWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function finishOpenPathFromPanel() {
+    completePendingOpenPath()
+    setPendingPreviewPointRef(null)
+    creationWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function finishOpenCompositeFromPanel() {
+    completePendingOpenComposite()
+    creationWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function setCompositeModeFromPanel(mode: 'line' | 'arc' | 'spline') {
+    setPendingCompositeMode(mode)
+    creationWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function applyEditFromPanel() {
+    stopNodeDrag()
+    resetLock()
+    applySketchEdit()
+    editWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function cancelEditFromPanel() {
+    stopNodeDrag()
+    resetLock()
+    cancelSketchEdit()
+    editWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function commitEditDimensionFromPanel() {
+    commitEditDimension()
+    editWorkflowPanel.focusCanvasAfterAction()
+  }
+
+  function cancelEditDimensionFromPanel() {
+    cancelEditDimension()
+    editWorkflowPanel.focusCanvasAfterAction()
   }
 
   function isActiveSnapPoint(point: Point | null | undefined): boolean {
@@ -2286,6 +2429,17 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       return [{ kind: 'arc_radius', control, arcStartAnchorIndex: control.index }]
     }
 
+    if (control.kind === 'segment') {
+      const seg = profile.segments[control.index]
+      if (seg.type === 'arc') {
+        return [{ kind: 'arc_radius', control: { kind: 'arc_handle', index: control.index }, arcStartAnchorIndex: control.index }]
+      }
+      const endAnchorIndex = profile.closed
+        ? (control.index + 1) % profile.segments.length
+        : control.index + 1
+      return [{ kind: 'endpoint', control: { kind: 'anchor', index: endAnchorIndex }, fromAnchorIndex: control.index }]
+    }
+
     return []
   }
 
@@ -2400,17 +2554,12 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       const segmentHitRadiusSq = NODE_HIT_RADIUS * NODE_HIT_RADIUS
       for (let index = 0; index < profile.segments.length; index += 1) {
         const segment = profile.segments[index]
-        if (segment.type !== 'line') {
-          continue
-        }
-
+        if (segment.type === 'circle') continue
         const start = anchorPointForIndex(profile, index)
-        const projected = projectPointToSegment(worldPoint, start, segment.to)
-        const projectedCanvas = worldToCanvas(projected.point, vt)
-        const d2 = distance2(point, projectedCanvas)
-        if (d2 <= Math.min(bestDistanceSq, segmentHitRadiusSq)) {
-          bestDistanceSq = d2
-          bestControl = { kind: 'segment', index, t: projected.t }
+        const candidate = nearestPointOnSegmentWithT(worldPoint, start, segment, vt)
+        if (candidate.distanceSqPx <= Math.min(bestDistanceSq, segmentHitRadiusSq)) {
+          bestDistanceSq = candidate.distanceSqPx
+          bestControl = { kind: 'segment', index, t: candidate.t }
         }
       }
     }
@@ -2538,6 +2687,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       return
     }
 
+    if (dimensionEditRef.current) cancelEditDimension()
     beginHistoryTransaction()
     setActiveControl(nextControl)
     isDraggingNodeRef.current = true
@@ -2584,6 +2734,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       const dy = point.cy - pending.canvasPoint.cy
       if (dx * dx + dy * dy > 25) {
         touchDragPendingRef.current = null
+        if (dimensionEditRef.current) cancelEditDimension()
         beginHistoryTransaction()
         setActiveControl(pending.control)
         isDraggingNodeRef.current = true
@@ -3060,7 +3211,6 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     livePointerWorldRef.current = null
     sketchEditPreviewRef.current = null
     pendingSketchFilletRef.current = null
-    pendingSketchExtensionRef.current = null
     setHoveredEditControl(null)
     setPendingOffsetPreviewPointRef(null)
     setPendingOffsetRawPreviewPointRef(null)
@@ -3289,6 +3439,24 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
             scheduleDraw()
           }
           return
+        }
+      }
+
+      if (selection.selectedNode?.type === 'feature' && selection.selectedFeatureId && !selection.sketchEditTool && !dimensionEdit) {
+        const feature = editableFeature()
+        if (feature) {
+          const control = hitEditableControl(point)
+          if (control && (control.kind === 'segment' || control.kind === 'anchor' || control.kind === 'arc_handle')) {
+            const steps = computeEditStepsForControl(feature.sketch.profile, control)
+            if (steps.length > 0) {
+              editDimStepsRef.current = steps
+              editDimStepIndexRef.current = 0
+              dimensionEditFeatureIdRef.current = selection.selectedFeatureId
+              beginHistoryTransaction()
+              applyEditDimStep(0, steps, selection.selectedFeatureId, project.meta.units)
+              return
+            }
+          }
         }
       }
 
@@ -3683,6 +3851,32 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     canvasRef.current?.focus({ preventScroll: true })
   }
 
+  function handleEditDimLiveChange(field: 'length' | 'angle' | 'radius', value: string) {
+    const prev = dimensionEditRef.current
+    if (!prev) return
+    const next = { ...prev, [field]: value }
+    setDimensionEdit(next)
+    const control = dimensionEditControlRef.current
+    const fId = dimensionEditFeatureIdRef.current
+    if (!control || !fId) return
+
+    if (control.kind === 'arc_handle') {
+      const feature = projectRef.current.features.find((f) => f.id === fId)
+      if (!feature) return
+      const profile = feature.sketch.profile
+      const seg = profile.segments[control.index]
+      if (!seg || seg.type !== 'arc') return
+      const arcStart = anchorPointForIndex(profile, control.index)
+      const newRadius = parseLengthInput(value, projectRef.current.meta.units) ?? 0
+      if (newRadius <= 0) return
+      const newHandle = arcHandleFromRadius(arcStart, seg, newRadius)
+      if (newHandle) moveFeatureControl(fId, control, newHandle)
+    } else {
+      const pt = computeDimensionEditPreviewPoint(next, projectRef.current.meta.units)
+      moveFeatureControl(fId, control, pt)
+    }
+  }
+
   // Called by the "Type" button in banners — opens dimension input without
   // the Tab toggle-close behaviour. Keyboard Tab keeps its existing logic.
   function triggerDimensionEdit() {
@@ -3719,11 +3913,43 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         return
       }
       if (pendingAdd.shape === 'composite' && pendingAdd.start && !pendingAdd.closed) {
+        if (pendingAdd.currentMode === 'arc' && pendingAdd.pendingArcEnd) {
+          const arcStart = pendingAdd.lastPoint ?? pendingAdd.start
+          const arcEnd = pendingAdd.pendingArcEnd
+          const previewPoint = pendingPreviewPointRef.current?.point
+          const halfChord = Math.hypot(arcEnd.x - arcStart.x, arcEnd.y - arcStart.y) / 2
+          let r = halfChord
+          if (previewPoint) {
+            const midX = (arcStart.x + arcEnd.x) / 2
+            const midY = (arcStart.y + arcEnd.y) / 2
+            const chordDx = arcEnd.x - arcStart.x
+            const chordDy = arcEnd.y - arcStart.y
+            const chordLen = Math.hypot(chordDx, chordDy)
+            if (chordLen > 1e-9) {
+              const perpX = -chordDy / chordLen
+              const perpY = chordDx / chordLen
+              const bulge = (previewPoint.x - midX) * perpX + (previewPoint.y - midY) * perpY
+              r = Math.max(halfChord, Math.abs(bulge) > 1e-9
+                ? (halfChord * halfChord + bulge * bulge) / (2 * Math.abs(bulge))
+                : halfChord)
+            }
+          }
+          const side = previewPoint ? (() => {
+            const cross = (arcEnd.x - arcStart.x) * (previewPoint.y - arcStart.y)
+              - (arcEnd.y - arcStart.y) * (previewPoint.x - arcStart.x)
+            return cross >= 0 ? 1 : -1
+          })() : 1
+          setDimensionEdit({ shape: 'composite', anchor: arcStart, arcStart, arcEnd, arcClockwise: side < 0, signX: 1, signY: 1, activeField: 'radius', width: '', height: '', radius: formatLength(r, units), length: '', angle: '' })
+          return
+        }
         const fromPoint = pendingAdd.lastPoint ?? pendingAdd.start
         const previewPoint = pendingPreviewPointRef.current?.point ?? fromPoint
         const dx = previewPoint.x - fromPoint.x
         const dy = previewPoint.y - fromPoint.y
-        setDimensionEdit({ shape: 'composite', anchor: fromPoint, signX: 1, signY: 1, activeField: 'length', width: '', height: '', radius: '', length: formatLength(Math.hypot(dx, dy), units), angle: (Math.atan2(dy, dx) * (180 / Math.PI)).toFixed(2).replace(/\.?0+$/, '') })
+        const len = Math.hypot(dx, dy)
+        const angleDeg = (Math.atan2(dy, dx) * (180 / Math.PI)).toFixed(2).replace(/\.?0+$/, '')
+        const defaultRadius = pendingAdd.currentMode === 'arc' ? formatLength(len > 1e-9 ? len : 0.5, units) : ''
+        setDimensionEdit({ shape: 'composite', anchor: fromPoint, signX: 1, signY: 1, activeField: 'length', width: '', height: '', radius: defaultRadius, length: formatLength(len, units), angle: angleDeg })
         return
       }
     }
@@ -4289,12 +4515,14 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
     if (event.key === 'Enter' && selection.mode === 'sketch_edit') {
       stopNodeDrag()
+      resetLock()
       applySketchEdit()
       return
     }
 
     if (event.key === 'Escape' && selection.mode === 'sketch_edit') {
       stopNodeDrag()
+      resetLock()
       cancelSketchEdit()
     }
   }
@@ -4397,163 +4625,6 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           className="sketch-toolpath-vis"
         />
       )}
-      {dimensionEdit && pendingAdd && !creationPanelShape && (() => {
-        const canvas = canvasRef.current
-        if (!canvas) return null
-        const vt = computeViewTransform(project.stock, canvas.width, canvas.height, viewState)
-        const previewPt = computeDimensionEditPreviewPoint(dimensionEdit, project.meta.units)
-
-        function commitDimensionEdit() {
-          const edit = dimensionEditRef.current
-          if (!edit) return
-          const pt = computeDimensionEditPreviewPoint(edit, projectRef.current.meta.units)
-          const pendingAdd = pendingAddRef.current
-          if ((edit.shape === 'polygon' || edit.shape === 'spline') && (pendingAdd?.shape === 'polygon' || pendingAdd?.shape === 'spline')) {
-            addPendingPolygonPoint(pt)
-            setPendingPreviewPointRef({ point: pt, session: pendingAdd.session })
-            setDimensionEdit(null)
-            canvasRef.current?.focus({ preventScroll: true })
-          } else if (pendingAdd?.shape === 'composite') {
-            addPendingCompositePoint(pt)
-            setPendingPreviewPointRef({ point: pt, session: pendingAdd.session })
-            setDimensionEdit(null)
-            canvasRef.current?.focus({ preventScroll: true })
-          } else {
-            placePendingAddAt(pt)
-            setPendingPreviewPointRef(null)
-            setDimensionEdit(null)
-          }
-        }
-
-        function makeDimInputKeyDown(field: 'width' | 'height' | 'radius' | 'length' | 'angle') {
-          return (e: KeyboardEvent<HTMLInputElement>) => {
-            e.stopPropagation()
-            if (e.key === 'Enter') {
-              e.preventDefault()
-              commitDimensionEdit()
-            } else if (e.key === 'Escape') {
-              e.preventDefault()
-              setDimensionEdit(null)
-              canvasRef.current?.focus({ preventScroll: true })
-            } else if (e.key === 'Tab') {
-              e.preventDefault()
-              const edit = dimensionEditRef.current
-              if (!edit) return
-              if (field === 'width') {
-                setDimensionEdit({ ...edit, activeField: 'height' })
-              } else if (field === 'length') {
-                setDimensionEdit({ ...edit, activeField: 'angle' })
-              } else {
-                setDimensionEdit(null)
-                canvasRef.current?.focus({ preventScroll: true })
-              }
-            }
-          }
-        }
-
-        if (dimensionEdit.shape === 'polygon' || dimensionEdit.shape === 'spline' || dimensionEdit.shape === 'composite') {
-          const fromC = worldToCanvas(dimensionEdit.anchor, vt)
-          const toC = worldToCanvas(previewPt, vt)
-          const layout = computeLinearInputLabel(fromC, toC, 14, 40)
-          const angleLabelX = layout.midX + layout.perpX * 36
-          const angleLabelY = layout.midY + layout.perpY * 36
-          return (
-            <>
-              <input
-                key="length"
-                ref={widthInputRef}
-                className="sketch-dim-input"
-                style={{ left: layout.labelX, top: layout.labelY, transform: `translate(-50%, -50%) rotate(${layout.angle}rad)` }}
-                value={dimensionEdit.length}
-                onChange={(e) => setDimensionEdit((prev) => prev ? { ...prev, length: e.target.value } : null)}
-                onKeyDown={makeDimInputKeyDown('length')}
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <input
-                key="angle"
-                ref={heightInputRef}
-                className="sketch-dim-input"
-                style={{ left: angleLabelX, top: angleLabelY, transform: `translate(-50%, -50%) rotate(${layout.angle}rad)` }}
-                value={dimensionEdit.angle}
-                onChange={(e) => setDimensionEdit((prev) => prev ? { ...prev, angle: e.target.value } : null)}
-                onKeyDown={makeDimInputKeyDown('angle')}
-                onFocus={(e) => e.currentTarget.select()}
-              />
-            </>
-          )
-        }
-
-        if (
-          pendingAdd.shape !== 'rect' && pendingAdd.shape !== 'circle'
-          && pendingAdd.shape !== 'ellipse'
-          && pendingAdd.shape !== 'tab' && pendingAdd.shape !== 'clamp'
-          && pendingAdd.shape !== 'composite'
-        ) return null
-        if (pendingAdd.shape !== 'composite' && !pendingAdd.anchor) return null
-        if (pendingAdd.shape === 'composite' && !pendingAdd.start) return null
-
-        if (dimensionEdit.shape === 'circle') {
-          const anchorC = worldToCanvas(dimensionEdit.anchor, vt)
-          const previewC = worldToCanvas(previewPt, vt)
-          const layout = computeLinearInputLabel(anchorC, previewC, 11, 40)
-          return (
-            <input
-              key="radius"
-              ref={radiusInputRef}
-              className="sketch-dim-input"
-              style={{ left: layout.labelX, top: layout.labelY, transform: `translate(-50%, -50%) rotate(${layout.angle}rad)` }}
-              value={dimensionEdit.radius}
-              onChange={(e) => setDimensionEdit((prev) => prev ? { ...prev, radius: e.target.value } : null)}
-              onKeyDown={makeDimInputKeyDown('radius')}
-              onFocus={(e) => e.currentTarget.select()}
-            />
-          )
-        }
-
-        const ax = dimensionEdit.anchor.x
-        const ay = dimensionEdit.anchor.y
-        const px = previewPt.x
-        const py = previewPt.y
-        const rectX = Math.min(ax, px)
-        const rectY = Math.min(ay, py)
-        const rectW = Math.abs(px - ax)
-        const rectH = Math.abs(py - ay)
-
-        const topLeft = worldToCanvas({ x: rectX, y: rectY }, vt)
-        const topRight = worldToCanvas({ x: rectX + rectW, y: rectY }, vt)
-        const widthLabelX = (topLeft.cx + topRight.cx) / 2
-        const widthLabelY = topLeft.cy + 11
-
-        const rightTop = worldToCanvas({ x: rectX + rectW, y: rectY }, vt)
-        const rightBottom = worldToCanvas({ x: rectX + rectW, y: rectY + rectH }, vt)
-        const heightLabelX = rightTop.cx - 11
-        const heightLabelY = (rightTop.cy + rightBottom.cy) / 2
-
-        return (
-          <>
-            <input
-              key="width"
-              ref={widthInputRef}
-              className="sketch-dim-input"
-              style={{ left: widthLabelX, top: widthLabelY, transform: 'translate(-50%, -50%)' }}
-              value={dimensionEdit.width}
-              onChange={(e) => setDimensionEdit((prev) => prev ? { ...prev, width: e.target.value } : null)}
-              onKeyDown={makeDimInputKeyDown('width')}
-              onFocus={(e) => e.currentTarget.select()}
-            />
-            <input
-              key="height"
-              ref={heightInputRef}
-              className="sketch-dim-input sketch-dim-input--rotated"
-              style={{ left: heightLabelX, top: heightLabelY, transform: 'translate(-50%, -50%) rotate(-90deg)' }}
-              value={dimensionEdit.height}
-              onChange={(e) => setDimensionEdit((prev) => prev ? { ...prev, height: e.target.value } : null)}
-              onKeyDown={makeDimInputKeyDown('height')}
-              onFocus={(e) => e.currentTarget.select()}
-            />
-          </>
-        )
-      })()}
       {dimensionEdit && selection.mode === 'sketch_edit' && !pendingAdd && (() => {
         const canvas = canvasRef.current
         if (!canvas) return null
@@ -4577,32 +4648,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           }
         }
 
-        function handleLiveChange(field: 'length' | 'angle' | 'radius', value: string) {
-          const prev = dimensionEditRef.current
-          if (!prev) return
-          const next = { ...prev, [field]: value }
-          setDimensionEdit(next)
-          const control = dimensionEditControlRef.current
-          const fId = dimensionEditFeatureIdRef.current
-          if (!control || !fId) return
-
-          if (control.kind === 'arc_handle') {
-            // Arc radius: compute new arc_handle point
-            const feature = projectRef.current.features.find((f) => f.id === fId)
-            if (!feature) return
-            const profile = feature.sketch.profile
-            const seg = profile.segments[control.index]
-            if (!seg || seg.type !== 'arc') return
-            const arcStart = anchorPointForIndex(profile, control.index)
-            const newRadius = parseLengthInput(value, projectRef.current.meta.units) ?? 0
-            if (newRadius <= 0) return
-            const newHandle = arcHandleFromRadius(arcStart, seg, newRadius)
-            if (newHandle) moveFeatureControl(fId, control, newHandle)
-          } else {
-            const pt = computeDimensionEditPreviewPoint(next, projectRef.current.meta.units)
-            moveFeatureControl(fId, control, pt)
-          }
-        }
+        const handleLiveChange = handleEditDimLiveChange
 
         // Arc radius step
         if (dimensionEdit.shape === 'circle') {
@@ -4703,43 +4749,6 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           />
         )
       })()}
-      {pendingConstraint && pendingConstraint.anchor && pendingConstraint.reference && constraintDistanceInput != null && (() => {
-        const canvas = canvasRef.current
-        if (!canvas) return null
-        const vt = computeViewTransform(project.stock, canvas.width, canvas.height, viewState)
-        const aC = worldToCanvas(pendingConstraint.anchor.point, vt)
-        const rC = worldToCanvas(pendingConstraint.reference.point, vt)
-        const midX = (aC.cx + rC.cx) / 2
-        const midY = (aC.cy + rC.cy) / 2
-        return (
-          <input
-            key="constraint-distance"
-            ref={constraintDistanceInputRef}
-            className="sketch-dim-input"
-            style={{ left: midX, top: midY, transform: 'translate(-50%, -50%)' }}
-            value={constraintDistanceInput}
-            onChange={(e) => setConstraintDistanceInput(e.target.value)}
-            onKeyDown={(e) => {
-              e.stopPropagation()
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                const parsed = parseLengthInput(constraintDistanceInput, project.meta.units)
-                if (parsed != null && parsed >= 0) {
-                  commitConstraintDistance(parsed)
-                  setConstraintDistanceInput(null)
-                  canvasRef.current?.focus({ preventScroll: true })
-                }
-              } else if (e.key === 'Escape') {
-                e.preventDefault()
-                cancelPendingConstraint()
-                setConstraintDistanceInput(null)
-                canvasRef.current?.focus({ preventScroll: true })
-              }
-            }}
-            onFocus={(e) => e.currentTarget.select()}
-          />
-        )
-      })()}
       {constraintEdit && (
         <input
           key={`constraint-edit-${constraintEdit.constraintId}`}
@@ -4769,34 +4778,6 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           onBlur={() => setConstraintEdit(null)}
           onFocus={(e) => e.currentTarget.select()}
         />
-      )}
-      {selection.mode === 'sketch_edit' && (
-        <div className="sketch-edit-banner">
-          <div>
-            {selection.sketchEditTool === 'add_point'
-              ? 'Add Point active. Click a segment to insert a point, or click an open-path end first to start an extension. Press '
-              : selection.sketchEditTool === 'delete_point'
-                ? 'Delete Point active. Click anchors to remove them. Press '
-                : selection.sketchEditTool === 'delete_segment'
-                  ? 'Delete Segment active. Click a segment to remove it. Press '
-                  : selection.sketchEditTool === 'disconnect'
-                    ? 'Disconnect active. Click an anchor to split the path there. Press '
-                : selection.sketchEditTool === 'fillet'
-                ? pendingSketchFilletRef.current
-                    ? 'Fillet active. Click a second point to define the corner round, or press Tab to type the radius. Press '
-                    : 'Fillet active. Click a line-line corner to start. Press '
-                  : isTablet
-                    ? 'Drag nodes or straight segments to reshape. Tap a node then use Dimension to type length/angle. Press '
-                    : 'Drag nodes or straight segments to reshape. Hover a node and press Tab to type length/angle. Press '}
-            <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Apply" onClick={() => { stopNodeDrag(); applySketchEdit() }} onKeyDown={(e) => { if (e.key === 'Enter') { stopNodeDrag(); applySketchEdit() } }}>Enter</kbd> to apply or <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={() => { stopNodeDrag(); cancelSketchEdit() }} onKeyDown={(e) => { if (e.key === 'Enter') { stopNodeDrag(); cancelSketchEdit() } }}>Esc</kbd> to cancel.
-          </div>
-          {editingFeatureHasSelfIntersection ? (
-            <div className="sketch-banner-warning">This profile self-intersects. 3D/CAM results may be invalid.</div>
-          ) : null}
-          {editingFeatureExceedsStock ? (
-            <div className="sketch-banner-warning">This profile extends outside the stock boundary.</div>
-          ) : null}
-        </div>
       )}
       {pendingOffset && (
         <CanvasWorkflowPanel
@@ -4976,10 +4957,25 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
             : creationPanelShape === 'circle' ? 'Circle'
             : creationPanelShape === 'ellipse' ? 'Ellipse'
             : creationPanelShape === 'tab' ? 'Tab'
-            : 'Clamp'
+            : creationPanelShape === 'clamp' ? 'Clamp'
+            : creationPanelShape === 'polygon' ? 'Polygon'
+            : creationPanelShape === 'spline' ? 'Spline'
+            : 'Composite'
           }
           step={
             creationDimEditActive ? 'Enter dimensions'
+            : creationPanelShape === 'composite'
+              ? (pendingAdd.shape === 'composite' && pendingAdd.start
+                ? (pendingAdd.currentMode === 'arc' && pendingAdd.pendingArcEnd
+                  ? 'Click arc curvature point'
+                  : `Add ${pendingAdd.currentMode} points`)
+                : 'Click first point')
+            : (creationPanelShape === 'polygon' || creationPanelShape === 'spline')
+              ? (creationPanelHasPoints
+                ? ('points' in pendingAdd && pendingAdd.points.length < 2
+                  ? 'Add one more point'
+                  : 'Add points or close')
+                : 'Click first point')
             : creationPanelHasAnchor
               ? (creationPanelShape === 'circle'
                 ? 'Click to set radius or enter dimensions'
@@ -5005,12 +5001,33 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
                   onClick={commitCreationDimensionEdit}
                 >Confirm</button>
               )}
-              {creationPanelHasAnchor && !creationDimEditActive && (
+              {(pendingAdd.shape === 'polygon' || pendingAdd.shape === 'spline') && 'points' in pendingAdd && pendingAdd.points.length >= 2 && creationTarget !== 'region' && !creationDimEditActive && (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn tablet-cmd-btn--confirm"
+                  onClick={finishOpenPathFromPanel}
+                >Finish</button>
+              )}
+              {pendingAdd.shape === 'composite' && pendingAdd.segments.length >= 1 && !pendingAdd.pendingArcEnd && creationTarget !== 'region' && !creationDimEditActive && (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn tablet-cmd-btn--confirm"
+                  onClick={finishOpenCompositeFromPanel}
+                >Finish</button>
+              )}
+              {creationCanDimEdit && !creationDimEditActive && (
                 <button
                   type="button"
                   className="tablet-cmd-btn"
                   onClick={triggerDimensionFromCreationPanel}
                 >Dimensions</button>
+              )}
+              {(creationPanelHasPoints || (pendingAdd.shape === 'composite' && pendingAdd.start)) && !creationDimEditActive && (
+                <button
+                  type="button"
+                  className="tablet-cmd-btn"
+                  onClick={undoFromCreationPanel}
+                >Undo</button>
               )}
               <button
                 type="button"
@@ -5020,6 +5037,25 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
             </>
           )}
         >
+          {pendingAdd.shape === 'composite' && pendingAdd.start && !pendingAdd.closed && !creationDimEditActive && (
+            <div className="canvas-workflow-panel__meta canvas-workflow-panel__mode-row">
+              <button
+                type="button"
+                className={`tablet-cmd-btn ${pendingAdd.currentMode === 'line' ? 'tablet-cmd-btn--active' : ''}`}
+                onClick={() => setCompositeModeFromPanel('line')}
+              >Line</button>
+              <button
+                type="button"
+                className={`tablet-cmd-btn ${pendingAdd.currentMode === 'arc' ? 'tablet-cmd-btn--active' : ''}`}
+                onClick={() => setCompositeModeFromPanel('arc')}
+              >Arc</button>
+              <button
+                type="button"
+                className={`tablet-cmd-btn ${pendingAdd.currentMode === 'spline' ? 'tablet-cmd-btn--active' : ''}`}
+                onClick={() => setCompositeModeFromPanel('spline')}
+              >Spline</button>
+            </div>
+          )}
           {creationDimEditActive && dimensionEdit && (
             <div className="canvas-workflow-panel__meta">
               {dimensionEdit.shape === 'circle' ? (
@@ -5046,6 +5082,115 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
                     autoFocus
                   />
                 </label>
+              ) : (dimensionEdit.shape === 'composite' && dimensionEdit.arcStart && dimensionEdit.arcEnd) ? (
+                <label className="canvas-workflow-panel__field">
+                  <span>Radius</span>
+                  <input
+                    ref={radiusInputRef}
+                    className="canvas-workflow-panel__count-input canvas-workflow-panel__distance-input"
+                    type="text"
+                    inputMode="decimal"
+                    value={dimensionEdit.radius}
+                    onChange={(e) => setDimensionEdit((prev) => prev ? { ...prev, radius: e.target.value } : null)}
+                    onFocus={(e) => e.currentTarget.select()}
+                    onKeyDown={(e) => {
+                      e.stopPropagation()
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        commitCreationDimensionEdit()
+                      } else if (e.key === 'Escape') {
+                        e.preventDefault()
+                        cancelCreationDimensionEdit()
+                      }
+                    }}
+                    autoFocus
+                  />
+                </label>
+              ) : (dimensionEdit.shape === 'polygon' || dimensionEdit.shape === 'spline' || dimensionEdit.shape === 'composite') ? (
+                <>
+                  <label className="canvas-workflow-panel__field">
+                    <span>Length</span>
+                    <input
+                      ref={widthInputRef}
+                      className="canvas-workflow-panel__count-input canvas-workflow-panel__distance-input"
+                      type="text"
+                      inputMode="decimal"
+                      value={dimensionEdit.length}
+                      onChange={(e) => setDimensionEdit((prev) => prev ? { ...prev, length: e.target.value } : null)}
+                      onFocus={(e) => e.currentTarget.select()}
+                      onKeyDown={(e) => {
+                        e.stopPropagation()
+                        if (e.key === 'Enter') {
+                          e.preventDefault()
+                          commitCreationDimensionEdit()
+                        } else if (e.key === 'Escape') {
+                          e.preventDefault()
+                          cancelCreationDimensionEdit()
+                        } else if (e.key === 'Tab') {
+                          e.preventDefault()
+                          heightInputRef.current?.focus({ preventScroll: true })
+                        }
+                      }}
+                      autoFocus
+                    />
+                  </label>
+                  <label className="canvas-workflow-panel__field">
+                    <span>Angle</span>
+                    <input
+                      ref={heightInputRef}
+                      className="canvas-workflow-panel__count-input canvas-workflow-panel__distance-input"
+                      type="text"
+                      inputMode="decimal"
+                      value={dimensionEdit.angle}
+                      onChange={(e) => setDimensionEdit((prev) => prev ? { ...prev, angle: e.target.value } : null)}
+                      onFocus={(e) => e.currentTarget.select()}
+                      onKeyDown={(e) => {
+                        e.stopPropagation()
+                        if (e.key === 'Enter') {
+                          e.preventDefault()
+                          commitCreationDimensionEdit()
+                        } else if (e.key === 'Escape') {
+                          e.preventDefault()
+                          cancelCreationDimensionEdit()
+                        } else if (e.key === 'Tab') {
+                          e.preventDefault()
+                          if (pendingAdd?.shape === 'composite' && pendingAdd.currentMode === 'arc' && !pendingAdd.pendingArcEnd) {
+                            radiusInputRef.current?.focus({ preventScroll: true })
+                          } else {
+                            widthInputRef.current?.focus({ preventScroll: true })
+                          }
+                        }
+                      }}
+                    />
+                  </label>
+                  {pendingAdd?.shape === 'composite' && pendingAdd.currentMode === 'arc' && !pendingAdd.pendingArcEnd && (
+                    <label className="canvas-workflow-panel__field">
+                      <span>Radius</span>
+                      <input
+                        ref={radiusInputRef}
+                        className="canvas-workflow-panel__count-input canvas-workflow-panel__distance-input"
+                        type="text"
+                        inputMode="decimal"
+                        value={dimensionEdit.radius}
+                        onChange={(e) => setDimensionEdit((prev) => prev ? { ...prev, radius: e.target.value } : null)}
+                        onFocus={(e) => e.currentTarget.select()}
+                        onKeyDown={(e) => {
+                          e.stopPropagation()
+                          if (e.key === 'Enter') {
+                            e.preventDefault()
+                            commitCreationDimensionEdit()
+                          } else if (e.key === 'Escape') {
+                            e.preventDefault()
+                            cancelCreationDimensionEdit()
+                          } else if (e.key === 'Tab') {
+                            e.preventDefault()
+                            widthInputRef.current?.focus({ preventScroll: true })
+                          }
+                        }}
+                      />
+                    </label>
+                  )}
+                </>
               ) : (
                 <>
                   <label className="canvas-workflow-panel__field">
@@ -5114,96 +5259,69 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       {pendingAdd && !creationPanelShape && (
         <div className="sketch-place-banner">
           <div>
-            {pendingAdd.shape === 'polygon' || pendingAdd.shape === 'spline'
-              ? pendingAdd.points.length === 0
-                ? `Click to place the first ${pendingAdd.shape} control point.`
-                : pendingAdd.points.length < 2
-                  ? 'Click to add one more control point. Press Tab to type length/angle.'
-                  : creationTarget === 'region'
-                    ? 'Click to add control points. Press Tab to type length/angle. Click the first point to close the region.'
-                    : 'Click to add control points. Press Tab to type length/angle. Click the first point to close, or press Enter / double-click to finish open.'
-            : pendingAdd.shape === 'origin'
+            {pendingAdd.shape === 'origin'
               ? 'Click the sketch to place machine X0 Y0. Z remains manual in Properties.'
-            : pendingAdd.shape === 'text'
-              ? 'Move the mouse to preview the text, then click to place it.'
-            : (pendingAdd.shape === 'rect' || pendingAdd.shape === 'circle' || pendingAdd.shape === 'ellipse' || pendingAdd.shape === 'tab' || pendingAdd.shape === 'clamp') && pendingAdd.anchor
-              ? pendingAdd.shape === 'rect'
-                ? 'Move the mouse to size the rectangle, then click the opposite corner. Press Tab to type dimensions.'
-                : pendingAdd.shape === 'tab'
-                  ? 'Move the mouse to size the tab footprint, then click the opposite corner. Press Tab to type dimensions.'
-                : pendingAdd.shape === 'clamp'
-                  ? 'Move the mouse to size the clamp footprint, then click the opposite corner. Press Tab to type dimensions.'
-                : pendingAdd.shape === 'ellipse'
-                  ? 'Move the mouse to set the radii, then click to confirm the ellipse. Press Tab to type dimensions.'
-                : 'Move the mouse to set the radius, then click again to confirm the circle. Press Tab to type the radius.'
-              : pendingAdd.shape === 'rect'
-                ? 'Click the sketch to set the rectangle corner, then click again to size it.'
-                : pendingAdd.shape === 'tab'
-                  ? 'Click the sketch to set the tab corner, then click again to size it.'
-                : pendingAdd.shape === 'clamp'
-                  ? 'Click the sketch to set the clamp corner, then click again to size it.'
-                : pendingAdd.shape === 'ellipse'
-                  ? 'Click the sketch to set the ellipse center, then click again to set the radii.'
-                : pendingAdd.shape === 'circle'
-                  ? 'Click the sketch to set the circle center, then click again to set the radius.'
-                    : !pendingAdd.start
-                      ? isTablet
-                        ? 'Tap to place the first composite point. Use Line / Arc / Spline buttons to switch modes.'
-                        : 'Click to place the first composite point. Press L for line, A for arc, or S for spline.'
-                      : pendingAdd.currentMode === 'arc'
-                          ? pendingAdd.pendingArcEnd
-                            ? isTablet
-                              ? 'Tap a third point on the arc to define curvature. Use Dimension to type position, Undo to go back.'
-                              : 'Click a third point on the arc to define curvature. Press Tab to type position, Backspace to undo.'
-                            : isTablet
-                              ? 'Tap to place the arc end point, then tap again to define the arc. Use Dimension to type position, or switch modes above.'
-                              : 'Click to place the arc end point, then click again to define the arc. Press Tab to type position, L or S to switch modes.'
-                          : pendingAdd.currentMode === 'spline'
-                            ? creationTarget === 'region'
-                              ? isTablet
-                                ? 'Tap to add a spline segment endpoint. Use Dimension to type length/angle. Tap the first point to close the region.'
-                                : 'Click to add a spline segment endpoint. Press Tab to type length/angle. Click the first point to close the region.'
-                              : isTablet
-                                ? 'Tap to add a spline segment endpoint. Use Dimension to type length/angle. Tap the first point to close, or use Finish.'
-                                : 'Click to add a spline segment endpoint. Press Tab to type length/angle. Click the first point to close, or press Enter to finish open.'
-                            : creationTarget === 'region'
-                              ? isTablet
-                                ? 'Tap to add connected line segments. Use Dimension to type length/angle. Tap the first point to close the region.'
-                                : 'Click to add connected line segments. Press Tab to type length/angle. Click the first point to close the region.'
-                              : isTablet
-                                ? 'Tap to add connected line segments. Use Dimension to type length/angle. Tap the first point to close, or use Finish.'
-                                : 'Click to add connected line segments. Press Tab to type length/angle. Click the first point to close, or press Enter to finish open.'}
-            {(() => {
-              const canType =
-                ((pendingAdd.shape === 'rect' || pendingAdd.shape === 'circle' || pendingAdd.shape === 'ellipse' || pendingAdd.shape === 'tab' || pendingAdd.shape === 'clamp') && !!pendingAdd.anchor)
-                || ((pendingAdd.shape === 'polygon' || pendingAdd.shape === 'spline') && pendingAdd.points.length >= 1)
-                || (pendingAdd.shape === 'composite' && !!pendingAdd.start && !pendingAdd.closed)
-              return canType ? (
-                <> Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Type exact value" onClick={triggerDimensionEdit} onKeyDown={(e) => { if (e.key === 'Enter') triggerDimensionEdit() }}>Tab</kbd> to type exact value.</>
-              ) : null
-            })()}
+              : pendingAdd.shape === 'text'
+                ? 'Move the mouse to preview the text, then click to place it.'
+                : null}
             {' '}Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingAdd} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingAdd() }}>Esc</kbd> to cancel.
           </div>
-          {pendingDraftHasSelfIntersection ? (
-            <div className="sketch-banner-warning">This profile self-intersects. 3D/CAM results may be invalid.</div>
-          ) : null}
-          {pendingDraftExceedsStock ? (
-            <div className="sketch-banner-warning">This profile extends outside the stock boundary.</div>
-          ) : null}
         </div>
       )}
       {pendingConstraint && (
-        <div className="sketch-place-banner">
-          <div>
-            <strong>Constraint:</strong>{' '}
-            {!pendingConstraint.anchor
-              ? 'Click a snap point on this feature to set the anchor.'
+        <CanvasWorkflowPanel
+          title="Constraint"
+          step={
+            !pendingConstraint.anchor
+              ? 'Pick anchor point'
               : !pendingConstraint.reference
-                ? 'Click a snap point on another feature to set the reference.'
-                : 'Type the distance and press Enter.'}
-            {' '}Press <kbd className="sketch-kbd-btn" role="button" tabIndex={0} title="Cancel" onClick={cancelPendingConstraint} onKeyDown={(e) => { if (e.key === 'Enter') cancelPendingConstraint() }}>Esc</kbd> to cancel.
-          </div>
-        </div>
+                ? 'Pick reference point'
+                : 'Set distance'
+          }
+          position={constraintWorkflowPanel.position}
+          panelRef={constraintWorkflowPanel.panelRef}
+          handleProps={constraintWorkflowPanel.handleProps}
+          actions={constraintDistanceReady ? (
+            <>
+              <button type="button" className="tablet-cmd-btn tablet-cmd-btn--confirm" onClick={commitConstraintFromPanel}>Confirm</button>
+              <button type="button" className="tablet-cmd-btn tablet-cmd-btn--cancel" onClick={cancelConstraintFromPanel}>Cancel</button>
+            </>
+          ) : (
+            <button type="button" className="tablet-cmd-btn tablet-cmd-btn--cancel" onClick={cancelConstraintFromPanel}>Cancel</button>
+          )}
+        >
+          {constraintDistanceReady && constraintDistanceInput != null && (
+            <label className="canvas-workflow-panel__field">
+              <span>Distance</span>
+              <input
+                ref={constraintDistanceInputRef}
+                className="canvas-workflow-panel__count-input canvas-workflow-panel__distance-input"
+                type="text"
+                inputMode="decimal"
+                value={constraintDistanceInput}
+                onChange={(e) => setConstraintDistanceInput(e.target.value)}
+                onFocus={(e) => e.currentTarget.select()}
+                onKeyDown={(e) => {
+                  e.stopPropagation()
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    commitConstraintFromPanel()
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault()
+                    cancelConstraintFromPanel()
+                  }
+                }}
+                autoFocus
+              />
+            </label>
+          )}
+          {!pendingConstraint.anchor && (
+            <div className="canvas-workflow-panel__summary">Tap a snap point on this feature.</div>
+          )}
+          {pendingConstraint.anchor && !pendingConstraint.reference && (
+            <div className="canvas-workflow-panel__summary">Tap a snap point on another feature.</div>
+          )}
+        </CanvasWorkflowPanel>
       )}
       {pendingMove && (
         <CanvasWorkflowPanel
@@ -5484,75 +5602,145 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           )}
         </CanvasWorkflowPanel>
       )}
-      {isTablet && (
-        <div className="tablet-command-bar">
-          {/* Composite drawing: mode switch + undo point */}
-          {pendingAdd?.shape === 'composite' && pendingAdd.start && !pendingAdd.closed && (
+      {editModeActive && (
+        <CanvasWorkflowPanel
+          title="Edit"
+          step={
+            editDimEditActive ? 'Enter dimensions'
+            : selection.sketchEditTool === 'add_point' ? 'Click to add points'
+            : selection.sketchEditTool === 'delete_point' ? 'Click to delete points'
+            : selection.sketchEditTool === 'delete_segment' ? 'Click to delete segments'
+            : selection.sketchEditTool === 'disconnect' ? 'Click an anchor to split'
+            : selection.sketchEditTool === 'fillet' ? (pendingSketchFilletRef.current ? 'Click second point or enter radius' : 'Click a corner')
+            : 'Drag nodes or click segments'
+          }
+          position={editWorkflowPanel.position}
+          panelRef={editWorkflowPanel.panelRef}
+          handleProps={editWorkflowPanel.handleProps}
+          actions={editDimEditActive ? (
             <>
-              <button
-                type="button"
-                className={`tablet-cmd-btn ${pendingAdd.currentMode === 'line' ? 'tablet-cmd-btn--active' : ''}`}
-                onClick={() => setPendingCompositeMode('line')}
-              >Line</button>
-              <button
-                type="button"
-                className={`tablet-cmd-btn ${pendingAdd.currentMode === 'arc' ? 'tablet-cmd-btn--active' : ''}`}
-                onClick={() => setPendingCompositeMode('arc')}
-              >Arc</button>
-              <button
-                type="button"
-                className={`tablet-cmd-btn ${pendingAdd.currentMode === 'spline' ? 'tablet-cmd-btn--active' : ''}`}
-                onClick={() => setPendingCompositeMode('spline')}
-              >Spline</button>
-              <button type="button" className="tablet-cmd-btn" onClick={undoPendingCompositeStep}>Undo</button>
+              <button type="button" className="tablet-cmd-btn tablet-cmd-btn--confirm" onClick={commitEditDimensionFromPanel}>Confirm</button>
+              <button type="button" className="tablet-cmd-btn tablet-cmd-btn--cancel" onClick={cancelEditDimensionFromPanel}>Cancel</button>
             </>
-          )}
-          {/* Polygon/spline drawing: undo point */}
-          {(pendingAdd?.shape === 'polygon' || pendingAdd?.shape === 'spline') && pendingAdd.points.length > 0 && (
-            <button type="button" className="tablet-cmd-btn" onClick={undoPendingPolygonPoint}>Undo</button>
-          )}
-          {/* Pending add: confirm + cancel (Move/Transform/Offset/Join/Cut now use workflow panels) */}
-          {pendingAdd && (
-            <>
-              {(pendingAdd.shape === 'composite' && pendingAdd.segments.length >= 1 && !pendingAdd.pendingArcEnd && creationTarget !== 'region') && (
-                <button type="button" className="tablet-cmd-btn tablet-cmd-btn--confirm" onClick={completePendingOpenComposite}>Finish</button>
-              )}
-              <button
-                type="button"
-                className="tablet-cmd-btn tablet-cmd-btn--cancel"
-                onClick={cancelPendingAdd}
-              >Cancel</button>
-            </>
-          )}
-          {/* Sketch edit mode: apply + cancel + dimension */}
-          {selection.mode === 'sketch_edit' && !pendingAdd && (
+          ) : (
             <>
               {armedForDimension && (
                 <button type="button" className="tablet-cmd-btn" onClick={() => { triggerDimensionEdit(); setArmedForDimension(false) }}>Dimension</button>
               )}
-              <button type="button" className="tablet-cmd-btn tablet-cmd-btn--confirm" onClick={() => { stopNodeDrag(); applySketchEdit() }}>Apply</button>
-              <button type="button" className="tablet-cmd-btn tablet-cmd-btn--cancel" onClick={() => { stopNodeDrag(); cancelSketchEdit() }}>Cancel</button>
+              <button type="button" className="tablet-cmd-btn tablet-cmd-btn--confirm" onClick={applyEditFromPanel}>Apply</button>
+              <button type="button" className="tablet-cmd-btn tablet-cmd-btn--cancel" onClick={cancelEditFromPanel}>Cancel</button>
             </>
           )}
-          {/* Dimension input: button for pending shapes */}
-          {pendingAdd && !pendingShapeAction && (() => {
-            const canType =
-              ((pendingAdd.shape === 'rect' || pendingAdd.shape === 'circle' || pendingAdd.shape === 'ellipse' || pendingAdd.shape === 'tab' || pendingAdd.shape === 'clamp') && !!pendingAdd.anchor)
-              || ((pendingAdd.shape === 'polygon' || pendingAdd.shape === 'spline') && pendingAdd.points.length >= 1)
-              || (pendingAdd.shape === 'composite' && !!pendingAdd.start && !pendingAdd.closed)
-            return canType ? (
-              <button type="button" className="tablet-cmd-btn" onClick={triggerDimensionEdit}>Dimension</button>
-            ) : null
-          })()}
-          {/* Axis lock during drag operations */}
-          {isDraggingAny && (
-            <button
-              type="button"
-              className="tablet-cmd-btn"
-              style={{ borderColor: lockModeGuideColor(lockModeRef.current) }}
-              onClick={cycleLock}
-            >{lockModeRef.current === 'none' ? 'Lock' : lockModeRef.current === 'x' ? 'Lock X' : 'Lock Y'}</button>
+        >
+          {editDimEditActive && dimensionEdit ? (
+            dimensionEdit.activeField === 'radius' ? (
+              <label className="canvas-workflow-panel__field">
+                <span>Radius</span>
+                <input
+                  ref={radiusInputRef}
+                  className="canvas-workflow-panel__count-input canvas-workflow-panel__distance-input"
+                  type="text"
+                  inputMode="decimal"
+                  value={dimensionEdit.radius}
+                  onChange={(e) => handleEditDimLiveChange('radius', e.target.value)}
+                  onFocus={(e) => e.currentTarget.select()}
+                  onKeyDown={(e) => {
+                    e.stopPropagation()
+                    if (e.key === 'Enter') {
+                      e.preventDefault()
+                      commitEditDimensionFromPanel()
+                    } else if (e.key === 'Escape') {
+                      e.preventDefault()
+                      cancelEditDimensionFromPanel()
+                    }
+                  }}
+                  autoFocus
+                />
+              </label>
+            ) : (
+              <>
+                <label className="canvas-workflow-panel__field">
+                  <span>Length</span>
+                  <input
+                    ref={widthInputRef}
+                    className="canvas-workflow-panel__count-input canvas-workflow-panel__distance-input"
+                    type="text"
+                    inputMode="decimal"
+                    value={dimensionEdit.length}
+                    onChange={(e) => handleEditDimLiveChange('length', e.target.value)}
+                    onFocus={(e) => e.currentTarget.select()}
+                    onKeyDown={(e) => {
+                      e.stopPropagation()
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        commitEditDimensionFromPanel()
+                      } else if (e.key === 'Escape') {
+                        e.preventDefault()
+                        cancelEditDimensionFromPanel()
+                      } else if (e.key === 'Tab') {
+                        e.preventDefault()
+                        heightInputRef.current?.focus({ preventScroll: true })
+                      }
+                    }}
+                    autoFocus
+                  />
+                </label>
+                <label className="canvas-workflow-panel__field">
+                  <span>Angle</span>
+                  <input
+                    ref={heightInputRef}
+                    className="canvas-workflow-panel__count-input canvas-workflow-panel__distance-input"
+                    type="text"
+                    inputMode="decimal"
+                    value={dimensionEdit.angle}
+                    onChange={(e) => handleEditDimLiveChange('angle', e.target.value)}
+                    onFocus={(e) => e.currentTarget.select()}
+                    onKeyDown={(e) => {
+                      e.stopPropagation()
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        commitEditDimensionFromPanel()
+                      } else if (e.key === 'Escape') {
+                        e.preventDefault()
+                        cancelEditDimensionFromPanel()
+                      } else if (e.key === 'Tab') {
+                        e.preventDefault()
+                        widthInputRef.current?.focus({ preventScroll: true })
+                      }
+                    }}
+                  />
+                </label>
+              </>
+            )
+          ) : (
+            <>
+              {editingFeatureHasSelfIntersection && (
+                <div className="canvas-workflow-panel__summary" style={{ color: 'var(--warning)' }}>Self-intersecting profile</div>
+              )}
+              {editingFeatureExceedsStock && (
+                <div className="canvas-workflow-panel__summary" style={{ color: 'var(--warning)' }}>Extends outside stock</div>
+              )}
+            </>
           )}
+        </CanvasWorkflowPanel>
+      )}
+      {lockMode !== 'none' && !isTablet && (
+        <button
+          type="button"
+          className="axis-lock-chip"
+          style={{ borderColor: lockModeGuideColor(lockMode), color: lockModeGuideColor(lockMode) }}
+          onClick={cycleLock}
+          title="Click to cycle axis lock (Alt)"
+        >{lockMode === 'x' ? 'Lock X' : 'Lock Y'}</button>
+      )}
+      {isTablet && (
+        <div className="tablet-command-bar">
+          <button
+            type="button"
+            className={`tablet-cmd-btn ${lockMode !== 'none' ? 'tablet-cmd-btn--active' : ''}`}
+            style={{ borderColor: lockModeGuideColor(lockMode) }}
+            onClick={cycleLock}
+          >{lockMode === 'none' ? 'Lock' : lockMode === 'x' ? 'Lock X' : 'Lock Y'}</button>
           {/* Multi-select toggle */}
           {selection.mode === 'feature' && !pendingAdd && !pendingMove && !pendingTransform && !pendingOffset && (
             <button

--- a/src/components/canvas/manualEntry.ts
+++ b/src/components/canvas/manualEntry.ts
@@ -132,6 +132,28 @@ export function computeDimensionEditPreviewPoint(
     return { x: edit.anchor.x + r, y: edit.anchor.y }
   }
 
+  if (edit.shape === 'composite' && edit.arcStart && edit.arcEnd) {
+    const r = Math.max(parseLengthInput(edit.radius, units) ?? 0, 0)
+    const arcStart = edit.arcStart
+    const arcEnd = edit.arcEnd
+    const midX = (arcStart.x + arcEnd.x) / 2
+    const midY = (arcStart.y + arcEnd.y) / 2
+    const chordDx = arcEnd.x - arcStart.x
+    const chordDy = arcEnd.y - arcStart.y
+    const halfChord = Math.hypot(chordDx, chordDy) / 2
+    if (halfChord < 1e-9 || r < halfChord) return edit.anchor
+
+    const chordLen = halfChord * 2
+    const perpX = -chordDy / chordLen
+    const perpY = chordDx / chordLen
+    const side = edit.arcClockwise ? -1 : 1
+    const sagitta = r - Math.sqrt(r * r - halfChord * halfChord)
+    return {
+      x: midX + side * sagitta * perpX,
+      y: midY + side * sagitta * perpY,
+    }
+  }
+
   if (edit.shape === 'polygon' || edit.shape === 'spline' || edit.shape === 'composite') {
     const len = Math.max(parseLengthInput(edit.length, units) ?? 0, 0)
     const angleDeg = parseFloat(edit.angle) || 0

--- a/src/components/canvas/useCanvasWorkflowPanel.ts
+++ b/src/components/canvas/useCanvasWorkflowPanel.ts
@@ -1,0 +1,134 @@
+import { useEffect, useRef, useState } from 'react'
+import type { PointerEvent as ReactPointerEvent, RefObject } from 'react'
+
+const DEFAULT_WORKFLOW_PANEL_MARGIN = 12
+
+export interface CanvasWorkflowPanelPosition {
+  x: number
+  y: number
+}
+
+interface UseCanvasWorkflowPanelOptions {
+  open: boolean
+  phaseKey: string | null
+  containerRef: RefObject<HTMLElement | null>
+  canvasRef: RefObject<HTMLElement | null>
+  clearTransientCanvasState: () => void
+  margin?: number
+}
+
+interface PanelDragState {
+  pointerId: number
+  startClientX: number
+  startClientY: number
+  startX: number
+  startY: number
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+export function useCanvasWorkflowPanel({
+  open,
+  phaseKey,
+  containerRef,
+  canvasRef,
+  clearTransientCanvasState,
+  margin = DEFAULT_WORKFLOW_PANEL_MARGIN,
+}: UseCanvasWorkflowPanelOptions) {
+  const [position, setPosition] = useState<CanvasWorkflowPanelPosition>({ x: margin, y: margin })
+  const panelRef = useRef<HTMLDivElement>(null)
+  const dragRef = useRef<PanelDragState | null>(null)
+  const callbacksRef = useRef({ clearTransientCanvasState, canvasRef })
+  const wasOpenRef = useRef(false)
+
+  useEffect(() => {
+    callbacksRef.current = { clearTransientCanvasState, canvasRef }
+  }, [clearTransientCanvasState, canvasRef])
+
+  function focusCanvasAfterAction() {
+    callbacksRef.current.clearTransientCanvasState()
+    callbacksRef.current.canvasRef.current?.focus({ preventScroll: true })
+    window.requestAnimationFrame(() => {
+      callbacksRef.current.clearTransientCanvasState()
+      callbacksRef.current.canvasRef.current?.focus({ preventScroll: true })
+    })
+  }
+
+  useEffect(() => {
+    const wasOpen = wasOpenRef.current
+    if (open || wasOpen) {
+      focusCanvasAfterAction()
+    }
+    wasOpenRef.current = open
+  }, [open, phaseKey])
+
+  function startDrag(event: ReactPointerEvent<HTMLDivElement>) {
+    if (event.button !== 0) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+    event.currentTarget.setPointerCapture(event.pointerId)
+    dragRef.current = {
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startX: position.x,
+      startY: position.y,
+    }
+  }
+
+  function drag(event: ReactPointerEvent<HTMLDivElement>) {
+    const dragState = dragRef.current
+    if (!dragState || dragState.pointerId !== event.pointerId) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const containerRect = containerRef.current?.getBoundingClientRect()
+    const panelRect = panelRef.current?.getBoundingClientRect()
+    const maxX = Math.max(margin, (containerRect?.width ?? 0) - (panelRect?.width ?? 0) - margin)
+    const maxY = Math.max(margin, (containerRect?.height ?? 0) - (panelRect?.height ?? 0) - margin)
+
+    setPosition({
+      x: clampNumber(dragState.startX + event.clientX - dragState.startClientX, margin, maxX),
+      y: clampNumber(dragState.startY + event.clientY - dragState.startClientY, margin, maxY),
+    })
+  }
+
+  function endDrag(event: ReactPointerEvent<HTMLDivElement>) {
+    const dragState = dragRef.current
+    if (!dragState || dragState.pointerId !== event.pointerId) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+    dragRef.current = null
+    try { event.currentTarget.releasePointerCapture(event.pointerId) } catch { /* already released */ }
+  }
+
+  function stopActionPointerPropagation(event: ReactPointerEvent<HTMLDivElement>) {
+    event.stopPropagation()
+  }
+
+  return {
+    position,
+    panelRef,
+    focusCanvasAfterAction,
+    handleProps: {
+      onPointerDown: startDrag,
+      onPointerMove: drag,
+      onPointerUp: endDrag,
+      onPointerCancel: endDrag,
+    },
+    actionRowProps: {
+      onPointerDown: stopActionPointerPropagation,
+    },
+  }
+}

--- a/src/components/export/ExportDialog.tsx
+++ b/src/components/export/ExportDialog.tsx
@@ -133,7 +133,7 @@ export function ExportDialog({ onClose, generateToolpath }: ExportDialogProps) {
                 <div style={{ fontSize: '13px', color: 'var(--text)' }}>
                   {activeDefinition?.name ?? 'None selected'}
                 </div>
-                <button className="btn-secondary" onClick={handleChangeMachine} type="button" style={{ height: '32px', padding: '0 12px' }}>
+                <button className="btn-secondary" onClick={handleChangeMachine} type="button" style={{ padding: '0 12px' }}>
                   Change
                 </button>
               </div>

--- a/src/components/export/ExportDialog.tsx
+++ b/src/components/export/ExportDialog.tsx
@@ -16,6 +16,7 @@
 
 import { useState, useMemo, useEffect } from 'react'
 import { useProjectStore } from '../../store/projectStore'
+import { useRestoreCanvasFocus } from '../../utils/useRestoreCanvasFocus'
 import { platform } from '../../platform'
 import {
   getActiveMachineDefinition,
@@ -32,6 +33,7 @@ interface ExportDialogProps {
 }
 
 export function ExportDialog({ onClose, generateToolpath }: ExportDialogProps) {
+  useRestoreCanvasFocus()
   const { project, selectProject, lastExportPath, markExported } = useProjectStore()
 
   const [emitToolChanges, setEmitToolChanges] = useState(true)

--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -19,6 +19,7 @@ import type { DragEvent, MouseEvent as ReactMouseEvent } from 'react'
 import type { FeatureOperation } from '../../types/project'
 import { useProjectStore } from '../../store/projectStore'
 import { Icon } from '../Icon'
+import { isTabletMode, useShellMode } from '../layout/useShellMode'
 
 interface FeatureTreeProps {
   onFeatureContextMenu?: (featureId: string, x: number, y: number) => void
@@ -68,6 +69,9 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
     selectStock,
     hoverFeature,
   } = useProjectStore()
+
+  const shellMode = useShellMode()
+  const tabletShell = isTabletMode(shellMode)
 
   const [dragItem, setDragItem] = useState<{ kind: 'feature' | 'folder'; id: string } | null>(null)
   const [featuresCollapsed, setFeaturesCollapsed] = useState(false)
@@ -140,6 +144,77 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
     dragOverTarget.current = null
   }
 
+  function handleMoveFeature(featureId: string, direction: -1 | 1) {
+    const feature = project.features.find((f) => f.id === featureId)
+    if (!feature) return
+
+    if (feature.folderId === null) {
+      const sectionEntries = project.featureTree.filter((entry) => {
+        if (entry.type === 'folder') {
+          const folder = project.featureFolders.find((f) => f.id === entry.folderId)
+          return feature.operation === 'region'
+            ? (folder?.section ?? 'features') === 'regions'
+            : (folder?.section ?? 'features') !== 'regions'
+        }
+        const f = project.features.find((item) => item.id === entry.featureId)
+        return feature.operation === 'region'
+          ? f?.operation === 'region'
+          : f?.operation !== 'region'
+      })
+      const entryIndex = sectionEntries.findIndex((e) => e.type === 'feature' && e.featureId === featureId)
+      const swapIndex = entryIndex + direction
+      if (entryIndex === -1 || swapIndex < 0 || swapIndex >= sectionEntries.length) return
+
+      const fullTree = [...project.featureTree]
+      const aIdx = fullTree.findIndex((e) => e === sectionEntries[entryIndex])
+      const bIdx = fullTree.findIndex((e) => e === sectionEntries[swapIndex])
+      if (aIdx === -1 || bIdx === -1) return
+      ;[fullTree[aIdx], fullTree[bIdx]] = [fullTree[bIdx], fullTree[aIdx]]
+      reorderFeatureTreeEntries(fullTree)
+    } else {
+      const siblings = project.features.filter((f) =>
+        f.folderId === feature.folderId && (feature.operation === 'region' ? f.operation === 'region' : f.operation !== 'region')
+      )
+      const sibIndex = siblings.findIndex((f) => f.id === featureId)
+      if (sibIndex === -1) return
+
+      if (direction === -1 && sibIndex > 0) {
+        moveFeatureTreeFeature(featureId, feature.folderId, siblings[sibIndex - 1].id)
+      } else if (direction === 1 && sibIndex < siblings.length - 1) {
+        if (sibIndex + 2 < siblings.length) {
+          moveFeatureTreeFeature(featureId, feature.folderId, siblings[sibIndex + 2].id)
+        } else {
+          moveFeatureTreeFeature(featureId, feature.folderId)
+        }
+      }
+    }
+  }
+
+  function handleMoveFolder(folderId: string, direction: -1 | 1) {
+    const folder = project.featureFolders.find((f) => f.id === folderId)
+    if (!folder) return
+
+    const section = folder.section ?? 'features'
+    const sectionEntries = project.featureTree.filter((entry) => {
+      if (entry.type === 'folder') {
+        const f = project.featureFolders.find((item) => item.id === entry.folderId)
+        return (f?.section ?? 'features') === section
+      }
+      const f = project.features.find((item) => item.id === entry.featureId)
+      return section === 'regions' ? f?.operation === 'region' : f?.operation !== 'region'
+    })
+    const entryIndex = sectionEntries.findIndex((e) => e.type === 'folder' && e.folderId === folderId)
+    const swapIndex = entryIndex + direction
+    if (entryIndex === -1 || swapIndex < 0 || swapIndex >= sectionEntries.length) return
+
+    const fullTree = [...project.featureTree]
+    const aIdx = fullTree.findIndex((e) => e === sectionEntries[entryIndex])
+    const bIdx = fullTree.findIndex((e) => e === sectionEntries[swapIndex])
+    if (aIdx === -1 || bIdx === -1) return
+    ;[fullTree[aIdx], fullTree[bIdx]] = [fullTree[bIdx], fullTree[aIdx]]
+    reorderFeatureTreeEntries(fullTree)
+  }
+
   // Warn if first 2.5D feature is not 'add' — imported STL models may be first.
   // since the store enforces it, but a loaded file could be malformed.
   const machiningFeatures = project.features.filter((feature) => feature.operation !== 'region')
@@ -161,13 +236,24 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
     return feature?.operation !== 'region'
   })
 
-  function renderFeatureRow(featureId: string, depth: number) {
+  const regionRootEntries = project.featureTree.filter((entry) => {
+    if (entry.type === 'folder') {
+      const folder = project.featureFolders.find((item) => item.id === entry.folderId)
+      return (folder?.section ?? 'features') === 'regions'
+    }
+    const feature = project.features.find((item) => item.id === entry.featureId)
+    return feature?.operation === 'region' && feature.folderId === null
+  })
+
+  function renderFeatureRow(featureId: string, depth: number, siblingIndex?: number, siblingCount?: number) {
     const feature = project.features.find((entry) => entry.id === featureId)
     if (!feature) {
       return null
     }
 
     const index = project.features.findIndex((entry) => entry.id === feature.id)
+    const canMoveUp = tabletShell && siblingIndex !== undefined && siblingIndex > 0
+    const canMoveDown = tabletShell && siblingIndex !== undefined && siblingCount !== undefined && siblingIndex < siblingCount - 1
     return (
       <TreeRow
         key={feature.id}
@@ -201,6 +287,8 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
           }
           onFeatureContextMenu(feature.id, x, y)
         } : undefined}
+        onMoveUp={canMoveUp ? () => handleMoveFeature(feature.id, -1) : undefined}
+        onMoveDown={canMoveDown ? () => handleMoveFeature(feature.id, 1) : undefined}
         draggable
         onDragStart={() => handleFeatureDragStart(feature.id)}
         onDragEnd={() => setDragItem(null)}
@@ -301,9 +389,9 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                 ⚠ First 2.5D feature must be <strong>Add</strong>. The 3D model will not build until this is fixed.
               </div>
             )}
-            {rootEntries.map((entry) => {
+            {rootEntries.map((entry, rootIdx) => {
               if (entry.type === 'feature') {
-                return renderFeatureRow(entry.featureId, 1)
+                return renderFeatureRow(entry.featureId, 1, rootIdx, rootEntries.length)
               }
 
               const folder = project.featureFolders.find((item) => item.id === entry.folderId)
@@ -313,6 +401,8 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
 
               const folderFeatures = project.features.filter((feature) => feature.folderId === folder.id && feature.operation !== 'region')
               const folderVisible = folderFeatures.some((f) => f.visible)
+              const canMoveFolderUp = tabletShell && rootIdx > 0
+              const canMoveFolderDown = tabletShell && rootIdx < rootEntries.length - 1
               return (
                 <div key={folder.id}>
                   <TreeRow
@@ -328,6 +418,8 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                     onMouseLeave={() => hoverFeature(null)}
                     onSelectAllFeatures={folderFeatures.length > 0 ? () => selectFolderFeatures(folder.id) : undefined}
                     onToggleVisible={folderFeatures.length > 0 ? () => toggleFolderVisible(folder.id) : undefined}
+                    onMoveUp={canMoveFolderUp ? () => handleMoveFolder(folder.id, -1) : undefined}
+                    onMoveDown={canMoveFolderDown ? () => handleMoveFolder(folder.id, 1) : undefined}
                     draggable
                     onDragStart={() => handleFolderDragStart(folder.id)}
                     onDragEnd={() => setDragItem(null)}
@@ -339,7 +431,7 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                       {folderFeatures.length === 0 ? (
                         <div className="feature-tree-empty">Empty folder.</div>
                       ) : (
-                        folderFeatures.map((feature) => renderFeatureRow(feature.id, 2))
+                        folderFeatures.map((feature, fIdx) => renderFeatureRow(feature.id, 2, fIdx, folderFeatures.length))
                       )}
                     </div>
                   ) : null}
@@ -366,24 +458,20 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
           <div className="feature-tree-empty">No regions yet.</div>
         ) : (
           <div className="tree-children">
-            {project.featureTree.map((entry) => {
+            {regionRootEntries.map((entry, regionIdx) => {
               if (entry.type === 'feature') {
-                const feature = project.features.find((item) => item.id === entry.featureId)
-                return feature?.operation === 'region' && feature.folderId === null
-                  ? renderFeatureRow(entry.featureId, 1)
-                  : null
+                return renderFeatureRow(entry.featureId, 1, regionIdx, regionRootEntries.length)
               }
 
               const folder = project.featureFolders.find((item) => item.id === entry.folderId)
               if (!folder) {
                 return null
               }
-              if ((folder.section ?? 'features') !== 'regions') {
-                return null
-              }
 
               const folderFeatures = project.features.filter((feature) => feature.folderId === folder.id && feature.operation === 'region')
               const folderVisible = folderFeatures.some((f) => f.visible)
+              const canMoveFolderUp = tabletShell && regionIdx > 0
+              const canMoveFolderDown = tabletShell && regionIdx < regionRootEntries.length - 1
               return (
                 <div key={`regions-${folder.id}`}>
                   <TreeRow
@@ -399,6 +487,8 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                     onMouseLeave={() => hoverFeature(null)}
                     onSelectAllFeatures={folderFeatures.length > 0 ? () => selectFeatures(folderFeatures.map((feature) => feature.id)) : undefined}
                     onToggleVisible={folderFeatures.length > 0 ? () => toggleRegionFolderVisible(folder.id) : undefined}
+                    onMoveUp={canMoveFolderUp ? () => handleMoveFolder(folder.id, -1) : undefined}
+                    onMoveDown={canMoveFolderDown ? () => handleMoveFolder(folder.id, 1) : undefined}
                     draggable
                     onDragStart={() => handleFolderDragStart(folder.id)}
                     onDragEnd={() => setDragItem(null)}
@@ -410,7 +500,7 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                       {folderFeatures.length === 0 ? (
                         <div className="feature-tree-empty">Empty folder.</div>
                       ) : (
-                        folderFeatures.map((feature) => renderFeatureRow(feature.id, 2))
+                        folderFeatures.map((feature, fIdx) => renderFeatureRow(feature.id, 2, fIdx, folderFeatures.length))
                       )}
                     </div>
                   ) : null}
@@ -537,6 +627,8 @@ interface TreeRowProps {
   onContextMenu?: (event: ReactMouseEvent<HTMLDivElement>) => void
   onEditEntry?: () => void
   onMoreMenu?: (x: number, y: number) => void
+  onMoveUp?: () => void
+  onMoveDown?: () => void
   draggable?: boolean
   onDragStart?: () => void
   onDragEnd?: () => void
@@ -567,6 +659,8 @@ function TreeRow({
   onContextMenu,
   onEditEntry,
   onMoreMenu,
+  onMoveUp,
+  onMoveDown,
   draggable,
   onDragStart,
   onDragEnd,
@@ -580,6 +674,12 @@ function TreeRow({
   // Popup menu state for operation selector — stores viewport position for fixed positioning
   const operationBtnRef = useRef<HTMLButtonElement>(null)
   const [operationMenuPos, setOperationMenuPos] = useState<{ top: number; left: number } | null>(null)
+  const moveUpRef = useRef(onMoveUp)
+  const moveDownRef = useRef(onMoveDown)
+  moveUpRef.current = onMoveUp
+  moveDownRef.current = onMoveDown
+  const gripDragRef = useRef<{ lastSwapY: number; pointerId: number } | null>(null)
+  const hasGrip = onMoveUp || onMoveDown
 
   return (
     <div
@@ -636,6 +736,53 @@ function TreeRow({
                       : 'node'
         )}
       </span>
+      {hasGrip ? (
+        <button
+          type="button"
+          className="tree-action-btn tree-drag-grip"
+          title="Drag to reorder"
+          aria-label="Drag to reorder"
+          onPointerDown={(e) => {
+            if (e.pointerType !== 'touch') return
+            e.preventDefault()
+            e.stopPropagation()
+            e.currentTarget.setPointerCapture(e.pointerId)
+            gripDragRef.current = { lastSwapY: e.clientY, pointerId: e.pointerId }
+          }}
+          onPointerMove={(e) => {
+            const state = gripDragRef.current
+            if (!state || state.pointerId !== e.pointerId) return
+            e.preventDefault()
+            const delta = e.clientY - state.lastSwapY
+            const threshold = 36
+            if (delta > threshold && moveDownRef.current) {
+              moveDownRef.current()
+              state.lastSwapY = e.clientY
+            } else if (delta < -threshold && moveUpRef.current) {
+              moveUpRef.current()
+              state.lastSwapY = e.clientY
+            }
+          }}
+          onPointerUp={(e) => {
+            gripDragRef.current = null
+            if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+              e.currentTarget.releasePointerCapture(e.pointerId)
+            }
+          }}
+          onPointerCancel={(e) => {
+            gripDragRef.current = null
+            if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+              e.currentTarget.releasePointerCapture(e.pointerId)
+            }
+          }}
+        >
+          <svg viewBox="0 0 14 14" width="12" height="12" focusable="false" aria-hidden="true" style={{ display: 'block' }}>
+            <circle cx="5" cy="3.5" r="1.2" fill="currentColor" /><circle cx="9" cy="3.5" r="1.2" fill="currentColor" />
+            <circle cx="5" cy="7" r="1.2" fill="currentColor" /><circle cx="9" cy="7" r="1.2" fill="currentColor" />
+            <circle cx="5" cy="10.5" r="1.2" fill="currentColor" /><circle cx="9" cy="10.5" r="1.2" fill="currentColor" />
+          </svg>
+        </button>
+      ) : null}
       <span className="tree-label" title={label}>{label}</span>
       <div className="tree-row-actions">
         {(kind === 'features' || kind === 'regions' || kind === 'tabs' || kind === 'clamps') && onShowAll ? (

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { useCallback, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { useProjectStore } from '../../store/projectStore'
 import { getStockBounds } from '../../types/project'
 import { formatLength } from '../../utils/units'
 import { PanelSplit } from '../cam/PanelSplit'
+import { isTabletMode, useShellMode } from './useShellMode'
 import '../../styles/layout.css'
 
 interface AppShellProps {
@@ -70,6 +71,8 @@ export function AppShell({
   onRightTabChange,
   statusBarExtras,
 }: AppShellProps) {
+  const shellMode = useShellMode()
+  const tabletShell = isTabletMode(shellMode)
   const [rightDrawerOpen, setRightDrawerOpen] = useState(false)
 
   const LC_STORAGE_KEY = 'panel-split:left-center'
@@ -99,25 +102,21 @@ export function AppShell({
   const leftPanelRef = useRef<HTMLElement>(null)
   const centrePanelRef = useRef<HTMLElement>(null)
   const rightPanelRef = useRef<HTMLElement>(null)
+  const activeDividerRef = useRef<{ side: 'left' | 'right'; pointerId: number } | null>(null)
 
   const showLeft = workspaceLayout === 'lcr' || workspaceLayout === 'lc'
   const showRight = workspaceLayout === 'lcr' || workspaceLayout === 'cr'
+  const showDockedRight = showRight && !tabletShell
 
-  const handleDividerPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    e.currentTarget.setPointerCapture(e.pointerId)
-  }, [])
-
-  const handleLeftDividerPointerMove = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!e.currentTarget.hasPointerCapture(e.pointerId)) return
+  const resizeLeftPanel = useCallback(
+    (clientX: number) => {
       const leftEl = leftPanelRef.current
       const centreEl = centrePanelRef.current
       if (!leftEl || !centreEl) return
       const leftRect = leftEl.getBoundingClientRect()
       const centreRect = centreEl.getBoundingClientRect()
       const totalWidth = centreRect.right - leftRect.left
-      const offsetX = e.clientX - leftRect.left
+      const offsetX = clientX - leftRect.left
       const minRatio = MIN_LEFT_WIDTH / totalWidth
       const maxRatio = 1 - MIN_CENTER_WIDTH / totalWidth
       const newRatio = Math.max(minRatio, Math.min(maxRatio, offsetX / totalWidth))
@@ -127,16 +126,15 @@ export function AppShell({
     [],
   )
 
-  const handleRightDividerPointerMove = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!e.currentTarget.hasPointerCapture(e.pointerId)) return
+  const resizeRightPanel = useCallback(
+    (clientX: number) => {
       const centreEl = centrePanelRef.current
       const rightEl = rightPanelRef.current
       if (!centreEl || !rightEl) return
       const centreRect = centreEl.getBoundingClientRect()
       const rightRect = rightEl.getBoundingClientRect()
       const totalWidth = rightRect.right - centreRect.left
-      const offsetX = e.clientX - centreRect.left
+      const offsetX = clientX - centreRect.left
       const minRatio = MIN_RIGHT_WIDTH / totalWidth
       const maxRatio = 1 - MIN_CENTER_WIDTH / totalWidth
       const newRatio = Math.max(minRatio, Math.min(maxRatio, 1 - offsetX / totalWidth))
@@ -146,15 +144,70 @@ export function AppShell({
     [],
   )
 
+  const startDividerResize = useCallback((side: 'left' | 'right', e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    activeDividerRef.current = { side, pointerId: e.pointerId }
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId)
+    } catch {
+      // Window-level pointer tracking below keeps resizing working if capture is unavailable.
+    }
+  }, [])
+
+  const handleLeftDividerPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (activeDividerRef.current?.side !== 'left' && !e.currentTarget.hasPointerCapture(e.pointerId)) return
+      resizeLeftPanel(e.clientX)
+    },
+    [resizeLeftPanel],
+  )
+
+  const handleRightDividerPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (activeDividerRef.current?.side !== 'right' && !e.currentTarget.hasPointerCapture(e.pointerId)) return
+      resizeRightPanel(e.clientX)
+    },
+    [resizeRightPanel],
+  )
+
+  useEffect(() => {
+    function handleWindowPointerMove(event: PointerEvent) {
+      const active = activeDividerRef.current
+      if (!active || active.pointerId !== event.pointerId) return
+      event.preventDefault()
+      if (active.side === 'left') {
+        resizeLeftPanel(event.clientX)
+      } else {
+        resizeRightPanel(event.clientX)
+      }
+    }
+
+    function handleWindowPointerEnd(event: PointerEvent) {
+      const active = activeDividerRef.current
+      if (active && active.pointerId === event.pointerId) {
+        activeDividerRef.current = null
+      }
+    }
+
+    window.addEventListener('pointermove', handleWindowPointerMove, { passive: false })
+    window.addEventListener('pointerup', handleWindowPointerEnd)
+    window.addEventListener('pointercancel', handleWindowPointerEnd)
+    return () => {
+      window.removeEventListener('pointermove', handleWindowPointerMove)
+      window.removeEventListener('pointerup', handleWindowPointerEnd)
+      window.removeEventListener('pointercancel', handleWindowPointerEnd)
+    }
+  }, [resizeLeftPanel, resizeRightPanel])
+
   // left=L/(L+C), right=R/(C+R) → express as fr with centre always 1fr:
   //   L fr = leftRatio/(1-leftRatio), R fr = rightRatio/(1-rightRatio)
   const bodyStyle: React.CSSProperties = {}
-  if (showLeft || showRight) {
+  if (showLeft || showDockedRight) {
     const railPrefix = toolbarOrientation === 'left' ? 'var(--left-toolbar-width) ' : ''
     const leftCol = showLeft
       ? `minmax(${MIN_LEFT_WIDTH}px, ${leftPanelRatio / (1 - leftPanelRatio)}fr) `
       : ''
-    const rightCol = showRight
+    const rightCol = showDockedRight
       ? ` minmax(${MIN_RIGHT_WIDTH}px, ${rightPanelRatio / (1 - rightPanelRatio)}fr)`
       : ''
     bodyStyle.gridTemplateColumns = `${railPrefix}${leftCol}minmax(${MIN_CENTER_WIDTH}px, 1fr)${rightCol}`
@@ -187,7 +240,7 @@ export function AppShell({
   ] as const
 
   return (
-    <div className="app-shell" data-right-open={rightDrawerOpen ? 'true' : undefined}>
+    <div className="app-shell" data-shell-mode={shellMode} data-right-open={rightDrawerOpen ? 'true' : undefined}>
       {rightDrawerOpen && (
         <div
           className="tablet-drawer-scrim"
@@ -206,7 +259,7 @@ export function AppShell({
           aria-expanded={rightDrawerOpen}
           onClick={() => setRightDrawerOpen(true)}
         >
-          CAM
+          Operations{project.operations.length > 0 ? ` ${project.operations.length}` : ''}
         </button>
       </header>
 
@@ -238,7 +291,7 @@ export function AppShell({
             className="panel-resize-divider"
             role="separator"
             aria-orientation="vertical"
-            onPointerDown={handleDividerPointerDown}
+            onPointerDown={(event) => startDividerResize('left', event)}
             onPointerMove={handleLeftDividerPointerMove}
           />
         </aside>
@@ -328,51 +381,55 @@ export function AppShell({
                 Simulation
               </button>
               <div className="panel-tabs-spacer" />
-              <div className="workspace-layout-controls" aria-label="Workspace layout presets">
-                {workspaceLayouts.map((layout) => (
-                  <button
-                    key={layout.id}
-                    className={`workspace-layout-btn ${workspaceLayout === layout.id ? 'workspace-layout-btn--active' : ''}`}
-                    type="button"
-                    title={layout.label}
-                    aria-label={layout.label}
-                    onClick={() => onWorkspaceLayoutChange(layout.id)}
-                  >
-                    <span className={`workspace-layout-icon workspace-layout-icon--${layout.id}`} aria-hidden="true">
-                      <span />
-                      <span />
-                      <span />
-                    </span>
-                  </button>
-                ))}
-              </div>
-              <div className="toolbar-orientation-controls" aria-label="Toolbar orientation">
-                <button
-                  className={`toolbar-orientation-btn ${toolbarOrientation === 'top' ? 'toolbar-orientation-btn--active' : ''}`}
-                  type="button"
-                  title="Use top toolbar"
-                  aria-label="Use top toolbar"
-                  onClick={() => onToolbarOrientationChange('top')}
-                >
-                  <span className="toolbar-orientation-icon toolbar-orientation-icon--top" aria-hidden="true">
-                    <span />
-                    <span />
-                  </span>
-                </button>
-                <button
-                  className={`toolbar-orientation-btn ${toolbarOrientation === 'left' ? 'toolbar-orientation-btn--active' : ''}`}
-                  type="button"
-                  title={toolbarOrientationForced ? 'Left toolbar is disabled below 920px wide' : 'Use left toolbar'}
-                  aria-label={toolbarOrientationForced ? 'Left toolbar is disabled below 920px wide' : 'Use left toolbar'}
-                  onClick={() => onToolbarOrientationChange('left')}
-                  disabled={toolbarOrientationForced}
-                >
-                  <span className="toolbar-orientation-icon toolbar-orientation-icon--left" aria-hidden="true">
-                    <span />
-                    <span />
-                  </span>
-                </button>
-              </div>
+              {!tabletShell && (
+                <>
+                  <div className="workspace-layout-controls" aria-label="Workspace layout presets">
+                    {workspaceLayouts.map((layout) => (
+                      <button
+                        key={layout.id}
+                        className={`workspace-layout-btn ${workspaceLayout === layout.id ? 'workspace-layout-btn--active' : ''}`}
+                        type="button"
+                        title={layout.label}
+                        aria-label={layout.label}
+                        onClick={() => onWorkspaceLayoutChange(layout.id)}
+                      >
+                        <span className={`workspace-layout-icon workspace-layout-icon--${layout.id}`} aria-hidden="true">
+                          <span />
+                          <span />
+                          <span />
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                  <div className="toolbar-orientation-controls" aria-label="Toolbar orientation">
+                    <button
+                      className={`toolbar-orientation-btn ${toolbarOrientation === 'top' ? 'toolbar-orientation-btn--active' : ''}`}
+                      type="button"
+                      title="Use top toolbar"
+                      aria-label="Use top toolbar"
+                      onClick={() => onToolbarOrientationChange('top')}
+                    >
+                      <span className="toolbar-orientation-icon toolbar-orientation-icon--top" aria-hidden="true">
+                        <span />
+                        <span />
+                      </span>
+                    </button>
+                    <button
+                      className={`toolbar-orientation-btn ${toolbarOrientation === 'left' ? 'toolbar-orientation-btn--active' : ''}`}
+                      type="button"
+                      title={toolbarOrientationForced ? 'Left toolbar is disabled below 920px wide' : 'Use left toolbar'}
+                      aria-label={toolbarOrientationForced ? 'Left toolbar is disabled below 920px wide' : 'Use left toolbar'}
+                      onClick={() => onToolbarOrientationChange('left')}
+                      disabled={toolbarOrientationForced}
+                    >
+                      <span className="toolbar-orientation-icon toolbar-orientation-icon--left" aria-hidden="true">
+                        <span />
+                        <span />
+                      </span>
+                    </button>
+                  </div>
+                </>
+              )}
             </div>
             <div className="centre-stage">
               <div
@@ -404,12 +461,12 @@ export function AppShell({
               </div>
             </div>
           </div>
-          {showRight && (
+          {showDockedRight && (
             <div
               className="panel-resize-divider"
               role="separator"
               aria-orientation="vertical"
-              onPointerDown={handleDividerPointerDown}
+              onPointerDown={(event) => startDividerResize('right', event)}
               onPointerMove={handleRightDividerPointerMove}
             />
           )}
@@ -580,6 +637,9 @@ export function AppShell({
           </button>
         </div>
         {statusBarExtras}
+        {import.meta.env.DEV && (
+          <span className="statusbar-shell-mode" title="Shell mode (dev only)">{shellMode}</span>
+        )}
       </footer>
     </div>
   )

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -20,6 +20,9 @@ import { getStockBounds } from '../../types/project'
 import { formatLength } from '../../utils/units'
 import { PanelSplit } from '../cam/PanelSplit'
 import { isTabletMode, useShellMode } from './useShellMode'
+import { TopCommandBar } from './TopCommandBar'
+import { ToolRail } from './ToolRail'
+import type { SnapMode, SnapSettings } from '../../sketch/snapping'
 import '../../styles/layout.css'
 
 interface AppShellProps {
@@ -42,6 +45,14 @@ interface AppShellProps {
   rightTab: 'operations' | 'tools'
   onRightTabChange: (tab: 'operations' | 'tools') => void
   statusBarExtras?: ReactNode
+  onZoomToModel: () => void
+  onZoomWindow: () => void
+  zoomWindowActive: boolean
+  onImportComplete?: () => void
+  snapSettings: SnapSettings
+  activeSnapMode?: SnapMode | null
+  onToggleSnapEnabled: () => void
+  onToggleSnapMode: (mode: SnapMode) => void
 }
 
 function nextTab<T extends string>(tabs: readonly T[], current: T, direction: 1 | -1): T {
@@ -70,10 +81,19 @@ export function AppShell({
   rightTab,
   onRightTabChange,
   statusBarExtras,
+  onZoomToModel,
+  onZoomWindow,
+  zoomWindowActive,
+  onImportComplete,
+  snapSettings,
+  activeSnapMode,
+  onToggleSnapEnabled,
+  onToggleSnapMode,
 }: AppShellProps) {
   const shellMode = useShellMode()
   const tabletShell = isTabletMode(shellMode)
   const [rightDrawerOpen, setRightDrawerOpen] = useState(false)
+  const [leftDrawerOpen, setLeftDrawerOpen] = useState(false)
 
   const LC_STORAGE_KEY = 'panel-split:left-center'
   const CR_STORAGE_KEY = 'panel-split:center-right'
@@ -202,7 +222,7 @@ export function AppShell({
   // left=L/(L+C), right=R/(C+R) → express as fr with centre always 1fr:
   //   L fr = leftRatio/(1-leftRatio), R fr = rightRatio/(1-rightRatio)
   const bodyStyle: React.CSSProperties = {}
-  if (showLeft || showDockedRight) {
+  if (!tabletShell && (showLeft || showDockedRight)) {
     const railPrefix = toolbarOrientation === 'left' ? 'var(--left-toolbar-width) ' : ''
     const leftCol = showLeft
       ? `minmax(${MIN_LEFT_WIDTH}px, ${leftPanelRatio / (1 - leftPanelRatio)}fr) `
@@ -240,32 +260,55 @@ export function AppShell({
   ] as const
 
   return (
-    <div className="app-shell" data-shell-mode={shellMode} data-right-open={rightDrawerOpen ? 'true' : undefined}>
-      {rightDrawerOpen && (
+    <div className="app-shell" data-shell-mode={shellMode} data-right-open={rightDrawerOpen ? 'true' : undefined} data-left-open={leftDrawerOpen ? 'true' : undefined}>
+      {(rightDrawerOpen || leftDrawerOpen) && (
         <div
           className="tablet-drawer-scrim"
           aria-hidden="true"
-          onClick={() => setRightDrawerOpen(false)}
+          onClick={() => { setRightDrawerOpen(false); setLeftDrawerOpen(false) }}
         />
       )}
       {/* ── Top toolbar ── */}
-      <header className={`app-toolbar app-toolbar--${toolbarOrientation}`}>
-        {toolbarOrientation === 'left' ? globalToolbar : toolbar}
-        <button
-          className="tablet-drawer-toggle toolbar-btn"
-          type="button"
-          title="Open operations panel"
-          aria-label="Open operations panel"
-          aria-expanded={rightDrawerOpen}
-          onClick={() => setRightDrawerOpen(true)}
-        >
-          Operations{project.operations.length > 0 ? ` ${project.operations.length}` : ''}
-        </button>
-      </header>
+      {tabletShell ? (
+        <header className="app-toolbar app-toolbar--tablet">
+          <TopCommandBar
+            centerTab={centerTab}
+            onCenterTabChange={onCenterTabChange}
+            onZoomToModel={onZoomToModel}
+            onZoomWindow={onZoomWindow}
+            zoomWindowActive={zoomWindowActive}
+            onOpenLeftDrawer={() => setLeftDrawerOpen(true)}
+            onOpenRightDrawer={() => setRightDrawerOpen(true)}
+            onImportComplete={onImportComplete}
+            snapSettings={snapSettings}
+            activeSnapMode={activeSnapMode}
+            onToggleSnapEnabled={onToggleSnapEnabled}
+            onToggleSnapMode={onToggleSnapMode}
+          />
+        </header>
+      ) : (
+        <header className={`app-toolbar app-toolbar--${toolbarOrientation}`}>
+          {toolbarOrientation === 'left' ? globalToolbar : toolbar}
+          <button
+            className="tablet-drawer-toggle toolbar-btn"
+            type="button"
+            title="Open operations panel"
+            aria-label="Open operations panel"
+            aria-expanded={rightDrawerOpen}
+            onClick={() => setRightDrawerOpen(true)}
+          >
+            Operations{project.operations.length > 0 ? ` ${project.operations.length}` : ''}
+          </button>
+        </header>
+      )}
 
       {/* Main work area */}
-      <div className={`app-body app-body--${workspaceLayout} app-body--toolbar-${toolbarOrientation}`} style={bodyStyle}>
-        {toolbarOrientation === 'left' ? (
+      <div className={`app-body app-body--${workspaceLayout} app-body--toolbar-${toolbarOrientation} ${tabletShell ? 'app-body--tablet' : ''}`} style={bodyStyle}>
+        {tabletShell ? (
+          <aside className="app-left-rail app-left-rail--tablet" aria-label="Tools">
+            <ToolRail onZoomToModel={onZoomToModel} onImportComplete={onImportComplete} />
+          </aside>
+        ) : toolbarOrientation === 'left' ? (
           <aside className="app-left-rail" aria-label="Creation tools">
             {creationToolbar}
           </aside>
@@ -275,6 +318,14 @@ export function AppShell({
           <PanelSplit storageKey="project-tree" initialRatio={0.55} minFirst={160} minSecond={160}>
             <section className="panel panel-tree">
               <div className="panel-header">
+                <button
+                  className="tablet-drawer-close tablet-drawer-close--left"
+                  type="button"
+                  aria-label="Close project panel"
+                  onClick={() => setLeftDrawerOpen(false)}
+                >
+                  ✕
+                </button>
                 Project Tree
                 <span className="feature-count">
                   {project.features.length + project.featureFolders.length + project.tabs.length + project.clamps.length + 6}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -94,6 +94,7 @@ export function AppShell({
   const tabletShell = isTabletMode(shellMode)
   const [rightDrawerOpen, setRightDrawerOpen] = useState(false)
   const [leftDrawerOpen, setLeftDrawerOpen] = useState(false)
+  const [statusBarExpanded, setStatusBarExpanded] = useState(false)
 
   const LC_STORAGE_KEY = 'panel-split:left-center'
   const CR_STORAGE_KEY = 'panel-split:center-right'
@@ -261,6 +262,13 @@ export function AppShell({
 
   return (
     <div className="app-shell" data-shell-mode={shellMode} data-right-open={rightDrawerOpen ? 'true' : undefined} data-left-open={leftDrawerOpen ? 'true' : undefined}>
+      <div className="tablet-rotate-overlay" aria-hidden="true">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="4" y="2" width="16" height="20" rx="2" />
+          <path d="M12 18h.01" />
+        </svg>
+        <span>Please rotate your device to landscape mode</span>
+      </div>
       {(rightDrawerOpen || leftDrawerOpen) && (
         <div
           className="tablet-drawer-scrim"
@@ -610,13 +618,25 @@ export function AppShell({
 
       </div>
 
-      <footer className="app-statusbar">
+      <footer className={`app-statusbar ${tabletShell ? (statusBarExpanded ? 'app-statusbar--tablet-expanded' : 'app-statusbar--tablet-compact') : ''}`}>
         <span>{project.meta.name}</span>
         <span>{project.meta.units.toUpperCase()}</span>
         <span>
           Stock: {formatLength(stockWidth, project.meta.units)} × {formatLength(stockHeight, project.meta.units)} × {formatLength(project.stock.thickness, project.meta.units)} {project.meta.units}
         </span>
-        <div className="statusbar-visibility" aria-label="View visibility">
+        {tabletShell ? (
+          <button
+            type="button"
+            className="statusbar-expand-btn"
+            onClick={() => setStatusBarExpanded((v) => !v)}
+            title={statusBarExpanded ? 'Collapse status bar' : 'Expand status bar'}
+            aria-label={statusBarExpanded ? 'Collapse status bar' : 'Expand status bar'}
+            aria-expanded={statusBarExpanded}
+          >
+            {statusBarExpanded ? '▾' : '▸'}
+          </button>
+        ) : null}
+        <div className={`statusbar-visibility ${tabletShell && !statusBarExpanded ? 'statusbar-visibility--hidden' : ''}`} aria-label="View visibility">
           <button
             className={`statusbar-toggle ${project.grid.visible ? 'statusbar-toggle--active' : ''}`}
             type="button"

--- a/src/components/layout/SnapPopover.tsx
+++ b/src/components/layout/SnapPopover.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react'
+import { Icon } from '../Icon'
+import type { SnapMode, SnapSettings } from '../../sketch/snapping'
+
+interface SnapPopoverProps {
+  snapSettings: SnapSettings
+  activeSnapMode?: SnapMode | null
+  onToggleSnapEnabled: () => void
+  onToggleSnapMode: (mode: SnapMode) => void
+}
+
+const SNAP_MODES: { mode: SnapMode; icon: string; label: string }[] = [
+  { mode: 'grid', icon: 'snap-grid', label: 'Snap to grid' },
+  { mode: 'point', icon: 'snap-point', label: 'Snap to point' },
+  { mode: 'line', icon: 'snap-line', label: 'Snap to line' },
+  { mode: 'midpoint', icon: 'snap-midpoint', label: 'Snap to midpoint' },
+  { mode: 'center', icon: 'snap-center', label: 'Snap to center' },
+  { mode: 'perpendicular', icon: 'snap-perpendicular', label: 'Snap perpendicular' },
+]
+
+export function SnapPopover({
+  snapSettings,
+  activeSnapMode,
+  onToggleSnapEnabled,
+  onToggleSnapMode,
+}: SnapPopoverProps) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handlePointerDown(event: PointerEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  const enabledCount = snapSettings.modes.length
+
+  return (
+    <div className="snap-popover-host" ref={containerRef}>
+      <div className="toolbar-action">
+        <button
+          className={`toolbar-icon-btn ${snapSettings.enabled ? 'toolbar-icon-btn--active' : ''} ${activeSnapMode ? 'toolbar-icon-btn--live' : ''}`}
+          type="button"
+          aria-label={snapSettings.enabled ? `Snapping enabled (${enabledCount} modes)` : 'Snapping disabled'}
+          aria-expanded={open}
+          onClick={() => setOpen((prev) => !prev)}
+        >
+          <Icon id="snap" />
+          {snapSettings.enabled && enabledCount > 0 && (
+            <span className="snap-popover-badge">{enabledCount}</span>
+          )}
+        </button>
+        <span className="toolbar-tooltip toolbar-tooltip--bottom" role="tooltip">
+          Snap settings
+        </span>
+      </div>
+      {open && (
+        <div className="snap-popover" role="menu">
+          <div className="snap-popover-header">
+            <button
+              className={`snap-popover-enable-btn ${snapSettings.enabled ? 'snap-popover-enable-btn--active' : ''}`}
+              type="button"
+              onClick={() => onToggleSnapEnabled()}
+            >
+              {snapSettings.enabled ? 'Enabled' : 'Disabled'}
+            </button>
+          </div>
+          <div className="snap-popover-grid">
+            {SNAP_MODES.map(({ mode, icon, label }) => {
+              const active = snapSettings.enabled && snapSettings.modes.includes(mode)
+              const emphasized = snapSettings.enabled && activeSnapMode === mode
+              return (
+                <button
+                  key={mode}
+                  className={`snap-popover-item ${active ? 'snap-popover-item--active' : ''} ${emphasized ? 'snap-popover-item--live' : ''}`}
+                  type="button"
+                  role="menuitemcheckbox"
+                  aria-checked={active}
+                  aria-label={label}
+                  onClick={() => onToggleSnapMode(mode)}
+                >
+                  <Icon id={icon} />
+                  <span className="snap-popover-item-label">{label.replace('Snap ', '').replace('to ', '')}</span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/layout/ToolRail.tsx
+++ b/src/components/layout/ToolRail.tsx
@@ -1,0 +1,316 @@
+import { useState } from 'react'
+import { Icon } from '../Icon'
+import { useProjectStore } from '../../store/projectStore'
+import { featureHasClosedGeometry } from '../../text'
+import { TextToolDialog } from '../project/TextToolDialog'
+import type { FeatureAlignment, FeatureDistribution, SketchEditTool } from '../../store/types'
+import type { TextToolConfig } from '../../text'
+
+function RailButton({
+  icon,
+  label,
+  active = false,
+  emphasized = false,
+  disabled = false,
+  onClick,
+}: {
+  icon: string
+  label: string
+  active?: boolean
+  emphasized?: boolean
+  disabled?: boolean
+  onClick: () => void
+}) {
+  return (
+    <div className="tool-rail__action">
+      <button
+        className={`tool-rail__btn ${active ? 'tool-rail__btn--active' : ''} ${emphasized ? 'tool-rail__btn--live' : ''}`}
+        type="button"
+        aria-label={label}
+        disabled={disabled}
+        onClick={(e) => {
+          onClick()
+          e.currentTarget.blur()
+        }}
+      >
+        <Icon id={icon} />
+      </button>
+      <span className="tool-rail__tooltip" role="tooltip">{label}</span>
+    </div>
+  )
+}
+
+interface ToolRailProps {
+  onZoomToModel: () => void
+  onImportComplete?: () => void
+}
+
+export function ToolRail({ onZoomToModel: _onZoomToModel, onImportComplete: _onImportComplete }: ToolRailProps) {
+  void _onZoomToModel
+  void _onImportComplete
+
+  const {
+    project,
+    pendingAdd,
+    selection,
+    pendingMove,
+    pendingTransform,
+    pendingOffset,
+    pendingShapeAction,
+    pendingConstraint,
+    creationTarget,
+    setCreationTarget,
+    startAddRectPlacement,
+    startAddCirclePlacement,
+    startAddEllipsePlacement,
+    startAddPolygonPlacement,
+    startAddSplinePlacement,
+    startAddCompositePlacement,
+    startAddTextPlacement,
+    startMoveFeature,
+    startCopyFeature,
+    startResizeFeature,
+    startRotateFeature,
+    startMirrorFeature,
+    startJoinSelectedFeatures,
+    startCutSelectedFeatures,
+    startOffsetSelectedFeatures,
+    alignFeatures,
+    distributeFeatures,
+    deleteFeatures,
+    setSketchEditTool,
+    beginConstraint,
+    cancelPendingAdd,
+    cancelPendingMove,
+    cancelPendingTransform,
+    cancelPendingOffset,
+    cancelPendingShapeAction,
+    cancelPendingConstraint,
+  } = useProjectStore()
+
+  const [showTextDialog, setShowTextDialog] = useState(false)
+  const [showAlignPopover, setShowAlignPopover] = useState(false)
+  const [showDistributePopover, setShowDistributePopover] = useState(false)
+
+  const selectedFeatureIds = selection.mode === 'feature' ? selection.selectedFeatureIds : []
+  const primarySelectedFeatureId = selection.selectedFeatureId ?? selectedFeatureIds[0] ?? null
+  const selectedFeatures = selectedFeatureIds
+    .map((id) => project.features.find((f) => f.id === id) ?? null)
+    .filter((f): f is NonNullable<typeof f> => f !== null)
+  const hasSelectedFeatures = selectedFeatureIds.length > 0
+  const hasLockedSelectedFeatures = selectedFeatures.some((f) => f.locked)
+  const hasClosedSelectedFeatures = selectedFeatures.length > 0 && selectedFeatures.every((f) => featureHasClosedGeometry(f))
+  const hasOffsetEligibleSelectedFeatures = hasClosedSelectedFeatures && selectedFeatures.every((f) => f.kind !== 'text')
+  const alignableCount = selectedFeatures.filter((f) => !f.locked).length
+  const canAlign = alignableCount >= 2
+  const canDistribute = alignableCount >= 3
+  const featureSketchEditActive = selection.mode === 'sketch_edit' && selection.selectedNode?.type === 'feature' && !!selection.selectedFeatureId
+
+  function togglePlacement(shape: 'rect' | 'circle' | 'ellipse' | 'polygon' | 'spline' | 'composite', start: () => void) {
+    if (pendingAdd?.shape === shape) {
+      cancelPendingAdd()
+      return
+    }
+    start()
+  }
+
+  function handleTextTool() {
+    if (pendingAdd) cancelPendingAdd()
+    setShowTextDialog(true)
+  }
+
+  function confirmTextTool(config: TextToolConfig) {
+    startAddTextPlacement(config)
+    setShowTextDialog(false)
+  }
+
+  function handleMove() {
+    if (!primarySelectedFeatureId) return
+    if (pendingMove?.entityType === 'feature' && pendingMove.mode === 'move') { cancelPendingMove(); return }
+    startMoveFeature(primarySelectedFeatureId)
+  }
+
+  function handleCopy() {
+    if (!primarySelectedFeatureId) return
+    if (pendingMove?.entityType === 'feature' && pendingMove.mode === 'copy') { cancelPendingMove(); return }
+    startCopyFeature(primarySelectedFeatureId)
+  }
+
+  function handleResize() {
+    if (!primarySelectedFeatureId) return
+    if (pendingTransform?.mode === 'resize') { cancelPendingTransform(); return }
+    startResizeFeature(primarySelectedFeatureId)
+  }
+
+  function handleRotate() {
+    if (!primarySelectedFeatureId) return
+    if (pendingTransform?.mode === 'rotate') { cancelPendingTransform(); return }
+    startRotateFeature(primarySelectedFeatureId)
+  }
+
+  function handleMirror() {
+    if (!primarySelectedFeatureId) return
+    if (pendingTransform?.mode === 'mirror') { cancelPendingTransform(); return }
+    startMirrorFeature(primarySelectedFeatureId)
+  }
+
+  function handleJoin() {
+    if (pendingShapeAction?.kind === 'join') { cancelPendingShapeAction(); return }
+    startJoinSelectedFeatures()
+  }
+
+  function handleCut() {
+    if (pendingShapeAction?.kind === 'cut') { cancelPendingShapeAction(); return }
+    startCutSelectedFeatures()
+  }
+
+  function handleOffset() {
+    if (pendingOffset) { cancelPendingOffset(); return }
+    startOffsetSelectedFeatures()
+  }
+
+  function handleConstraint() {
+    if (pendingConstraint) { cancelPendingConstraint(); return }
+    const featureId = (selection.selectedNode?.type === 'feature' ? selection.selectedNode.featureId : null) ?? selection.selectedFeatureId
+    if (!featureId) return
+    if (featureSketchEditActive) setSketchEditTool(null)
+    beginConstraint(featureId)
+  }
+
+  function handleAlign(alignment: FeatureAlignment) {
+    const ids = selectedFeatures.filter((f) => !f.locked).map((f) => f.id)
+    if (ids.length < 2) return
+    alignFeatures(ids, alignment)
+    setShowAlignPopover(false)
+  }
+
+  function handleDistribute(distribution: FeatureDistribution) {
+    const ids = selectedFeatures.filter((f) => !f.locked).map((f) => f.id)
+    if (ids.length < 3) return
+    distributeFeatures(ids, distribution)
+    setShowDistributePopover(false)
+  }
+
+  function toggleSketchEditTool(tool: SketchEditTool) {
+    if (!featureSketchEditActive) return
+    setSketchEditTool(selection.sketchEditTool === tool ? null : tool)
+  }
+
+  return (
+    <>
+      <nav className="tool-rail" aria-label="Tools">
+        {/* Creation target toggle */}
+        <div className="tool-rail__section">
+          <div className="tool-rail__target-toggle">
+            <button
+              className={`tool-rail__target-btn ${creationTarget === 'feature' ? 'tool-rail__target-btn--active' : ''}`}
+              type="button"
+              aria-label="Create features"
+              aria-pressed={creationTarget === 'feature'}
+              onClick={() => setCreationTarget('feature')}
+            >
+              <Icon id="plus" />
+            </button>
+            <button
+              className={`tool-rail__target-btn tool-rail__target-btn--region ${creationTarget === 'region' ? 'tool-rail__target-btn--active' : ''}`}
+              type="button"
+              aria-label="Create regions"
+              aria-pressed={creationTarget === 'region'}
+              onClick={() => setCreationTarget('region')}
+            >
+              <Icon id="pocket" />
+            </button>
+          </div>
+        </div>
+
+        {/* Creation tools */}
+        <div className="tool-rail__section">
+          <RailButton icon="rect" label="Rectangle" active={pendingAdd?.shape === 'rect'} onClick={() => togglePlacement('rect', startAddRectPlacement)} />
+          <RailButton icon="circle" label="Circle" active={pendingAdd?.shape === 'circle'} onClick={() => togglePlacement('circle', startAddCirclePlacement)} />
+          <RailButton icon="ellipse" label="Ellipse" active={pendingAdd?.shape === 'ellipse'} onClick={() => togglePlacement('ellipse', startAddEllipsePlacement)} />
+          <RailButton icon="polygon" label="Polygon" active={pendingAdd?.shape === 'polygon'} onClick={() => togglePlacement('polygon', startAddPolygonPlacement)} />
+          <RailButton icon="spline" label="Spline" active={pendingAdd?.shape === 'spline'} onClick={() => togglePlacement('spline', startAddSplinePlacement)} />
+          <RailButton icon="composite" label="Composite" active={pendingAdd?.shape === 'composite'} onClick={() => togglePlacement('composite', startAddCompositePlacement)} />
+          <RailButton icon="text" label="Text" active={pendingAdd?.shape === 'text'} onClick={handleTextTool} />
+        </div>
+
+        {/* Edit tools (visible when features selected) */}
+        {hasSelectedFeatures && (
+          <div className="tool-rail__section">
+            <RailButton icon="copy" label="Copy" active={pendingMove?.entityType === 'feature' && pendingMove.mode === 'copy'} onClick={handleCopy} />
+            <RailButton icon="move" label="Move" active={pendingMove?.entityType === 'feature' && pendingMove.mode === 'move'} disabled={hasLockedSelectedFeatures} onClick={handleMove} />
+            <RailButton icon="trash" label="Delete" onClick={() => deleteFeatures(selectedFeatureIds)} />
+            <RailButton icon="resize" label="Resize" active={pendingTransform?.mode === 'resize'} disabled={hasLockedSelectedFeatures} onClick={handleResize} />
+            <RailButton icon="rotate" label="Rotate" active={pendingTransform?.mode === 'rotate'} disabled={hasLockedSelectedFeatures} onClick={handleRotate} />
+            <RailButton icon="mirror" label="Mirror" active={pendingTransform?.mode === 'mirror'} disabled={hasLockedSelectedFeatures} onClick={handleMirror} />
+            <RailButton icon="offset" label="Offset" active={!!pendingOffset} disabled={hasLockedSelectedFeatures || !hasOffsetEligibleSelectedFeatures} onClick={handleOffset} />
+            <RailButton icon="constraint" label="Constraint" active={!!pendingConstraint} disabled={hasLockedSelectedFeatures} onClick={handleConstraint} />
+            <RailButton icon="merge" label="Join" active={pendingShapeAction?.kind === 'join'} onClick={handleJoin} />
+            <RailButton icon="cut" label="Cut" active={pendingShapeAction?.kind === 'cut'} onClick={handleCut} />
+          </div>
+        )}
+
+        {/* Alignment/distribution (multi-select) */}
+        {canAlign && (
+          <div className="tool-rail__section">
+            <div className="tool-rail__action">
+              <button
+                className={`tool-rail__btn ${showAlignPopover ? 'tool-rail__btn--active' : ''}`}
+                type="button"
+                aria-label="Align features"
+                onClick={() => { setShowAlignPopover((v) => !v); setShowDistributePopover(false) }}
+              >
+                <Icon id="align" />
+              </button>
+              <span className="tool-rail__tooltip" role="tooltip">Align</span>
+              {showAlignPopover && (
+                <div className="tool-rail__popover">
+                  <button type="button" aria-label="Align left" onClick={() => handleAlign('left')}><Icon id="align-left" /></button>
+                  <button type="button" aria-label="Align center horizontal" onClick={() => handleAlign('center_horizontal')}><Icon id="align-center-horizontal" /></button>
+                  <button type="button" aria-label="Align right" onClick={() => handleAlign('right')}><Icon id="align-right" /></button>
+                  <button type="button" aria-label="Align top" onClick={() => handleAlign('top')}><Icon id="align-top" /></button>
+                  <button type="button" aria-label="Align center vertical" onClick={() => handleAlign('center_vertical')}><Icon id="align-center-vertical" /></button>
+                  <button type="button" aria-label="Align bottom" onClick={() => handleAlign('bottom')}><Icon id="align-bottom" /></button>
+                </div>
+              )}
+            </div>
+            {canDistribute && (
+              <div className="tool-rail__action">
+                <button
+                  className={`tool-rail__btn ${showDistributePopover ? 'tool-rail__btn--active' : ''}`}
+                  type="button"
+                  aria-label="Distribute features"
+                  onClick={() => { setShowDistributePopover((v) => !v); setShowAlignPopover(false) }}
+                >
+                  <Icon id="distribute" />
+                </button>
+                <span className="tool-rail__tooltip" role="tooltip">Distribute</span>
+                {showDistributePopover && (
+                  <div className="tool-rail__popover">
+                    <button type="button" aria-label="Distribute horizontal gaps" onClick={() => handleDistribute('horizontal_gaps')}><Icon id="distribute-horizontal-gaps" /></button>
+                    <button type="button" aria-label="Distribute horizontal centers" onClick={() => handleDistribute('horizontal_centers')}><Icon id="distribute-horizontal-centers" /></button>
+                    <button type="button" aria-label="Distribute vertical gaps" onClick={() => handleDistribute('vertical_gaps')}><Icon id="distribute-vertical-gaps" /></button>
+                    <button type="button" aria-label="Distribute vertical centers" onClick={() => handleDistribute('vertical_centers')}><Icon id="distribute-vertical-centers" /></button>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Sketch edit tools */}
+        {featureSketchEditActive && (
+          <div className="tool-rail__section">
+            <RailButton icon="point-add" label="Add point" active={selection.sketchEditTool === 'add_point'} onClick={() => toggleSketchEditTool('add_point')} />
+            <RailButton icon="point-delete" label="Delete point" active={selection.sketchEditTool === 'delete_point'} onClick={() => toggleSketchEditTool('delete_point')} />
+            <RailButton icon="segment-delete" label="Delete segment" active={selection.sketchEditTool === 'delete_segment'} onClick={() => toggleSketchEditTool('delete_segment')} />
+            <RailButton icon="disconnect" label="Disconnect" active={selection.sketchEditTool === 'disconnect'} onClick={() => toggleSketchEditTool('disconnect')} />
+            <RailButton icon="fillet" label="Fillet" active={selection.sketchEditTool === 'fillet'} onClick={() => toggleSketchEditTool('fillet')} />
+          </div>
+        )}
+      </nav>
+
+      {showTextDialog && <TextToolDialog onClose={() => setShowTextDialog(false)} onConfirm={confirmTextTool} />}
+    </>
+  )
+}

--- a/src/components/layout/TopCommandBar.tsx
+++ b/src/components/layout/TopCommandBar.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState } from 'react'
+import { Icon } from '../Icon'
+import { useProjectStore } from '../../store/projectStore'
+import { useFileActions } from '../../platform/useFileActions'
+import { ImportGeometryDialog } from '../project/ImportGeometryDialog'
+import { NewProjectDialog } from '../project/NewProjectDialog'
+import type { SnapMode, SnapSettings } from '../../sketch/snapping'
+import { SnapPopover } from './SnapPopover'
+
+interface TopCommandBarProps {
+  centerTab: 'sketch' | 'preview3d' | 'simulation'
+  onCenterTabChange: (tab: 'sketch' | 'preview3d' | 'simulation') => void
+  onZoomToModel: () => void
+  onZoomWindow: () => void
+  zoomWindowActive: boolean
+  onOpenLeftDrawer: () => void
+  onOpenRightDrawer: () => void
+  onImportComplete?: () => void
+  snapSettings: SnapSettings
+  activeSnapMode?: SnapMode | null
+  onToggleSnapEnabled: () => void
+  onToggleSnapMode: (mode: SnapMode) => void
+}
+
+export function TopCommandBar({
+  centerTab,
+  onCenterTabChange,
+  onZoomToModel,
+  onZoomWindow,
+  zoomWindowActive,
+  onOpenLeftDrawer,
+  onOpenRightDrawer,
+  onImportComplete,
+  snapSettings,
+  activeSnapMode,
+  onToggleSnapEnabled,
+  onToggleSnapMode,
+}: TopCommandBarProps) {
+  const fileActions = useFileActions()
+  const {
+    project,
+    dirty,
+    history,
+    setProjectName,
+    undo,
+    redo,
+  } = useProjectStore()
+
+  const [editingName, setEditingName] = useState(false)
+  const [nameVal, setNameVal] = useState(project.meta.name)
+  const [showNewProjectDialog, setShowNewProjectDialog] = useState(false)
+  const [showImportDialog, setShowImportDialog] = useState(false)
+
+  useEffect(() => {
+    if (!editingName) setNameVal(project.meta.name)
+  }, [editingName, project.meta.name])
+
+  async function handleNew() {
+    const ok = await fileActions.confirmDiscardIfDirty()
+    if (ok) setShowNewProjectDialog(true)
+  }
+
+  return (
+    <>
+      <div className="top-command-bar">
+        {/* Left section: project drawer + project name */}
+        <div className="top-command-bar__left">
+          <button
+            className="top-cmd-btn"
+            type="button"
+            aria-label="Open project panel"
+            onClick={onOpenLeftDrawer}
+          >
+            <Icon id="project" />
+          </button>
+          <div className="top-command-bar__project">
+            {editingName ? (
+              <input
+                className="toolbar-name-input"
+                value={nameVal}
+                onChange={(e) => setNameVal(e.target.value)}
+                onBlur={() => {
+                  setProjectName(nameVal.trim() || 'Untitled')
+                  setEditingName(false)
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    setProjectName(nameVal.trim() || 'Untitled')
+                    setEditingName(false)
+                  }
+                  if (e.key === 'Escape') {
+                    setNameVal(project.meta.name)
+                    setEditingName(false)
+                  }
+                }}
+                autoFocus
+              />
+            ) : (
+              <button
+                className="top-command-bar__name"
+                type="button"
+                title="Rename project"
+                onClick={() => {
+                  setNameVal(project.meta.name)
+                  setEditingName(true)
+                }}
+              >
+                {project.meta.name}
+              </button>
+            )}
+            <span
+              className={`top-command-bar__save-state ${dirty ? 'top-command-bar__save-state--dirty' : ''}`}
+            >
+              {dirty ? 'Unsaved' : 'Saved'}
+            </span>
+          </div>
+        </div>
+
+        {/* Center section: file ops + undo/redo + view tabs */}
+        <div className="top-command-bar__center">
+          <div className="top-cmd-group">
+            <button className="top-cmd-btn" type="button" aria-label="New project" onClick={handleNew}>
+              <Icon id="new" />
+            </button>
+            <button className="top-cmd-btn" type="button" aria-label="Open project" onClick={() => fileActions.open()}>
+              <Icon id="open" />
+            </button>
+            <button className="top-cmd-btn" type="button" aria-label="Import geometry" onClick={() => setShowImportDialog(true)}>
+              <Icon id="import" />
+            </button>
+            <button
+              className={`top-cmd-btn ${dirty ? 'top-cmd-btn--emphasized' : ''}`}
+              type="button"
+              aria-label="Save project"
+              onClick={() => fileActions.save()}
+            >
+              <Icon id="save" />
+            </button>
+          </div>
+
+          <div className="top-cmd-group">
+            <button className="top-cmd-btn" type="button" aria-label="Undo" onClick={undo} disabled={history.past.length === 0}>
+              <Icon id="undo" />
+            </button>
+            <button className="top-cmd-btn" type="button" aria-label="Redo" onClick={redo} disabled={history.future.length === 0}>
+              <Icon id="redo" />
+            </button>
+          </div>
+
+          <div className="top-cmd-group top-cmd-group--tabs">
+            <button
+              className={`top-cmd-tab ${centerTab === 'sketch' ? 'top-cmd-tab--active' : ''}`}
+              type="button"
+              onClick={() => onCenterTabChange('sketch')}
+            >
+              Sketch
+            </button>
+            <button
+              className={`top-cmd-tab ${centerTab === 'preview3d' ? 'top-cmd-tab--active' : ''}`}
+              type="button"
+              onClick={() => onCenterTabChange('preview3d')}
+            >
+              3D
+            </button>
+            <button
+              className={`top-cmd-tab ${centerTab === 'simulation' ? 'top-cmd-tab--active' : ''}`}
+              type="button"
+              onClick={() => onCenterTabChange('simulation')}
+            >
+              Sim
+            </button>
+          </div>
+        </div>
+
+        {/* Right section: zoom + snap + operations */}
+        <div className="top-command-bar__right">
+          <div className="top-cmd-group">
+            <button className="top-cmd-btn" type="button" aria-label="Zoom to model" onClick={onZoomToModel}>
+              <Icon id="fit" />
+            </button>
+            <button
+              className={`top-cmd-btn ${zoomWindowActive ? 'top-cmd-btn--active' : ''}`}
+              type="button"
+              aria-label="Zoom selected"
+              onClick={onZoomWindow}
+            >
+              <Icon id="fit-window" />
+            </button>
+          </div>
+          <SnapPopover
+            snapSettings={snapSettings}
+            activeSnapMode={activeSnapMode}
+            onToggleSnapEnabled={onToggleSnapEnabled}
+            onToggleSnapMode={onToggleSnapMode}
+          />
+          <button
+            className="top-cmd-btn top-cmd-btn--operations"
+            type="button"
+            aria-label="Open operations panel"
+            onClick={onOpenRightDrawer}
+          >
+            Operations{project.operations.length > 0 ? ` ${project.operations.length}` : ''}
+          </button>
+        </div>
+      </div>
+
+      {showNewProjectDialog && (
+        <NewProjectDialog onClose={() => {
+          setNameVal(useProjectStore.getState().project.meta.name)
+          setEditingName(false)
+          setShowNewProjectDialog(false)
+        }} />
+      )}
+      {showImportDialog && (
+        <ImportGeometryDialog
+          onClose={() => setShowImportDialog(false)}
+          onImportComplete={onImportComplete}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/layout/useShellMode.ts
+++ b/src/components/layout/useShellMode.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+
+export type ShellMode = 'desktop-wide' | 'desktop-compact' | 'tablet' | 'tablet-compact'
+
+const COARSE_QUERY = '(pointer: coarse)'
+const NO_HOVER_QUERY = '(hover: none)'
+
+function computeShellMode(width: number, isCoarse: boolean): ShellMode {
+  if (isCoarse) {
+    return width >= 900 ? 'tablet' : 'tablet-compact'
+  }
+  return width >= 1400 ? 'desktop-wide' : 'desktop-compact'
+}
+
+export function useShellMode(): ShellMode {
+  const [mode, setMode] = useState<ShellMode>(() => {
+    const isCoarse = window.matchMedia(COARSE_QUERY).matches || window.matchMedia(NO_HOVER_QUERY).matches
+    return computeShellMode(window.innerWidth, isCoarse)
+  })
+
+  useEffect(() => {
+    const coarseMql = window.matchMedia(COARSE_QUERY)
+    const noHoverMql = window.matchMedia(NO_HOVER_QUERY)
+
+    function update() {
+      const isCoarse = coarseMql.matches || noHoverMql.matches
+      setMode(computeShellMode(window.innerWidth, isCoarse))
+    }
+
+    window.addEventListener('resize', update)
+    coarseMql.addEventListener('change', update)
+    noHoverMql.addEventListener('change', update)
+
+    return () => {
+      window.removeEventListener('resize', update)
+      coarseMql.removeEventListener('change', update)
+      noHoverMql.removeEventListener('change', update)
+    }
+  }, [])
+
+  return mode
+}
+
+export function isTabletMode(mode: ShellMode): boolean {
+  return mode === 'tablet' || mode === 'tablet-compact'
+}

--- a/src/components/project/ImportGeometryDialog.tsx
+++ b/src/components/project/ImportGeometryDialog.tsx
@@ -16,6 +16,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import type { CSSProperties, ChangeEvent } from 'react'
+import { useRestoreCanvasFocus } from '../../utils/useRestoreCanvasFocus'
 import { importDxfString, importSvgString, inspectDxfString, inspectSvgString, type ImportInspection, type ImportSourceType } from '../../import'
 import {
   clampImportedMeshSilhouetteZSteps,
@@ -99,6 +100,7 @@ function detectSourceType(fileName: string): ImportSourceType | null {
 }
 
 export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeometryDialogProps) {
+  useRestoreCanvasFocus()
   const { project, importShapes } = useProjectStore()
   const [loadedFile, setLoadedFile] = useState<LoadedImportFile | null>(null)
   const [sourceUnits, setSourceUnits] = useState<Units | ''>('')

--- a/src/components/project/NewProjectDialog.tsx
+++ b/src/components/project/NewProjectDialog.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ChangeEvent } from 'react'
 import { useProjectStore } from '../../store/projectStore'
+import { useRestoreCanvasFocus } from '../../utils/useRestoreCanvasFocus'
 import { getStockBounds, newProject } from '../../types/project'
 import type { Project } from '../../types/project'
 import { formatLength } from '../../utils/units'
@@ -73,6 +74,7 @@ function setupOnlyTemplate(template: Project): Project {
 }
 
 export function NewProjectDialog({ onClose, onCreated }: NewProjectDialogProps) {
+  useRestoreCanvasFocus()
   const { project, createNewProject } = useProjectStore()
   const [templateKind, setTemplateKind] = useState<TemplateKind>('blank_metric')
   const [fileTemplate, setFileTemplate] = useState<Project | null>(null)

--- a/src/components/project/NewProjectDialog.tsx
+++ b/src/components/project/NewProjectDialog.tsx
@@ -241,7 +241,7 @@ export function NewProjectDialog({ onClose, onCreated }: NewProjectDialogProps) 
               <input
                 ref={fileInputRef}
                 type="file"
-                accept=".camj,.json"
+                accept=".camj,.json,application/json"
                 onChange={handleTemplateFileChange}
                 style={{ display: 'none' }}
               />

--- a/src/components/project/TextToolDialog.tsx
+++ b/src/components/project/TextToolDialog.tsx
@@ -19,6 +19,7 @@ import type { FeatureOperation, TextFontStyle } from '../../types/project'
 import { useRestoreCanvasFocus } from '../../utils/useRestoreCanvasFocus'
 import { defaultFontIdForStyle, defaultTextToolConfig, getTextFontOptions, type TextToolConfig } from '../../text'
 import { useProjectStore } from '../../store/projectStore'
+import { Select } from '../Select'
 
 interface TextToolDialogProps {
   onClose: () => void
@@ -70,7 +71,7 @@ export function TextToolDialog({ onClose, onConfirm }: TextToolDialogProps) {
 
   return (
     <div className="dialog-backdrop" onClick={onClose}>
-      <div className="dialog" onClick={(event) => event.stopPropagation()}>
+      <div className="dialog dialog--import dialog--no-clip" onClick={(event) => event.stopPropagation()}>
         <div className="dialog-header">
           <h2 className="dialog-title">Add Text</h2>
           <button className="dialog-close" onClick={onClose} aria-label="Close" type="button">
@@ -80,7 +81,7 @@ export function TextToolDialog({ onClose, onConfirm }: TextToolDialogProps) {
           </button>
         </div>
 
-        <div className="dialog-body">
+        <div className="dialog-body dialog-body--import">
           <div className="dialog-section">
             <div className="dialog-section-group">
               <label className="dialog-section-title" htmlFor="text-tool-value">Text</label>
@@ -96,24 +97,26 @@ export function TextToolDialog({ onClose, onConfirm }: TextToolDialogProps) {
               </div>
             </div>
             <div className="dialog-section-group">
-              <label className="dialog-section-title" htmlFor="text-tool-style">Font Style</label>
+              <label className="dialog-section-title">Font Style</label>
               <div className="properties-field">
-                <select id="text-tool-style" value={style} onChange={(event) => setStyle(event.target.value as TextFontStyle)}>
-                  <option value="skeleton">Skeleton</option>
-                  <option value="outline">Outline</option>
-                </select>
+                <Select
+                  value={style}
+                  options={[
+                    { value: 'skeleton' as TextFontStyle, label: 'Skeleton' },
+                    { value: 'outline' as TextFontStyle, label: 'Outline' },
+                  ]}
+                  onChange={(v) => setStyle(v)}
+                />
               </div>
             </div>
             <div className="dialog-section-group">
-              <label className="dialog-section-title" htmlFor="text-tool-font">Font</label>
+              <label className="dialog-section-title">Font</label>
               <div className="properties-field">
-                <select id="text-tool-font" value={fontId} onChange={(event) => setFontId(event.target.value as typeof fontId)}>
-                  {fontOptions.map((font) => (
-                    <option key={font.id} value={font.id}>
-                      {font.label}
-                    </option>
-                  ))}
-                </select>
+                <Select
+                  value={fontId}
+                  options={fontOptions.map((font) => ({ value: font.id, label: font.label }))}
+                  onChange={(v) => setFontId(v as typeof fontId)}
+                />
               </div>
             </div>
             <div className="dialog-section-group">
@@ -130,12 +133,16 @@ export function TextToolDialog({ onClose, onConfirm }: TextToolDialogProps) {
               </div>
             </div>
             <div className="dialog-section-group">
-              <label className="dialog-section-title" htmlFor="text-tool-operation">Operation</label>
+              <label className="dialog-section-title">Operation</label>
               <div className="properties-field">
-                <select id="text-tool-operation" value={operation} onChange={(event) => setOperation(event.target.value as FeatureOperation)}>
-                  <option value="subtract">Subtract</option>
-                  <option value="add">Add</option>
-                </select>
+                <Select
+                  value={operation}
+                  options={[
+                    { value: 'subtract' as FeatureOperation, label: 'Subtract' },
+                    { value: 'add' as FeatureOperation, label: 'Add' },
+                  ]}
+                  onChange={(v) => setOperation(v)}
+                />
               </div>
             </div>
             <div className="cam-field-message">

--- a/src/components/project/TextToolDialog.tsx
+++ b/src/components/project/TextToolDialog.tsx
@@ -16,6 +16,7 @@
 
 import { useEffect, useState } from 'react'
 import type { FeatureOperation, TextFontStyle } from '../../types/project'
+import { useRestoreCanvasFocus } from '../../utils/useRestoreCanvasFocus'
 import { defaultFontIdForStyle, defaultTextToolConfig, getTextFontOptions, type TextToolConfig } from '../../text'
 import { useProjectStore } from '../../store/projectStore'
 
@@ -25,6 +26,7 @@ interface TextToolDialogProps {
 }
 
 export function TextToolDialog({ onClose, onConfirm }: TextToolDialogProps) {
+  useRestoreCanvasFocus()
   const units = useProjectStore((state) => state.project.meta.units)
   const defaults = defaultTextToolConfig(units)
   const [text, setText] = useState(defaults.text)

--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -221,6 +221,8 @@ function createOrbitControls(
   const panRight = new THREE.Vector3()
   const panUp = new THREE.Vector3()
   const cameraDirection = new THREE.Vector3()
+  const touchPointers = new Map<number, { x: number; y: number }>()
+  let gestureState: { centerX: number; centerY: number; distance: number } | null = null
 
   function updateCamera() {
     camera.up.set(cameraUp[0], cameraUp[1], cameraUp[2])
@@ -281,6 +283,20 @@ function createOrbitControls(
       return
     }
 
+    if (event.pointerType === 'touch') {
+      touchPointers.set(event.pointerId, { x: event.clientX, y: event.clientY })
+      if (touchPointers.size >= 2) {
+        dragMode = null
+        const points = [...touchPointers.values()]
+        gestureState = {
+          centerX: (points[0].x + points[1].x) / 2,
+          centerY: (points[0].y + points[1].y) / 2,
+          distance: Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y),
+        }
+        return
+      }
+    }
+
     const nextDragMode =
       event.button === 0 && !event.shiftKey ? 'rotate'
       : event.button === 1 || event.button === 2 || (event.button === 0 && event.shiftKey) ? 'pan'
@@ -298,6 +314,12 @@ function createOrbitControls(
   }
 
   function onPointerUp(event: PointerEvent) {
+    if (event.pointerType === 'touch') {
+      touchPointers.delete(event.pointerId)
+      if (touchPointers.size < 2) {
+        gestureState = null
+      }
+    }
     dragMode = null
     if (domElement.hasPointerCapture?.(event.pointerId)) {
       domElement.releasePointerCapture(event.pointerId)
@@ -307,6 +329,23 @@ function createOrbitControls(
   function onPointerMove(event: PointerEvent) {
     if (isInteractionBlocked()) {
       return
+    }
+
+    if (event.pointerType === 'touch' && touchPointers.has(event.pointerId)) {
+      touchPointers.set(event.pointerId, { x: event.clientX, y: event.clientY })
+      if (touchPointers.size >= 2 && gestureState) {
+        const points = [...touchPointers.values()]
+        const newCenterX = (points[0].x + points[1].x) / 2
+        const newCenterY = (points[0].y + points[1].y) / 2
+        const newDistance = Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y)
+        if (gestureState.distance > 0 && newDistance > 0) {
+          spherical.radius = Math.max(MIN_CAMERA_RADIUS, Math.min(MAX_CAMERA_RADIUS, spherical.radius * (gestureState.distance / newDistance)))
+        }
+        panByPixels(newCenterX - gestureState.centerX, newCenterY - gestureState.centerY)
+        gestureState = { centerX: newCenterX, centerY: newCenterY, distance: newDistance }
+        updateCamera()
+        return
+      }
     }
 
     if (!dragMode) {
@@ -667,6 +706,21 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
     const controls = controlsRef.current
     if (!scene || !controls) {
       return
+    }
+
+    // Force renderer resize to current mount dimensions.
+    // When the component first mounts (tab hidden), the mount may have zero or
+    // incorrect dimensions.  On tab switch to simulation, the ResizeObserver
+    // only fires on actual dimension changes — but switching tabs only toggles
+    // opacity/visibility, not size.  Resize explicitly here so camera aspect
+    // and renderer viewport are correct before mesh creation and auto-frame.
+    const mount = mountRef.current
+    const renderer = rendererRef.current
+    const camera = cameraRef.current
+    if (mount && renderer && camera) {
+      renderer.setSize(mount.clientWidth, mount.clientHeight)
+      camera.aspect = mount.clientWidth / mount.clientHeight
+      camera.updateProjectionMatrix()
     }
 
     if (playbackEnabled) {

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -392,6 +392,8 @@ function createOrbitControls(
   const panRight = new THREE.Vector3()
   const panUp = new THREE.Vector3()
   const cameraDirection = new THREE.Vector3()
+  const touchPointers = new Map<number, { x: number; y: number }>()
+  let gestureState: { centerX: number; centerY: number; distance: number } | null = null
 
   function applyDefaultOrientation(preserveRadius = true) {
     applyPreset('iso', preserveRadius, false)
@@ -461,6 +463,21 @@ function createOrbitControls(
       return
     }
 
+    if (e.pointerType === 'touch') {
+      touchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY })
+      if (touchPointers.size >= 2) {
+        dragMode = null
+        const points = [...touchPointers.values()]
+        gestureState = {
+          centerX: (points[0].x + points[1].x) / 2,
+          centerY: (points[0].y + points[1].y) / 2,
+          distance: Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y),
+        }
+        onPresetChange(null)
+        return
+      }
+    }
+
     const nextDragMode =
       e.button === 0 && !e.shiftKey ? 'rotate'
       : e.button === 1 || e.button === 2 || (e.button === 0 && e.shiftKey) ? 'pan'
@@ -478,6 +495,12 @@ function createOrbitControls(
   }
 
   function onPointerUp(e: PointerEvent) {
+    if (e.pointerType === 'touch') {
+      touchPointers.delete(e.pointerId)
+      if (touchPointers.size < 2) {
+        gestureState = null
+      }
+    }
     dragMode = null
     if (domElement.hasPointerCapture?.(e.pointerId)) {
       domElement.releasePointerCapture(e.pointerId)
@@ -487,6 +510,23 @@ function createOrbitControls(
   function onPointerMove(e: PointerEvent) {
     if (isInteractionBlocked()) {
       return
+    }
+
+    if (e.pointerType === 'touch' && touchPointers.has(e.pointerId)) {
+      touchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY })
+      if (touchPointers.size >= 2 && gestureState) {
+        const points = [...touchPointers.values()]
+        const newCenterX = (points[0].x + points[1].x) / 2
+        const newCenterY = (points[0].y + points[1].y) / 2
+        const newDistance = Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y)
+        if (gestureState.distance > 0 && newDistance > 0) {
+          spherical.radius = Math.max(MIN_CAMERA_RADIUS, Math.min(MAX_CAMERA_RADIUS, spherical.radius * (gestureState.distance / newDistance)))
+        }
+        panByPixels(newCenterX - gestureState.centerX, newCenterY - gestureState.centerY)
+        gestureState = { centerX: newCenterX, centerY: newCenterY, distance: newDistance }
+        updateCamera()
+        return
+      }
     }
 
     if (!dragMode) return

--- a/src/engine/simulation/gpuMesh.ts
+++ b/src/engine/simulation/gpuMesh.ts
@@ -31,8 +31,12 @@ export function createHeightfieldTexture(grid: SimulationGrid): THREE.DataTextur
     THREE.RedFormat,
     THREE.FloatType,
   )
-  texture.minFilter = THREE.LinearFilter
-  texture.magFilter = THREE.LinearFilter
+  // NearestFilter is required: many mobile GPUs (including iPad) lack
+  // OES_texture_float_linear, so LinearFilter on an R32F texture returns
+  // garbage in vertex texture fetches. The heightfield is discrete (one
+  // Z per cell) and vertices sit on cell corners, so nearest is correct.
+  texture.minFilter = THREE.NearestFilter
+  texture.magFilter = THREE.NearestFilter
   texture.needsUpdate = true
   return texture
 }

--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,7 @@
 
 @import './styles/layout.css';
 @import './styles/dialog.css';
+@import './styles/canvas-workflow.css';
 @import './styles/tablet.css';
 
 :root {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -55,7 +55,10 @@ function isPhoneSizedTouchDevice() {
     return false
   }
 
-  return window.matchMedia('(max-width: 760px) and (pointer: coarse)').matches
+  const mq = window.matchMedia('(pointer: coarse)')
+  if (!mq.matches) return false
+  const short = Math.min(window.innerWidth, window.innerHeight)
+  return short < 500
 }
 
 function UnsupportedMobileScreen() {

--- a/src/platform/browser.ts
+++ b/src/platform/browser.ts
@@ -92,7 +92,7 @@ export const browserPlatform: PlatformApi = {
   isDesktop: false,
 
   async openProjectFile(): Promise<OpenProjectResult | null> {
-    const file = await pickFile('.camj,.json')
+    const file = await pickFile('.camj,.json,application/json')
     if (!file) return null
     const content = await readFileAsText(file)
     return { content, path: null }

--- a/src/sketch/useAxisLock.ts
+++ b/src/sketch/useAxisLock.ts
@@ -14,49 +14,40 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { LockMode } from '../types/axisLock'
 import type { Point } from '../types/project'
 
 /**
- * Manages axis lock state during drag operations.
- *
- * Pressing Alt/Option while dragging cycles through: none → x → y → none.
- * The lock is automatically reset when `active` becomes false.
- *
- * @param active - Whether a drag operation is currently in progress.
- * @returns Object with the current lock mode ref and a function to apply the lock to a point.
- */
-/**
- * @param active - Whether a drag operation is currently in progress.
  * @param onLockChange - Called whenever the lock mode changes so the caller can redraw.
  */
-export function useAxisLock(active: boolean, onLockChange?: () => void) {
+export function useAxisLock(onLockChange?: () => void) {
   const lockModeRef = useRef<LockMode>('none')
+  const [lockMode, setLockMode] = useState<LockMode>('none')
   const onLockChangeRef = useRef(onLockChange)
   onLockChangeRef.current = onLockChange
 
-  // Reset lock when drag ends
-  useEffect(() => {
-    if (!active) {
-      lockModeRef.current = 'none'
-    }
-  }, [active])
+  function setLock(mode: LockMode) {
+    lockModeRef.current = mode
+    setLockMode(mode)
+    onLockChangeRef.current?.()
+  }
 
   const handleKeyDown = useCallback((event: KeyboardEvent) => {
-    if (!active) return
     if (event.key !== 'Alt') return
-    // Prevent browser default (e.g. focus menu bar on some platforms)
     event.preventDefault()
-    lockModeRef.current = cycleLockMode(lockModeRef.current)
-    onLockChangeRef.current?.()
-  }, [active])
+    setLock(cycleLockMode(lockModeRef.current))
+  }, [])
 
   useEffect(() => {
-    if (!active) return
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [active, handleKeyDown])
+  }, [handleKeyDown])
+
+  const reset = useCallback(() => {
+    lockModeRef.current = 'none'
+    setLockMode('none')
+  }, [])
 
   /**
    * Applies the current lock mode to constrain `point` relative to `origin`.
@@ -72,11 +63,10 @@ export function useAxisLock(active: boolean, onLockChange?: () => void) {
   }, [])
 
   const cycleLock = useCallback(() => {
-    lockModeRef.current = cycleLockMode(lockModeRef.current)
-    onLockChangeRef.current?.()
+    setLock(cycleLockMode(lockModeRef.current))
   }, [])
 
-  return { lockModeRef, applyLock, cycleLock }
+  return { lockModeRef, lockMode, applyLock, cycleLock, reset }
 }
 
 /** Cycles through lock modes: none → x → y → none */

--- a/src/sketch/useAxisLock.ts
+++ b/src/sketch/useAxisLock.ts
@@ -71,7 +71,12 @@ export function useAxisLock(active: boolean, onLockChange?: () => void) {
     return point
   }, [])
 
-  return { lockModeRef, applyLock }
+  const cycleLock = useCallback(() => {
+    lockModeRef.current = cycleLockMode(lockModeRef.current)
+    onLockChangeRef.current?.()
+  }, [])
+
+  return { lockModeRef, applyLock, cycleLock }
 }
 
 /** Cycles through lock modes: none → x → y → none */

--- a/src/sketch/useCanvasGestures.ts
+++ b/src/sketch/useCanvasGestures.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type { SketchViewState } from '../components/canvas/viewTransform'
+
+interface GestureCallbacks {
+  getCanvas: () => HTMLCanvasElement | null
+  getViewState: () => SketchViewState
+  setViewState: (updater: (prev: SketchViewState) => SketchViewState) => void
+  getBaseTransform: () => { scale: number; offsetX: number; offsetY: number }
+  canvasToWorld: (cx: number, cy: number) => { x: number; y: number }
+  minZoom: number
+}
+
+interface Pointer {
+  x: number
+  y: number
+}
+
+export function useCanvasGestures(callbacks: GestureCallbacks) {
+  const callbacksRef = useRef(callbacks)
+  useEffect(() => { callbacksRef.current = callbacks })
+
+  const pointersRef = useRef<Map<number, Pointer>>(new Map())
+  const gestureActiveRef = useRef(false)
+  const prevDistRef = useRef(0)
+  const prevCenterRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+
+  const handlePointerDown = useCallback((e: PointerEvent) => {
+    if (e.pointerType !== 'touch') return
+
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY })
+
+    if (pointersRef.current.size === 2) {
+      gestureActiveRef.current = true
+      const [a, b] = [...pointersRef.current.values()]
+      prevDistRef.current = Math.hypot(b.x - a.x, b.y - a.y)
+      prevCenterRef.current = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 }
+    }
+  }, [])
+
+  const handlePointerMove = useCallback((e: PointerEvent) => {
+    if (e.pointerType !== 'touch') return
+    if (!pointersRef.current.has(e.pointerId)) return
+
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY })
+
+    if (pointersRef.current.size < 2 || !gestureActiveRef.current) return
+
+    const [a, b] = [...pointersRef.current.values()]
+    const dist = Math.hypot(b.x - a.x, b.y - a.y)
+    const center = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 }
+
+    const { getCanvas, getViewState, setViewState, getBaseTransform, canvasToWorld, minZoom } = callbacksRef.current
+    const canvas = getCanvas()
+    if (!canvas) return
+
+    const rect = canvas.getBoundingClientRect()
+    const canvasCenter = { cx: center.x - rect.left, cy: center.y - rect.top }
+
+    const panDx = center.x - prevCenterRef.current.x
+    const panDy = center.y - prevCenterRef.current.y
+
+    if (prevDistRef.current > 0 && dist > 0) {
+      const zoomFactor = dist / prevDistRef.current
+      const viewState = getViewState()
+      const base = getBaseTransform()
+      const worldBefore = canvasToWorld(canvasCenter.cx, canvasCenter.cy)
+      const nextZoom = Math.max(minZoom, viewState.zoom * zoomFactor)
+      const nextScale = base.scale * nextZoom
+
+      setViewState(() => ({
+        zoom: nextZoom,
+        panX: canvasCenter.cx - base.offsetX - worldBefore.x * nextScale + panDx,
+        panY: canvasCenter.cy - base.offsetY - worldBefore.y * nextScale + panDy,
+      }))
+    } else {
+      setViewState((prev) => ({
+        ...prev,
+        panX: prev.panX + panDx,
+        panY: prev.panY + panDy,
+      }))
+    }
+
+    prevDistRef.current = dist
+    prevCenterRef.current = center
+  }, [])
+
+  const handlePointerUp = useCallback((e: PointerEvent) => {
+    if (e.pointerType !== 'touch') return
+    pointersRef.current.delete(e.pointerId)
+    if (pointersRef.current.size < 2) {
+      gestureActiveRef.current = false
+      prevDistRef.current = 0
+    }
+  }, [])
+
+  useEffect(() => {
+    const canvas = callbacksRef.current.getCanvas()
+    if (!canvas) return
+
+    canvas.addEventListener('pointerdown', handlePointerDown)
+    canvas.addEventListener('pointermove', handlePointerMove)
+    canvas.addEventListener('pointerup', handlePointerUp)
+    canvas.addEventListener('pointercancel', handlePointerUp)
+
+    return () => {
+      canvas.removeEventListener('pointerdown', handlePointerDown)
+      canvas.removeEventListener('pointermove', handlePointerMove)
+      canvas.removeEventListener('pointerup', handlePointerUp)
+      canvas.removeEventListener('pointercancel', handlePointerUp)
+    }
+  }, [handlePointerDown, handlePointerMove, handlePointerUp])
+
+  return { isGestureActive: gestureActiveRef }
+}

--- a/src/styles/canvas-workflow.css
+++ b/src/styles/canvas-workflow.css
@@ -17,7 +17,7 @@
 .canvas-workflow-panel {
   position: absolute;
   z-index: 26;
-  width: min(300px, calc(100% - 24px));
+  width: min(340px, calc(100% - 24px));
   border: 1px solid rgba(200, 156, 98, 0.7);
   border-radius: 8px;
   background:
@@ -133,4 +133,10 @@
 .canvas-workflow-panel__actions {
   justify-content: flex-end;
   padding: 0 12px 12px;
+}
+
+.canvas-workflow-panel__actions .tablet-cmd-btn {
+  height: 34px;
+  padding: 0 10px;
+  font-size: 12px;
 }

--- a/src/styles/canvas-workflow.css
+++ b/src/styles/canvas-workflow.css
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.canvas-workflow-panel {
+  position: absolute;
+  z-index: 26;
+  width: min(300px, calc(100% - 24px));
+  border: 1px solid rgba(200, 156, 98, 0.7);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(29, 35, 38, 0.96), rgba(15, 21, 27, 0.94));
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.38);
+  color: var(--text);
+  overflow: hidden;
+  pointer-events: auto;
+}
+
+.canvas-workflow-panel__handle {
+  display: grid;
+  grid-template-columns: 18px auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 0 12px;
+  border-bottom: 1px solid rgba(200, 156, 98, 0.24);
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+
+.canvas-workflow-panel__handle:active {
+  cursor: grabbing;
+}
+
+.canvas-workflow-panel__grip {
+  width: 14px;
+  height: 18px;
+  opacity: 0.72;
+  background-image:
+    radial-gradient(circle, var(--text-dim) 1.5px, transparent 2px),
+    radial-gradient(circle, var(--text-dim) 1.5px, transparent 2px);
+  background-position: 0 0, 7px 0;
+  background-size: 7px 7px;
+}
+
+.canvas-workflow-panel__title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--accent-strong);
+}
+
+.canvas-workflow-panel__body {
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+}
+
+.canvas-workflow-panel__step {
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.canvas-workflow-panel__summary {
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.canvas-workflow-panel__meta,
+.canvas-workflow-panel__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.canvas-workflow-panel__check {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 32px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.canvas-workflow-panel__field {
+  display: grid;
+  grid-template-columns: max-content minmax(72px, 1fr);
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 32px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.canvas-workflow-panel__check input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+}
+
+.canvas-workflow-panel__count-input {
+  width: 80px;
+  height: 32px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: #0f1820;
+  color: var(--text);
+  padding: 0 8px;
+  outline: none;
+  font-size: 13px;
+}
+
+.canvas-workflow-panel__count-input:focus {
+  border-color: var(--accent);
+}
+
+.canvas-workflow-panel__actions {
+  justify-content: flex-end;
+  padding: 0 12px 12px;
+}

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -500,3 +500,73 @@
     padding-top: 16px;
   }
 }
+
+/* ── Tablet touch targets for dialogs ──────────────────── */
+
+[data-shell-mode="tablet"] .import-dialog__info-row,
+[data-shell-mode="tablet-compact"] .import-dialog__info-row {
+  min-height: 44px;
+}
+
+[data-shell-mode="tablet"] .import-dialog__info-row select,
+[data-shell-mode="tablet"] .import-dialog__info-row input[type="number"],
+[data-shell-mode="tablet-compact"] .import-dialog__info-row select,
+[data-shell-mode="tablet-compact"] .import-dialog__info-row input[type="number"] {
+  height: 44px;
+  font-size: 16px;
+}
+
+[data-shell-mode="tablet"] .import-dialog__toggle-row,
+[data-shell-mode="tablet-compact"] .import-dialog__toggle-row {
+  min-height: 44px;
+}
+
+[data-shell-mode="tablet"] .import-dialog__toggle-input,
+[data-shell-mode="tablet-compact"] .import-dialog__toggle-input {
+  width: 22px;
+  height: 22px;
+}
+
+[data-shell-mode="tablet"] .import-dialog__layer-row,
+[data-shell-mode="tablet-compact"] .import-dialog__layer-row {
+  min-height: 44px;
+  padding: 8px 10px;
+}
+
+[data-shell-mode="tablet"] .import-dialog__layer-row input[type="checkbox"],
+[data-shell-mode="tablet-compact"] .import-dialog__layer-row input[type="checkbox"] {
+  width: 22px;
+  height: 22px;
+}
+
+[data-shell-mode="tablet"] .export-option input,
+[data-shell-mode="tablet-compact"] .export-option input {
+  width: 22px;
+  height: 22px;
+}
+
+[data-shell-mode="tablet"] .export-option,
+[data-shell-mode="tablet-compact"] .export-option {
+  min-height: 44px;
+}
+
+[data-shell-mode="tablet"] .feat-btn,
+[data-shell-mode="tablet-compact"] .feat-btn {
+  height: 38px;
+  font-size: 13px;
+}
+
+[data-shell-mode="tablet"] .dialog input,
+[data-shell-mode="tablet"] .dialog select,
+[data-shell-mode="tablet"] .dialog textarea,
+[data-shell-mode="tablet-compact"] .dialog input,
+[data-shell-mode="tablet-compact"] .dialog select,
+[data-shell-mode="tablet-compact"] .dialog textarea {
+  min-height: 44px;
+  font-size: 16px;
+}
+
+[data-shell-mode="tablet"] .dialog button,
+[data-shell-mode="tablet-compact"] .dialog button {
+  min-height: 38px;
+}

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -38,6 +38,14 @@
   overflow: hidden;
 }
 
+.dialog--no-clip {
+  overflow: visible;
+}
+
+.dialog--no-clip .dialog-body {
+  overflow: visible;
+}
+
 .dialog--import {
   max-width: 480px;
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -50,6 +50,14 @@
   padding: 6px 10px;
 }
 
+.app-toolbar--tablet {
+  padding: 4px 8px;
+  gap: 0;
+  overflow: visible;
+  position: relative;
+  z-index: 20;
+}
+
 .toolbar {
   display: flex;
   flex-wrap: wrap;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1218,104 +1218,11 @@
   cursor: copy;
 }
 
-.sketch-edit-banner {
-  position: absolute;
-  top: 12px;
-  left: 12px;
-  z-index: 4;
-  background: rgba(17, 24, 32, 0.92);
-  border: 1px solid var(--accent);
-  color: #f5d9b5;
-  border-radius: 8px;
-  padding: 8px 10px;
-  font-size: 12px;
-}
-
 .sketch-banner-warning {
   margin-top: 6px;
   color: #f7b86a;
 }
 
-.sketch-edit-banner kbd,
-.sketch-place-banner kbd {
-  border: 1px solid var(--line-strong);
-  border-bottom-width: 2px;
-  border-radius: 4px;
-  padding: 1px 4px;
-  background: #0f161f;
-}
-
-.sketch-kbd-btn {
-  cursor: pointer;
-  user-select: none;
-}
-
-.sketch-kbd-btn:hover {
-  border-color: var(--accent);
-  color: var(--accent-strong);
-}
-
-@media (pointer: coarse) {
-  .sketch-kbd-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: var(--touch-target, 44px);
-    min-height: var(--touch-target, 44px);
-    padding: 0 10px;
-    font-size: 13px;
-    border-radius: 6px;
-    vertical-align: middle;
-  }
-}
-
-.sketch-place-banner {
-  position: absolute;
-  bottom: 12px;
-  left: 12px;
-  z-index: 4;
-  background: rgba(26, 21, 14, 0.92);
-  border: 1px solid #c89c62;
-  color: #f0d3af;
-  border-radius: 8px;
-  padding: 8px 10px;
-  font-size: 12px;
-  line-height: 1.2;
-  display: inline-flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 0;
-}
-
-.sketch-place-toggle {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 6px;
-  margin: 0 10px 0 8px;
-  color: #f0d3af;
-  white-space: nowrap;
-}
-
-.sketch-place-toggle input {
-  margin: 0;
-  position: relative;
-  top: 1px;
-}
-
-.sketch-place-count {
-  width: 56px;
-  height: 28px;
-  border: 1px solid var(--line-strong);
-  border-radius: 6px;
-  background: #0f1820;
-  color: var(--text);
-  padding: 0 8px;
-  outline: none;
-}
-
-.sketch-place-count:focus {
-  border-color: var(--accent);
-}
 
 .sketch-depth-legend {
   position: absolute;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -581,6 +581,7 @@
 
 .simulation-viewport {
   position: relative;
+  width: 100%;
   height: 100%;
   background:
     radial-gradient(circle at top left, rgba(120, 170, 255, 0.08), transparent 34%),
@@ -1769,6 +1770,8 @@
   height: 32px;
   padding: 0 8px;
   min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .properties-field select {
@@ -2024,7 +2027,7 @@
   line-height: 1.45;
 }
 
-@media (max-width: 1180px) {
+@media (max-width: 399px) {
   .properties-field {
     grid-template-columns: 1fr;
     align-items: stretch;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1189,6 +1189,22 @@
   touch-action: none;
 }
 
+.axis-lock-chip {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  z-index: 20;
+  padding: 2px 10px;
+  border: 1px solid;
+  border-radius: 4px;
+  background: rgba(15, 21, 27, 0.85);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  pointer-events: auto;
+  line-height: 22px;
+}
+
 .sketch-canvas--placing {
   cursor: copy;
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1186,6 +1186,7 @@
   display: block;
   cursor: crosshair;
   outline: none;
+  touch-action: none;
 }
 
 .sketch-canvas--placing {

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -343,3 +343,77 @@
   color: orange;
   font-family: monospace;
 }
+
+/* ── Floating tablet command bar ────────────────────────── */
+
+.tablet-command-bar {
+  display: none;
+}
+
+[data-shell-mode="tablet"] .tablet-command-bar,
+[data-shell-mode="tablet-compact"] .tablet-command-bar {
+  display: flex;
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  z-index: 20;
+  gap: 6px;
+  padding: 6px;
+  border-radius: 10px;
+  background: rgba(16, 24, 33, 0.88);
+  border: 1px solid var(--line);
+  backdrop-filter: blur(8px);
+  pointer-events: auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  max-width: 320px;
+}
+
+.tablet-cmd-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  height: 40px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--bg-elev-1);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.tablet-cmd-btn:active {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.tablet-cmd-btn--active {
+  background: rgba(220, 165, 106, 0.18);
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.tablet-cmd-btn--confirm {
+  background: rgba(60, 180, 60, 0.15);
+  border-color: rgba(60, 180, 60, 0.4);
+  color: #7ddf7d;
+}
+
+.tablet-cmd-btn--cancel {
+  background: rgba(220, 60, 60, 0.12);
+  border-color: rgba(220, 60, 60, 0.35);
+  color: #df8080;
+}
+
+.tablet-cmd-btn:disabled {
+  cursor: default;
+  opacity: 0.52;
+}
+
+.tablet-cmd-btn--active:disabled {
+  opacity: 1;
+}

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -76,13 +76,11 @@
   .app-body--toolbar-left,
   .app-body--lcr,
   .app-body--cr {
-    grid-template-columns: minmax(200px, 20%) minmax(0, 1fr) !important;
     grid-template-areas: 'left centre' !important;
   }
 
   .app-body--lc,
   .app-body--toolbar-left.app-body--lc {
-    grid-template-columns: minmax(200px, 20%) minmax(0, 1fr) !important;
     grid-template-areas: 'left centre' !important;
   }
 
@@ -98,14 +96,22 @@
   }
 }
 
-/* Hide the drawer toggle on desktop */
-.tablet-drawer-toggle {
+/* Also support the JS-driven shell mode attribute */
+[data-shell-mode="tablet"] .tablet-drawer-toggle,
+[data-shell-mode="tablet-compact"] .tablet-drawer-toggle {
+  display: inline-flex;
+}
+
+/* Hide the drawer toggle on desktop — must come before the tablet
+   overrides or use lower specificity so they can win. Using :where()
+   gives specificity 0 so the tablet rules always take precedence. */
+:where(.app-shell) .tablet-drawer-toggle {
   display: none;
 }
 
 /* Scrim is only rendered by React when the drawer is open, but ensure
    it never shows on desktop even if the component renders it */
-.tablet-drawer-scrim {
+:where(.app-shell) .tablet-drawer-scrim {
   display: none;
 }
 
@@ -113,6 +119,11 @@
   .tablet-drawer-scrim {
     display: block;
   }
+}
+
+[data-shell-mode="tablet"] .tablet-drawer-scrim,
+[data-shell-mode="tablet-compact"] .tablet-drawer-scrim {
+  display: block;
 }
 
 /* ── Touch targets: toolbar ───────────────────────────────── */
@@ -221,6 +232,66 @@
   }
 }
 
+/* ── Shell-mode attribute selectors for drawer layout ────── */
+
+[data-shell-mode="tablet"] .panel-right,
+[data-shell-mode="tablet-compact"] .panel-right {
+  position: fixed;
+  inset: 0 0 0 auto;
+  z-index: 50;
+  width: min(340px, 88vw);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elev-1);
+  border-left: 1px solid var(--line);
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.45);
+  transform: translateX(100%);
+  transition: transform 0.22s ease;
+  grid-area: unset;
+}
+
+[data-shell-mode="tablet"] .app-shell[data-right-open="true"] .panel-right,
+[data-shell-mode="tablet-compact"] .app-shell[data-right-open="true"] .panel-right {
+  transform: translateX(0);
+}
+
+/* Also allow data-right-open on the shell itself (the attribute IS on .app-shell) */
+.app-shell[data-shell-mode="tablet"][data-right-open="true"] .panel-right,
+.app-shell[data-shell-mode="tablet-compact"][data-right-open="true"] .panel-right {
+  transform: translateX(0);
+}
+
+[data-shell-mode="tablet"] .app-body,
+[data-shell-mode="tablet"] .app-body--toolbar-left,
+[data-shell-mode="tablet"] .app-body--lcr,
+[data-shell-mode="tablet"] .app-body--cr,
+[data-shell-mode="tablet-compact"] .app-body,
+[data-shell-mode="tablet-compact"] .app-body--toolbar-left,
+[data-shell-mode="tablet-compact"] .app-body--lcr,
+[data-shell-mode="tablet-compact"] .app-body--cr {
+  grid-template-areas: 'left centre' !important;
+}
+
+[data-shell-mode="tablet"] .app-body--c,
+[data-shell-mode="tablet-compact"] .app-body--c {
+  grid-template-columns: minmax(0, 1fr) !important;
+  grid-template-areas: 'centre' !important;
+}
+
+[data-shell-mode="tablet"] .panel-left .panel-resize-divider,
+[data-shell-mode="tablet-compact"] .panel-left .panel-resize-divider {
+  right: -20px;
+  width: 28px;
+}
+
+[data-shell-mode="tablet"] .panel-split__divider,
+[data-shell-mode="tablet-compact"] .panel-split__divider {
+  min-height: 28px;
+  margin: -10px 0;
+  position: relative;
+  z-index: 10;
+}
+
 /* ── Drawer close button ─────────────────────────────────── */
 
 .tablet-drawer-close {
@@ -245,4 +316,30 @@
   .tablet-drawer-close:hover {
     color: var(--text);
   }
+}
+
+[data-shell-mode="tablet"] .tablet-drawer-close,
+[data-shell-mode="tablet-compact"] .tablet-drawer-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--touch-target, 44px);
+  height: var(--touch-target, 44px);
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+/* ── Dev mode shell badge ──────────────────────────────── */
+
+.statusbar-shell-mode {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(255, 165, 0, 0.2);
+  color: orange;
+  font-family: monospace;
 }

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -164,6 +164,7 @@
     height: var(--touch-target, 44px);
     min-width: var(--touch-target, 44px);
     min-height: var(--touch-target, 44px);
+    font-size: 22px;
   }
 
   .tree-action-btn .icon-sprite {
@@ -190,6 +191,15 @@
   .properties-field button:not(.tree-action-btn) {
     height: var(--touch-target, 44px);
   }
+
+}
+
+
+/* ── Tablet shell: tree button font size ───────────────── */
+
+[data-shell-mode="tablet"] .tree-action-btn,
+[data-shell-mode="tablet-compact"] .tree-action-btn {
+  font-size: 22px;
 }
 
 /* ── Touch targets: CAM buttons ─────────────────────────── */
@@ -941,3 +951,233 @@
 [data-shell-mode="tablet-compact"] .centre-workspace {
   grid-template-rows: 1fr;
 }
+
+/* ── Drag grip handle (tablet only) ──────────────────────── */
+
+.tree-drag-grip {
+  display: none;
+}
+
+[data-shell-mode="tablet"] .tree-row:has(.tree-drag-grip),
+[data-shell-mode="tablet-compact"] .tree-row:has(.tree-drag-grip) {
+  grid-template-columns: 36px minmax(0, 1fr) auto;
+  gap: 4px;
+  padding-left: 0 !important;
+}
+
+[data-shell-mode="tablet"] .tree-row:has(.tree-drag-grip) .tree-branch,
+[data-shell-mode="tablet-compact"] .tree-row:has(.tree-drag-grip) .tree-branch {
+  display: none;
+}
+
+[data-shell-mode="tablet"] .tree-drag-grip,
+[data-shell-mode="tablet-compact"] .tree-drag-grip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 36px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: grab;
+  touch-action: none;
+  opacity: 0.6;
+  padding: 0;
+}
+
+[data-shell-mode="tablet"] .tree-drag-grip:active,
+[data-shell-mode="tablet-compact"] .tree-drag-grip:active {
+  cursor: grabbing;
+  opacity: 1;
+  color: var(--text);
+}
+
+/* ── Status bar compact mode (tablet) ────────────────────── */
+
+.statusbar-expand-btn {
+  display: none;
+}
+
+.app-statusbar--tablet-compact,
+.app-statusbar--tablet-expanded {
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+
+.app-statusbar--tablet-compact {
+  max-height: 28px;
+  min-height: 28px;
+  padding: 4px 14px;
+  gap: 8px;
+  font-size: 11px;
+}
+
+.app-statusbar--tablet-expanded {
+  flex-wrap: wrap;
+}
+
+.app-statusbar--tablet-compact .statusbar-expand-btn,
+.app-statusbar--tablet-expanded .statusbar-expand-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 20px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 10px;
+  flex-shrink: 0;
+}
+
+.statusbar-expand-btn:active {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.statusbar-visibility--hidden {
+  display: none;
+}
+
+/* ── Operations drawer polish ────────────────────────────── */
+
+[data-shell-mode="tablet"] .cam-section-header,
+[data-shell-mode="tablet-compact"] .cam-section-header {
+  min-height: 44px;
+  padding: 0 10px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+[data-shell-mode="tablet"] .cam-section-header .feature-count,
+[data-shell-mode="tablet-compact"] .cam-section-header .feature-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 11px;
+  background: rgba(220, 165, 106, 0.2);
+  color: var(--accent-strong);
+  font-size: 11px;
+  font-weight: 700;
+  margin-left: 6px;
+}
+
+[data-shell-mode="tablet"] .cam-section-toolbar,
+[data-shell-mode="tablet-compact"] .cam-section-toolbar {
+  min-height: 44px;
+}
+
+[data-shell-mode="tablet"] .cam-header-action,
+[data-shell-mode="tablet-compact"] .cam-header-action {
+  min-height: 38px;
+  padding: 0 14px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 8px;
+}
+
+[data-shell-mode="tablet"] .cam-operation-tree .tree-row:has(.tree-drag-grip),
+[data-shell-mode="tablet-compact"] .cam-operation-tree .tree-row:has(.tree-drag-grip) {
+  grid-template-columns: 36px minmax(0, 1fr) auto;
+  gap: 4px;
+  padding-left: 0 !important;
+}
+
+[data-shell-mode="tablet"] .cam-operation-tree .tree-row:has(.tree-drag-grip) .tree-branch,
+[data-shell-mode="tablet-compact"] .cam-operation-tree .tree-row:has(.tree-drag-grip) .tree-branch {
+  display: none;
+}
+
+[data-shell-mode="tablet"] .cam-operation-badge,
+[data-shell-mode="tablet-compact"] .cam-operation-badge {
+  padding: 2px 8px;
+  font-size: 11px;
+  border-radius: 4px;
+}
+
+/* Warning messages in the operations panel */
+[data-shell-mode="tablet"] .cam-field-message,
+[data-shell-mode="tablet-compact"] .cam-field-message {
+  font-size: 12px;
+  padding: 8px 10px;
+}
+
+/* ── Dialog audit: touch-friendly dialogs ────────────────── */
+
+@media (pointer: coarse) {
+  .dialog {
+    max-width: min(560px, 92vw);
+    max-height: 88vh;
+    overflow-y: auto;
+  }
+
+  .dialog input,
+  .dialog select,
+  .dialog textarea {
+    min-height: 44px;
+    font-size: 16px;
+  }
+
+  .dialog button {
+    min-height: 44px;
+    padding: 0 16px;
+  }
+
+  .dialog-header {
+    min-height: 48px;
+    padding: 0 16px;
+    font-size: 16px;
+  }
+
+  .dialog-footer {
+    padding: 12px 16px;
+    gap: 10px;
+  }
+
+  .dialog-footer button {
+    flex: 1;
+    min-height: 48px;
+  }
+
+  .import-dialog-body {
+    flex-direction: column;
+    overflow-y: auto;
+  }
+
+  .import-dialog-layers {
+    max-height: 200px;
+    overflow-y: auto;
+  }
+}
+
+/* ── Tablet portrait rotate overlay ─────────────────────── */
+
+.tablet-rotate-overlay {
+  display: none;
+}
+
+@media (orientation: portrait) {
+  [data-shell-mode="tablet"] > .tablet-rotate-overlay,
+  [data-shell-mode="tablet-compact"] > .tablet-rotate-overlay {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    position: fixed;
+    inset: 0;
+    z-index: 99999;
+    background: #0b1219;
+    color: var(--text-dim);
+    font-size: 18px;
+    text-align: center;
+    padding: 32px;
+  }
+}
+

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -57,10 +57,12 @@
     transition: transform 0.22s ease;
     /* Override the grid-area assignment from the narrow desktop breakpoint */
     grid-area: unset;
+    pointer-events: none;
   }
 
   .app-shell[data-right-open="true"] .panel-right {
     transform: translateX(0);
+    pointer-events: auto;
   }
 
   /* Scrim behind the open drawer */
@@ -247,18 +249,19 @@
   box-shadow: -8px 0 32px rgba(0, 0, 0, 0.45);
   transform: translateX(100%);
   transition: transform 0.22s ease;
-  grid-area: unset;
+  pointer-events: none;
 }
 
 [data-shell-mode="tablet"] .app-shell[data-right-open="true"] .panel-right,
 [data-shell-mode="tablet-compact"] .app-shell[data-right-open="true"] .panel-right {
   transform: translateX(0);
+  pointer-events: auto;
 }
 
-/* Also allow data-right-open on the shell itself (the attribute IS on .app-shell) */
 .app-shell[data-shell-mode="tablet"][data-right-open="true"] .panel-right,
 .app-shell[data-shell-mode="tablet-compact"][data-right-open="true"] .panel-right {
   transform: translateX(0);
+  pointer-events: auto;
 }
 
 [data-shell-mode="tablet"] .app-body,
@@ -278,10 +281,10 @@
   grid-template-areas: 'centre' !important;
 }
 
-[data-shell-mode="tablet"] .panel-left .panel-resize-divider,
-[data-shell-mode="tablet-compact"] .panel-left .panel-resize-divider {
-  right: -20px;
-  width: 28px;
+/* Hide all panel resize dividers on tablet — panels are drawers now */
+[data-shell-mode="tablet"] .panel-resize-divider,
+[data-shell-mode="tablet-compact"] .panel-resize-divider {
+  display: none;
 }
 
 [data-shell-mode="tablet"] .panel-split__divider,
@@ -342,6 +345,7 @@
   background: rgba(255, 165, 0, 0.2);
   color: orange;
   font-family: monospace;
+  margin-left: auto;
 }
 
 /* ── Floating tablet command bar ────────────────────────── */
@@ -416,4 +420,524 @@
 
 .tablet-cmd-btn--active:disabled {
   opacity: 1;
+}
+
+/* ── Top Command Bar (tablet) ──────────────────────────── */
+
+.top-command-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 48px;
+  padding: 4px 8px;
+}
+
+.top-command-bar__left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.top-command-bar__project {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.top-command-bar__name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 6px;
+  height: 36px;
+  border-radius: 6px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+}
+
+.top-command-bar__name:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.top-command-bar__save-state {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.top-command-bar__save-state--dirty {
+  color: var(--accent);
+}
+
+.top-command-bar__center {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  justify-content: center;
+  min-width: 0;
+}
+
+.top-command-bar__right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.top-cmd-group {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.top-cmd-group--tabs {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 8px;
+  padding: 2px;
+}
+
+.top-cmd-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.top-cmd-btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+}
+
+.top-cmd-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.top-cmd-btn--active {
+  background: rgba(220, 165, 106, 0.25);
+  color: var(--accent-strong);
+  box-shadow: inset 0 0 0 1.5px var(--accent);
+}
+
+.top-cmd-btn--emphasized {
+  color: var(--accent);
+}
+
+.top-cmd-btn--operations {
+  width: auto;
+  padding: 0 12px;
+  font-size: 12px;
+  font-weight: 600;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+.top-cmd-btn .icon-sprite {
+  width: 20px;
+  height: 20px;
+}
+
+.top-cmd-tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 34px;
+  padding: 0 12px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.top-cmd-tab:hover {
+  color: var(--text);
+}
+
+.top-cmd-tab--active {
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--text);
+  box-shadow: inset 0 0 0 1.5px rgba(255, 255, 255, 0.25);
+}
+
+/* ── Tool Rail (tablet) ────────────────────────────────── */
+
+.tool-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 48px;
+  padding: 4px 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: none;
+}
+
+.tool-rail::-webkit-scrollbar {
+  display: none;
+}
+
+.tool-rail__section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  width: 100%;
+}
+
+.tool-rail__section:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.tool-rail__action {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tool-rail__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.tool-rail__btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+}
+
+.tool-rail__btn--active {
+  background: rgba(220, 165, 106, 0.28);
+  color: var(--accent-strong);
+  box-shadow: inset 0 0 0 1.5px var(--accent);
+}
+
+.tool-rail__btn--live {
+  box-shadow: inset 0 0 0 1.5px var(--accent);
+}
+
+.tool-rail__btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.tool-rail__btn .icon-sprite {
+  width: 20px;
+  height: 20px;
+}
+
+.tool-rail__tooltip {
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: 8px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: var(--bg-elev-3);
+  color: var(--text);
+  font-size: 11px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 100;
+}
+
+.tool-rail__action:hover .tool-rail__tooltip {
+  opacity: 1;
+}
+
+.tool-rail__target-toggle {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.tool-rail__target-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 34px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.tool-rail__target-btn--active {
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--text);
+  box-shadow: inset 0 0 0 1.5px rgba(255, 255, 255, 0.3);
+}
+
+.tool-rail__target-btn--region.tool-rail__target-btn--active {
+  background: rgba(100, 180, 255, 0.2);
+  color: #7ec4ff;
+  box-shadow: inset 0 0 0 1.5px rgba(100, 180, 255, 0.4);
+}
+
+.tool-rail__target-btn .icon-sprite {
+  width: 18px;
+  height: 18px;
+}
+
+.tool-rail__popover {
+  position: absolute;
+  left: 100%;
+  top: 0;
+  margin-left: 6px;
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: 2px;
+  padding: 6px;
+  border-radius: 8px;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--line);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  z-index: 100;
+}
+
+.tool-rail__popover button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.tool-rail__popover button:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+}
+
+.tool-rail__popover button .icon-sprite {
+  width: 20px;
+  height: 20px;
+}
+
+/* ── Snap Popover ──────────────────────────────────────── */
+
+.snap-popover-host {
+  position: relative;
+  display: flex;
+  align-items: center;
+  z-index: 60;
+}
+
+.snap-popover-badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  border-radius: 7px;
+  background: var(--accent);
+  color: #1a1a1a;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 14px;
+  text-align: center;
+  pointer-events: none;
+}
+
+.snap-popover {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 6px;
+  padding: 8px;
+  border-radius: 10px;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--line);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  z-index: 100;
+  min-width: 180px;
+}
+
+.snap-popover-header {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 8px;
+}
+
+.snap-popover-enable-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 30px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  width: 100%;
+}
+
+.snap-popover-enable-btn--active {
+  background: rgba(60, 180, 60, 0.12);
+  border-color: rgba(60, 180, 60, 0.4);
+  color: #7ddf7d;
+}
+
+.snap-popover-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+}
+
+.snap-popover-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 38px;
+  padding: 0 8px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 11px;
+  white-space: nowrap;
+  transition: color 0.1s, background 0.1s;
+}
+
+.snap-popover-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+}
+
+.snap-popover-item--active,
+.snap-popover-item--active:hover {
+  background: rgba(220, 165, 106, 0.18);
+  color: var(--accent-strong);
+}
+
+.snap-popover-item--live {
+  box-shadow: inset 0 0 0 1.5px var(--accent);
+}
+
+.snap-popover-item .icon-sprite {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.snap-popover-item-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Left drawer (tablet) ──────────────────────────────── */
+
+[data-shell-mode="tablet"] .panel-left,
+[data-shell-mode="tablet-compact"] .panel-left {
+  position: fixed;
+  inset: 0 auto 0 0;
+  z-index: 50;
+  width: min(300px, 85vw);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elev-1);
+  border-right: 1px solid var(--line);
+  box-shadow: 8px 0 32px rgba(0, 0, 0, 0.45);
+  transform: translateX(-100%);
+  transition: transform 0.22s ease;
+  pointer-events: none;
+}
+
+.app-shell[data-shell-mode="tablet"][data-left-open="true"] .panel-left,
+.app-shell[data-shell-mode="tablet-compact"][data-left-open="true"] .panel-left {
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+/* Tablet body: tool rail + centre only */
+[data-shell-mode="tablet"] .app-body--tablet,
+[data-shell-mode="tablet-compact"] .app-body--tablet {
+  grid-template-columns: 48px minmax(0, 1fr) !important;
+  grid-template-rows: 1fr !important;
+  gap: 0 !important;
+  padding: 0 !important;
+}
+
+.app-left-rail--tablet {
+  width: 48px;
+  display: flex;
+  flex-direction: column;
+  align-content: start;
+  border-right: 1px solid var(--line);
+  background: color-mix(in oklab, var(--bg-elev-1) 80%, black);
+  overflow: hidden;
+  min-height: 0;
+}
+
+
+/* Left drawer close button visibility */
+.tablet-drawer-close--left {
+  display: none;
+}
+
+[data-shell-mode="tablet"] .tablet-drawer-close--left,
+[data-shell-mode="tablet-compact"] .tablet-drawer-close--left {
+  display: inline-flex;
+}
+
+/* Hide centre workspace tabs header on tablet (view tabs are in the top command bar) */
+[data-shell-mode="tablet"] .centre-workspace > .panel-tabs-header,
+[data-shell-mode="tablet-compact"] .centre-workspace > .panel-tabs-header {
+  display: none;
+}
+
+/* With the tabs header hidden, the workspace grid (auto 1fr) would put the stage
+   in the auto row and collapse it.  Switch to a single-row stretch layout. */
+[data-shell-mode="tablet"] .centre-workspace,
+[data-shell-mode="tablet-compact"] .centre-workspace {
+  grid-template-rows: 1fr;
 }

--- a/src/utils/useRestoreCanvasFocus.ts
+++ b/src/utils/useRestoreCanvasFocus.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react'
+
+export function useRestoreCanvasFocus() {
+  useEffect(() => {
+    return () => {
+      const canvas = document.querySelector<HTMLElement>('.sketch-canvas')
+      canvas?.focus({ preventScroll: true })
+    }
+  }, [])
+}


### PR DESCRIPTION
## Summary

Complete tablet UX overhaul making the app fully usable on iPad-class tablets (10"+, landscape). This implements PRs 1–4 from the combined tablet UX plan plus final polish.

### PR 1 — Shell mode + drawer discoverability + pointer events
- **Shell mode system** (`useShellMode`): reactive `desktop-wide | desktop-compact | tablet | tablet-compact` detection via width + pointer/hover media queries; sets `data-shell-mode` attribute on app shell root
- **Pointer event migration**: `onMouseDown/Up/Leave` → `onPointerDown/Up/Leave` with `setPointerCapture` for touch drags
- **Touch panning**: single-finger drag on empty canvas pans; tap selects features
- **Pinch-to-zoom + two-finger pan** (`useCanvasGestures`): tracks active touch pointers, computes zoom/pan deltas
- **Long-press context menu**: 500ms hold opens context menu on touch
- **Operations drawer discoverability**: always-visible "Operations" opener with count badge, close/scrim/Escape behavior
- **CSS foundation**: `touch-action: none` on canvas, `data-shell-mode` attribute selectors alongside media query fallbacks

### PR 2 — Touch gestures + tablet command bar
- **Floating tablet command bar**: context-sensitive bottom-right buttons (Lock, Multi-select, Line/Arc/Spline mode, Undo point, Confirm, Cancel)
- **Multi-select mode**: toggle in command bar, taps act as Shift-click
- **Axis lock cycle button**: exposes `cycleLock` from `useAxisLock`, shows current mode with guide color
- **Tap-to-arm nodes**: in sketch edit, tap (no drag) sets `hoveredEditControl` for dimension entry

### PR 2.5 — Canvas workflow panels
- **Reusable `CanvasWorkflowPanel` component**: draggable handle, clamped inside canvas, works with mouse/touch/pen, returns focus to canvas after actions
- **`useCanvasWorkflowPanel` hook**: drag mechanics, focus handoff, transient state cleanup
- **Migrated workflows**: Cut → Join → Move/Copy → Rotate/Resize/Mirror → Offset → Composite/Polygon/Spline drawing → Sketch edit → Constraint creation → Text/Origin placement
- **Feature creation panels**: Rectangle (W×H), Circle (radius), Ellipse (radii), Polygon (sides/radius), Line/Arc/Spline (length/angle), Composite (mode-dependent dimension entry including arc radius via sagitta formula)
- **Edit mode panel**: Apply/Cancel, click-to-edit segment dimensions (length+angle for lines, radius for arcs)
- **Constraint panel**: three-phase workflow (pick anchor → pick reference → set distance)
- **Dialog focus restoration** (`useRestoreCanvasFocus`): New Project, Import, Export, Text dialogs return focus to canvas on close

### PR 3 — Toolbar split + left drawer
- **TopCommandBar**: single non-wrapping row with project name, file ops, undo/redo, view tabs, zoom, snap popover, Operations opener
- **ToolRail**: vertical left rail with creation tools (rect/circle/ellipse/polygon/spline/composite/text) + edit tools on selection (move/copy/rotate/resize/mirror/offset/fillet/join/cut)
- **SnapPopover**: replaces 7 persistent snap buttons with one toggle + popover grid of 6 snap modes
- **Left panel drawer**: mirrors right drawer pattern, slides in from left with close/scrim

### PR 4 — Reorder + 3D/sim gestures + dialog audit + polish
- **Feature tree reorder**: Move Up/Down buttons on feature and CAM operation rows in tablet mode
- **3D/Simulation touch gestures**: one-finger orbit, two-finger pan, pinch zoom in both viewports
- **Dialog audit**: all dialogs (New Project, Import, Export, Text) verified at 1024×768 with 44px touch targets, 22px checkboxes, 16px font inputs
- **Status bar compact mode**: single-line on tablet, tap to expand

### Final polish (this commit)
- **Last old-style banner → workflow panel**: text/origin placement converted from `sketch-place-banner` to `CanvasWorkflowPanel` with tablet-friendly "Tap the sketch" instruction
- **Styled dropdowns in TextToolDialog**: 3 native `<select>` → custom `Select` component matching PropertiesPanel, with `dialog--no-clip` CSS for dropdown visibility
- **Fix .camj file picker on tablets**: added `application/json` MIME type to accept attributes so Android/ChromeOS file pickers recognize .camj files
- **Dead CSS cleanup**: removed ~93 lines of unused banner/kbd CSS classes

## Files changed (34 files, +5928 / −1068)

**New files:** `useShellMode.ts`, `CanvasWorkflowPanel.tsx`, `useCanvasWorkflowPanel.ts`, `useCanvasGestures.ts`, `TopCommandBar.tsx`, `ToolRail.tsx`, `SnapPopover.tsx`, `useRestoreCanvasFocus.ts`, `manualEntry.ts`, `canvas-workflow.css`, `dialog.css`

**Major changes:** `SketchCanvas.tsx` (+1750/−722), `AppShell.tsx` (+240/−59), `tablet.css` (+900/−45), `FeatureTree.tsx` (+140/−33), `CAMPanel.tsx` (+50/−13)

## Test plan

- [x] iPad Safari: tap features to select, single-finger drag pans, pinch zooms
- [x] Operations button visible when drawer closed, opens/closes/reopens
- [x] Left drawer: toggle opens, close button and scrim dismiss
- [x] Tool rail: all creation and edit tools selectable
- [x] Snap popover: toggle + 6 modes visible, toggling works
- [x] Workflow panels for all creation types: rect, circle, ellipse, polygon, spline, composite, text, origin
- [x] Dimension entry via panel buttons (replaces Tab key)
- [x] Cut/Join/Move/Rotate/Resize/Mirror/Offset: workflow panels with step-by-step guidance
- [x] Edit mode: tap segment to edit dimensions, Apply/Cancel
- [x] Constraint creation: anchor → reference → distance panel flow
- [x] Text dialog: styled dropdowns open/close without clipping
- [x] .camj file selectable in Android/ChromeOS file picker
- [x] 3D view: one-finger orbit, two-finger pan, pinch zoom
- [x] Simulation view: same gestures
- [x] New Project / Import / Export dialogs: fit at 1024×768, touch-sized controls
- [x] Desktop: zero regression — existing toolbar, panels, keyboard shortcuts unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)