### PR TITLE
Fix operation selection UX: touch targets, hints, chevrons, feedback

### DIFF
--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -1,0 +1,74 @@
+# Operation Selection UX Action Plan
+
+## Background
+UX review of the operation selection UI in CAMPanel identified seven improvements
+for desktop and tablet/touch users.
+
+## Items
+
+### P1 — Touch targets for compact pass buttons (tablet.css)
+**Problem:** `.cam-subtab--compact` overrides the base `.cam-subtab` min-height down to
+20 px. The tablet rule that fixes `.cam-subtab` to 44 px doesn't override `--compact`
+because specificity is equal. On a coarse-pointer device the Rough / Finish / Both
+buttons are too small to tap reliably.
+
+**Fix:** Add `@media (pointer: coarse)` block in `tablet.css` that restores
+`min-height: var(--touch-target, 44px)` on `.cam-subtab--compact` and bumps padding and
+font-size to match the base `.cam-subtab` touch target.
+
+---
+
+### P2 — Inform "Add Operation" button when no geometry is selected (CAMPanel.tsx + layout.css)
+**Problem:** Clicking "Add" opens the menu with all operation buttons disabled, but
+gives no upfront reason. Users can be confused about why nothing works.
+
+**Fix:** When `selection.selectedFeatureIds.length === 0`, add class
+`cam-header-action--warn` to the "Add" button (amber accent colour) and a `title`
+tooltip. The button stays enabled so users can still browse operation descriptions.
+Add `.cam-header-action--warn` CSS rule.
+
+---
+
+### P3 — Constrain operation add menu width on small/narrow viewports (layout.css)
+**Problem:** `.cam-add-menu--vertical` uses `width: 360px; max-width: 90vw;`.
+On narrow screens this can still push content off-screen.
+
+**Fix:** Replace with `width: min(360px, calc(100vw - 2rem));` — single expression
+that combines both constraints.
+
+---
+
+### P4 — Chevron on expandable info cards (OperationAddMenu.tsx + layout.css)
+**Problem:** The operation label button expands/collapses a detail card but there is
+no visual indicator that it is expandable. Users don't discover the feature.
+
+**Fix:** Add `<Icon id="chevron-down" size={12} />` inside the label button. Add CSS
+to rotate it 180° when the card is expanded, with a smooth transition.
+
+---
+
+### P5 — Transient confirmation for "Use current selection" (CAMPanel.tsx + layout.css)
+**Problem:** On success, `handleApplySelectionToOperation` clears `targetUpdateMessage`
+and gives no feedback. User has no confirmation the target was actually updated.
+
+**Fix:** Add a `selectionUpdateConfirm` state (string | null — holds the operationId).
+On success, set it to the operationId and schedule a `setTimeout` to clear it after
+2 000 ms. Render a `cam-field-message--success` span when it matches the current
+operation. Add `.cam-field-message--success { color: #7ddf7d; }` CSS rule.
+
+---
+
+### P6 — Replace Unicode ⧉ with Icon component (CAMPanel.tsx)
+**Problem:** The duplicate-operation button renders the Unicode character `⧉`, which
+renders inconsistently across platforms and has no semantic meaning for screen readers.
+
+**Fix:** Replace with `<Icon id="copy" size={14} />` (the existing "copy" symbol in
+`public/icons.svg`).
+
+---
+
+### P7 — Minimum row height in operation add menu (layout.css)
+**Problem:** `.cam-operation-row` has `min-height: 24px`, which is too cramped and
+makes rows hard to click accurately on both mouse and touch.
+
+**Fix:** Raise `min-height` to `40px`.

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -770,6 +770,7 @@ export function CAMPanel({
     selectionKey: string
     text: string
   } | null>(null)
+  const [selectionUpdateConfirm, setSelectionUpdateConfirm] = useState<string | null>(null)
   const [operationActionMessage, setOperationActionMessage] = useState<{
     operationId: string
     text: string
@@ -1188,6 +1189,9 @@ export function CAMPanel({
 
     updateOperation(selectedOperation.id, { target })
     setTargetUpdateMessage(null)
+    // P5: transient confirmation
+    setSelectionUpdateConfirm(selectedOperation.id)
+    setTimeout(() => setSelectionUpdateConfirm(null), 2000)
   }
 
   function handleAutoPlaceTabs() {
@@ -1239,8 +1243,9 @@ export function CAMPanel({
                     Export
                   </button>
                   <button
-                    className="cam-header-action"
+                    className={`cam-header-action${selection.selectedFeatureIds.length === 0 ? ' cam-header-action--warn' : ''}`}
                     type="button"
+                    title={selection.selectedFeatureIds.length === 0 ? 'Select geometry first, then choose an operation type' : undefined}
                     aria-expanded={showAddOperationMenu}
                     aria-haspopup="dialog"
                     onClick={() => {
@@ -1376,7 +1381,7 @@ export function CAMPanel({
                                 handleDuplicateOperation(operation.id)
                               }}
                             >
-                              ⧉
+                              <Icon id="copy" size={14} />
                             </button>
                             <button
                               className="tree-action-btn tree-action-btn--delete"
@@ -1628,9 +1633,11 @@ export function CAMPanel({
                     >
                       Use current selection
                     </button>
-                    {targetUpdateMessage
-                    && targetUpdateMessage.operationId === selectedOperation.id
-                    && targetUpdateMessage.selectionKey === selectionKey ? (
+                    {selectionUpdateConfirm === selectedOperation.id ? (
+                      <span className="cam-field-message cam-field-message--success">✓ Target updated</span>
+                    ) : targetUpdateMessage
+                      && targetUpdateMessage.operationId === selectedOperation.id
+                      && targetUpdateMessage.selectionKey === selectionKey ? (
                       <span className="cam-field-message">{targetUpdateMessage.text}</span>
                     ) : null}
                   </div>

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -781,6 +781,7 @@ export function CAMPanel({
   const addOperationMenuRef = useRef<HTMLDivElement>(null)
   const dragOverOperationId = useRef<string | null>(null)
   const gripDragRef = useRef<{ operationId: string; lastSwapY: number; pointerId: number } | null>(null)
+  const selectionUpdateConfirmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const {
     project,
     selection,
@@ -965,6 +966,14 @@ export function CAMPanel({
       window.removeEventListener('keydown', handleKeyDown)
     }
   }, [showAddOperationMenu])
+
+  useEffect(() => {
+    return () => {
+      if (selectionUpdateConfirmTimeoutRef.current !== null) {
+        clearTimeout(selectionUpdateConfirmTimeoutRef.current)
+      }
+    }
+  }, [])
 
   function handleAddTool() {
     const toolId = addTool()
@@ -1191,7 +1200,13 @@ export function CAMPanel({
     setTargetUpdateMessage(null)
     // P5: transient confirmation
     setSelectionUpdateConfirm(selectedOperation.id)
-    setTimeout(() => setSelectionUpdateConfirm(null), 2000)
+    if (selectionUpdateConfirmTimeoutRef.current !== null) {
+      clearTimeout(selectionUpdateConfirmTimeoutRef.current)
+    }
+    selectionUpdateConfirmTimeoutRef.current = setTimeout(() => {
+      setSelectionUpdateConfirm(null)
+      selectionUpdateConfirmTimeoutRef.current = null
+    }, 2000)
   }
 
   function handleAutoPlaceTabs() {

--- a/src/components/cam/OperationAddMenu.tsx
+++ b/src/components/cam/OperationAddMenu.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { OperationKind } from '../../types/project'
 import { operationDescriptions } from '../../types/operationDescriptions'
+import { Icon } from '../Icon'
 
 interface OperationButton {
   kind: OperationKind
@@ -78,10 +79,11 @@ export function OperationAddMenu({
                   <button
                     className={`cam-operation-label-btn ${isExpanded ? 'cam-operation-label-btn--expanded' : ''}`}
                     type="button"
-                    title={button.hint}
+                    title={button.hint ?? (isExpanded ? `Collapse ${button.label} info` : `Expand ${button.label} info`)}
                     onClick={() => setExpandedOperationKind(isExpanded ? null : button.kind)}
                   >
                     <span className="cam-operation-label">{button.label}</span>
+                    <Icon id="chevron-down" size={12} />
                   </button>
 
                   {operationSupportsPass(button.kind) ? (

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2593,6 +2593,12 @@
   background: rgba(61, 27, 24, 0.42);
 }
 
+/* P2: amber tint when no geometry is selected */
+.cam-header-action--warn {
+  border-color: rgba(220, 165, 106, 0.45);
+  color: var(--accent);
+}
+
 .cam-add-menu {
   position: absolute;
   top: calc(100% + 8px);
@@ -2627,6 +2633,13 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+/* P5: success confirmation colour */
+.cam-field-message--success {
+  color: #7ddf7d;
+  font-size: 11px;
+  line-height: 1.35;
 }
 
 .cam-field-message {
@@ -3243,8 +3256,8 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  width: 360px;
-  max-width: 90vw;
+  /* P3: single expression replaces width + max-width */
+  width: min(360px, calc(100vw - 2rem));
   max-height: 70vh;
   padding: 0;
   overflow-y: auto;
@@ -3283,7 +3296,8 @@
   align-items: center;
   gap: 6px;
   padding: 5px 10px;
-  min-height: 24px;
+  /* P7: more clickable row height */
+  min-height: 40px;
 }
 
 .cam-operation-row .feat-btn {
@@ -3303,9 +3317,25 @@
   text-align: left;
   font-size: 12px;
   font-weight: 600;
+  /* P4: flex so chevron icon sits inline with label */
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.cam-operation-label-btn .cam-operation-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
+}
+
+/* P4: chevron icon inside the label button */
+.cam-operation-label-btn .icon-sprite {
+  flex-shrink: 0;
+  opacity: 0.45;
+  transition: transform 0.18s ease, opacity 0.18s ease;
 }
 
 .cam-operation-label-btn:hover {
@@ -3314,6 +3344,11 @@
 
 .cam-operation-label-btn--expanded {
   color: var(--accent);
+}
+
+.cam-operation-label-btn--expanded .icon-sprite {
+  transform: rotate(180deg);
+  opacity: 1;
 }
 
 .cam-operation-label {

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -210,6 +210,14 @@
     min-height: var(--touch-target, 44px);
     padding: 0 14px;
   }
+
+  /* P1: restore touch target that .cam-subtab--compact overrides */
+  .cam-subtab--compact {
+    min-height: var(--touch-target, 44px);
+    padding: 0 10px;
+    font-size: 12px;
+    border-radius: 6px;
+  }
 }
 
 /* ── Split divider: larger hit area ─────────────────────── */


### PR DESCRIPTION
## Summary

Seven targeted UX improvements to the operation selection panel, covering tablet touch targets, discoverability, and feedback.

- **P1 — Touch targets (tablet):** `.cam-subtab--compact` was overriding the tablet 44 px touch target rule on the Rough / Finish / Both buttons. Fixed by adding an explicit `pointer: coarse` override in `tablet.css`.
- **P2 — Add button hint:** When no geometry is selected, the "Add" button now turns amber and shows a tooltip explaining why all operations are disabled. The button stays enabled so users can still browse descriptions.
- **P3 — Menu width on narrow screens:** `.cam-add-menu--vertical` now uses `width: min(360px, calc(100vw - 2rem))` instead of separate `width` + `max-width` properties.
- **P4 — Expandable card chevron:** Each operation label button in the add menu now shows a `chevron-down` icon that rotates 180° when the card is open — makes the expand/collapse action discoverable.
- **P5 — "Use current selection" confirmation:** After a successful target update, a green "✓ Target updated" message appears for 2 s, replacing the previous silent success.
- **P6 — Duplicate icon:** The Unicode `⧉` glyph on the duplicate-operation button is replaced with `<Icon id="copy" size={14} />` for consistent rendering across platforms.
- **P7 — Operation row height:** `.cam-operation-row` min-height raised from 24 px to 40 px for easier clicking.

## Test plan

- [x] On a touch device (or Chrome devtools coarse pointer emulation), confirm Rough / Finish / Both buttons are ≥ 44 px tall
- [x] With no features selected, open the Add menu — button should be amber with tooltip
- [x] Resize browser to a narrow width — Add menu should not overflow the viewport
- [x] Click an operation label in the Add menu — chevron should rotate; click again to collapse
- [x] With a valid selection, click "Use current selection" — green confirmation should appear for ~2 s
- [x] Duplicate an operation — icon should render as a copy symbol (not `⧉`)
- [x] Operation rows in the Add menu should be visibly taller and easier to click

🤖 Generated with [Claude Code](https://claude.com/claude-code)