### PR TITLE
Fix simulation heightfield rendering artifacts

### DIFF
--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -18,8 +18,8 @@ import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useSta
 import * as THREE from 'three'
 import { Icon } from '../Icon'
 import { buildClampMesh, buildOriginTriad } from '../../engine/csg'
-import { createHeightfieldTexture, createStockPlaneGeometry, createStockBoundaryGeometry, createDynamicProfileBoundaryGeometry, updateHeightfieldTexture } from '../../engine/simulation/gpuMesh'
-import { createBoundaryMaterial, createDynamicBoundaryMaterial, createHeightfieldMaterial } from '../../engine/simulation/heightfieldShader'
+import { createHeightfieldTexture, createStockPlaneGeometries, createDynamicProfileBoundaryGeometries, updateHeightfieldTexture } from '../../engine/simulation/gpuMesh'
+import { createDynamicBoundaryMaterial, createHeightfieldMaterial } from '../../engine/simulation/heightfieldShader'
 import { PlaybackController } from '../../engine/simulation/playback'
 import { buildToolMesh, disposeToolMesh } from '../../engine/simulation/toolMesh'
 import type { PlaybackPose } from '../../engine/simulation/playback'
@@ -181,6 +181,58 @@ const PLAYBACK_STEP_SIZES_IN = [0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5]
 const PLAYBACK_DEFAULT_STEP_MM = 2.5
 const PLAYBACK_DEFAULT_STEP_IN = 0.1
 const PLAYBACK_REBUILD_INTERVAL_MS = 0
+
+function disposeSceneObject(object: THREE.Object3D): void {
+  const geometries = new Set<THREE.BufferGeometry>()
+  const materials = new Set<THREE.Material>()
+
+  object.traverse((entry) => {
+    if (entry instanceof THREE.Mesh || entry instanceof THREE.Line) {
+      geometries.add(entry.geometry)
+      const material = entry.material
+      if (Array.isArray(material)) {
+        material.forEach((item) => materials.add(item))
+      } else {
+        materials.add(material)
+      }
+    }
+  })
+
+  geometries.forEach((geometry) => geometry.dispose())
+  materials.forEach((material) => material.dispose())
+}
+
+function buildHeightfieldSurfaceObject(
+  grid: SimulationGrid,
+  material: THREE.Material,
+): THREE.Object3D {
+  const geometries = createStockPlaneGeometries(grid)
+  if (geometries.length === 1) {
+    return new THREE.Mesh(geometries[0], material)
+  }
+
+  const group = new THREE.Group()
+  for (const geometry of geometries) {
+    group.add(new THREE.Mesh(geometry, material))
+  }
+  return group
+}
+
+function buildDynamicProfileBoundaryObject(
+  grid: SimulationGrid,
+  material: THREE.Material,
+): THREE.Object3D {
+  const geometries = createDynamicProfileBoundaryGeometries(grid)
+  if (geometries.length === 1) {
+    return new THREE.Mesh(geometries[0], material)
+  }
+
+  const group = new THREE.Group()
+  for (const geometry of geometries) {
+    group.add(new THREE.Mesh(geometry, material))
+  }
+  return group
+}
 
 function formatCoord(value: number, units: 'mm' | 'in'): string {
   if (!Number.isFinite(value)) return '\u2014'
@@ -493,7 +545,6 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   collidingClampIds,
   origin,
   stockColor,
-  stockHasProfile = false,
   zoomWindowActive = false,
   onZoomWindowComplete,
   playbackInput,
@@ -522,10 +573,10 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   const [displayPose, setDisplayPose] = useState<PlaybackPose>({ x: 0, y: 0, z: 0, moveKind: null })
   const playbackControllerRef = useRef<PlaybackController | null>(null)
   const toolMeshRef = useRef<THREE.Group | null>(null)
-  const playbackMaterialMeshRef = useRef<THREE.Mesh | null>(null)
-  const playbackBoundaryMeshRef = useRef<THREE.Mesh | null>(null)
+  const playbackMaterialMeshRef = useRef<THREE.Object3D | null>(null)
+  const playbackBoundaryMeshRef = useRef<THREE.Object3D | null>(null)
   const playbackHeightfieldTextureRef = useRef<THREE.DataTexture | null>(null)
-  const boundaryMeshRef = useRef<THREE.Mesh | null>(null)
+  const boundaryMeshRef = useRef<THREE.Object3D | null>(null)
   const playbackFrameRef = useRef<number>(0)
   const playbackLastTimeRef = useRef<number>(0)
   const playbackLastRebuildRef = useRef<number>(0)
@@ -565,24 +616,14 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   zoomWindowBoxRef.current = zoomWindowBox
 
   const disposeCurrentMesh = useCallback((scene: THREE.Scene) => {
-    if (objectRef.current instanceof THREE.Mesh) {
+    if (objectRef.current) {
       scene.remove(objectRef.current)
-      objectRef.current.geometry.dispose()
-      if (Array.isArray(objectRef.current.material)) {
-        objectRef.current.material.forEach((entry) => entry.dispose())
-      } else {
-        objectRef.current.material.dispose()
-      }
+      disposeSceneObject(objectRef.current)
       objectRef.current = null
     }
     if (boundaryMeshRef.current) {
       scene.remove(boundaryMeshRef.current)
-      boundaryMeshRef.current.geometry.dispose()
-      if (Array.isArray(boundaryMeshRef.current.material)) {
-        boundaryMeshRef.current.material.forEach((entry) => entry.dispose())
-      } else {
-        boundaryMeshRef.current.material.dispose()
-      }
+      disposeSceneObject(boundaryMeshRef.current)
       boundaryMeshRef.current = null
     }
   }, [])
@@ -621,7 +662,7 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   const zoomToModel = useCallback(() => {
     const controls = controlsRef.current
     const object = objectRef.current
-    if (!controls || !(object instanceof THREE.Mesh)) {
+    if (!controls || !object) {
       return
     }
 
@@ -736,31 +777,25 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
 
     const grid = simulation.grid
     const heightfieldTexture = createHeightfieldTexture(grid)
-    const planeGeometry = createStockPlaneGeometry(grid)
     const color = stockColor ? new THREE.Color(stockColor) : new THREE.Color(0xb5beca)
     const material = createHeightfieldMaterial(heightfieldTexture, grid, color)
-    const mesh = new THREE.Mesh(planeGeometry, material)
-    scene.add(mesh)
-    objectRef.current = mesh
+    const surface = buildHeightfieldSurfaceObject(grid, material)
+    scene.add(surface)
+    objectRef.current = surface
 
-    const boundaryGeometry = stockHasProfile
-      ? createDynamicProfileBoundaryGeometry(grid)
-      : createStockBoundaryGeometry(grid)
-    const boundaryMaterial = stockHasProfile
-      ? createDynamicBoundaryMaterial(heightfieldTexture, grid, color)
-      : createBoundaryMaterial(color)
-    const boundary = new THREE.Mesh(boundaryGeometry, boundaryMaterial)
+    const boundaryMaterial = createDynamicBoundaryMaterial(heightfieldTexture, grid, color)
+    const boundary = buildDynamicProfileBoundaryObject(grid, boundaryMaterial)
     scene.add(boundary)
     boundaryMeshRef.current = boundary
 
     if (!hasAutoFramedRef.current) {
-      const bounds = new THREE.Box3().setFromObject(mesh)
+      const bounds = new THREE.Box3().setFromObject(surface)
       if (!bounds.isEmpty()) {
         controls.fitToBounds(bounds, true)
         hasAutoFramedRef.current = true
       }
     }
-  }, [disposeCurrentMesh, playbackEnabled, simulation, stockColor, stockHasProfile])
+  }, [disposeCurrentMesh, playbackEnabled, simulation, stockColor])
 
   const rebuildPlaybackGeometry = useCallback(() => {
     const controller = playbackControllerRef.current
@@ -796,19 +831,12 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
     if (!playbackEnabled || !playbackInput) {
       if (playbackMaterialMeshRef.current) {
         scene.remove(playbackMaterialMeshRef.current)
-        playbackMaterialMeshRef.current.geometry.dispose()
-        const mat = playbackMaterialMeshRef.current.material
-        if (Array.isArray(mat)) { mat.forEach((entry) => entry.dispose()) } else { mat.dispose() }
+        disposeSceneObject(playbackMaterialMeshRef.current)
         playbackMaterialMeshRef.current = null
       }
       if (playbackBoundaryMeshRef.current) {
         scene.remove(playbackBoundaryMeshRef.current)
-        playbackBoundaryMeshRef.current.geometry.dispose()
-        if (Array.isArray(playbackBoundaryMeshRef.current.material)) {
-          playbackBoundaryMeshRef.current.material.forEach((entry) => entry.dispose())
-        } else {
-          playbackBoundaryMeshRef.current.material.dispose()
-        }
+        disposeSceneObject(playbackBoundaryMeshRef.current)
         playbackBoundaryMeshRef.current = null
       }
       if (playbackHeightfieldTextureRef.current) {
@@ -841,21 +869,15 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
     const grid = controller.liveGrid
     const heightfieldTexture = createHeightfieldTexture(grid)
     playbackHeightfieldTextureRef.current = heightfieldTexture
-    const planeGeometry = createStockPlaneGeometry(grid)
     const color = stockColor ? new THREE.Color(stockColor) : new THREE.Color(0xb5beca)
     const material = createHeightfieldMaterial(heightfieldTexture, grid, color)
-    const mesh = new THREE.Mesh(planeGeometry, material)
-    scene.add(mesh)
-    playbackMaterialMeshRef.current = mesh
+    const surface = buildHeightfieldSurfaceObject(grid, material)
+    scene.add(surface)
+    playbackMaterialMeshRef.current = surface
 
     {
-      const boundaryGeometry = stockHasProfile
-        ? createDynamicProfileBoundaryGeometry(grid)
-        : createStockBoundaryGeometry(grid)
-      const boundaryMaterial = stockHasProfile
-        ? createDynamicBoundaryMaterial(heightfieldTexture, grid, color)
-        : createBoundaryMaterial(color)
-      const boundary = new THREE.Mesh(boundaryGeometry, boundaryMaterial)
+      const boundaryMaterial = createDynamicBoundaryMaterial(heightfieldTexture, grid, color)
+      const boundary = buildDynamicProfileBoundaryObject(grid, boundaryMaterial)
       scene.add(boundary)
       playbackBoundaryMeshRef.current = boundary
     }
@@ -876,19 +898,12 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
     return () => {
       if (playbackMaterialMeshRef.current) {
         scene.remove(playbackMaterialMeshRef.current)
-        playbackMaterialMeshRef.current.geometry.dispose()
-        const mat = playbackMaterialMeshRef.current.material
-        if (Array.isArray(mat)) { mat.forEach((entry) => entry.dispose()) } else { mat.dispose() }
+        disposeSceneObject(playbackMaterialMeshRef.current)
         playbackMaterialMeshRef.current = null
       }
       if (playbackBoundaryMeshRef.current) {
         scene.remove(playbackBoundaryMeshRef.current)
-        playbackBoundaryMeshRef.current.geometry.dispose()
-        if (Array.isArray(playbackBoundaryMeshRef.current.material)) {
-          playbackBoundaryMeshRef.current.material.forEach((entry) => entry.dispose())
-        } else {
-          playbackBoundaryMeshRef.current.material.dispose()
-        }
+        disposeSceneObject(playbackBoundaryMeshRef.current)
         playbackBoundaryMeshRef.current = null
       }
       if (playbackHeightfieldTextureRef.current) {
@@ -902,7 +917,7 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
       }
       playbackControllerRef.current = null
     }
-  }, [playbackEnabled, playbackInput, stockColor, stockHasProfile, updateToolMeshPose])
+  }, [playbackEnabled, playbackInput, stockColor, updateToolMeshPose])
 
   useEffect(() => {
     if (!playbackEnabled || !isPlaying) {
@@ -1125,7 +1140,7 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
     // then auto-frame if a mesh exists.
     const timer = setTimeout(() => {
       const object = objectRef.current
-      if (object instanceof THREE.Mesh) {
+      if (object) {
         const bounds = new THREE.Box3().setFromObject(object)
         if (!bounds.isEmpty()) {
           controls.fitToBounds(bounds, true)

--- a/src/engine/simulation/gpuMesh.test.ts
+++ b/src/engine/simulation/gpuMesh.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for GPU simulation mesh construction.
+ *
+ * Run with: npx tsx src/engine/simulation/gpuMesh.test.ts
+ */
+
+import { createDynamicProfileBoundaryGeometries, createStockPlaneGeometries, createStockPlaneGeometry } from './gpuMesh'
+import type { SimulationGrid } from './types'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function makeGrid(cols: number, rows: number): SimulationGrid {
+  return {
+    originX: 0,
+    originY: 0,
+    cellSize: 1,
+    cols,
+    rows,
+    stockBottomZ: 0,
+    stockTopZ: 10,
+    topZ: new Float32Array(cols * rows).fill(10),
+  }
+}
+
+function testUsesUint16WhenVertexIdsFit(): void {
+  const geometry = createStockPlaneGeometry(makeGrid(280, 140))
+  const index = geometry.getIndex()
+  if (!index) throw new Error('Assertion failed: expected indexed geometry')
+  assert(index.array instanceof Uint16Array, 'expected Uint16 indices when all vertex ids fit in 16 bits')
+  geometry.dispose()
+}
+
+function testChunksLargePlanesIntoUint16Geometry(): void {
+  const geometries = createStockPlaneGeometries(makeGrid(280, 280))
+  assert(geometries.length > 1, 'expected square high-detail plane to be chunked')
+
+  for (const geometry of geometries) {
+    const position = geometry.getAttribute('position')
+    const index = geometry.getIndex()
+    assert(position.count <= 65535, `expected chunk vertex count to fit in Uint16, got ${position.count}`)
+    if (!index) throw new Error('Assertion failed: expected indexed chunk geometry')
+    assert(index.array instanceof Uint16Array, 'expected chunk to use Uint16 indices')
+    geometry.dispose()
+  }
+}
+
+function testChunksLargeDynamicProfileBoundaries(): void {
+  const geometries = createDynamicProfileBoundaryGeometries(makeGrid(280, 280))
+  assert(geometries.length > 1, 'expected high-detail dynamic profile boundary to be chunked')
+
+  for (const geometry of geometries) {
+    const position = geometry.getAttribute('position')
+    assert(position.count <= 65535, `expected boundary chunk vertex count to stay small, got ${position.count}`)
+    geometry.dispose()
+  }
+}
+
+testUsesUint16WhenVertexIdsFit()
+testChunksLargePlanesIntoUint16Geometry()
+testChunksLargeDynamicProfileBoundaries()
+console.log('gpu mesh tests passed')

--- a/src/engine/simulation/gpuMesh.ts
+++ b/src/engine/simulation/gpuMesh.ts
@@ -17,6 +17,10 @@
 import * as THREE from 'three'
 import type { DirtyRegion, SimulationGrid } from './types'
 
+const MAX_UINT16_INDEX = 65535
+const STOCK_PLANE_CHUNK_CELLS = 128
+const PROFILE_BOUNDARY_CHUNK_CELLS = 64
+
 /**
  * Build a `DataTexture` backed by the grid's `topZ` Float32Array. The texture
  * uses a single RED channel so each texel stores one height value. The array is
@@ -55,20 +59,49 @@ export function createHeightfieldTexture(grid: SimulationGrid): THREE.DataTextur
  * vertices at cell centers with UVs that map exactly to texel centers.
  */
 export function createStockPlaneGeometry(grid: SimulationGrid): THREE.BufferGeometry {
+  return createStockPlaneGeometryChunk(grid, 0, 0, grid.cols, grid.rows)
+}
+
+export function createStockPlaneGeometries(grid: SimulationGrid): THREE.BufferGeometry[] {
+  const fullVertexCount = (grid.cols + 1) * (grid.rows + 1)
+  if (fullVertexCount <= MAX_UINT16_INDEX) {
+    return [createStockPlaneGeometry(grid)]
+  }
+
+  const geometries: THREE.BufferGeometry[] = []
+  for (let rowStart = 0; rowStart < grid.rows; rowStart += STOCK_PLANE_CHUNK_CELLS) {
+    const chunkRows = Math.min(STOCK_PLANE_CHUNK_CELLS, grid.rows - rowStart)
+    for (let colStart = 0; colStart < grid.cols; colStart += STOCK_PLANE_CHUNK_CELLS) {
+      const chunkCols = Math.min(STOCK_PLANE_CHUNK_CELLS, grid.cols - colStart)
+      geometries.push(createStockPlaneGeometryChunk(grid, colStart, rowStart, chunkCols, chunkRows))
+    }
+  }
+  return geometries
+}
+
+function createStockPlaneGeometryChunk(
+  grid: SimulationGrid,
+  colStart: number,
+  rowStart: number,
+  chunkCols: number,
+  chunkRows: number,
+): THREE.BufferGeometry {
   const { originX, originY, cellSize, cols, rows } = grid
 
   // One vertex per cell corner → (cols+1) × (rows+1) vertices
-  const vertCols = cols + 1
-  const vertRows = rows + 1
+  const vertCols = chunkCols + 1
+  const vertRows = chunkRows + 1
   const vertexCount = vertCols * vertRows
   const positions = new Float32Array(vertexCount * 3)
   const uvs = new Float32Array(vertexCount * 2)
 
-  for (let row = 0; row <= rows; row += 1) {
-    for (let col = 0; col <= cols; col += 1) {
+  for (let row = 0; row <= chunkRows; row += 1) {
+    const gridRow = rowStart + row
+    for (let col = 0; col <= chunkCols; col += 1) {
+      const gridCol = colStart + col
       const idx = row * vertCols + col
-      const worldX = originX + col * cellSize
-      const worldZ = originY + row * cellSize
+      const worldX = originX + gridCol * cellSize
+      const worldZ = originY + gridRow * cellSize
 
       positions[idx * 3] = worldX
       positions[idx * 3 + 1] = 0 // Y displaced by shader
@@ -77,17 +110,17 @@ export function createStockPlaneGeometry(grid: SimulationGrid): THREE.BufferGeom
       // UV maps to texel centers: col 0 → 0.5/cols, col cols → (cols-0.5)/cols
       // At cell boundaries we average neighboring texels, which is correct for
       // vertex positions sitting on cell edges.
-      uvs[idx * 2] = Math.max(0, Math.min(1, col / cols))
-      uvs[idx * 2 + 1] = Math.max(0, Math.min(1, row / rows))
+      uvs[idx * 2] = Math.max(0, Math.min(1, gridCol / cols))
+      uvs[idx * 2 + 1] = Math.max(0, Math.min(1, gridRow / rows))
     }
   }
 
   // Two triangles per cell
-  const indexCount = cols * rows * 6
-  const indices = indexCount > 65535 ? new Uint32Array(indexCount) : new Uint16Array(indexCount)
+  const indexCount = chunkCols * chunkRows * 6
+  const indices = vertexCount > MAX_UINT16_INDEX ? new Uint32Array(indexCount) : new Uint16Array(indexCount)
   let offset = 0
-  for (let row = 0; row < rows; row += 1) {
-    for (let col = 0; col < cols; col += 1) {
+  for (let row = 0; row < chunkRows; row += 1) {
+    for (let col = 0; col < chunkCols; col += 1) {
       const tl = row * vertCols + col
       const tr = tl + 1
       const bl = (row + 1) * vertCols + col
@@ -295,6 +328,37 @@ export function createProfileBoundaryGeometry(grid: SimulationGrid): THREE.Buffe
  * without geometry rebuilds.
  */
 export function createDynamicProfileBoundaryGeometry(grid: SimulationGrid): THREE.BufferGeometry {
+  return createDynamicProfileBoundaryGeometryChunk(grid, 0, 0, grid.cols, grid.rows)
+}
+
+export function createDynamicProfileBoundaryGeometries(grid: SimulationGrid): THREE.BufferGeometry[] {
+  if (grid.cols * grid.rows * 6 <= MAX_UINT16_INDEX) {
+    return [createDynamicProfileBoundaryGeometry(grid)]
+  }
+
+  const geometries: THREE.BufferGeometry[] = []
+  for (let rowStart = 0; rowStart < grid.rows; rowStart += PROFILE_BOUNDARY_CHUNK_CELLS) {
+    const chunkRows = Math.min(PROFILE_BOUNDARY_CHUNK_CELLS, grid.rows - rowStart)
+    for (let colStart = 0; colStart < grid.cols; colStart += PROFILE_BOUNDARY_CHUNK_CELLS) {
+      const chunkCols = Math.min(PROFILE_BOUNDARY_CHUNK_CELLS, grid.cols - colStart)
+      const geometry = createDynamicProfileBoundaryGeometryChunk(grid, colStart, rowStart, chunkCols, chunkRows)
+      if (geometry.getAttribute('position').count > 0) {
+        geometries.push(geometry)
+      } else {
+        geometry.dispose()
+      }
+    }
+  }
+  return geometries
+}
+
+function createDynamicProfileBoundaryGeometryChunk(
+  grid: SimulationGrid,
+  colStart: number,
+  rowStart: number,
+  chunkCols: number,
+  chunkRows: number,
+): THREE.BufferGeometry {
   const { originX, originY, cellSize, cols, rows, stockBottomZ } = grid
   const positions: number[] = []
   const normals: number[] = []
@@ -307,8 +371,11 @@ export function createDynamicProfileBoundaryGeometry(grid: SimulationGrid): THRE
     col >= 0 && col < cols && row >= 0 && row < rows &&
     grid.topZ[row * cols + col] > stockBottomZ + eps
 
-  for (let row = 0; row < rows; row += 1) {
-    for (let col = 0; col < cols; col += 1) {
+  const rowEnd = Math.min(rows, rowStart + chunkRows)
+  const colEnd = Math.min(cols, colStart + chunkCols)
+
+  for (let row = rowStart; row < rowEnd; row += 1) {
+    for (let col = colStart; col < colEnd; col += 1) {
       if (!hasMaterial(col, row)) continue
 
       const x0 = originX + col * cellSize

--- a/src/engine/simulation/heightfieldShader.ts
+++ b/src/engine/simulation/heightfieldShader.ts
@@ -66,7 +66,13 @@ const fragmentShader = /* glsl */ `
   ${LIGHTING_GLSL}
 
   void main() {
-    if (vHeight <= uStockBottomZ + 0.000001) {
+    float threshold = uStockBottomZ + 0.000001;
+    vec2 maxCellIndex = (vec2(1.0) / uTexelSize) - vec2(1.0);
+    vec2 cellIndex = floor(clamp(vUv / uTexelSize, vec2(0.0), maxCellIndex));
+    vec2 cellUv = (cellIndex + vec2(0.5)) * uTexelSize;
+    float cellHeight = texture2D(uHeightfield, cellUv).r;
+
+    if (cellHeight <= threshold) {
       discard;
     }
 
@@ -75,7 +81,6 @@ const fragmentShader = /* glsl */ `
     float hD = texture2D(uHeightfield, vUv - vec2(0.0, uTexelSize.y)).r;
     float hU = texture2D(uHeightfield, vUv + vec2(0.0, uTexelSize.y)).r;
 
-    float threshold = uStockBottomZ + 0.000001;
     if (hL <= threshold) hL = vHeight;
     if (hR <= threshold) hR = vHeight;
     if (hD <= threshold) hD = vHeight;


### PR DESCRIPTION
## Summary
- chunk simulation heightfield top surfaces to avoid large indexed draws that produced Chrome/macOS artifacts
- chunk dynamic profile boundary geometry and use it for rectangular stock too, so through-cuts remove bottom faces correctly
- discard cut-through top fragments based on the underlying heightfield cell
- add focused GPU mesh construction coverage

## Verification
- npx tsx src/engine/simulation/gpuMesh.test.ts
- npm run build