### PR TITLE
Split multi-body STL/OBJ imports into per-body sketch features

### DIFF
--- a/planning/archive/MULTI_BODY_STL_IMPORT_Plan.md
+++ b/planning/archive/MULTI_BODY_STL_IMPORT_Plan.md
@@ -1,0 +1,90 @@
+---
+status: Done
+created: 2026-05-19
+---
+
+# Multi-Body STL Import Plan
+
+## Goal
+
+Fix the STL/OBJ importer so a mesh containing multiple disjoint bodies becomes **multiple sketch features** (one per body) instead of a single feature whose 2D outline and shaded silhouette disagree. Repro path: export a project as STL, re-import it, export again, re-import — the second re-import currently produces one feature whose orange profile covers one body but whose interior shading shows silhouettes of every body. After this change, each disjoint body in the imported mesh becomes its own `SketchFeature` with its own profile, silhouette paths, mesh asset, and Z bounds. Single-body imports keep the current behavior verbatim.
+
+## Approach
+
+1. **Detect connected components on the (welded) triangle mesh.** After the existing `BufferGeometryUtils.mergeVertices(_, 1e-5)` weld in [importedMesh.ts:392](src/engine/importedMesh.ts:392) — extended/mirrored on the normalized `ImportedTriangleMesh` we already operate on — run union-find over triangle edges (each triangle contributes 3 edges; union their endpoint vertex indices). Each connected vertex set defines a body; triangles inherit their component from any of their three vertices.
+2. **Split into sub-meshes.** For each component, build a new `ImportedTriangleMesh` containing only its triangles, with vertex indices re-mapped and a recomputed bbox. Reuse [normalizeImportedMeshForStorage](src/engine/importedMesh.ts) shape (positions/indices/bounds).
+3. **Run the existing profile pipeline per sub-mesh.** Call `extractImportedMeshProfileAndBounds` on each sub-mesh — no change to its internals, just call it N times. This gives per-body `profile`, `silhouettePaths`, `z_top`, `z_bottom`.
+4. **Create N features, one per body.** Each gets its own mesh asset in `project.modelAssets` (separate `meshAssetId` per feature). Naming: `<base>` for the first, `<base> (2)`, `<base> (3)`, … Place all bodies into a new feature folder named after the file so they stay grouped in the tree. Each feature is independently transformable.
+5. **Short-circuit when there's one body.** If the connected-component pass yields exactly one component, fall back to today's single-feature code path verbatim — same mesh asset, same `silhouettePaths`, same outputs. No behavior change for single-body imports or for any saved project.
+6. **Apply to STL and OBJ.** The split logic lives in the generic `extractImportedModelProfileAndBounds` / `ImportGeometryDialog` model branch, not an STL-only path.
+
+Key design choices to call out:
+- **Component detection on the welded mesh, not the raw STL triangles** — STL stores each triangle's 3 vertices independently, so without welding every triangle would look like its own component. The weld tolerance `1e-5` (existing) is reused; not widened.
+- **One mesh asset per body**, not a shared asset with triangle-range hints — simpler ownership, lets each feature be independently deleted/moved without dangling references. Storage cost grows linearly with body count, which is acceptable for typical inputs (most STL imports are single-body; round-tripped projects tend to have <10 bodies).
+- **No new public API surface in stl.ts**: introduce one new helper (`splitMeshByConnectedComponents`) used inside the import flow. The exported `extractImportedMeshProfileAndBounds` and `extractStlProfileAndBounds` signatures don't change — they still return a single profile, used both by the single-body fast path and by each per-body call.
+
+## Files affected
+
+- [src/engine/importedMesh.ts](src/engine/importedMesh.ts) — new exported function `splitMeshByConnectedComponents(mesh: ImportedTriangleMesh): ImportedTriangleMesh[]` that returns an array of disjoint sub-meshes (length 1 when the input is already a single body). Uses union-find over the index buffer. Recomputes each sub-mesh's `bounds`.
+- [src/import/stl.ts](src/import/stl.ts) — no signature changes. May add a small helper that runs `extractImportedMeshProfileAndBounds` for each sub-mesh and returns an array of `{ profile, silhouettePaths, z_bottom, z_top, mesh }` — optional, depends on how cleanly the dialog code reads.
+- [src/components/project/ImportGeometryDialog.tsx](src/components/project/ImportGeometryDialog.tsx) — the model-import branch (`isModelSourceType(loadedFile.sourceType)` block, ~lines 234–309) is refactored to:
+  1. Split the normalized mesh into bodies.
+  2. Loop: per body, project, render top-view, create a feature, register its own `meshAssetId`.
+  3. If >1 body, create a `FeatureFolder` named after the file and assign all new features to it.
+  4. Naming: `name`, `name (2)`, `name (3)`, …
+  5. Progress reporting updated so per-body work scales proportionally (e.g. 70% projection budget divided across N bodies).
+- [src/import/stl.test.ts](src/import/stl.test.ts) — add tests (see Tests section).
+- [src/engine/importedMesh.test.ts](src/engine/importedMesh.test.ts) — add tests for `splitMeshByConnectedComponents`.
+- [src/import/INDEX.md](src/import/) — no current INDEX; not adding one (existing convention skips it). Worth a brief comment update in the file headers if helpful.
+
+No changes to:
+- `src/types/project.ts` data model — `STLFeatureData` already supports per-feature `meshAssetId`, and `project.modelAssets` is already a keyed map.
+- `src/engine/csg.ts` — already builds one solid per feature.
+- The export pipeline (out of scope; that work is in a parallel branch).
+- The 3D viewport — already renders each feature's mesh asset independently.
+
+## Tests
+
+All under the existing `npx tsx`-runnable harness pattern (see [src/import/stl.test.ts](src/import/stl.test.ts)). Tests live next to the code they cover.
+
+1. **`splitMeshByConnectedComponents` unit tests** (`src/engine/importedMesh.test.ts`):
+   - Single connected mesh (e.g. existing frustum fixture) → returns 1 sub-mesh with identical positions/indices (up to ordering).
+   - Two disjoint cubes constructed in test → returns exactly 2 sub-meshes; vertex/triangle counts sum to original; each sub-mesh's bbox matches the corresponding cube; no shared vertex indices across sub-meshes.
+   - Three disjoint cubes → returns 3 sub-meshes.
+   - Two cubes touching at exactly one vertex (after `1e-5` weld) → returns 1 sub-mesh (documented expectation; weld bridges them).
+   - Empty mesh → returns empty array.
+
+2. **Multi-body STL import end-to-end** (`src/import/stl.test.ts`):
+   - Construct a binary/ASCII STL with two non-touching cubes positioned, say, at `[0..10]³` and `[20..30]³`.
+   - Wire it through `loadImportedTriangleMesh` → `normalizeImportedMeshForStorage` → `splitMeshByConnectedComponents` → `extractImportedMeshProfileAndBounds` per sub-mesh.
+   - Assert: 2 results; profile bbox of result[0] matches cube 1 in XY; profile bbox of result[1] matches cube 2 in XY; per-body `z_bottom`/`z_top` match the per-cube Z extents; per-body `silhouettePaths` has exactly one outer contour.
+
+3. **Single-body STL import regression** (`src/import/stl.test.ts`):
+   - Existing frustum fixture still produces exactly one feature-equivalent result with the same profile and silhouette as today.
+
+4. **Importing a saved single-body project doesn't change** — covered by (3) since the data shape is unchanged.
+
+`npm run build` must pass.
+
+## Open questions / risks
+
+Resolved with the user:
+
+- **Q1 — Grouping (resolved):** Create a `FeatureFolder` named after the file and place all N bodies inside it. Each body is still independently transformable.
+- **Q3 — Body-count cap (resolved):** Cap at **64 bodies**. Above the cap, fall back to today's single-feature behavior and show a post-import warning (`window.alert` style, matching the existing DXF warning pattern in [ImportGeometryDialog.tsx:336](src/components/project/ImportGeometryDialog.tsx)) so the user knows their input exceeded the limit and a single-body import was used instead.
+- **Q5 — Model-export branch (resolved):** Export work will be merged into `main` by the time this plan is implemented. This fix is independent of it; rebasing onto main before opening the PR will give a fully reproducible end-to-end fix.
+
+Still flagged as risks but not blocking:
+
+- **Q2 — Touching-but-not-welded bodies.** Two bodies that share a face within the `1e-5` weld tolerance collapse into one component. For round-tripped exports we control, this is exactly what we want (a unioned body stays unioned). For hand-authored inputs with intentionally-touching bodies that the user wants split, this heuristic will fail. Acceptable for v1; documented in code.
+- **Q4 — Mesh-asset storage.** Each body becomes its own `PersistedImportedMesh` in `project.modelAssets`. For an N-body file, total bytes are roughly the same as one combined asset (triangles partitioned, not duplicated). No measurable extra storage cost.
+- **Q6 — Backward compat with the existing `silhouettePaths` field.** `STLFeatureData.silhouettePaths` is documented as "the first/largest path is mirrored in `sketch.profile`". For per-body features we keep the same invariant: each body's outer contour is the only entry whose silhouette is mirrored as its profile, so the existing canvas rendering at [SketchCanvas.tsx:1278](src/components/canvas/SketchCanvas.tsx:1278) will draw outline-matching-shading correctly. Verify during implementation that the canvas does not rely on `silhouettePaths` being "every projected polygon of the whole mesh".
+
+## Out of scope
+
+- The model-export pipeline (`src/engine/modelExport/`) on its parallel branch — not touched here.
+- Repairing non-manifold STLs. The existing fallback chain (manifold → waterline → triangle-projection) is unchanged.
+- A "merge bodies" UX action. Users can boolean-union manually if needed.
+- Changing exports to write a single welded mesh. Multi-body STL output is standard.
+- Widening the global weld tolerance.
+- Migrating existing saved projects with multi-body single-feature STL imports. Those keep working as today; users can re-import to get the new split behavior.

--- a/src/components/project/ImportGeometryDialog.tsx
+++ b/src/components/project/ImportGeometryDialog.tsx
@@ -29,6 +29,7 @@ import {
   loadImportedTriangleMesh,
   normalizeImportedMeshForStorage,
   serializeImportedMesh,
+  splitMeshByConnectedComponents,
   type ImportedModelFormat,
   type ModelAxisOrientation,
 } from '../../engine/importedMesh'
@@ -46,6 +47,14 @@ interface ImportGeometryDialogProps {
   onClose: () => void
   onImportComplete?: () => void
 }
+
+/**
+ * Maximum number of disjoint bodies the model importer will split into
+ * individual features. Above this cap, the file is imported as a single
+ * feature with a warning. Manifold's `project()` is run once per body, so an
+ * uncapped import could be unboundedly slow for pathological inputs.
+ */
+const MAX_IMPORT_BODIES = 64
 
 function sourceTypeLabel(sourceType: ImportSourceType): string {
   if (sourceType === 'svg') return 'SVG'
@@ -236,7 +245,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
         const modelLabel = sourceTypeLabel(loadedFile.sourceType)
         const modelScale = sourceUnits === project.meta.units ? 1 : (sourceUnits === 'inch' ? 25.4 : 1/25.4)
         const requestedSilhouetteZSteps = parseSilhouetteZStepsInput(silhouetteZSteps)
-        
+
         const fileData = loadedFile.modelBuffer
         if (!fileData) throw new Error('Missing file data')
 
@@ -244,7 +253,7 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
         setLoadingProgress(5)
         let parsedMesh = loadImportedTriangleMesh(modelFormat, fileData, axisSwap)
         if (!parsedMesh) throw new Error(`Failed to parse ${modelLabel} mesh`)
-        setLoadingProgress(12)
+        setLoadingProgress(10)
 
         setLoadingStage('Normalizing mesh')
         const importedMesh = normalizeImportedMeshForStorage(parsedMesh, modelScale)
@@ -255,58 +264,103 @@ export function ImportGeometryDialog({ onClose, onImportComplete }: ImportGeomet
           project.meta.units,
         )
         const resolvedSilhouetteZSteps = requestedSilhouetteZSteps ?? automaticSilhouetteZSteps
-        
-        setLoadingStage(`Projecting silhouette (${resolvedSilhouetteZSteps} Z steps)`)
-        setLoadingProgress(15)
-        const modelInfo = await extractImportedMeshProfileAndBounds(importedMesh, (p) => {
-          setLoadingProgress(15 + Math.round(p * 0.7))
-        }, { silhouetteZSteps: resolvedSilhouetteZSteps })
-        if (!modelInfo) throw new Error(`Failed to parse ${modelLabel} or generate silhouette`)
 
-        setLoadingStage('Preparing preview')
-        setLoadingProgress(88)
-        let topViewDataUrl: string | undefined
-        try {
-          const url = renderImportedMeshTopViewToDataUrl(importedMesh)
-          if (url) topViewDataUrl = url
-        } catch {
-          // top-view rendering is best-effort
+        setLoadingStage('Detecting bodies')
+        setLoadingProgress(13)
+        const detectedBodies = splitMeshByConnectedComponents(importedMesh)
+        let bodiesToImport: typeof detectedBodies
+        let truncationWarning: string | null = null
+        if (detectedBodies.length <= 1) {
+          bodiesToImport = [importedMesh]
+        } else if (detectedBodies.length > MAX_IMPORT_BODIES) {
+          bodiesToImport = [importedMesh]
+          truncationWarning = (
+            `The imported ${modelLabel} contains ${detectedBodies.length} disjoint bodies, ` +
+            `which exceeds the per-import limit of ${MAX_IMPORT_BODIES}. ` +
+            `Imported as a single feature; the bodies will not be individually selectable. ` +
+            `Split the file into smaller pieces or boolean-union it before importing if you need per-body features.`
+          )
+        } else {
+          bodiesToImport = detectedBodies
+        }
+        const splitIntoBodies = bodiesToImport.length > 1
+
+        const baseName = loadedFile.fileName.replace(/\.(stl|obj)$/i, '')
+        const { addFeature, addFeatureFolder, updateFeatureFolder } = useProjectStore.getState()
+
+        let importFolderId: string | null = null
+        if (splitIntoBodies) {
+          importFolderId = addFeatureFolder('features')
+          updateFeatureFolder(importFolderId, { name: baseName })
         }
 
-        setLoadingStage('Storing model')
-        setLoadingProgress(95)
-        const { addFeature } = useProjectStore.getState()
-        const featureId = crypto.randomUUID()
-        
-        addFeature({
-          id: featureId,
-          name: loadedFile.fileName.replace(/\.(stl|obj)$/i, ''),
-          kind: 'stl',
-          folderId: null,
-          stl: {
-            format: modelFormat,
-            filePath: undefined,
-            mesh: serializeImportedMesh(importedMesh, modelFormat),
-            scale: 1,
-            axisSwap: 'none',
-            silhouettePaths: modelInfo.silhouettePaths,
-            topViewDataUrl,
-          },
-          sketch: {
-            profile: modelInfo.profile,
-            origin: { x: 0, y: 0 },
-            orientationAngle: 0,
-            dimensions: [],
-            constraints: []
-          },
-          operation: 'model',
-          z_top: modelInfo.z_top,
-          z_bottom: modelInfo.z_bottom,
-          visible: true,
-          locked: false
-        })
+        const newFeatureIds: string[] = []
+        const projectionBudget = 70
+        const projectionStart = 15
+
+        for (let bodyIndex = 0; bodyIndex < bodiesToImport.length; bodyIndex += 1) {
+          const bodyMesh = bodiesToImport[bodyIndex]
+          const bodyLabel = splitIntoBodies
+            ? `Body ${bodyIndex + 1} / ${bodiesToImport.length}`
+            : modelLabel
+          const bodyStart = projectionStart + (bodyIndex / bodiesToImport.length) * projectionBudget
+          const bodyEnd = projectionStart + ((bodyIndex + 1) / bodiesToImport.length) * projectionBudget
+
+          setLoadingStage(`Projecting silhouette — ${bodyLabel} (${resolvedSilhouetteZSteps} Z steps)`)
+          setLoadingProgress(Math.round(bodyStart))
+          const modelInfo = await extractImportedMeshProfileAndBounds(bodyMesh, (p) => {
+            setLoadingProgress(Math.round(bodyStart + (bodyEnd - bodyStart) * (p / 100)))
+          }, { silhouetteZSteps: resolvedSilhouetteZSteps })
+          if (!modelInfo) {
+            throw new Error(`Failed to generate silhouette for ${bodyLabel.toLowerCase()} of ${modelLabel} import`)
+          }
+
+          let bodyTopViewDataUrl: string | undefined
+          try {
+            const url = renderImportedMeshTopViewToDataUrl(bodyMesh)
+            if (url) bodyTopViewDataUrl = url
+          } catch {
+            // top-view rendering is best-effort
+          }
+
+          const featureId = crypto.randomUUID()
+          const featureName = bodyIndex === 0 ? baseName : `${baseName} (${bodyIndex + 1})`
+          addFeature({
+            id: featureId,
+            name: featureName,
+            kind: 'stl',
+            folderId: importFolderId,
+            stl: {
+              format: modelFormat,
+              filePath: undefined,
+              mesh: serializeImportedMesh(bodyMesh, modelFormat),
+              scale: 1,
+              axisSwap: 'none',
+              silhouettePaths: modelInfo.silhouettePaths,
+              topViewDataUrl: bodyTopViewDataUrl,
+            },
+            sketch: {
+              profile: modelInfo.profile,
+              origin: { x: 0, y: 0 },
+              orientationAngle: 0,
+              dimensions: [],
+              constraints: [],
+            },
+            operation: 'model',
+            z_top: modelInfo.z_top,
+            z_bottom: modelInfo.z_bottom,
+            visible: true,
+            locked: false,
+          })
+          newFeatureIds.push(featureId)
+        }
+
         setLoadingProgress(100)
-        createdIds = [featureId]
+        createdIds = newFeatureIds
+
+        if (truncationWarning) {
+          window.alert(truncationWarning)
+        }
       } else {
         setLoadingStage('Importing geometry')
         const result = loadedFile.sourceType === 'svg'

--- a/src/engine/importedMesh.test.ts
+++ b/src/engine/importedMesh.test.ts
@@ -7,6 +7,7 @@
 import * as THREE from 'three'
 import {
   MAX_UINT16_INDEX,
+  computeMeshBounds,
   loadImportedBufferGeometry,
   loadImportedTriangleMesh,
   loadObjBufferGeometry,
@@ -18,6 +19,7 @@ import {
   loadStlTriangleMesh,
   normalizeImportedMeshForStorage,
   serializeImportedMesh,
+  splitMeshByConnectedComponents,
   triangleMeshToBufferGeometryChunks,
   type ImportedTriangleMesh,
   type ModelAxisOrientation,
@@ -450,6 +452,201 @@ function testLoadPersistedBufferGeometryChunksInvariant(): void {
   for (const chunk of chunks) chunk.dispose()
 }
 
+/**
+ * Build an axis-aligned cube triangle mesh (12 triangles, 8 vertices) at the
+ * given origin and with the given side length. Vertices are pre-shared, so the
+ * resulting mesh forms a single connected component under union-find without
+ * requiring weld.
+ */
+function makeCubeMesh(originX: number, originY: number, originZ: number, side: number): ImportedTriangleMesh {
+  const corners: Array<[number, number, number]> = [
+    [0, 0, 0], [side, 0, 0], [side, side, 0], [0, side, 0],
+    [0, 0, side], [side, 0, side], [side, side, side], [0, side, side],
+  ]
+  const positions = new Float32Array(8 * 3)
+  for (let i = 0; i < 8; i += 1) {
+    positions[i * 3] = originX + corners[i][0]
+    positions[i * 3 + 1] = originY + corners[i][1]
+    positions[i * 3 + 2] = originZ + corners[i][2]
+  }
+  // 6 faces × 2 triangles, CCW from outside.
+  const faces: number[][] = [
+    [0, 2, 1], [0, 3, 2], // -Z
+    [4, 5, 6], [4, 6, 7], // +Z
+    [0, 1, 5], [0, 5, 4], // -Y
+    [2, 3, 7], [2, 7, 6], // +Y
+    [1, 2, 6], [1, 6, 5], // +X
+    [0, 4, 7], [0, 7, 3], // -X
+  ]
+  const index = new Uint32Array(faces.length * 3)
+  for (let i = 0; i < faces.length; i += 1) {
+    index[i * 3] = faces[i][0]
+    index[i * 3 + 1] = faces[i][1]
+    index[i * 3 + 2] = faces[i][2]
+  }
+  return { positions, index, bounds: computeMeshBounds(positions) }
+}
+
+function concatMeshes(...meshes: ImportedTriangleMesh[]): ImportedTriangleMesh {
+  const totalVerts = meshes.reduce((acc, m) => acc + m.positions.length / 3, 0)
+  const totalTris = meshes.reduce((acc, m) => acc + m.index.length / 3, 0)
+  const positions = new Float32Array(totalVerts * 3)
+  const index = new Uint32Array(totalTris * 3)
+  let vOffset = 0
+  let iOffset = 0
+  for (const mesh of meshes) {
+    positions.set(mesh.positions, vOffset * 3)
+    for (let i = 0; i < mesh.index.length; i += 1) {
+      index[iOffset + i] = mesh.index[i] + vOffset
+    }
+    vOffset += mesh.positions.length / 3
+    iOffset += mesh.index.length
+  }
+  return { positions, index, bounds: computeMeshBounds(positions) }
+}
+
+function testSplitSingleBody(): void {
+  console.log('Testing splitMeshByConnectedComponents single-body passthrough...')
+  const cube = makeCubeMesh(0, 0, 0, 5)
+  const split = splitMeshByConnectedComponents(cube)
+  assert(split.length === 1, `expected 1 component for a single cube, got ${split.length}`)
+  assert(split[0].positions.length === cube.positions.length, 'vertex count should be preserved')
+  assert(split[0].index.length === cube.index.length, 'triangle count should be preserved')
+  assert(split[0] !== cube, 'returned mesh should be a clone, not the input reference')
+  assert(approx(split[0].bounds.maxX, 5), `expected maxX=5, got ${split[0].bounds.maxX}`)
+}
+
+function testSplitTwoDisjointCubes(): void {
+  console.log('Testing splitMeshByConnectedComponents two disjoint cubes...')
+  const cubeA = makeCubeMesh(0, 0, 0, 10)
+  const cubeB = makeCubeMesh(20, 0, 0, 10)
+  const merged = concatMeshes(cubeA, cubeB)
+  const split = splitMeshByConnectedComponents(merged)
+  assert(split.length === 2, `expected 2 components, got ${split.length}`)
+
+  const totalVerts = split.reduce((acc, m) => acc + m.positions.length / 3, 0)
+  const totalTris = split.reduce((acc, m) => acc + m.index.length / 3, 0)
+  assert(totalVerts === merged.positions.length / 3, 'vertex counts must sum to input')
+  assert(totalTris === merged.index.length / 3, 'triangle counts must sum to input')
+
+  // Find which sub-mesh corresponds to which cube via X bounds.
+  const sortedByX = [...split].sort((a, b) => a.bounds.minX - b.bounds.minX)
+  assert(approx(sortedByX[0].bounds.minX, 0) && approx(sortedByX[0].bounds.maxX, 10),
+    `expected first body X=[0,10], got [${sortedByX[0].bounds.minX},${sortedByX[0].bounds.maxX}]`)
+  assert(approx(sortedByX[1].bounds.minX, 20) && approx(sortedByX[1].bounds.maxX, 30),
+    `expected second body X=[20,30], got [${sortedByX[1].bounds.minX},${sortedByX[1].bounds.maxX}]`)
+
+  // Each sub-mesh should be self-contained: indices reference only its own vertices.
+  for (const sub of split) {
+    const subVerts = sub.positions.length / 3
+    for (let i = 0; i < sub.index.length; i += 1) {
+      assert(sub.index[i] < subVerts, `sub-mesh index ${sub.index[i]} out of range (verts=${subVerts})`)
+    }
+  }
+}
+
+function testSplitThreeDisjointCubes(): void {
+  console.log('Testing splitMeshByConnectedComponents three disjoint cubes...')
+  const merged = concatMeshes(
+    makeCubeMesh(0, 0, 0, 5),
+    makeCubeMesh(20, 0, 0, 5),
+    makeCubeMesh(0, 20, 0, 5),
+  )
+  const split = splitMeshByConnectedComponents(merged)
+  assert(split.length === 3, `expected 3 components, got ${split.length}`)
+}
+
+function testSplitEmptyMesh(): void {
+  console.log('Testing splitMeshByConnectedComponents empty mesh...')
+  const empty: ImportedTriangleMesh = {
+    positions: new Float32Array(0),
+    index: new Uint32Array(0),
+    bounds: { minX: 0, maxX: 0, minY: 0, maxY: 0, minZ: 0, maxZ: 0 },
+  }
+  const split = splitMeshByConnectedComponents(empty)
+  assert(split.length === 0, `expected 0 components for empty mesh, got ${split.length}`)
+}
+
+/**
+ * Build a cube whose 12 triangles each carry their own copy of every vertex
+ * position (36 distinct vertex slots, all positionally coincident in groups
+ * of 3 at each corner). This mimics STLLoader output before merging, where
+ * per-face normals prevent attribute-based weld from collapsing positional
+ * duplicates. The connected-component algorithm must rely on position
+ * equivalence to recognize this as a single body.
+ */
+function makeUnweldedCubeMesh(originX: number, originY: number, originZ: number, side: number): ImportedTriangleMesh {
+  const corners: Array<[number, number, number]> = [
+    [0, 0, 0], [side, 0, 0], [side, side, 0], [0, side, 0],
+    [0, 0, side], [side, 0, side], [side, side, side], [0, side, side],
+  ]
+  const faces: number[][] = [
+    [0, 2, 1], [0, 3, 2],
+    [4, 5, 6], [4, 6, 7],
+    [0, 1, 5], [0, 5, 4],
+    [2, 3, 7], [2, 7, 6],
+    [1, 2, 6], [1, 6, 5],
+    [0, 4, 7], [0, 7, 3],
+  ]
+  const positions = new Float32Array(faces.length * 3 * 3)
+  const index = new Uint32Array(faces.length * 3)
+  for (let t = 0; t < faces.length; t += 1) {
+    for (let k = 0; k < 3; k += 1) {
+      const cornerIdx = faces[t][k]
+      const c = corners[cornerIdx]
+      const vSlot = t * 3 + k
+      positions[vSlot * 3] = originX + c[0]
+      positions[vSlot * 3 + 1] = originY + c[1]
+      positions[vSlot * 3 + 2] = originZ + c[2]
+      index[vSlot] = vSlot
+    }
+  }
+  return { positions, index, bounds: computeMeshBounds(positions) }
+}
+
+function testSplitPositionWeldRecognizesSingleBody(): void {
+  console.log('Testing splitMeshByConnectedComponents position-weld on unwelded cube...')
+  // Each triangle has its own vertex copies. Index-only union-find would
+  // give 12 disjoint components (one per triangle). Position-based weld must
+  // collapse them to 1 body — this is the STLLoader-output shape that
+  // triggered the 384-bodies regression.
+  const cube = makeUnweldedCubeMesh(0, 0, 0, 5)
+  const split = splitMeshByConnectedComponents(cube)
+  assert(split.length === 1, `expected 1 component via position weld, got ${split.length}`)
+  assert(approx(split[0].bounds.maxX, 5), `expected maxX=5, got ${split[0].bounds.maxX}`)
+}
+
+function testSplitPositionWeldTwoUnweldedCubes(): void {
+  console.log('Testing splitMeshByConnectedComponents position-weld on two unwelded cubes...')
+  const cubeA = makeUnweldedCubeMesh(0, 0, 0, 10)
+  const cubeB = makeUnweldedCubeMesh(20, 0, 0, 10)
+  const merged = concatMeshes(cubeA, cubeB)
+  const split = splitMeshByConnectedComponents(merged)
+  assert(split.length === 2, `expected 2 components via position weld, got ${split.length}`)
+
+  const sortedByX = [...split].sort((a, b) => a.bounds.minX - b.bounds.minX)
+  assert(approx(sortedByX[0].bounds.maxX, 10), `body A maxX=${sortedByX[0].bounds.maxX}, expected 10`)
+  assert(approx(sortedByX[1].bounds.minX, 20), `body B minX=${sortedByX[1].bounds.minX}, expected 20`)
+}
+
+function testSplitSharedVertexTreatedAsOne(): void {
+  console.log('Testing splitMeshByConnectedComponents shared-corner bodies treated as one...')
+  // Two cubes sharing a single vertex via the concat (we construct that by
+  // overlapping a vertex). We pre-shared the vertex by using the same index.
+  // We build it manually: cube A at origin with corner (0,0,0); cube B sharing
+  // that corner. The union-find sees one component because they share a vertex.
+  const cubeA = makeCubeMesh(0, 0, 0, 5)
+  const cubeB = makeCubeMesh(0, 0, 0, 5) // identical positions → after concat, vertices duplicated
+  // Build a mesh where cubeB triangles re-use the SAME vertex indices as cubeA.
+  const positions = new Float32Array(cubeA.positions)
+  const index = new Uint32Array(cubeA.index.length + cubeB.index.length)
+  index.set(cubeA.index, 0)
+  index.set(cubeB.index, cubeA.index.length)
+  const mesh: ImportedTriangleMesh = { positions, index, bounds: computeMeshBounds(positions) }
+  const split = splitMeshByConnectedComponents(mesh)
+  assert(split.length === 1, `expected 1 component when bodies share vertices, got ${split.length}`)
+}
+
 testAxisOrientations()
 testTriangleMeshCacheReuse()
 testGeometryCloneCache()
@@ -464,5 +661,12 @@ testChunkerLargeMeshSplits()
 testChunkerVertexShared()
 testChunkerMergeVertices()
 testLoadPersistedBufferGeometryChunksInvariant()
+testSplitSingleBody()
+testSplitTwoDisjointCubes()
+testSplitThreeDisjointCubes()
+testSplitEmptyMesh()
+testSplitPositionWeldRecognizesSingleBody()
+testSplitPositionWeldTwoUnweldedCubes()
+testSplitSharedVertexTreatedAsOne()
 
 console.log('importedMesh tests passed')

--- a/src/engine/importedMesh.ts
+++ b/src/engine/importedMesh.ts
@@ -740,6 +740,148 @@ export function loadImportedBufferGeometry(
   }
 }
 
+/**
+ * Position-equivalence tolerance for connected-component detection. Two
+ * vertices closer than this on every axis are treated as the same body
+ * attachment point. Independent of `BufferGeometryUtils.mergeVertices` —
+ * that weld hashes per-attribute (position + normal), so STLLoader output
+ * leaves a body's shared corners split across multiple "vertices" (one per
+ * incident face normal). Index-only union-find then over-splits the mesh
+ * into hundreds of fake bodies. The position-only weld below is local to
+ * this function and does not touch the imported mesh's stored indices,
+ * which the 3D viewport depends on for per-face shading normals.
+ */
+const COMPONENT_WELD_TOLERANCE = 1e-5
+
+/**
+ * Partition a triangle mesh into disjoint connected components. Returns one
+ * sub-mesh per component, each with vertex indices remapped to a compact range
+ * and bounds recomputed. The input mesh is not mutated. If the mesh forms a
+ * single connected component, the returned array has length 1 (a clone of the
+ * input). Two bodies whose surfaces touch within
+ * `COMPONENT_WELD_TOLERANCE` will collapse into one component — this is the
+ * desired behavior for round-tripped exports (a unioned body stays unioned)
+ * and acceptable for hand-authored inputs.
+ */
+export function splitMeshByConnectedComponents(mesh: ImportedTriangleMesh): ImportedTriangleMesh[] {
+  const vertexCount = mesh.positions.length / 3
+  const triangleCount = mesh.index.length / 3
+  if (vertexCount === 0 || triangleCount === 0) return []
+
+  // Position-canonical vertex id per input vertex via spatial hashing.
+  // Vertices whose quantized cell coordinates match share a canonical id.
+  const inverseTolerance = 1 / COMPONENT_WELD_TOLERANCE
+  const canonicalIdByVertex = new Int32Array(vertexCount)
+  const cellToCanonical = new Map<string, number>()
+  let canonicalCount = 0
+  for (let v = 0; v < vertexCount; v += 1) {
+    const x = mesh.positions[v * 3]
+    const y = mesh.positions[v * 3 + 1]
+    const z = mesh.positions[v * 3 + 2]
+    const key = `${Math.round(x * inverseTolerance)},${Math.round(y * inverseTolerance)},${Math.round(z * inverseTolerance)}`
+    let id = cellToCanonical.get(key)
+    if (id === undefined) {
+      id = canonicalCount
+      canonicalCount += 1
+      cellToCanonical.set(key, id)
+    }
+    canonicalIdByVertex[v] = id
+  }
+
+  const parent = new Int32Array(canonicalCount)
+  for (let i = 0; i < canonicalCount; i += 1) parent[i] = i
+
+  function find(x: number): number {
+    let r = x
+    while (parent[r] !== r) r = parent[r]
+    let cursor = x
+    while (parent[cursor] !== r) {
+      const next = parent[cursor]
+      parent[cursor] = r
+      cursor = next
+    }
+    return r
+  }
+
+  function union(a: number, b: number): void {
+    const ra = find(a)
+    const rb = find(b)
+    if (ra !== rb) parent[ra] = rb
+  }
+
+  for (let t = 0; t < triangleCount; t += 1) {
+    const a = canonicalIdByVertex[mesh.index[t * 3]]
+    const b = canonicalIdByVertex[mesh.index[t * 3 + 1]]
+    const c = canonicalIdByVertex[mesh.index[t * 3 + 2]]
+    union(a, b)
+    union(b, c)
+  }
+
+  const triComponentRoot = new Int32Array(triangleCount)
+  const rootSet = new Set<number>()
+  for (let t = 0; t < triangleCount; t += 1) {
+    const root = find(canonicalIdByVertex[mesh.index[t * 3]])
+    triComponentRoot[t] = root
+    rootSet.add(root)
+  }
+
+  if (rootSet.size <= 1) {
+    return [{
+      positions: new Float32Array(mesh.positions),
+      index: new Uint32Array(mesh.index),
+      bounds: { ...mesh.bounds },
+    }]
+  }
+
+  const roots = Array.from(rootSet)
+  const subMeshes: ImportedTriangleMesh[] = []
+  for (const root of roots) {
+    const vertexRemap = new Int32Array(vertexCount)
+    vertexRemap.fill(-1)
+    let nextVertex = 0
+    let triCount = 0
+
+    for (let t = 0; t < triangleCount; t += 1) {
+      if (triComponentRoot[t] !== root) continue
+      triCount += 1
+      for (let k = 0; k < 3; k += 1) {
+        const v = mesh.index[t * 3 + k]
+        if (vertexRemap[v] === -1) {
+          vertexRemap[v] = nextVertex
+          nextVertex += 1
+        }
+      }
+    }
+
+    const subPositions = new Float32Array(nextVertex * 3)
+    for (let v = 0; v < vertexCount; v += 1) {
+      const dst = vertexRemap[v]
+      if (dst === -1) continue
+      subPositions[dst * 3] = mesh.positions[v * 3]
+      subPositions[dst * 3 + 1] = mesh.positions[v * 3 + 1]
+      subPositions[dst * 3 + 2] = mesh.positions[v * 3 + 2]
+    }
+
+    const subIndices = new Uint32Array(triCount * 3)
+    let outIndex = 0
+    for (let t = 0; t < triangleCount; t += 1) {
+      if (triComponentRoot[t] !== root) continue
+      subIndices[outIndex] = vertexRemap[mesh.index[t * 3]]
+      subIndices[outIndex + 1] = vertexRemap[mesh.index[t * 3 + 1]]
+      subIndices[outIndex + 2] = vertexRemap[mesh.index[t * 3 + 2]]
+      outIndex += 3
+    }
+
+    subMeshes.push({
+      positions: subPositions,
+      index: subIndices,
+      bounds: computeMeshBounds(subPositions),
+    })
+  }
+
+  return subMeshes
+}
+
 export function computeMeshBounds(positions: Float32Array): ImportedMeshBounds {
   let minX = Infinity, maxX = -Infinity
   let minY = Infinity, maxY = -Infinity

--- a/src/import/stl.test.ts
+++ b/src/import/stl.test.ts
@@ -4,7 +4,12 @@
  * Run with: npx tsx src/import/stl.test.ts
  */
 
-import { extractStlProfileAndBounds } from './stl'
+import {
+  loadImportedTriangleMesh,
+  normalizeImportedMeshForStorage,
+  splitMeshByConnectedComponents,
+} from '../engine/importedMesh'
+import { extractImportedMeshProfileAndBounds, extractStlProfileAndBounds } from './stl'
 
 type AxisSwap = 'none' | 'yz' | 'xz' | 'xy'
 
@@ -102,8 +107,99 @@ async function testSilhouetteArtifactsAreFiltered(): Promise<void> {
   assert(result!.silhouettePaths.length === 1, `expected one significant silhouette path, got ${result!.silhouettePaths.length}`)
 }
 
+/**
+ * Build an ASCII STL whose body is a unit axis-aligned cube at the given
+ * origin and side length. 12 triangles, normals omitted (set to 0 0 0; the
+ * STL loader does not require accurate normals).
+ */
+function makeCubeStlLines(originX: number, originY: number, originZ: number, side: number, label: string): string[] {
+  const corners: Array<[number, number, number]> = [
+    [0, 0, 0], [side, 0, 0], [side, side, 0], [0, side, 0],
+    [0, 0, side], [side, 0, side], [side, side, side], [0, side, side],
+  ]
+  function world(corner: [number, number, number]): [number, number, number] {
+    return [originX + corner[0], originY + corner[1], originZ + corner[2]]
+  }
+  const faces: Array<[number, number, number]> = [
+    [0, 2, 1], [0, 3, 2],
+    [4, 5, 6], [4, 6, 7],
+    [0, 1, 5], [0, 5, 4],
+    [2, 3, 7], [2, 7, 6],
+    [1, 2, 6], [1, 6, 5],
+    [0, 4, 7], [0, 7, 3],
+  ]
+  const lines: string[] = [`solid ${label}`]
+  for (const face of faces) {
+    lines.push('  facet normal 0 0 0')
+    lines.push('    outer loop')
+    for (const cornerIdx of face) {
+      const w = world(corners[cornerIdx])
+      lines.push(`      vertex ${w[0]} ${w[1]} ${w[2]}`)
+    }
+    lines.push('    endloop')
+    lines.push('  endfacet')
+  }
+  lines.push(`endsolid ${label}`)
+  return lines
+}
+
+function makeTwoCubesStlBase64(): string {
+  // Two disjoint cubes, axis-aligned, separated in X with a 10-unit gap so
+  // welding at 1e-5 cannot bridge them. The "solid" wrapper for the second
+  // cube is omitted because the STL loader treats multiple solids as a
+  // single triangle stream anyway.
+  const linesA = makeCubeStlLines(0, 0, 0, 10, 'cubeA')
+  const linesB = makeCubeStlLines(20, 0, 0, 10, 'cubeB')
+  return btoa([...linesA, ...linesB].join('\n') + '\n')
+}
+
+async function testMultiBodyImportSplits(): Promise<void> {
+  console.log('Testing multi-body STL splits into per-body profiles...')
+  const stlBase64 = makeTwoCubesStlBase64()
+  const parsed = loadImportedTriangleMesh('stl', stlBase64, 'none')
+  assert(parsed !== null, 'two-cube STL must parse')
+  const normalized = normalizeImportedMeshForStorage(parsed!, 1)
+  const bodies = splitMeshByConnectedComponents(normalized)
+  assert(bodies.length === 2, `expected 2 bodies for two disjoint cubes, got ${bodies.length}`)
+
+  // Pin order by X so the assertions are stable.
+  bodies.sort((a, b) => a.bounds.minX - b.bounds.minX)
+
+  const resultA = await extractImportedMeshProfileAndBounds(bodies[0])
+  const resultB = await extractImportedMeshProfileAndBounds(bodies[1])
+  assert(resultA !== null && resultB !== null, 'each body must yield a profile')
+
+  // Per-body Z extents match the source cubes.
+  assert(approx(resultA!.z_bottom, 0) && approx(resultA!.z_top, 10),
+    `body A z=[${resultA!.z_bottom},${resultA!.z_top}], expected [0,10]`)
+  assert(approx(resultB!.z_bottom, 0) && approx(resultB!.z_top, 10),
+    `body B z=[${resultB!.z_bottom},${resultB!.z_top}], expected [0,10]`)
+
+  // Body A's profile must live entirely within X=[0,10]; body B within X=[20,30].
+  function profileBboxX(profile: { start: { x: number; y: number }; segments: Array<{ to: { x: number; y: number } }> }): { min: number; max: number } {
+    let min = profile.start.x
+    let max = profile.start.x
+    for (const seg of profile.segments) {
+      if (seg.to.x < min) min = seg.to.x
+      if (seg.to.x > max) max = seg.to.x
+    }
+    return { min, max }
+  }
+  const aX = profileBboxX(resultA!.profile)
+  const bX = profileBboxX(resultB!.profile)
+  assert(approx(aX.min, 0, 1e-3) && approx(aX.max, 10, 1e-3),
+    `body A profile X=[${aX.min},${aX.max}], expected [0,10]`)
+  assert(approx(bX.min, 20, 1e-3) && approx(bX.max, 30, 1e-3),
+    `body B profile X=[${bX.min},${bX.max}], expected [20,30]`)
+
+  // Each body should produce a single outer silhouette path.
+  assert(resultA!.silhouettePaths.length === 1, `body A silhouettePaths=${resultA!.silhouettePaths.length}, expected 1`)
+  assert(resultB!.silhouettePaths.length === 1, `body B silhouettePaths=${resultB!.silhouettePaths.length}, expected 1`)
+}
+
 testAxisBounds()
   .then(() => testSilhouetteArtifactsAreFiltered())
+  .then(() => testMultiBodyImportSplits())
   .then(() => console.log('stl import tests passed'))
   .catch((error) => {
     console.error(error)


### PR DESCRIPTION
## Summary

- Detect disjoint bodies in imported STL/OBJ meshes via position-welded connected-component union-find, independent of the per-attribute `mergeVertices` weld that over-splits STLLoader output.
- Up to **64 bodies** become individual `SketchFeature`s grouped under a new `FeatureFolder` named after the source file. Above the cap, fall back to single-feature import with a `window.alert` warning.
- Each body gets its own projection, silhouette paths, profile, Z bounds, and `modelAssets` entry. Single-body inputs and pre-existing projects are unchanged.

## Why

A single STL with N disjoint bodies used to land as one feature whose 2D outline (the largest projected polygon) disagreed with its interior shading (the union of *every* body's projected silhouette). The mismatch became visible round-tripping through the new model exporter: each export → re-import cycle accumulated bodies, and the sketch view rendered them mashed together while the 3D view rendered them correctly.

The position-only weld at `1e-5` is needed because `BufferGeometryUtils.mergeVertices` hashes by all geometry attributes (position + per-face normal). Index-only union-find on STLLoader output therefore over-splits a single body into hundreds of fake components — the user-reported "384 disjoint bodies" symptom on a two-body file.

## Test plan

- [x] `npm test` — all 15 test files pass on this branch
- [x] `npm run build` — clean
- [x] Two-cube STL fixture confirms split + per-body profile bounds + per-body Z extents (`src/import/stl.test.ts`)
- [x] Synthetic STLLoader-style unwelded cube (each triangle owns its corners) is recognised as a single body via the position weld (`src/engine/importedMesh.test.ts`)
- [x] Manual: export a pocketed-block project, re-import, repeat — the second re-import now lands as a folder containing one feature per body, each with matching outline/shading, independently movable
- [x] Manual: existing single-body STL projects load and render unchanged

## Notes

- Plan archived at [`planning/archive/MULTI_BODY_STL_IMPORT_Plan.md`](planning/archive/MULTI_BODY_STL_IMPORT_Plan.md).
- Builds on top of `a85056c` (Chrome/macOS STL render fix) — full end-to-end repro now works in Chrome.