### PR TITLE
fix(simulation): rebuild boundary wall geometry when cells are cut through during playback

### DIFF
--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -576,6 +576,11 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   const playbackMaterialMeshRef = useRef<THREE.Object3D | null>(null)
   const playbackBoundaryMeshRef = useRef<THREE.Object3D | null>(null)
   const playbackHeightfieldTextureRef = useRef<THREE.DataTexture | null>(null)
+  // Cached stock color for boundary geometry rebuilds during playback.
+  const playbackStockColorRef = useRef<THREE.Color>(new THREE.Color(0xb5beca))
+  useEffect(() => {
+    playbackStockColorRef.current = stockColor ? new THREE.Color(stockColor) : new THREE.Color(0xb5beca)
+  }, [stockColor])
   const boundaryMeshRef = useRef<THREE.Object3D | null>(null)
   const playbackFrameRef = useRef<number>(0)
   const playbackLastTimeRef = useRef<number>(0)
@@ -803,9 +808,29 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
     if (!controller || !texture) {
       return
     }
+
+    // Always push the latest heightfield data to the GPU texture.
     const dirtyRegion = controller.getDirtyRegion()
     updateHeightfieldTexture(texture, dirtyRegion)
     controller.clearDirtyRegion()
+
+    // When cells have been cut all the way through, new wall faces are exposed on
+    // neighboring cells. The boundary mesh geometry (built once at playback start)
+    // doesn't include those walls, so we rebuild it from the current grid state.
+    if (controller.getBoundaryChanged()) {
+      controller.clearBoundaryChanged()
+      const scene = sceneRef.current
+      if (scene && playbackBoundaryMeshRef.current) {
+        scene.remove(playbackBoundaryMeshRef.current)
+        disposeSceneObject(playbackBoundaryMeshRef.current)
+        playbackBoundaryMeshRef.current = null
+
+        const boundaryMaterial = createDynamicBoundaryMaterial(texture, controller.liveGrid, playbackStockColorRef.current)
+        const boundary = buildDynamicProfileBoundaryObject(controller.liveGrid, boundaryMaterial)
+        scene.add(boundary)
+        playbackBoundaryMeshRef.current = boundary
+      }
+    }
   }, [])
 
 

--- a/src/engine/simulation/playback.test.ts
+++ b/src/engine/simulation/playback.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the ApplyMoveResult / PlaybackController boundary-tracking contract
+ * introduced to fix simulation playback walls disappearing when cells are cut
+ * through to stockBottomZ (PR #103).
+ *
+ * Run with: npx tsx src/engine/simulation/playback.test.ts
+ */
+
+import { PlaybackController, type PlaybackToolInfo } from './playback'
+import { applyMoveToGrid } from './replay'
+import type { ToolpathMove } from '../toolpaths/types'
+import type { SimulationGrid } from './types'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function makeFullGrid(): SimulationGrid {
+  // 3x3 unit grid, stock from z=0 to z=10, all cells full.
+  // Cell centers are at (0.5, 0.5), (1.5, 0.5), (2.5, 0.5), (0.5, 1.5), ...
+  return {
+    originX: 0,
+    originY: 0,
+    cellSize: 1,
+    cols: 3,
+    rows: 3,
+    stockBottomZ: 0,
+    stockTopZ: 10,
+    topZ: new Float32Array(9).fill(10),
+  }
+}
+
+function stationaryCut(x: number, y: number, z: number): ToolpathMove {
+  return { kind: 'cut', from: { x, y, z }, to: { x, y, z } }
+}
+
+function testPartialCutDoesNotReportCellCleared(): void {
+  const grid = makeFullGrid()
+  // Flat endmill at center of cell (1,1), tip at z=5 — cuts material away from
+  // topZ=10 down to z=5, but the cell still has material above stockBottomZ.
+  const result = applyMoveToGrid(grid, stationaryCut(1.5, 1.5, 5), 0.4, 'flat_endmill', null)
+
+  assert(result.changedCount === 1, `expected one cell to change, got ${result.changedCount}`)
+  assert(grid.topZ[1 * 3 + 1] === 5, `expected center cell topZ=5, got ${grid.topZ[1 * 3 + 1]}`)
+  assert(
+    result.anyCellCleared === false,
+    'partial cut that leaves material above stockBottomZ must not set anyCellCleared',
+  )
+}
+
+function testFullCutToStockBottomReportsCellCleared(): void {
+  const grid = makeFullGrid()
+  // Flat endmill at center of cell (1,1), tip at z=-0.5 — clamped at stockBottomZ=0,
+  // so the cell transitions from material to empty.
+  const result = applyMoveToGrid(grid, stationaryCut(1.5, 1.5, -0.5), 0.4, 'flat_endmill', null)
+
+  assert(result.changedCount === 1, `expected one cell to change, got ${result.changedCount}`)
+  assert(grid.topZ[1 * 3 + 1] === 0, `expected center cell topZ to clamp to stockBottomZ, got ${grid.topZ[1 * 3 + 1]}`)
+  assert(
+    result.anyCellCleared === true,
+    'cell transition from material to stockBottomZ must set anyCellCleared',
+  )
+}
+
+function testRepeatedFullCutDoesNotRereportCleared(): void {
+  const grid = makeFullGrid()
+  applyMoveToGrid(grid, stationaryCut(1.5, 1.5, -0.5), 0.4, 'flat_endmill', null)
+  // Second cut on the already-empty cell should not change anything and must
+  // not falsely report another clear transition.
+  const result = applyMoveToGrid(grid, stationaryCut(1.5, 1.5, -0.5), 0.4, 'flat_endmill', null)
+  assert(result.changedCount === 0, `expected no changes on second cut, got ${result.changedCount}`)
+  assert(
+    result.anyCellCleared === false,
+    'repeated cut on already-empty cell must not report anyCellCleared again',
+  )
+}
+
+const flatTool: PlaybackToolInfo = { toolType: 'flat_endmill', toolRadius: 0.4, vBitAngle: null }
+
+function testPlaybackControllerBoundaryChangedOnCutThrough(): void {
+  const baseGrid = makeFullGrid()
+  const controller = new PlaybackController(baseGrid, [stationaryCut(1.5, 1.5, -0.5)], flatTool, {
+    maxSegmentLength: 0,
+  })
+
+  assert(
+    controller.getBoundaryChanged() === false,
+    'PlaybackController must start with boundaryChanged=false',
+  )
+
+  controller.advance(1)
+
+  assert(
+    controller.getBoundaryChanged() === true,
+    'PlaybackController must set boundaryChanged when a cut-through occurs',
+  )
+
+  controller.clearBoundaryChanged()
+  assert(
+    controller.getBoundaryChanged() === false,
+    'clearBoundaryChanged() must reset the flag',
+  )
+}
+
+function testPlaybackControllerBoundaryUnchangedForPartialCut(): void {
+  const baseGrid = makeFullGrid()
+  const controller = new PlaybackController(baseGrid, [stationaryCut(1.5, 1.5, 5)], flatTool, {
+    maxSegmentLength: 0,
+  })
+
+  controller.advance(1)
+
+  assert(
+    controller.getBoundaryChanged() === false,
+    'partial cut that leaves material must not set boundaryChanged on the controller',
+  )
+}
+
+function testPlaybackControllerResetForcesBoundaryRebuild(): void {
+  const baseGrid = makeFullGrid()
+  const controller = new PlaybackController(baseGrid, [stationaryCut(1.5, 1.5, 5)], flatTool, {
+    maxSegmentLength: 0,
+  })
+  controller.advance(1)
+  controller.clearBoundaryChanged()
+
+  controller.reset()
+  assert(
+    controller.getBoundaryChanged() === true,
+    'reset() must force a boundary rebuild so walls match the base grid state',
+  )
+}
+
+testPartialCutDoesNotReportCellCleared()
+testFullCutToStockBottomReportsCellCleared()
+testRepeatedFullCutDoesNotRereportCleared()
+testPlaybackControllerBoundaryChangedOnCutThrough()
+testPlaybackControllerBoundaryUnchangedForPartialCut()
+testPlaybackControllerResetForcesBoundaryRebuild()
+console.log('playback boundary-tracking tests passed')

--- a/src/engine/simulation/playback.ts
+++ b/src/engine/simulation/playback.ts
@@ -109,6 +109,12 @@ export class PlaybackController {
   private finished = false
   private lastMoveApplied = -1
   private frameDirtyRegion: DirtyRegion | null = null
+  /**
+   * Set to true when any cell transitions from material to empty (topZ hits stockBottomZ)
+   * during advance(). This signals the viewport to rebuild boundary wall geometry since
+   * new wall faces may have been exposed. Cleared by clearBoundaryChanged().
+   */
+  private boundaryChanged = false
 
   constructor(
     baseGrid: SimulationGrid,
@@ -136,6 +142,7 @@ export class PlaybackController {
     this.finished = this.moves.length === 0
     this.lastMoveApplied = -1
     this.frameDirtyRegion = null
+    this.boundaryChanged = true  // force a boundary rebuild after reset so walls reflect base state
   }
 
   getDirtyRegion(): DirtyRegion | null {
@@ -144,6 +151,14 @@ export class PlaybackController {
 
   clearDirtyRegion(): void {
     this.frameDirtyRegion = null
+  }
+
+  getBoundaryChanged(): boolean {
+    return this.boundaryChanged
+  }
+
+  clearBoundaryChanged(): void {
+    this.boundaryChanged = false
   }
 
   private expandDirtyRegion(region: DirtyRegion): void {
@@ -221,6 +236,9 @@ export class PlaybackController {
             gridChanged = true
             this.expandDirtyRegion(result.dirtyRegion!)
           }
+          if (result.anyCellCleared) {
+            this.boundaryChanged = true
+          }
           this.lastMoveApplied = this.moveIndex
         }
         this.advanceToNextMove()
@@ -242,6 +260,9 @@ export class PlaybackController {
           if (result.changedCount > 0) {
             gridChanged = true
             this.expandDirtyRegion(result.dirtyRegion!)
+          }
+          if (result.anyCellCleared) {
+            this.boundaryChanged = true
           }
           this.lastMoveApplied = this.moveIndex
         }
@@ -270,6 +291,9 @@ export class PlaybackController {
           if (result.changedCount > 0) {
             gridChanged = true
             this.expandDirtyRegion(result.dirtyRegion!)
+          }
+          if (result.anyCellCleared) {
+            this.boundaryChanged = true
           }
         }
 

--- a/src/engine/simulation/replay.ts
+++ b/src/engine/simulation/replay.ts
@@ -66,6 +66,12 @@ export function moveIsMaterialRemoving(move: ToolpathMove): boolean {
 export interface ApplyMoveResult {
   changedCount: number
   dirtyRegion: DirtyRegion | null
+  /**
+   * True if at least one cell transitioned from having material (topZ > stockBottomZ)
+   * to being cleared (topZ <= stockBottomZ). When this happens the boundary wall
+   * geometry needs to be rebuilt because new wall faces may have been exposed.
+   */
+  anyCellCleared: boolean
 }
 
 export function applyMoveToGrid(
@@ -83,6 +89,7 @@ export function applyMoveToGrid(
   const [colStart, colEnd] = pointToCellRange(minX, maxX, grid.originX, grid.cellSize, grid.cols)
   const [rowStart, rowEnd] = pointToCellRange(minY, maxY, grid.originY, grid.cellSize, grid.rows)
   let changed = 0
+  let anyCellCleared = false
   let dirtyColMin = grid.cols
   let dirtyColMax = -1
   let dirtyRowMin = grid.rows
@@ -115,6 +122,10 @@ export function applyMoveToGrid(
       const idx = indexFor(grid, col, row)
       const nextZ = Math.max(grid.stockBottomZ, cutZ)
       if (nextZ < grid.topZ[idx] - 1e-9) {
+        // Detect material → empty transitions so the caller can rebuild boundary walls.
+        if (grid.topZ[idx] > grid.stockBottomZ + 1e-6 && nextZ <= grid.stockBottomZ + 1e-6) {
+          anyCellCleared = true
+        }
         grid.topZ[idx] = nextZ
         changed += 1
         if (col < dirtyColMin) dirtyColMin = col
@@ -128,6 +139,7 @@ export function applyMoveToGrid(
   return {
     changedCount: changed,
     dirtyRegion: changed > 0 ? { colMin: dirtyColMin, colMax: dirtyColMax, rowMin: dirtyRowMin, rowMax: dirtyRowMax } : null,
+    anyCellCleared,
   }
 }
 


### PR DESCRIPTION
## Problem

During tool playback, vertical walls on pocket boundaries would appear as open space as the tool cut through them. The static simulation result (without playback) was correct — the issue was specific to the animated play mode.

### Root cause

The boundary wall geometry is built **once** when playback starts, based on the initial grid state where all cells are full. The geometry only emits wall quads where a cell has a neighbor with no material (i.e. the outer stock profile boundary). As the tool cuts cells all the way to `stockBottomZ`, those cells become effectively empty — but their still-full neighbors were never given wall geometry facing inward, since they weren't on any boundary at creation time. The heightfield texture update kept the top surface correct, but no wall faces existed for the newly-exposed sides.

## Changes

**`src/engine/simulation/replay.ts`**
- `applyMoveToGrid` now returns `anyCellCleared: boolean` — set to `true` when a cell transitions from having material (`topZ > stockBottomZ`) to empty (`topZ <= stockBottomZ`)

**`src/engine/simulation/playback.ts`**
- `PlaybackController` accumulates a `boundaryChanged` flag whenever `anyCellCleared` is reported by any move in `advance()`
- Also set to `true` on `reset()` so boundary geometry is always correct after stop/replay
- Exposed via `getBoundaryChanged()` / `clearBoundaryChanged()`

**`src/components/simulation/SimulationViewport.tsx`**
- `rebuildPlaybackGeometry` now checks `boundaryChanged` after updating the heightfield texture
- When set, disposes the old boundary mesh and rebuilds it from the current live grid state, so newly-exposed wall faces appear immediately
- Boundary rebuild only fires when cells actually clear — no per-frame overhead during normal cutting

## Testing

1. Open an operation with a pocket or profile cut
2. Enable Tool Playback
3. Play through the operation — pocket walls should remain solid throughout, matching the final static simulation result