### PR TITLE
fix: edge route outside avoids cutting into other add features

### DIFF
--- a/src/engine/toolpaths/edge.ts
+++ b/src/engine/toolpaths/edge.ts
@@ -32,7 +32,7 @@ import {
 } from './geometry'
 import { isFeatureFirst, mergeToolpathResults, perFeatureOperations } from './multiFeature'
 import { buildInsetRegions, buildOuterContours, cutClosedContours, resolveBandBottomZ } from './pocket'
-import { buildRegionMask, clipToolpathResultToRegionMask, splitFeatureTargets } from './regions'
+import { buildMaskFromClipperPaths, buildRegionMask, clipToolpathResultToObstaclesByLevel, clipToolpathResultToRegionMask, splitFeatureTargets } from './regions'
 import { resolveInsideEdgeRegions } from './resolver'
 import { significantSilhouettePaths } from './silhouette'
 
@@ -245,13 +245,6 @@ function isEdgeRouteTargetFeature(feature: SketchFeature, operation: Operation):
   if (feature.operation === 'region') return true
   if (operation.kind === 'edge_route_inside') return feature.operation === 'subtract'
   return feature.operation === 'add' || feature.operation === 'model'
-}
-
-function resolveContourPaths(paths: ClipperPath[], offsetDistance: number): Point[][] {
-  const offset = offsetPaths(paths, offsetDistance * DEFAULT_CLIPPER_SCALE)
-  return offset
-    .map((entry) => fromClipperPath(entry))
-    .filter((points) => points.length >= 3)
 }
 
 function resolveEffectiveBottom(feature: SketchFeature, project: Project, operation: Operation): number | null {
@@ -502,6 +495,37 @@ function generateEdgeRouteToolpathSingle(project: Project, operation: Operation)
     }
   }
 
+  const targetFeatureIdSet = new Set(closedTargetFeatures.map((feature) => feature.id))
+  const allAdditiveObstacles = project.features
+    .flatMap((feature) => (feature.operation === 'model' ? [feature] : expandFeatureGeometry(feature)))
+    .filter((feature) => (feature.operation === 'add' || feature.operation === 'model') && featureHasClosedGeometry(feature))
+    .filter((feature) => !targetFeatureIdSet.has(feature.id))
+    .map((feature) => ({
+      paths: featureToClipperPaths(feature),
+      span: resolveFeatureZSpan(project, feature),
+    }))
+
+  const obstacleMaskCache = new Map<string, ReturnType<typeof buildMaskFromClipperPaths>>()
+  function obstacleMaskForZ(z: number) {
+    const key = z.toFixed(9)
+    const cached = obstacleMaskCache.get(key)
+    if (cached !== undefined) return cached
+    const activePaths = allAdditiveObstacles
+      .filter(({ span }) => z <= span.max && z >= span.min)
+      .flatMap(({ paths }) => paths)
+    let mask: ReturnType<typeof buildMaskFromClipperPaths> = null
+    if (activePaths.length > 0) {
+      mask = buildMaskFromClipperPaths(offsetPaths(activePaths, tool.radius * DEFAULT_CLIPPER_SCALE))
+    }
+    obstacleMaskCache.set(key, mask)
+    return mask
+  }
+
+  function resolveContourPaths(paths: ClipperPath[]): Point[][] {
+    const offset = offsetPaths(paths, offsetDistance * DEFAULT_CLIPPER_SCALE)
+    return offset.map((entry) => fromClipperPath(entry)).filter((points) => points.length >= 3)
+  }
+
   const shouldAttemptCombinedOutside = operation.kind === 'edge_route_outside' && routableTargets.length > 1
   if (shouldAttemptCombinedOutside) {
     const referenceTarget = routableTargets[0]
@@ -513,7 +537,6 @@ function generateEdgeRouteToolpathSingle(project: Project, operation: Operation)
     if (canCombineOutsideTargets) {
       const rawContours = resolveContourPaths(
         unionPaths(routableTargets.flatMap((target) => target.contourPaths)),
-        offsetDistance,
       )
 
       if (rawContours.length === 0) {
@@ -536,7 +559,7 @@ function generateEdgeRouteToolpathSingle(project: Project, operation: Operation)
 
   if (moves.length === 0) {
     for (const target of routableTargets) {
-      const rawContours = resolveContourPaths(target.contourPaths, offsetDistance)
+      const rawContours = resolveContourPaths(target.contourPaths)
       if (rawContours.length === 0) {
         warnings.push(`No valid contour could be generated for ${target.feature.name}`)
         continue
@@ -560,11 +583,14 @@ function generateEdgeRouteToolpathSingle(project: Project, operation: Operation)
     bounds = updateBounds(bounds, move.to)
   }
 
-  const result = {
+  let result: ToolpathResult = {
     operationId: operation.id,
     moves,
     warnings,
     bounds,
+  }
+  if (allAdditiveObstacles.length > 0) {
+    result = clipToolpathResultToObstaclesByLevel(project, result, obstacleMaskForZ)
   }
   return clipToolpathResultToRegionMask(project, result, regionMask)
 }

--- a/src/engine/toolpaths/regions.ts
+++ b/src/engine/toolpaths/regions.ts
@@ -103,6 +103,14 @@ export function buildRegionMask(regionFeatures: SketchFeature[]): RegionMask | n
   }
 }
 
+export function buildMaskFromClipperPaths(paths: ClipperPath[]): RegionMask | null {
+  if (paths.length === 0) return null
+  return {
+    paths,
+    containsPoint: (point) => pointInClipperPaths(point, paths),
+  }
+}
+
 export function featurePathToClipper(feature: SketchFeature): ClipperPath | null {
   if (!feature.sketch.profile.closed) return null
   const flattened = flattenProfile(feature.sketch.profile)
@@ -276,6 +284,59 @@ function computeBounds(moves: ToolpathMove[]): ToolpathBounds | null {
     bounds = updateBounds(bounds, move.to)
   }
   return bounds
+}
+
+export function clipToolpathResultToObstaclesByLevel(
+  project: Project,
+  result: ToolpathResult,
+  maskForZ: (z: number) => RegionMask | null,
+): ToolpathResult {
+  if (result.moves.length === 0) return result
+
+  const safeZ = getOperationSafeZ(project)
+  const clippedMoves: ToolpathMove[] = []
+  let current: ToolpathPoint | null = null
+  const cutMoves = result.moves.filter((move) => move.kind === 'cut')
+
+  for (const move of cutMoves) {
+    const mask = maskForZ(move.to.z)
+    if (!mask) {
+      current = pushSafeTransition(clippedMoves, current, move.from, safeZ)
+      clippedMoves.push(move)
+      current = move.to
+      continue
+    }
+
+    const inverseMask: RegionMask = {
+      paths: mask.paths,
+      containsPoint: (point) => !pointInClipperPaths(point, mask.paths),
+    }
+
+    const fragments = clipCutMoveToRegion(move, inverseMask)
+    for (const fragment of fragments) {
+      current = pushSafeTransition(clippedMoves, current, fragment.from, safeZ)
+      clippedMoves.push({
+        ...move,
+        from: fragment.from,
+        to: fragment.to,
+      })
+      current = fragment.to
+    }
+  }
+
+  if (current && Math.abs(current.z - safeZ) > 1e-9) {
+    clippedMoves.push({
+      kind: 'rapid',
+      from: current,
+      to: { x: current.x, y: current.y, z: safeZ },
+    })
+  }
+
+  return {
+    ...result,
+    moves: clippedMoves,
+    bounds: computeBounds(clippedMoves),
+  }
 }
 
 export function clipToolpathResultToRegionMask(

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -703,6 +703,69 @@ function testEdgeOutsideIgnoresTinyStoredModelSilhouetteArtifacts() {
 }
 
 // ---------------------------------------------------------------------------
+// Edge outside: obstacle avoidance — toolpath must not cut into other add features
+// ---------------------------------------------------------------------------
+
+function makeAddFeature(id: string, x: number, y: number, w: number, h: number, zTop: number, zBottom: number): SketchFeature {
+  return {
+    id,
+    name: id,
+    kind: 'rect',
+    folderId: null,
+    sketch: {
+      profile: rectProfile(x, y, w, h),
+      origin: { x: 0, y: 0 },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+    operation: 'add',
+    z_top: zTop,
+    z_bottom: zBottom,
+    visible: true,
+    locked: false,
+  }
+}
+
+function testEdgeOutsideClipsAroundNonSelectedAddFeatures() {
+  console.log('Testing edge_route_outside clips moves around non-selected add features...')
+
+  const tool = makeFlatEndmill('t1', 4)
+  // featureA at x=0..10, featureB at x=12..22. Gap = 2mm < tool diameter (4mm).
+  // Edge out routes around featureA only, but moves that enter featureB's
+  // keep-away zone (featureB expanded by tool.radius = 2, so x >= 10) are clipped.
+  const featureA = makeAddFeature('a', 0, 0, 10, 10, 6, 0)
+  const featureB = makeAddFeature('b', 12, 0, 10, 10, 6, 0)
+  const project = baseProject([tool], [featureA, featureB])
+
+  const op = makePocketOp({
+    kind: 'edge_route_outside',
+    target: { source: 'features', featureIds: ['a'] },
+    toolRef: 't1',
+  })
+
+  const result = generateEdgeRouteToolpath(project, op)
+  const cuts = cutMoves(result.moves)
+  assert(cuts.length > 0, 'outside edge route produces cut moves')
+
+  // Tool center must not enter featureB's keep-away zone. FeatureB spans
+  // x=[12..22], expanded by tool.radius (2) means keep-away starts at x=10.
+  // No cut move's tool center should be inside the expanded obstacle area.
+  const violatingCuts = cuts.filter((move) => {
+    const inKeepAwayY = move.to.y >= -2 && move.to.y <= 12
+    const inKeepAwayX = move.to.x >= 10 && move.to.x <= 24
+    return inKeepAwayX && inKeepAwayY
+  })
+
+  assert(
+    violatingCuts.length === 0,
+    `expected no cuts inside featureB keep-away zone, got ${violatingCuts.length} (first at x=${violatingCuts[0]?.to.x.toFixed(2)}, y=${violatingCuts[0]?.to.y.toFixed(2)})`,
+  )
+
+  console.log('edge_route_outside obstacle clipping (non-selected): PASSED')
+}
+
+// ---------------------------------------------------------------------------
 // V-carve: feature_first emits independent per-feature toolpath
 // ---------------------------------------------------------------------------
 
@@ -880,6 +943,7 @@ try {
   testEdgeOutsideAcceptsModelSilhouette()
   testEdgeOutsideUsesStoredModelSilhouettePaths()
   testEdgeOutsideIgnoresTinyStoredModelSilhouetteArtifacts()
+  testEdgeOutsideClipsAroundNonSelectedAddFeatures()
   testVCarveFeatureFirstProducesSameMoveCount()
   testSurfaceCleanMultiTargetProtectsTallerTarget()
   testFollowLineRegionClipsOpenPath()


### PR DESCRIPTION
## Summary
- Edge route outside now detects all other add/model features in the project as obstacles
- At each step-down level, only obstacles whose Z span includes that level are active — upper passes where an obstacle doesn't exist yet run the full contour unblocked
- Obstacle silhouettes are expanded by tool radius to form keep-away zones; cut moves entering these zones are clipped or removed with proper retract/reposition transitions
- Adds `clipToolpathResultToObstaclesByLevel` and `buildMaskFromClipperPaths` utilities to the regions module

## Test plan
- [x] Builds clean (`tsc -b --noEmit` + `vite build`)
- [x] Existing edge route tests pass
- [x] New test: `testEdgeOutsideClipsAroundNonSelectedAddFeatures` verifies obstacle clipping
- [x] Manual test with `work/edge-out-test.camj` — circle + rectangle with different heights, verify upper passes go full contour and lower passes clip around the circle

🤖 Generated with [Claude Code](https://claude.com/claude-code)