### PR TITLE
Add 3D model export with STL format

### DIFF
--- a/planning/archive/MODEL_EXPORT_Plan.md
+++ b/planning/archive/MODEL_EXPORT_Plan.md
@@ -1,0 +1,151 @@
+---
+status: Done
+created: 2026-05-18
+---
+
+# Model Export Plan
+
+## Goal
+
+Let users export the current project's 3D model to common mesh/CAD interchange formats so they can hand it off to slicers, viewers, or other CAM tools. Ship STL first (binary + ASCII), but build the surrounding plumbing so adding OBJ, 3MF, STEP, etc. later is a small, self-contained change instead of another round of UI work.
+
+User-visible outcome: a new "Export Model…" entry (separate from the existing G-code export) opens a dialog where the user picks a format, sets format-specific options (binary vs ASCII for STL, what to include), picks a filename, and clicks Export — which then drives the native Save dialog (or browser save flow) to choose the location.
+
+## Approach
+
+### 1. Format registry (new)
+
+Introduce a small registry in `src/engine/modelExport/` so each format is one file:
+
+```ts
+// src/engine/modelExport/types.ts
+export interface ModelExportFormat<TOptions = unknown> {
+  id: string                        // 'stl'
+  name: string                      // 'STL (Stereolithography)'
+  extension: string                 // 'stl'
+  mimeType: string                  // 'model/stl' (or 'application/octet-stream')
+  defaultOptions: TOptions
+  // Renders the React fragment for format-specific options.
+  renderOptions: (props: {
+    options: TOptions
+    onChange: (next: TOptions) => void
+  }) => React.ReactNode
+  // Produces the file bytes/text from the assembled mesh + user options.
+  export: (input: ModelExportInput, options: TOptions) => Promise<ModelExportOutput>
+}
+
+export interface ModelExportInput {
+  project: Project
+  // Pre-built triangle mesh in *world* coordinates (Y-up, the same orientation
+  // that's shown in the 3D viewport, with the render-only inversions undone so
+  // the exported geometry uses the project's design coordinates).
+  triangles: { positions: Float32Array, index: Uint32Array }
+}
+
+export interface ModelExportOutput {
+  data: Uint8Array | string
+  encoding: 'binary' | 'text'
+}
+```
+
+`src/engine/modelExport/index.ts` exports `MODEL_EXPORT_FORMATS: ModelExportFormat[]` and a `getModelExportFormat(id)` helper. Adding OBJ later = add `obj.ts` and one line in the index.
+
+### 2. Mesh assembly (new)
+
+`src/engine/modelExport/assemble.ts` builds the triangle mesh once, format-agnostic:
+
+- Reuse the same Manifold pipeline `buildBooleanModel` already uses in `src/engine/csg.ts`, but stop one step short of `manifoldMeshToGeometry` so we keep raw `vertProperties` + `triVerts`. Refactor `csg.ts` to extract a `buildBooleanModelMesh(project, visibleFeatures)` that returns `{ positions, index } | null`; `buildBooleanModel` becomes a thin wrapper around it that wraps in a Three.js mesh.
+- Include STL `add` features in the boolean union (today `buildBooleanModel` skips them because they're drawn as an overlay; for export the user expects the full visible model — confirm in the dialog with an "include imported meshes" option, default on).
+- Skip `region` features and open polyline features (they aren't real solids).
+- "Machined result" (stock minus subtracts) is explicitly a follow-up. v1 exports only the design model.
+- **Coordinates: internal design coords, preserved 1:1.** Z is up (matches STL convention). Y is whatever the rest of the app uses internally (screen-Y from the 2D sketch). Rationale: the STL importer in this codebase reads triangle positions straight into internal coords without any Y flip, so exporting with a Y-flip breaks round-trip — the re-imported model lands mirrored across the X-axis from the original. Exporting in internal coords keeps round-trip exact and matches what the 3D viewport and G-code pipeline already treat as canonical. External viewers/slicers see the model with the sketch top-view Y direction; Z is still up so it's right-side-up. Users who care about a specific Y orientation in a downstream tool can rotate it there.
+
+### 3. STL writer (new)
+
+`src/engine/modelExport/stl.ts`:
+
+- `STLOptions = { format: 'binary' | 'ascii', includeImportedMeshes: boolean }`
+- Binary STL: standard 80-byte header + uint32 triangle count + 50 bytes/triangle (12 floats + 2-byte attr). Compute per-face normal from the three vertices.
+- ASCII STL: emit `solid <name> … endsolid` with `facet normal … outer loop … endloop endfacet`.
+- Unit test (`stl.test.ts`): round-trip a known mesh through the binary writer and re-parse it with the existing `src/import/stl.ts` parser; assert vertex count, triangle count, and bounds match.
+
+### 4. Platform: binary file save (extension)
+
+The current `PlatformApi` only has `saveTextFile`. Add `saveBinaryFile(suggestedName, data: Uint8Array, extension, existingPath?)`:
+
+- **Browser** (`src/platform/browser.ts`): reuse the existing `saveFile` helper but pass the `Uint8Array` directly to `new Blob([...])` / `writable.write(...)` (both accept binary). Generalize `saveFile` to take `BlobPart` instead of `string`.
+- **Desktop** (`src/platform/desktop.ts`): use `writeFile` (binary) from `@tauri-apps/plugin-fs` instead of `writeTextFile`.
+
+ASCII STL can still go through `saveTextFile`; binary STL needs `saveBinaryFile`.
+
+### 4b. Curve quality control
+
+2D-extrude features pass through `profileToPolygon` in `csg.ts`, which uses a fixed `ARC_STEP_RADIANS = π/18` (10°) — fine for the viewport but coarse for STL. We parameterize this:
+
+- `profileToPolygon(profile, arcStepRadians)` and `buildFeatureSolid(..., arcStepRadians?)` take an optional override; default preserves viewport behavior. Bezier subdivision scales the same way so curve quality is consistent.
+- New `CurveQuality` type (`'coarse' | 'normal' | 'fine' | 'very_fine'`) maps to `{10°, 5°, 2°, 1°}` per arc segment in `CURVE_QUALITY_ARC_STEP_RADIANS`.
+- `ModelExportAssembleOptions` carries `curveQuality`; the assemble pass threads it into `buildFeatureSolid`.
+- Dialog adds a `Select` for "Curve quality" (default Normal/5°) above the format-specific options. Re-assembles on change so the triangle count summary reflects the choice.
+
+### 5. Model Export dialog (new)
+
+`src/components/export/ModelExportDialog.tsx`:
+
+- Format dropdown (driven by `MODEL_EXPORT_FORMATS`) — disabled options grey out cleanly when only STL exists, so the UI doesn't visibly change once we add formats.
+- Filename input (defaulted to `project.meta.name`, sanitized).
+- Format-specific options panel rendered by `format.renderOptions(...)` — for STL: binary/ascii radio, "Include imported (STL) meshes" checkbox.
+- A small summary line (e.g. "Triangles: 12,438 — est. file size: 610 KB"). Compute size from triangle count for binary STL; skip for ASCII.
+- Footer: Cancel / Export. Export calls the chosen format's `export(...)`, then `platform.saveBinaryFile` or `saveTextFile` depending on `encoding`. Show warnings if the mesh is empty.
+- Track a `lastModelExportPath` in the store (mirrors the existing `lastExportPath` for G-code) so subsequent exports default to the same folder. Plumb via `markModelExported(path)` on the project store.
+
+Reuse the existing dialog CSS (`dialog-backdrop`, `dialog`, `dialog-section`, …) — no new styling needed.
+
+### 6. Entry point
+
+- Add an "Export model" icon button in the global toolbar's first group, directly after the existing "Import geometry" button. Use the existing `export` icon in `public/icons.svg` (same tray glyph as `import`, arrow reversed — no new icon to author).
+- Wire it through `GlobalActions` → `Toolbar` → `App.tsx` the same way `onImport` is plumbed today, adding an `onExportModel` prop alongside `onImport`.
+- Add a state pair in `App.tsx` (`showModelExportDialog`) wired identically to the G-code dialog.
+- Leave the existing CAM panel G-code "Export" button untouched.
+- Hook into desktop menu later if needed — out of scope for v1.
+
+## Files affected
+
+- *(new)* `src/engine/modelExport/types.ts` — registry/option types.
+- *(new)* `src/engine/modelExport/index.ts` — `MODEL_EXPORT_FORMATS`, `getModelExportFormat`.
+- *(new)* `src/engine/modelExport/assemble.ts` — builds `{positions,index}` from the project.
+- *(new)* `src/engine/modelExport/stl.ts` — binary + ASCII STL writers.
+- *(new)* `src/engine/modelExport/stl.test.ts` — unit tests (round-trip through importer).
+- `src/engine/csg.ts` — extract `buildBooleanModelMesh` so it can be shared without the Three.js wrapping; no behavior change for the viewport.
+- `src/engine/INDEX.md` — list the new `modelExport/` subfolder.
+- *(new)* `src/components/export/ModelExportDialog.tsx` — the dialog.
+- `src/platform/api.ts` — add `saveBinaryFile` to the interface.
+- `src/platform/browser.ts` — implement `saveBinaryFile`, generalize internal `saveFile` to accept `BlobPart`.
+- `src/platform/desktop.ts` — implement `saveBinaryFile` via `writeFile`.
+- `src/store/projectStore.ts` (or matching slice) — add `lastModelExportPath` + `markModelExported`.
+- `src/components/layout/Toolbar.tsx` — add `onExportModel` prop on `GlobalActions` / `Toolbar` / `GlobalToolbar` / `CreationToolbar`; render an `export`-icon `ToolbarActionButton` next to the existing `import` button.
+- `src/App.tsx` — `showModelExportDialog` state, render `ModelExportDialog`, pass `onExportModel` to the toolbar wherever `onImport` is already passed.
+
+## Tests
+
+- `src/engine/modelExport/stl.test.ts`:
+  - Binary writer: triangle/vertex counts and AABB match input after re-parsing with `src/import/stl.ts`.
+  - ASCII writer: same round-trip, plus a small text-shape assertion (`solid` / `endsolid`, expected number of `facet` blocks).
+  - Empty input → returns valid empty STL (0 triangles).
+- `src/engine/modelExport/assemble.test.ts` (optional, light): with a trivial project (one box add feature), asserts the resulting mesh has the expected triangle count and AABB.
+- No UI snapshot tests — dialog behavior is exercised manually via `npm run build` + browser smoke check (the user runs the dev server).
+
+## Open questions / risks
+
+- **What does "the model" mean?** v1 = the design model that's visible in the 3D viewport (the unioned manifold result + STL adds when the option is on). The "machined result" (stock minus subtracts) is a separate export — explicitly a follow-up.
+- **Non-manifold STL adds.** `buildFeatureSolid` already falls back to a 2.5D silhouette extrusion when an imported STL isn't manifold. The export will inherit that fallback, so a non-manifold STL "add" gets exported as a blocky extrusion. Worth a non-blocking warning in the dialog if any feature hit the fallback.
+- **Large meshes.** Binary STL is fine to several million triangles, but the manifold union can be slow for very heavy STL features. We already accept this slowness in the 3D viewport, so no new perf work in v1; if it bites, we can cache the assembled mesh keyed off the same hash `buildBooleanModel` uses.
+- **iOS / mobile save.** Browser save flow already works for G-code; same path applies. Binary STL via `Blob` works on all current targets.
+
+## Out of scope
+
+- OBJ, 3MF, STEP exporters (the registry makes these straightforward follow-ups).
+- Exporting the "machined-result" geometry (stock minus subtracts).
+- Per-feature / per-selection export.
+- Color / material export (vertex colors, MTL).
+- Desktop menu entry for Export Model (G-code menu plumbing stays as-is).
+- Tabs and clamps in the exported mesh (they're CAM scaffolding, not the model).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { SimulationViewport, type SimulationViewportHandle } from './components/
 import { Viewport3D, type Viewport3DHandle } from './components/viewport3d/Viewport3D'
 import { type ToolpathVisibility, DEFAULT_TOOLPATH_VISIBILITY } from './components/ToolpathVisibilityPanel'
 import { ExportDialog } from './components/export/ExportDialog'
+import { ModelExportDialog } from './components/export/ModelExportDialog'
 import { NewProjectDialog } from './components/project/NewProjectDialog'
 import { DEFAULT_SNAP_SETTINGS, SNAP_SETTINGS_STORAGE_KEY, type SnapMode, type SnapSettings, normalizeSnapSettings } from './sketch/snapping'
 import { useProjectStore } from './store/projectStore'
@@ -96,6 +97,7 @@ function App() {
   const [isSimulationPending, startSimulationTransition] = useTransition()
   const [simulationMode, setSimulationMode] = useState<'selected' | 'visible'>('selected')
   const [showExportDialog, setShowExportDialog] = useState(false)
+  const [showModelExportDialog, setShowModelExportDialog] = useState(false)
   const [showNewProjectDialog, setShowNewProjectDialog] = useState(false)
   const [zoomWindowActive, setZoomWindowActive] = useState(false)
   const [toolpathVisibility, setToolpathVisibility] = useState<ToolpathVisibility>(DEFAULT_TOOLPATH_VISIBILITY)
@@ -878,11 +880,12 @@ function App() {
     <>
       <AppShell
         toolbar={
-          <Toolbar 
+          <Toolbar
             onZoomToModel={handleZoomToModel}
             onZoomWindow={handleZoomWindow}
             zoomWindowActive={zoomWindowActive}
             onImportComplete={handleImportComplete}
+            onExportModel={() => setShowModelExportDialog(true)}
             snapSettings={snapSettings}
             activeSnapMode={activeSnapMode}
             onToggleSnapEnabled={handleToggleSnapEnabled}
@@ -895,6 +898,7 @@ function App() {
             onZoomWindow={handleZoomWindow}
             zoomWindowActive={zoomWindowActive}
             onImportComplete={handleImportComplete}
+            onExportModel={() => setShowModelExportDialog(true)}
             snapSettings={snapSettings}
             activeSnapMode={activeSnapMode}
             onToggleSnapEnabled={handleToggleSnapEnabled}
@@ -988,12 +992,17 @@ function App() {
         onZoomWindow={handleZoomWindow}
         zoomWindowActive={zoomWindowActive}
         onImportComplete={handleImportComplete}
+        onExportModel={() => setShowModelExportDialog(true)}
         snapSettings={snapSettings}
         activeSnapMode={activeSnapMode}
         onToggleSnapEnabled={handleToggleSnapEnabled}
         onToggleSnapMode={handleToggleSnapMode}
       />
-      
+
+      {showModelExportDialog && (
+        <ModelExportDialog onClose={() => setShowModelExportDialog(false)} />
+      )}
+
       {showExportDialog && (
         <ExportDialog
           onClose={() => setShowExportDialog(false)}

--- a/src/components/export/ModelExportDialog.tsx
+++ b/src/components/export/ModelExportDialog.tsx
@@ -1,0 +1,304 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import { useProjectStore } from '../../store/projectStore'
+import { useRestoreCanvasFocus } from '../../utils/useRestoreCanvasFocus'
+import { Select } from '../Select'
+import { platform } from '../../platform'
+import {
+  MODEL_EXPORT_FORMATS,
+  STL_DEFAULT_OPTIONS,
+  assembleModelExportMesh,
+  countTriangles,
+  estimateStlFileSize,
+  getModelExportFormat,
+  type CurveQuality,
+  type ExportTriangleMesh,
+  type STLExportOptions,
+} from '../../engine/modelExport'
+
+interface ModelExportDialogProps {
+  onClose: () => void
+}
+
+interface AssembledMesh {
+  mesh: ExportTriangleMesh
+  warnings: string[]
+}
+
+export function ModelExportDialog({ onClose }: ModelExportDialogProps) {
+  useRestoreCanvasFocus()
+  const { project, lastModelExportPath, markModelExported } = useProjectStore()
+
+  const [formatId, setFormatId] = useState<string>(MODEL_EXPORT_FORMATS[0]?.id ?? 'stl')
+  const [stlOptions, setStlOptions] = useState<STLExportOptions>(STL_DEFAULT_OPTIONS)
+  const [curveQuality, setCurveQuality] = useState<CurveQuality>('normal')
+  const [fileName, setFileName] = useState<string>(() => sanitizeFileName(project.meta.name))
+  const [assembled, setAssembled] = useState<AssembledMesh | null>(null)
+  const [assembling, setAssembling] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [exporting, setExporting] = useState(false)
+
+  const format = useMemo(() => getModelExportFormat(formatId) ?? MODEL_EXPORT_FORMATS[0], [formatId])
+
+  // Re-assemble whenever the user toggles "include imported meshes" — the
+  // assembled mesh is the only piece of state that depends on that option.
+  useEffect(() => {
+    let cancelled = false
+    setAssembling(true)
+    setErrorMessage(null)
+    assembleModelExportMesh(project, {
+      includeImportedMeshes: stlOptions.includeImportedMeshes,
+      curveQuality,
+    })
+      .then((result) => {
+        if (cancelled) return
+        setAssembled({ mesh: result.mesh, warnings: result.warnings })
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return
+        setErrorMessage(error instanceof Error ? error.message : String(error))
+        setAssembled(null)
+      })
+      .finally(() => {
+        if (!cancelled) setAssembling(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [project, stlOptions.includeImportedMeshes, curveQuality])
+
+  const triangleCount = assembled ? countTriangles(assembled.mesh) : 0
+  const estimatedSize = assembled && format?.id === 'stl'
+    ? estimateStlFileSize(assembled.mesh, stlOptions.format)
+    : null
+
+  const warnings = useMemo(() => {
+    const list = [...(assembled?.warnings ?? [])]
+    if (assembled && triangleCount === 0) {
+      list.push('No solid geometry to export — add visible features first.')
+    }
+    return list
+  }, [assembled, triangleCount])
+
+  async function handleExport() {
+    if (!assembled || !format || triangleCount === 0) return
+    setExporting(true)
+    try {
+      const output = await format.export(
+        { project, mesh: assembled.mesh },
+        format.id === 'stl' ? stlOptions : format.defaultOptions,
+      )
+      const suggestedName = sanitizeFileName(fileName || project.meta.name)
+      const savedPath = output.encoding === 'binary'
+        ? await platform.saveBinaryFile(
+            suggestedName,
+            output.data as Uint8Array,
+            format.extension,
+            format.mimeType,
+            lastModelExportPath,
+          )
+        : await platform.saveTextFile(
+            suggestedName,
+            output.data as string,
+            format.extension,
+            lastModelExportPath,
+          )
+      if (savedPath) {
+        markModelExported(savedPath)
+        onClose()
+      }
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : String(error))
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  return (
+    <div className="dialog-backdrop" onClick={onClose}>
+      <div className="dialog" onClick={(event) => event.stopPropagation()}>
+        <div className="dialog-header">
+          <h2 className="dialog-title">Export Model</h2>
+          <button className="dialog-close" onClick={onClose} aria-label="Close">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="dialog-body">
+          <div className="dialog-section">
+            <div className="dialog-section-group">
+              <label className="dialog-section-title">Format</label>
+              <Select
+                value={formatId}
+                options={MODEL_EXPORT_FORMATS.map((f) => ({ value: f.id, label: f.name }))}
+                onChange={setFormatId}
+              />
+            </div>
+
+            <div className="dialog-section-group">
+              <label className="dialog-section-title" htmlFor="model-export-name">File name</label>
+              <div className="properties-field">
+                <input
+                  id="model-export-name"
+                  type="text"
+                  value={fileName}
+                  onChange={(event) => setFileName(event.target.value)}
+                  spellCheck={false}
+                />
+              </div>
+              <div style={{ fontSize: '11px', color: 'var(--text-dim)' }}>
+                Saved as <code>{`${sanitizeFileName(fileName || project.meta.name)}.${format?.extension ?? ''}`}</code>. The location is chosen in the next dialog.
+              </div>
+            </div>
+
+            <div className="dialog-section-group">
+              <label className="dialog-section-title">Curve quality</label>
+              <Select<CurveQuality>
+                value={curveQuality}
+                options={CURVE_QUALITY_OPTIONS}
+                onChange={setCurveQuality}
+              />
+              <div style={{ fontSize: '11px', color: 'var(--text-dim)' }}>
+                Controls how finely arcs and bezier curves are tessellated. Finer = more triangles, smoother curves.
+              </div>
+            </div>
+
+            {format?.id === 'stl' && (
+              <StlOptionsPanel options={stlOptions} onChange={setStlOptions} />
+            )}
+
+            <div className="dialog-section-group">
+              <label className="dialog-section-title">Summary</label>
+              <div style={{ fontSize: '13px', color: 'var(--text)', display: 'grid', gap: '4px' }}>
+                <div>{assembling ? 'Assembling mesh…' : `${triangleCount.toLocaleString()} triangles`}</div>
+                {estimatedSize !== null && (
+                  <div style={{ fontSize: '11px', color: 'var(--text-dim)' }}>
+                    Estimated file size: {formatBytes(estimatedSize)}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {warnings.length > 0 && (
+              <div className="dialog-section-group">
+                <label className="dialog-section-title">Warnings</label>
+                <div className="export-warning-list">
+                  {warnings.map((warning, index) => (
+                    <div key={index} className="export-warning">{warning}</div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {errorMessage && (
+              <div className="dialog-section-group">
+                <label className="dialog-section-title">Error</label>
+                <div className="export-warning">{errorMessage}</div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="dialog-footer">
+          <button className="btn-secondary" onClick={onClose} type="button" disabled={exporting}>
+            Cancel
+          </button>
+          <button
+            className="btn-primary"
+            onClick={handleExport}
+            disabled={!assembled || triangleCount === 0 || assembling || exporting}
+            type="button"
+          >
+            {exporting ? 'Exporting…' : `Export .${format?.extension ?? ''}`}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function StlOptionsPanel({
+  options,
+  onChange,
+}: {
+  options: STLExportOptions
+  onChange: (next: STLExportOptions) => void
+}) {
+  return (
+    <>
+      <div className="dialog-section-group">
+        <label className="dialog-section-title">STL encoding</label>
+        <div className="export-option-group">
+          <label className="export-option">
+            <input
+              type="radio"
+              name="stl-format"
+              checked={options.format === 'binary'}
+              onChange={() => onChange({ ...options, format: 'binary' })}
+            />
+            Binary (recommended — smaller, faster)
+          </label>
+          <label className="export-option">
+            <input
+              type="radio"
+              name="stl-format"
+              checked={options.format === 'ascii'}
+              onChange={() => onChange({ ...options, format: 'ascii' })}
+            />
+            ASCII (human-readable)
+          </label>
+        </div>
+      </div>
+      <div className="dialog-section-group">
+        <label className="dialog-section-title">Contents</label>
+        <div className="export-option-group">
+          <label className="export-option">
+            <input
+              type="checkbox"
+              checked={options.includeImportedMeshes}
+              onChange={(event) => onChange({ ...options, includeImportedMeshes: event.target.checked })}
+            />
+            Include imported meshes
+          </label>
+        </div>
+      </div>
+    </>
+  )
+}
+
+const CURVE_QUALITY_OPTIONS: { value: CurveQuality, label: string }[] = [
+  { value: 'coarse', label: 'Coarse (10° — matches 3D viewport)' },
+  { value: 'normal', label: 'Normal (5°)' },
+  { value: 'fine', label: 'Fine (2°)' },
+  { value: 'very_fine', label: 'Very fine (1°)' },
+]
+
+function sanitizeFileName(name: string): string {
+  const trimmed = name.trim().replace(/\s+/g, '_').replace(/[\\/:*?"<>|]+/g, '')
+  return trimmed || 'model'
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -49,6 +49,7 @@ interface AppShellProps {
   onZoomWindow: () => void
   zoomWindowActive: boolean
   onImportComplete?: () => void
+  onExportModel: () => void
   snapSettings: SnapSettings
   activeSnapMode?: SnapMode | null
   onToggleSnapEnabled: () => void
@@ -85,6 +86,7 @@ export function AppShell({
   onZoomWindow,
   zoomWindowActive,
   onImportComplete,
+  onExportModel,
   snapSettings,
   activeSnapMode,
   onToggleSnapEnabled,
@@ -288,6 +290,7 @@ export function AppShell({
             onOpenLeftDrawer={() => setLeftDrawerOpen(true)}
             onOpenRightDrawer={() => setRightDrawerOpen(true)}
             onImportComplete={onImportComplete}
+            onExportModel={onExportModel}
             snapSettings={snapSettings}
             activeSnapMode={activeSnapMode}
             onToggleSnapEnabled={onToggleSnapEnabled}

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -41,6 +41,7 @@ interface ToolbarProps {
   onZoomWindow: () => void
   zoomWindowActive?: boolean
   onImportComplete?: () => void
+  onExportModel: () => void
 }
 
 interface SnapToolbarProps {
@@ -527,6 +528,7 @@ function GlobalActions({
   onNew,
   onOpen,
   onImport,
+  onExportModel,
   onSave,
   onUndo,
   onRedo,
@@ -540,6 +542,7 @@ function GlobalActions({
   onNew: () => void
   onOpen: () => void
   onImport: () => void
+  onExportModel: () => void
   onSave: () => void
   onUndo: () => void
   onRedo: () => void
@@ -554,6 +557,7 @@ function GlobalActions({
         <ToolbarActionButton icon="new" label="New project" onClick={onNew} />
         <ToolbarActionButton icon="open" label="Open project" onClick={onOpen} />
         <ToolbarActionButton icon="import" label="Import geometry" onClick={onImport} />
+        <ToolbarActionButton icon="export" label="Export model" onClick={onExportModel} />
         <ToolbarActionButton
           icon="save"
           label={projectDirty ? 'Save project with unsaved changes' : 'Save project'}
@@ -1204,6 +1208,7 @@ export function GlobalToolbar({
   onZoomWindow,
   zoomWindowActive = false,
   onImportComplete,
+  onExportModel,
   snapSettings,
   activeSnapMode,
   onToggleSnapEnabled,
@@ -1229,6 +1234,7 @@ export function GlobalToolbar({
           onNew={toolbar.handleNewProject}
           onOpen={toolbar.handleLoad}
           onImport={toolbar.handleImport}
+          onExportModel={onExportModel}
           onSave={toolbar.handleSave}
           onUndo={toolbar.handleUndo}
           onRedo={toolbar.handleRedo}
@@ -1363,6 +1369,7 @@ export function Toolbar({
   onZoomWindow,
   zoomWindowActive = false,
   onImportComplete,
+  onExportModel,
   snapSettings,
   activeSnapMode,
   onToggleSnapEnabled,
@@ -1388,6 +1395,7 @@ export function Toolbar({
           onNew={toolbar.handleNewProject}
           onOpen={toolbar.handleLoad}
           onImport={toolbar.handleImport}
+          onExportModel={onExportModel}
           onSave={toolbar.handleSave}
           onUndo={toolbar.handleUndo}
           onRedo={toolbar.handleRedo}

--- a/src/components/layout/TopCommandBar.tsx
+++ b/src/components/layout/TopCommandBar.tsx
@@ -16,6 +16,7 @@ interface TopCommandBarProps {
   onOpenLeftDrawer: () => void
   onOpenRightDrawer: () => void
   onImportComplete?: () => void
+  onExportModel: () => void
   snapSettings: SnapSettings
   activeSnapMode?: SnapMode | null
   onToggleSnapEnabled: () => void
@@ -31,6 +32,7 @@ export function TopCommandBar({
   onOpenLeftDrawer,
   onOpenRightDrawer,
   onImportComplete,
+  onExportModel,
   snapSettings,
   activeSnapMode,
   onToggleSnapEnabled,
@@ -127,6 +129,9 @@ export function TopCommandBar({
             </button>
             <button className="top-cmd-btn" type="button" aria-label="Import geometry" onClick={() => setShowImportDialog(true)}>
               <Icon id="import" />
+            </button>
+            <button className="top-cmd-btn" type="button" aria-label="Export model" onClick={onExportModel}>
+              <Icon id="export" />
             </button>
             <button
               className={`top-cmd-btn ${dirty ? 'top-cmd-btn--emphasized' : ''}`}

--- a/src/engine/INDEX.md
+++ b/src/engine/INDEX.md
@@ -15,6 +15,11 @@ Pure-logic CAM core. No React, no DOM. Everything here is testable in isolation.
   - `definitions/` — bundled machine definitions (Marlin, GRBL flavors, etc.)
   - `types.ts` — `MachineDefinition` and validation
   - `utils.ts` — formatting helpers
+- `modelExport/` — 3D model export (STL today; pluggable format registry)
+  - `index.ts` — public API and `MODEL_EXPORT_FORMATS` registry
+  - `types.ts` — format/option interfaces
+  - `assemble.ts` — manifold union → standard Z-up right-handed export mesh
+  - `stl.ts` — binary + ASCII STL writers and the `stlExportFormat` entry
 - `simulation/` — voxel-based material removal sim (state, stepping, voxel grid)
 
 ## Conventions

--- a/src/engine/csg.ts
+++ b/src/engine/csg.ts
@@ -27,6 +27,11 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 
 const ARC_STEP_RADIANS = Math.PI / 18
 
+/** Default 10° per arc segment — matches the 3D viewport tessellation. */
+export const DEFAULT_ARC_STEP_RADIANS = ARC_STEP_RADIANS
+/** Default 18 segments per bezier — derived from the default arc step. */
+const DEFAULT_BEZIER_SEGMENTS = 18
+
 let manifoldModulePromise: Promise<ManifoldToplevel> | null = null
 let manifoldModuleInstance: ManifoldToplevel | null = null
 
@@ -117,9 +122,18 @@ export function profileToShape(profile: SketchProfile): THREE.Shape {
   return shape
 }
 
-function profileToPolygon(profile: SketchProfile): [number, number][] {
+function profileToPolygon(
+  profile: SketchProfile,
+  arcStepRadians: number = ARC_STEP_RADIANS,
+): [number, number][] {
   const points: [number, number][] = [[profile.start.x, profile.start.y]]
   let current = profile.start
+
+  // Scale bezier subdivision the same way arcs scale, so curve quality is consistent.
+  const bezierSegments = Math.max(
+    8,
+    Math.round(DEFAULT_BEZIER_SEGMENTS * (ARC_STEP_RADIANS / arcStepRadians)),
+  )
 
   for (const seg of profile.segments) {
     if (seg.type === 'line') {
@@ -129,9 +143,8 @@ function profileToPolygon(profile: SketchProfile): [number, number][] {
     }
 
     if (seg.type === 'bezier') {
-      const segmentCount = 18
-      for (let index = 1; index <= segmentCount; index += 1) {
-        const point = bezierPoint(current, seg.control1, seg.control2, seg.to, index / segmentCount)
+      for (let index = 1; index <= bezierSegments; index += 1) {
+        const point = bezierPoint(current, seg.control1, seg.control2, seg.to, index / bezierSegments)
         points.push([point.x, point.y])
       }
       current = seg.to
@@ -151,7 +164,7 @@ function profileToPolygon(profile: SketchProfile): [number, number][] {
       else if (!clockwise && sweep < 0) sweep += Math.PI * 2
     }
 
-    const segmentCount = Math.max(8, Math.ceil(Math.abs(sweep) / ARC_STEP_RADIANS))
+    const segmentCount = Math.max(8, Math.ceil(Math.abs(sweep) / arcStepRadians))
     for (let index = 1; index <= segmentCount; index += 1) {
       const angle = startAngle + (sweep * index) / segmentCount
       points.push([
@@ -645,7 +658,8 @@ function manifoldMeshToGeometry(mesh: import('manifold-3d').Mesh): THREE.BufferG
 export function buildFeatureSolid(
   module: ManifoldToplevel,
   project: Project,
-  feature: SketchFeature
+  feature: SketchFeature,
+  arcStepRadians: number = ARC_STEP_RADIANS,
 ): ManifoldSolid | null {
   const asset = feature.kind === 'stl' ? featureModelAsset(project, feature) : null
   if (asset) {
@@ -693,9 +707,9 @@ export function buildFeatureSolid(
       console.warn('STL is non-manifold, falling back to 2.5D silhouette extrusion for boolean model.', error)
       
       // Treat as a 2.5D composite feature by extruding the silhouette.
-      // This allows non-manifold STLs to participate in boolean operations (like pockets/cuts) 
+      // This allows non-manifold STLs to participate in boolean operations (like pockets/cuts)
       // based on their footprint.
-      const contour = profileToPolygon(feature.sketch.profile)
+      const contour = profileToPolygon(feature.sketch.profile, arcStepRadians)
       if (contour.length < 3) {
         return null
       }
@@ -718,7 +732,7 @@ export function buildFeatureSolid(
     return null
   }
 
-  const contour = profileToPolygon(feature.sketch.profile)
+  const contour = profileToPolygon(feature.sketch.profile, arcStepRadians)
   if (contour.length < 3) {
     return null
   }

--- a/src/engine/modelExport/assemble.ts
+++ b/src/engine/modelExport/assemble.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Manifold as ManifoldSolid } from 'manifold-3d'
+import { buildFeatureSolid, getManifoldModule, loadSTLTransformedGeometry } from '../csg'
+import { expandFeatureGeometry } from '../../text'
+import type { Project, SketchFeature } from '../../types/project'
+import {
+  CURVE_QUALITY_ARC_STEP_RADIANS,
+  type ExportTriangleMesh,
+  type ModelExportAssembleOptions,
+  type ModelExportAssembleResult,
+} from './types'
+
+/**
+ * Build the boolean union of all visible solid features for export.
+ *
+ * Output is in PureCutCNC's internal design coordinates (Z-up, Y oriented the
+ * same way the rest of the app stores it — i.e. matches the sketch data). This
+ * makes round-tripping (export → re-import as STL feature) preserve position,
+ * and matches what the 3D viewport and G-code pipeline already treat as
+ * canonical. External viewers/slicers will see the model with Y in the same
+ * direction the sketch top-view uses; Z is still up so the model imports the
+ * right way up. Users who care about a particular Y orientation in a downstream
+ * tool can rotate there.
+ */
+export async function assembleModelExportMesh(
+  project: Project,
+  options: ModelExportAssembleOptions,
+): Promise<ModelExportAssembleResult> {
+  const module = await getManifoldModule()
+  const warnings: string[] = []
+  const arcStepRadians = CURVE_QUALITY_ARC_STEP_RADIANS[options.curveQuality]
+
+  const visibleFeatures = project.features.filter((feature) => feature.visible)
+  const expanded = visibleFeatures.flatMap((feature) => expandFeatureGeometry(feature, false))
+
+  // 1) Build the boolean union of add/subtract features. Imported-mesh
+  //    features (operation === 'model') are excluded here — matching the
+  //    viewport's behavior — and appended as raw triangles in step (2).
+  //    Unioning them here would silently fill pockets when the underlying
+  //    STL is non-manifold (buildFeatureSolid falls back to a 2.5D silhouette
+  //    extrusion, which is a plain block).
+  let booleanMesh: ExportTriangleMesh = { positions: new Float32Array(0), index: new Uint32Array(0) }
+  let current: ManifoldSolid | null = null
+  try {
+    for (const feature of expanded) {
+      if (!shouldIncludeInBoolean(feature)) continue
+
+      let solid: ManifoldSolid | null = null
+      try {
+        solid = buildFeatureSolid(module, project, feature, arcStepRadians)
+        if (!solid) continue
+
+        if (!current) {
+          if (feature.operation === 'add') {
+            current = solid
+            solid = null
+          }
+          continue
+        }
+
+        const next = feature.operation === 'subtract'
+          ? module.Manifold.difference(current, solid)
+          : module.Manifold.union(current, solid)
+
+        current.delete()
+        current = next
+      } finally {
+        solid?.delete()
+      }
+    }
+
+    if (current) {
+      booleanMesh = manifoldMeshToExportMesh(current.getMesh())
+    }
+  } finally {
+    current?.delete()
+  }
+
+  // 2) Append imported-mesh features as raw triangles, transformed into
+  //    design space (scale, z-stretch, rotate, translate to sketch origin).
+  //    This preserves their actual geometry — pockets, holes, fine
+  //    detail — independent of whether they're manifold.
+  const meshes: ExportTriangleMesh[] = [booleanMesh]
+  if (options.includeImportedMeshes) {
+    for (const feature of expanded) {
+      if (feature.operation !== 'model') continue
+      const transformed = loadSTLTransformedGeometry(feature, project)
+      if (!transformed) continue
+      meshes.push({
+        positions: new Float32Array(transformed.positions),
+        index: new Uint32Array(transformed.index),
+      })
+    }
+  }
+
+  return { mesh: concatMeshes(meshes), warnings }
+}
+
+function shouldIncludeInBoolean(feature: SketchFeature): boolean {
+  return feature.operation === 'add' || feature.operation === 'subtract'
+}
+
+function concatMeshes(meshes: ExportTriangleMesh[]): ExportTriangleMesh {
+  let totalVerts = 0
+  let totalIndices = 0
+  for (const m of meshes) {
+    totalVerts += m.positions.length / 3
+    totalIndices += m.index.length
+  }
+  const positions = new Float32Array(totalVerts * 3)
+  const index = new Uint32Array(totalIndices)
+  let vOff = 0
+  let iOff = 0
+  for (const m of meshes) {
+    positions.set(m.positions, vOff * 3)
+    for (let i = 0; i < m.index.length; i += 1) {
+      index[iOff + i] = m.index[i] + vOff
+    }
+    vOff += m.positions.length / 3
+    iOff += m.index.length
+  }
+  return { positions, index }
+}
+
+/**
+ * Convert a Manifold mesh into an export triangle mesh, preserving manifold's
+ * coordinates and winding 1:1. Manifold's `numProp` may be ≥ 3 (extra
+ * properties beyond position), so we strip down to xyz here.
+ */
+function manifoldMeshToExportMesh(mesh: import('manifold-3d').Mesh): ExportTriangleMesh {
+  const numVerts = mesh.numVert
+  const positions = new Float32Array(numVerts * 3)
+  for (let i = 0; i < numVerts; i += 1) {
+    const src = i * mesh.numProp
+    const dst = i * 3
+    positions[dst] = mesh.vertProperties[src]
+    positions[dst + 1] = mesh.vertProperties[src + 1]
+    positions[dst + 2] = mesh.vertProperties[src + 2]
+  }
+
+  const index = new Uint32Array(mesh.triVerts)
+  return { positions, index }
+}
+
+export function countTriangles(mesh: ExportTriangleMesh): number {
+  return mesh.index.length / 3
+}

--- a/src/engine/modelExport/index.ts
+++ b/src/engine/modelExport/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { stlExportFormat } from './stl'
+import type { ModelExportFormat } from './types'
+
+export {
+  CURVE_QUALITY_ARC_STEP_RADIANS,
+  type CurveQuality,
+  type ExportTriangleMesh,
+  type ModelExportAssembleOptions,
+  type ModelExportAssembleResult,
+  type ModelExportFormat,
+  type ModelExportInput,
+  type ModelExportOutput,
+} from './types'
+export { assembleModelExportMesh, countTriangles } from './assemble'
+export {
+  STL_DEFAULT_OPTIONS,
+  estimateStlFileSize,
+  stlExportFormat,
+  writeAsciiStl,
+  writeBinaryStl,
+  type STLExportOptions,
+} from './stl'
+
+export const MODEL_EXPORT_FORMATS: ModelExportFormat[] = [stlExportFormat as ModelExportFormat]
+
+export function getModelExportFormat(id: string): ModelExportFormat | null {
+  return MODEL_EXPORT_FORMATS.find((format) => format.id === id) ?? null
+}

--- a/src/engine/modelExport/stl.test.ts
+++ b/src/engine/modelExport/stl.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the STL writer used by the model export pipeline.
+ *
+ * Run with: npx tsx src/engine/modelExport/stl.test.ts
+ */
+
+import { writeAsciiStl, writeBinaryStl } from './stl'
+import type { ExportTriangleMesh } from './types'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function approx(a: number, b: number, epsilon = 1e-5): boolean {
+  return Math.abs(a - b) < epsilon
+}
+
+// Unit cube (8 verts, 12 triangles), Z-up.
+function unitCubeMesh(): ExportTriangleMesh {
+  const positions = new Float32Array([
+    0, 0, 0,  1, 0, 0,  1, 1, 0,  0, 1, 0,
+    0, 0, 1,  1, 0, 1,  1, 1, 1,  0, 1, 1,
+  ])
+  const index = new Uint32Array([
+    0, 2, 1,  0, 3, 2, // bottom (-Z)
+    4, 5, 6,  4, 6, 7, // top (+Z)
+    0, 1, 5,  0, 5, 4, // -Y
+    1, 2, 6,  1, 6, 5, // +X
+    2, 3, 7,  2, 7, 6, // +Y
+    3, 0, 4,  3, 4, 7, // -X
+  ])
+  return { positions, index }
+}
+
+interface ParsedStl {
+  triangleCount: number
+  vertexCount: number
+  bounds: { min: [number, number, number], max: [number, number, number] }
+  normals: Array<[number, number, number]>
+}
+
+function parseBinaryStl(bytes: Uint8Array): ParsedStl {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const triCount = view.getUint32(80, true)
+  let offset = 84
+  const min: [number, number, number] = [Infinity, Infinity, Infinity]
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity]
+  const normals: Array<[number, number, number]> = []
+  for (let t = 0; t < triCount; t += 1) {
+    const nx = view.getFloat32(offset, true); offset += 4
+    const ny = view.getFloat32(offset, true); offset += 4
+    const nz = view.getFloat32(offset, true); offset += 4
+    normals.push([nx, ny, nz])
+    for (let v = 0; v < 3; v += 1) {
+      const x = view.getFloat32(offset, true); offset += 4
+      const y = view.getFloat32(offset, true); offset += 4
+      const z = view.getFloat32(offset, true); offset += 4
+      if (x < min[0]) min[0] = x
+      if (y < min[1]) min[1] = y
+      if (z < min[2]) min[2] = z
+      if (x > max[0]) max[0] = x
+      if (y > max[1]) max[1] = y
+      if (z > max[2]) max[2] = z
+    }
+    offset += 2 // attribute byte count
+  }
+  return { triangleCount: triCount, vertexCount: triCount * 3, bounds: { min, max }, normals }
+}
+
+function parseAsciiStl(text: string): ParsedStl {
+  const lines = text.split('\n')
+  let triangleCount = 0
+  const min: [number, number, number] = [Infinity, Infinity, Infinity]
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity]
+  const normals: Array<[number, number, number]> = []
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (line.startsWith('facet normal ')) {
+      const [, , nx, ny, nz] = line.split(/\s+/)
+      normals.push([Number(nx), Number(ny), Number(nz)])
+      triangleCount += 1
+    } else if (line.startsWith('vertex ')) {
+      const [, x, y, z] = line.split(/\s+/)
+      const fx = Number(x), fy = Number(y), fz = Number(z)
+      if (fx < min[0]) min[0] = fx
+      if (fy < min[1]) min[1] = fy
+      if (fz < min[2]) min[2] = fz
+      if (fx > max[0]) max[0] = fx
+      if (fy > max[1]) max[1] = fy
+      if (fz > max[2]) max[2] = fz
+    }
+  }
+  return { triangleCount, vertexCount: triangleCount * 3, bounds: { min, max }, normals }
+}
+
+function testBinaryRoundTrip(): void {
+  console.log('Testing binary STL writer round-trip...')
+  const cube = unitCubeMesh()
+  const bytes = writeBinaryStl(cube)
+  assert(bytes.byteLength === 84 + 12 * 50, `unexpected byte length ${bytes.byteLength}`)
+  const parsed = parseBinaryStl(bytes)
+  assert(parsed.triangleCount === 12, `expected 12 triangles, got ${parsed.triangleCount}`)
+  for (let i = 0; i < 3; i += 1) {
+    assert(approx(parsed.bounds.min[i], 0), `min[${i}] = ${parsed.bounds.min[i]}`)
+    assert(approx(parsed.bounds.max[i], 1), `max[${i}] = ${parsed.bounds.max[i]}`)
+  }
+  for (const [nx, ny, nz] of parsed.normals) {
+    assert(approx(Math.hypot(nx, ny, nz), 1, 1e-3), `expected unit normal, got ${nx},${ny},${nz}`)
+  }
+}
+
+function testAsciiRoundTrip(): void {
+  console.log('Testing ASCII STL writer round-trip...')
+  const cube = unitCubeMesh()
+  const text = writeAsciiStl(cube, 'cube')
+  assert(text.startsWith('solid cube'), 'expected solid header')
+  assert(text.trimEnd().endsWith('endsolid cube'), 'expected endsolid footer')
+  const parsed = parseAsciiStl(text)
+  assert(parsed.triangleCount === 12, `expected 12 facets, got ${parsed.triangleCount}`)
+  for (let i = 0; i < 3; i += 1) {
+    assert(approx(parsed.bounds.min[i], 0), `ascii min[${i}] = ${parsed.bounds.min[i]}`)
+    assert(approx(parsed.bounds.max[i], 1), `ascii max[${i}] = ${parsed.bounds.max[i]}`)
+  }
+}
+
+function testEmptyMesh(): void {
+  console.log('Testing empty STL writers...')
+  const empty: ExportTriangleMesh = { positions: new Float32Array(0), index: new Uint32Array(0) }
+  const binary = writeBinaryStl(empty)
+  assert(binary.byteLength === 84, `empty binary should be 84 bytes, got ${binary.byteLength}`)
+  assert(new DataView(binary.buffer).getUint32(80, true) === 0, 'empty binary should have 0 triangles')
+
+  const text = writeAsciiStl(empty, 'empty')
+  const parsed = parseAsciiStl(text)
+  assert(parsed.triangleCount === 0, `empty ascii should have 0 facets, got ${parsed.triangleCount}`)
+}
+
+function testWindingNormals(): void {
+  console.log('Testing per-face normal direction...')
+  // Single CCW triangle in the XY plane viewed from +Z → normal should be (0,0,1).
+  const mesh: ExportTriangleMesh = {
+    positions: new Float32Array([0, 0, 0,  1, 0, 0,  0, 1, 0]),
+    index: new Uint32Array([0, 1, 2]),
+  }
+  const parsed = parseBinaryStl(writeBinaryStl(mesh))
+  assert(approx(parsed.normals[0][0], 0) && approx(parsed.normals[0][1], 0) && approx(parsed.normals[0][2], 1),
+    `expected (0,0,1) normal, got ${parsed.normals[0].join(',')}`)
+}
+
+testBinaryRoundTrip()
+testAsciiRoundTrip()
+testEmptyMesh()
+testWindingNormals()
+console.log('model export stl writer tests passed')

--- a/src/engine/modelExport/stl.ts
+++ b/src/engine/modelExport/stl.ts
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ExportTriangleMesh, ModelExportFormat, ModelExportInput, ModelExportOutput } from './types'
+
+export interface STLExportOptions {
+  /** Binary STL is ~6× smaller and faster to read; ASCII is human-inspectable. */
+  format: 'binary' | 'ascii'
+  /** When false, features rendered as visual overlays (`operation: 'model'`) are excluded. */
+  includeImportedMeshes: boolean
+}
+
+export const STL_DEFAULT_OPTIONS: STLExportOptions = {
+  format: 'binary',
+  includeImportedMeshes: true,
+}
+
+const BINARY_HEADER_BYTES = 80
+const BINARY_TRIANGLE_BYTES = 50
+
+/** Estimated file size in bytes for the given mesh under the given STL format. */
+export function estimateStlFileSize(mesh: ExportTriangleMesh, format: STLExportOptions['format']): number {
+  const triCount = mesh.index.length / 3
+  if (format === 'binary') {
+    return BINARY_HEADER_BYTES + 4 + triCount * BINARY_TRIANGLE_BYTES
+  }
+  // ASCII average per facet ≈ 145 bytes (rough but useful for the dialog hint).
+  return Math.round(20 + triCount * 145)
+}
+
+export function writeBinaryStl(mesh: ExportTriangleMesh): Uint8Array {
+  const { positions, index } = mesh
+  const triCount = index.length / 3
+  const buffer = new ArrayBuffer(BINARY_HEADER_BYTES + 4 + triCount * BINARY_TRIANGLE_BYTES)
+  const view = new DataView(buffer)
+
+  // The 80-byte header is informational only — most parsers ignore it.
+  const header = `PureCutCNC STL export`
+  for (let i = 0; i < Math.min(header.length, BINARY_HEADER_BYTES); i += 1) {
+    view.setUint8(i, header.charCodeAt(i))
+  }
+
+  view.setUint32(BINARY_HEADER_BYTES, triCount, true)
+
+  let offset = BINARY_HEADER_BYTES + 4
+  for (let t = 0; t < triCount; t += 1) {
+    const ia = index[t * 3] * 3
+    const ib = index[t * 3 + 1] * 3
+    const ic = index[t * 3 + 2] * 3
+
+    const ax = positions[ia], ay = positions[ia + 1], az = positions[ia + 2]
+    const bx = positions[ib], by = positions[ib + 1], bz = positions[ib + 2]
+    const cx = positions[ic], cy = positions[ic + 1], cz = positions[ic + 2]
+
+    const ux = bx - ax, uy = by - ay, uz = bz - az
+    const vx = cx - ax, vy = cy - ay, vz = cz - az
+    let nx = uy * vz - uz * vy
+    let ny = uz * vx - ux * vz
+    let nz = ux * vy - uy * vx
+    const len = Math.hypot(nx, ny, nz)
+    if (len > 0) {
+      nx /= len
+      ny /= len
+      nz /= len
+    }
+
+    view.setFloat32(offset, nx, true); offset += 4
+    view.setFloat32(offset, ny, true); offset += 4
+    view.setFloat32(offset, nz, true); offset += 4
+    view.setFloat32(offset, ax, true); offset += 4
+    view.setFloat32(offset, ay, true); offset += 4
+    view.setFloat32(offset, az, true); offset += 4
+    view.setFloat32(offset, bx, true); offset += 4
+    view.setFloat32(offset, by, true); offset += 4
+    view.setFloat32(offset, bz, true); offset += 4
+    view.setFloat32(offset, cx, true); offset += 4
+    view.setFloat32(offset, cy, true); offset += 4
+    view.setFloat32(offset, cz, true); offset += 4
+    view.setUint16(offset, 0, true); offset += 2
+  }
+
+  return new Uint8Array(buffer)
+}
+
+export function writeAsciiStl(mesh: ExportTriangleMesh, solidName = 'model'): string {
+  const { positions, index } = mesh
+  const triCount = index.length / 3
+  const lines: string[] = [`solid ${solidName}`]
+
+  for (let t = 0; t < triCount; t += 1) {
+    const ia = index[t * 3] * 3
+    const ib = index[t * 3 + 1] * 3
+    const ic = index[t * 3 + 2] * 3
+
+    const ax = positions[ia], ay = positions[ia + 1], az = positions[ia + 2]
+    const bx = positions[ib], by = positions[ib + 1], bz = positions[ib + 2]
+    const cx = positions[ic], cy = positions[ic + 1], cz = positions[ic + 2]
+
+    const ux = bx - ax, uy = by - ay, uz = bz - az
+    const vx = cx - ax, vy = cy - ay, vz = cz - az
+    let nx = uy * vz - uz * vy
+    let ny = uz * vx - ux * vz
+    let nz = ux * vy - uy * vx
+    const len = Math.hypot(nx, ny, nz)
+    if (len > 0) {
+      nx /= len; ny /= len; nz /= len
+    }
+
+    lines.push(`  facet normal ${fmt(nx)} ${fmt(ny)} ${fmt(nz)}`)
+    lines.push('    outer loop')
+    lines.push(`      vertex ${fmt(ax)} ${fmt(ay)} ${fmt(az)}`)
+    lines.push(`      vertex ${fmt(bx)} ${fmt(by)} ${fmt(bz)}`)
+    lines.push(`      vertex ${fmt(cx)} ${fmt(cy)} ${fmt(cz)}`)
+    lines.push('    endloop')
+    lines.push('  endfacet')
+  }
+
+  lines.push(`endsolid ${solidName}`)
+  return lines.join('\n') + '\n'
+}
+
+function fmt(value: number): string {
+  if (!Number.isFinite(value)) return '0'
+  // 6 decimals is enough for typical CAD precision and keeps files compact.
+  return value.toFixed(6)
+}
+
+function sanitizeSolidName(name: string): string {
+  return name.replace(/[^A-Za-z0-9_\-]+/g, '_') || 'model'
+}
+
+export const stlExportFormat: ModelExportFormat<STLExportOptions> = {
+  id: 'stl',
+  name: 'STL (Stereolithography)',
+  extension: 'stl',
+  mimeType: 'model/stl',
+  defaultOptions: STL_DEFAULT_OPTIONS,
+  renderOptions: () => null, // Provided by the dialog itself (avoids React import in this file).
+  export(input: ModelExportInput, options: STLExportOptions): ModelExportOutput {
+    if (options.format === 'ascii') {
+      return {
+        data: writeAsciiStl(input.mesh, sanitizeSolidName(input.project.meta.name)),
+        encoding: 'text',
+      }
+    }
+    return {
+      data: writeBinaryStl(input.mesh),
+      encoding: 'binary',
+    }
+  },
+}

--- a/src/engine/modelExport/types.ts
+++ b/src/engine/modelExport/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactNode } from 'react'
+import type { Project } from '../../types/project'
+
+/** Triangle mesh in standard right-handed Z-up coordinates (the STL/CAD convention). */
+export interface ExportTriangleMesh {
+  /** Interleaved xyz vertex positions. */
+  positions: Float32Array
+  /** Triangle vertex indices (length is a multiple of 3). */
+  index: Uint32Array
+}
+
+/**
+ * Tessellation quality preset for arc/bezier curves in 2D sketches when
+ * they're converted to a polygon prior to extrusion. Coarser presets produce
+ * fewer triangles and match the 3D viewport's tessellation; finer presets
+ * approximate true curves more closely.
+ */
+export type CurveQuality = 'coarse' | 'normal' | 'fine' | 'very_fine'
+
+/** Maps a curve quality preset to its arc step in radians (smaller = finer). */
+export const CURVE_QUALITY_ARC_STEP_RADIANS: Record<CurveQuality, number> = {
+  coarse: Math.PI / 18,    // 10° — matches 3D viewport tessellation
+  normal: Math.PI / 36,    // 5°
+  fine: Math.PI / 90,      // 2°
+  very_fine: Math.PI / 180, // 1°
+}
+
+export interface ModelExportAssembleOptions {
+  /**
+   * Include features stored as imported meshes that are rendered as visual
+   * overlays in the 3D viewport (`operation === 'model'`). When false the
+   * exported mesh matches exactly what the viewport's boolean preview shows.
+   */
+  includeImportedMeshes: boolean
+  /** Curve tessellation quality. Defaults to 'normal'. */
+  curveQuality: CurveQuality
+}
+
+export interface ModelExportAssembleResult {
+  mesh: ExportTriangleMesh
+  /** Non-blocking notes worth surfacing in the dialog (e.g. fallback geometry used). */
+  warnings: string[]
+}
+
+export interface ModelExportInput {
+  project: Project
+  mesh: ExportTriangleMesh
+}
+
+export interface ModelExportOutput {
+  /** File bytes (binary formats) or text (ASCII formats). */
+  data: Uint8Array | string
+  /** Tells the caller which save path to use on the platform API. */
+  encoding: 'binary' | 'text'
+}
+
+export interface ModelExportFormat<TOptions = unknown> {
+  id: string
+  /** Human-readable name shown in the dialog format dropdown. */
+  name: string
+  /** File extension without the leading dot. */
+  extension: string
+  /** MIME type used by the browser blob save fallback. */
+  mimeType: string
+  defaultOptions: TOptions
+  /** React node for the format-specific option controls in the dialog. */
+  renderOptions: (props: {
+    options: TOptions
+    onChange: (next: TOptions) => void
+  }) => ReactNode
+  /**
+   * Serialize the assembled mesh to the format's byte/text representation.
+   * Implementations should be synchronous unless they genuinely need async work.
+   */
+  export: (input: ModelExportInput, options: TOptions) => Promise<ModelExportOutput> | ModelExportOutput
+}

--- a/src/platform/api.ts
+++ b/src/platform/api.ts
@@ -69,6 +69,22 @@ export interface PlatformApi {
   ): Promise<string | null>
 
   /**
+   * Write a binary file (e.g. binary STL).
+   *
+   * - If existingPath is provided, write to that path without a dialog.
+   * - Otherwise show a Save As dialog first.
+   *
+   * Returns the path written to, or null if the user cancels.
+   */
+  saveBinaryFile(
+    suggestedName: string,
+    content: Uint8Array,
+    extension: string,
+    mimeType: string,
+    existingPath?: string | null
+  ): Promise<string | null>
+
+  /**
    * Prompt the user to choose a JSON file and return its content.
    * Returns null if the user cancels.
    */

--- a/src/platform/browser.ts
+++ b/src/platform/browser.ts
@@ -56,7 +56,7 @@ function readFileAsText(file: File): Promise<string> {
   })
 }
 
-function triggerDownload(content: string, fileName: string, mimeType: string): void {
+function triggerDownload(content: BlobPart, fileName: string, mimeType: string): void {
   const blob = new Blob([content], { type: mimeType })
   const url = URL.createObjectURL(blob)
   const anchor = document.createElement('a')
@@ -73,7 +73,7 @@ function triggerDownload(content: string, fileName: string, mimeType: string): v
  * Falls back to triggerDownload (always succeeds) when the API is missing.
  */
 async function saveFile(
-  content: string,
+  content: BlobPart,
   fileName: string,
   mimeType: string,
   description: string,
@@ -147,6 +147,23 @@ export const browserPlatform: PlatformApi = {
       ? suggestedName
       : `${suggestedName}.${extension}`
     return saveFile(content, fileName, 'text/plain', `${extension.toUpperCase()} file`, [`.${extension}`])
+  },
+
+  async saveBinaryFile(
+    suggestedName: string,
+    content: Uint8Array,
+    extension: string,
+    mimeType: string
+  ): Promise<string | null> {
+    const fileName = suggestedName.endsWith(`.${extension}`)
+      ? suggestedName
+      : `${suggestedName}.${extension}`
+    // Copy into a Uint8Array<ArrayBuffer> so it satisfies BlobPart under
+    // TS 5.7+ (the default Uint8Array generic is now ArrayBufferLike which
+    // includes SharedArrayBuffer and isn't a BlobPart).
+    const buffer = new ArrayBuffer(content.byteLength)
+    new Uint8Array(buffer).set(content)
+    return saveFile(buffer, fileName, mimeType, `${extension.toUpperCase()} file`, [`.${extension}`])
   },
 
   async pickJsonFile(): Promise<string | null> {

--- a/src/platform/desktop.ts
+++ b/src/platform/desktop.ts
@@ -15,7 +15,7 @@
  */
 
 import { open, save, confirm } from '@tauri-apps/plugin-dialog'
-import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs'
+import { readTextFile, writeFile, writeTextFile } from '@tauri-apps/plugin-fs'
 import type { PlatformApi, OpenProjectResult, PickGeometryResult } from './api'
 
 // ---------------------------------------------------------------------------
@@ -73,6 +73,28 @@ export const desktopPlatform: PlatformApi = {
 
     if (!targetPath) return null
     await writeTextFile(targetPath, content)
+    return targetPath
+  },
+
+  async saveBinaryFile(
+    suggestedName: string,
+    content: Uint8Array,
+    extension: string,
+    _mimeType: string,
+    existingPath?: string | null
+  ): Promise<string | null> {
+    let targetPath = existingPath ?? null
+
+    if (!targetPath) {
+      const base = suggestedName.replace(new RegExp(`\\.${extension}$`), '')
+      targetPath = await save({
+        defaultPath: `${base}.${extension}`,
+        filters: [{ name: `${extension.toUpperCase()} file`, extensions: [extension] }],
+      })
+    }
+
+    if (!targetPath) return null
+    await writeFile(targetPath, content)
     return targetPath
   },
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -3066,6 +3066,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
   backdropImageLoading: false,
   filePath: null,
   lastExportPath: null,
+  lastModelExportPath: null,
   dirty: false,
   projectLoading: false,
   projectKey: 0,
@@ -3614,6 +3615,9 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
 
   markExported: (path) =>
     set({ lastExportPath: path }),
+
+  markModelExported: (path) =>
+    set({ lastModelExportPath: path }),
 
   undo: () =>
     set((state) => {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -208,6 +208,8 @@ export interface ProjectStore {
   filePath: string | null
   /** Path of the most recent G-code export. Null until first export this session. */
   lastExportPath: string | null
+  /** Path of the most recent 3D model export. Null until first export this session. */
+  lastModelExportPath: string | null
   /** True when the project has unsaved changes. */
   dirty: boolean
 
@@ -235,6 +237,8 @@ export interface ProjectStore {
   markSaved: (path: string | null) => void
   /** Called after a successful G-code export — records the export path. */
   markExported: (path: string) => void
+  /** Called after a successful 3D model export — records the export path. */
+  markModelExported: (path: string) => void
   undo: () => void
   redo: () => void
   beginHistoryTransaction: () => void


### PR DESCRIPTION
## Summary

- Adds 3D model export with a pluggable format registry (STL ships first, both binary + ASCII). New "Export model" toolbar button opens a dialog with format, filename, curve quality (Coarse/Normal/Fine/Very fine), and format-specific options (binary vs ASCII, include imported meshes).
- Mesh assembly matches the 3D viewport: boolean union of add/subtract features via manifold-3d, then imported-mesh features (`operation: 'model'`) appended as raw transformed triangles so their real geometry is preserved. Output uses internal design coordinates so export → re-import preserves position.
- Plumbing: `profileToPolygon` and `buildFeatureSolid` now accept an optional `arcStepRadians`; platform API gains `saveBinaryFile` (browser Blob / Tauri `writeFile`); store gains `lastModelExportPath` / `markModelExported` mirroring the G-code export pattern.

Plan: [planning/archive/MODEL_EXPORT_Plan.md](planning/archive/MODEL_EXPORT_Plan.md)

## Test plan

- [x] `npm run build` is clean (verified locally).
- [x] `npx tsx src/engine/modelExport/stl.test.ts` passes (binary + ASCII round-trip, empty mesh, winding/normal direction).
- [x] Click the new export icon next to Import in the toolbar; dialog opens with format/name/quality/options.
- [x] Export a binary STL of a simple feature-based project; opens correctly Z-up in MeshLab/PrusaSlicer (Y may be mirrored vs the sketch top view — design choice noted in the plan).
- [x] Export an ASCII STL; same project produces a valid ASCII file with `solid`/`endsolid` markers.
- [x] Round-trip (export → re-import) places the re-imported model at the same position as the original.
- [x] Curve quality dropdown changes triangle count for projects with arcs/circles; estimated file size updates live.
- [x] "Include imported meshes" toggle controls whether previously-imported STL features are bundled into the export.

## Known follow-ups

- Re-importing a multi-body STL (which is what re-exporting a project that already has an imported STL produces) shows a confused-looking sketch view: a single feature outline with the combined silhouette of all bodies inside. This is a pre-existing limitation of the STL importer (`extractImportedMeshProfileAndBounds` in `src/import/stl.ts` picks the single largest polygon as the profile while the silhouette paths include all polygons). The 3D view is unaffected. Tracked as a separate task — fix is to split multi-body STLs into one feature per body on import.
- Some imported STLs (including round-tripped ones) trigger a "STL is non-manifold" warning in the console because manifold-3d can't validate them. The existing 2.5D-silhouette fallback handles this; the warning is benign. Tighter import-weld tolerance and warning suppression are out of scope here.