### PR TITLE
Fix parallel finish skipping tabs regardless of depth

### DIFF
--- a/planning/archive/PARALLEL_FINISH_TAB_Z_AWARENESS_Plan.md
+++ b/planning/archive/PARALLEL_FINISH_TAB_Z_AWARENESS_Plan.md
@@ -1,0 +1,54 @@
+---
+status: Done
+created: 2026-05-23
+---
+
+# Parallel Finish Tab Z-Awareness Plan
+
+## Goal
+
+3D surface parallel finish currently carves a hole in its toolpath above every tab in the project, regardless of how far below the cutting surface the tab sits. The user has observed that a tab whose `z_top` is well below the locally machined Z still causes the toolpath to skip the tab's XY footprint. The fix: tabs must affect the parallel finish only where the cutter would actually intersect tab material, and otherwise be ignored.
+
+## Approach
+
+Replace the current "subtract every tab footprint from coverage" behaviour (which is unconditional and 2D) with a Z-aware constraint that mirrors how subtract features are already handled:
+
+1. In `generateFinishSurfaceParallel`, stop using `buildProtectedFootprintPaths` for tabs by passing `includeTabs: false`. Tabs are no longer removed from the 2D coverage contour.
+2. Extend `minCutZAtPoint` (constructed in `generateFinishSurfaceToolpath` and threaded into the parallel strategy) so that for any point inside an active tab's XY footprint it returns at least `tab.z_top`. The existing `clampSurfaceSegmentToMinZ` already enforces `cutZ = max(surfaceZ, minCutZAtPoint(point))`, so:
+   - Where the local surface sits above `tab.z_top`, the clamp is a no-op — the cutter sweeps over the tab area normally.
+   - Where the local surface dips at or below `tab.z_top`, Z is raised to `tab.z_top`, preserving tab material from `z_bottom` upward.
+3. The tab XY footprint test should expand the tab rectangle by the cutter radius so the cutter centerline cannot pass closer to the tab than its actual edge. (Same expansion the old `buildProtectedFootprintPaths` was applying.)
+4. Only the parallel strategy is affected. Waterline already passes a per-ring `z` to `buildProtectedFootprintPaths` and handles tabs through its own machinery (`includeTabs: false`); no change there.
+
+### Why not a Z-keyed call to `buildProtectedFootprintPaths`?
+
+Parallel finish has no single Z — each scanline sample point has its own surface Z. A 2D Z-keyed query would force an arbitrary choice (operation top? bottom?) and reintroduce the same class of bug.
+
+## Files affected
+
+- `src/engine/toolpaths/finishSurfaceParallel.ts` — pass `includeTabs: false` to `buildProtectedFootprintPaths`. No other change in this file.
+- `src/engine/toolpaths/finishSurface.ts` — extend the `minCutZAtPoint` closure built in `generateFinishSurfaceToolpath` so that for any XY point inside an expanded tab footprint (tab rect expanded by `tool.radius`), the returned floor is `max(currentFloor, tab.z_top)`. Precompute the expanded tab footprints (Clipper paths + `z_top`) once outside the closure for performance.
+- `src/engine/toolpaths/finishSurface.test.ts` — add a regression test described below.
+
+No new files. No changes to `modelProtection.ts`, the waterline strategy, or the data model.
+
+## Tests
+
+Add a structural unit test in `src/engine/toolpaths/finishSurface.test.ts`:
+
+- **`testParallelFinishCutsOverDeepTab`** — build a flat-ish STL feature with model top at e.g. Z=10 over a small XY area, place a tab whose `z_top` is well below the lowest cut Z (e.g. tab z range −5..−2 while the surface is at +10). Run parallel finish. Assert that the generated moves cover the XY area above the tab (no hole punched in the toolpath over the tab) — concretely, sample the move points inside the tab's expanded footprint and require at least one cutting move there at the surface Z. The current code would generate zero moves above the tab footprint; the fix should produce coverage.
+
+- **`testParallelFinishPreservesTabWhenSurfaceDipsIntoIt`** — a model surface that locally dips below `tab.z_top` inside the tab footprint. Assert that move Zs inside the tab footprint never drop below `tab.z_top` (within numerical tolerance), confirming the clamp engages.
+
+Both tests use the existing parallel finish entry point (`generateFinishSurfaceToolpath` with `pocketPattern !== 'waterline'`) and the project/fixture builders already in `finishSurface.test.ts`.
+
+## Open questions / risks
+
+- The tab radial expansion: keeping it at exactly `tool.radius` matches the prior behaviour and is symmetric with how the waterline path treats tabs. No edge-case change expected, but worth flagging in case future tooling wants per-operation control.
+- Performance: building one expanded Clipper path per tab once, then doing `PointInPolygon` per surface sample, is the same per-point cost shape that `safeSubtractBottomZAtPoint` already pays. Surfaces with many sample points × many tabs could grow, but the projects we target have a handful of tabs at most.
+
+## Out of scope
+
+- Rough surface, waterline finish, and any non-parallel strategy.
+- Adjusting tab geometry semantics (still rectangular `z_bottom..z_top` boxes).
+- The companion question of tab handling in 2.5D pocket/profile strategies — already handled by their own paths and not affected here.

--- a/src/engine/toolpaths/finishSurface.test.ts
+++ b/src/engine/toolpaths/finishSurface.test.ts
@@ -1592,4 +1592,95 @@ function testParallelFinishLinksScanlinesOnFlatPocket(): void {
 
 testParallelFinishLinksScanlinesOnFlatPocket()
 
+function testParallelFinishCutsOverDeepTab(): void {
+  console.log('Testing parallel finish cuts over a deep tab in the pocket floor...')
+  const { project } = makeProject()
+  project.features = [
+    makePocketBlockModelFeature(),
+    makeRegionFeatureRect('region-pocket', 6.5, 3.5, 7, 3),
+  ]
+  normalizeProjectFeatures(project)
+  // Tab sits inside the pocket footprint with its top well BELOW the pocket
+  // floor (floor at z=2, tab top at z=0.5). The cutter never touches the tab,
+  // so the toolpath must still cover this XY area.
+  const tabRect = { x: 8, y: 4, w: 4, h: 2 }
+  project.tabs = [{
+    id: 'deep-tab',
+    name: 'Deep tab',
+    ...tabRect,
+    z_top: 0.5,
+    z_bottom: 0,
+    visible: true,
+  }]
+
+  const op: Operation = {
+    ...makeOperation(),
+    target: { source: 'features', featureIds: ['model1', 'region-pocket'] },
+    pocketPattern: 'parallel',
+    stepover: 0.4,
+    stockToLeaveAxial: 0,
+    stockToLeaveRadial: 0,
+  }
+  project.operations = [op]
+  const result = generateFinishSurfaceToolpath(project, op)
+  assert(result.warnings.length === 0, `unexpected warnings: ${result.warnings.join(', ')}`)
+
+  const cutsOverTab = cutMoves(result.moves).filter((move) => (
+    pointInsideRect(move.to, tabRect) || pointInsideRect(move.from, tabRect)
+  ))
+  assert(cutsOverTab.length > 0,
+    `expected parallel finish cuts above a deep tab (tab top z=0.5, surface z=2), got ${cutsOverTab.length}; tab is being treated as protected at all depths`)
+}
+
+function testParallelFinishPreservesTabWhenSurfaceDipsIntoIt(): void {
+  console.log('Testing parallel finish clamps Z up to tab.z_top inside tab footprint...')
+  const { project } = makeProject()
+  project.features = [
+    makePocketBlockModelFeature(),
+    makeRegionFeatureRect('region-pocket', 6.5, 3.5, 7, 3),
+  ]
+  normalizeProjectFeatures(project)
+  // Tab top sits ABOVE the pocket floor — the natural finish surface dips
+  // into the tab. The toolpath must raise its Z to tab.z_top inside the
+  // tab footprint so the tab is left standing.
+  const tabRect = { x: 8, y: 4, w: 4, h: 2 }
+  const tabTopZ = 2.5
+  project.tabs = [{
+    id: 'shallow-tab',
+    name: 'Shallow tab',
+    ...tabRect,
+    z_top: tabTopZ,
+    z_bottom: 0.5,
+    visible: true,
+  }]
+
+  const op: Operation = {
+    ...makeOperation(),
+    target: { source: 'features', featureIds: ['model1', 'region-pocket'] },
+    pocketPattern: 'parallel',
+    stepover: 0.4,
+    stockToLeaveAxial: 0,
+    stockToLeaveRadial: 0,
+  }
+  project.operations = [op]
+  const result = generateFinishSurfaceToolpath(project, op)
+  assert(result.warnings.length === 0, `unexpected warnings: ${result.warnings.join(', ')}`)
+
+  const eps = 1e-6
+  const cutsBelowTabTopInTab = cutMoves(result.moves).filter((move) => (
+    pointInsideRect(move.to, tabRect) && move.to.z < tabTopZ - eps
+  ))
+  assert(cutsBelowTabTopInTab.length === 0,
+    `expected no cut moves below tab.z_top=${tabTopZ} inside tab footprint, got ${cutsBelowTabTopInTab.length}; clamp is not engaging`)
+
+  const cutsInTab = cutMoves(result.moves).filter((move) => (
+    pointInsideRect(move.to, tabRect)
+  ))
+  assert(cutsInTab.length > 0,
+    `expected some cut moves inside tab footprint (clamped to z=${tabTopZ}), got none`)
+}
+
+testParallelFinishCutsOverDeepTab()
+testParallelFinishPreservesTabWhenSurfaceDipsIntoIt()
+
 console.log('finishSurface tests passed')

--- a/src/engine/toolpaths/finishSurface.ts
+++ b/src/engine/toolpaths/finishSurface.ts
@@ -27,10 +27,12 @@ import { generateStepLevels, retractToSafe, updateBounds } from './pocket'
 import { loadSTLTransformedGeometry } from '../csg'
 import { splitFeatureTargets } from './regions'
 import {
+  buildExpandedTabFootprints,
   offsetClipperPaths,
   relatedIntersectingAddFeatures,
   relatedSubtractFeatures,
   safeSubtractBottomZAtPoint,
+  tabTopZAtPoint,
 } from './modelProtection'
 import {
   generateFinishSurfaceParallel,
@@ -232,9 +234,18 @@ export function generateFinishSurfaceToolpath(
 
   const safeZ = getOperationSafeZ(project)
   const warnings: string[] = []
-  const minCutZAtPoint = (point: Point): number => (
-    safeSubtractBottomZAtPoint(relatedSubtracts, point) ?? effectiveBottom
-  )
+  // Tabs constrain the parallel-finish cut Z per-point: at any XY inside an
+  // expanded tab footprint, the cutter tip must stay at or above tab.z_top so
+  // the tab material from z_bottom..z_top is preserved. Tabs whose top sits
+  // below the surface being cut still get clamped, but the natural surface Z
+  // is already higher and the clamp is a no-op — i.e., the toolpath sweeps
+  // over deep tabs normally rather than skipping their XY footprint.
+  const tabFootprints = buildExpandedTabFootprints(project, tool.radius)
+  const minCutZAtPoint = (point: Point): number => {
+    const floor = safeSubtractBottomZAtPoint(relatedSubtracts, point) ?? effectiveBottom
+    const tabTop = tabTopZAtPoint(tabFootprints, point)
+    return tabTop !== null ? Math.max(floor, tabTop) : floor
+  }
 
   const strategyResult = operation.pocketPattern === 'waterline'
     ? generateFinishSurfaceWaterline(

--- a/src/engine/toolpaths/finishSurfaceParallel.ts
+++ b/src/engine/toolpaths/finishSurfaceParallel.ts
@@ -726,11 +726,16 @@ export function generateFinishSurfaceParallel(
   const scanIndex = 0
   const baseContours = modelSilhouetteContours(modelFeature)
   const baseCoveragePaths = unionClipperPaths(coverageContoursToClipperPaths(baseContours))
+  // Tabs are NOT 2D-subtracted from coverage here — they were being subtracted
+  // unconditionally, which carved a hole above every tab regardless of how far
+  // below the cut surface the tab actually sat. Tab preservation is instead
+  // handled per-point via minCutZAtPoint, which clamps cut Z up to tab.z_top
+  // only where the surface would otherwise dip into a tab.
   const protectedPaths = buildProtectedFootprintPaths(project, {
     targetFeatureIds: new Set(operation.target.source === 'features' ? operation.target.featureIds : []),
     featureExpansion: tool.radius + Math.max(0, operation.stockToLeaveRadial),
-    tabExpansion: tool.radius,
     clampExpansion: tool.radius,
+    includeTabs: false,
     machiningEnvelopePaths: baseCoveragePaths,
   })
   const baseBounds = computeContourBounds([baseContours])

--- a/src/engine/toolpaths/modelProtection.ts
+++ b/src/engine/toolpaths/modelProtection.ts
@@ -386,6 +386,52 @@ export function safeSubtractBottomZAtPoint(
   return deepestClearanceBottom ?? shallowestContainingBottom
 }
 
+export interface ExpandedTabFootprint {
+  paths: ClipperPath[]
+  topZ: number
+}
+
+export function buildExpandedTabFootprints(
+  project: Project,
+  tabExpansion: number,
+): ExpandedTabFootprint[] {
+  const expansion = Math.max(0, tabExpansion)
+  const footprints: ExpandedTabFootprint[] = []
+  for (const tab of project.tabs) {
+    if (!tab.visible) continue
+    const profile = rectProfile(tab.x, tab.y, tab.w, tab.h)
+    const rawPath = toClipperPath(
+      normalizeWinding(flattenProfile(profile).points, false),
+      DEFAULT_CLIPPER_SCALE,
+    )
+    const expanded = expansion > 0 ? offsetClipperPaths([rawPath], expansion) : [rawPath]
+    if (expanded.length === 0) continue
+    footprints.push({ paths: expanded, topZ: tab.z_top })
+  }
+  return footprints
+}
+
+export function tabTopZAtPoint(
+  footprints: ExpandedTabFootprint[],
+  point: Point,
+): number | null {
+  if (footprints.length === 0) return null
+  const clipperPoint = {
+    X: Math.round(point.x * DEFAULT_CLIPPER_SCALE),
+    Y: Math.round(point.y * DEFAULT_CLIPPER_SCALE),
+  }
+  let highest: number | null = null
+  for (const footprint of footprints) {
+    const inside = footprint.paths.some((path) => (
+      (ClipperLib.Clipper as unknown as { PointInPolygon(point: { X: number; Y: number }, path: ClipperPath): number })
+        .PointInPolygon(clipperPoint, path) !== 0
+    ))
+    if (!inside) continue
+    highest = highest === null ? footprint.topZ : Math.max(highest, footprint.topZ)
+  }
+  return highest
+}
+
 export function buildProtectedFootprintPaths(
   project: Project,
   options: ProtectedFootprintOptions,


### PR DESCRIPTION
## Summary

- Parallel finish was unconditionally subtracting every tab's XY footprint from its coverage contour via `buildProtectedFootprintPaths` (called without a `z`), which carved a hole in the toolpath even when the tab sat far below the cutting surface.
- Switched to Z-aware per-point clamping: added `buildExpandedTabFootprints` and `tabTopZAtPoint` helpers in `modelProtection.ts`, extended `minCutZAtPoint` in `finishSurface.ts` to clamp cut Z up to `tab.z_top` inside expanded tab footprints, and passed `includeTabs: false` to `buildProtectedFootprintPaths` in `finishSurfaceParallel.ts`.
- The cutter now sweeps over deep tabs normally (no hole), and only raises Z to `tab.z_top` where the surface actually dips into a tab.

Plan: [planning/archive/PARALLEL_FINISH_TAB_Z_AWARENESS_Plan.md](planning/archive/PARALLEL_FINISH_TAB_Z_AWARENESS_Plan.md)

## Test plan

- [x] `testParallelFinishCutsOverDeepTab` — tab with `z_top` well below surface produces toolpath coverage above it (no hole)
- [x] `testParallelFinishPreservesTabWhenSurfaceDipsIntoIt` — cut Z is clamped to `tab.z_top` where the surface dips into the tab
- [x] Full `npm run build` passes (tsc + all 17 test files + vite)
- [x] Manual verification in app: parallel finish over a project with tabs at various depths