### PR TITLE
Fix Chrome toolpath line rendering

### DIFF
--- a/planning/archive/CHROME_TOOLPATH_LINE_RENDERING_Plan.md
+++ b/planning/archive/CHROME_TOOLPATH_LINE_RENDERING_Plan.md
@@ -1,0 +1,41 @@
+---
+status: Done
+created: 2026-05-27
+---
+
+# Chrome Toolpath Line Rendering Plan
+
+## Goal
+
+Fix Chrome-on-macOS rendering of dense 3D toolpath overlays where ANGLE's Metal backend draws rough/waterline cut lines in an incorrect upright plane, while the generated toolpath data remains correct and Safari/Firefox render correctly.
+
+## Approach
+
+- Keep CAM/toolpath generation unchanged; the rough and finish move bounds are already correct.
+- Change the 3D viewport toolpath overlay submission so dense cut layers are broken into bounded `THREE.LineSegments` geometries instead of one very large line buffer per layer.
+- Factor the toolpath line-buffer construction into a small helper that can be unit-tested without WebGL.
+- Preserve existing visibility toggles, colors, opacity, direction arrows, and endpoint markers.
+- Prefer a conservative chunk size that avoids the Chrome ANGLE Metal corruption without adding excessive Three objects.
+
+## Files affected
+
+- `src/components/viewport3d/Viewport3D.tsx` — chunk dense toolpath line segment buffers and optionally factor buffer construction helpers.
+- `src/components/viewport3d/Viewport3D.test.ts` *(new, if practical with existing test runner)* — verify chunked line-buffer bounds and segment counts for synthetic toolpaths.
+- `src/components/INDEX.md` — update only if a new test/helper file changes the folder map.
+
+## Tests
+
+- Add a focused unit test for chunking/bounds logic if the helper can stay independent of DOM/WebGL.
+- Run `npm run build` before considering the fix complete.
+- Manually verify `work/Old-man-simple.camj` in Chrome ANGLE Metal with only rough cuts visible and with finish adaptive refinement enabled.
+
+## Open questions / risks
+
+- The optimal chunk size may need one Chrome test pass on the affected AMD/Metal machine.
+- If chunking does not solve the ANGLE Metal corruption, the fallback is a different rendering path for toolpath cuts, such as generated tube/quad meshes or thicker line primitives.
+
+## Out of scope
+
+- Changing rough surface or waterline CAM algorithms.
+- Changing simulation rendering.
+- Adding browser/GPU detection UI.

--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -14,7 +14,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 
 ## Subfolders (by area)
 - `canvas/` — 2D sketch canvas: drawing, snapping, panning/zoom, pointer handling
-- `viewport3d/` — Three.js 3D preview of the CSG-derived model
+- `viewport3d/` — Three.js 3D preview of the CSG-derived model, including toolpath overlay helpers
 - `simulation/` — voxel toolpath simulation viewport and playback controls
 - `cam/` — CAM panels (tools, operations, parameters)
 - `feature-tree/` — sketch feature tree UI (reordering, visibility, grouping)

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -23,6 +23,7 @@ import { useProjectStore } from '../../store/projectStore'
 import { buildOriginTriad, buildScene } from '../../engine/csg'
 import { getStockBounds, rectProfile } from '../../types/project'
 import { getFeatureGeometryProfiles } from '../../text'
+import { buildToolpathLinePositionChunks, toolpathPointToWorldTuple } from './toolpathOverlay'
 
 function configureGridMaterial(material: THREE.Material | THREE.Material[]) {
   const materials = Array.isArray(material) ? material : [material]
@@ -113,7 +114,7 @@ function disposeObject3D(object: THREE.Object3D) {
 }
 
 function toolpathPointToWorld(point: ToolpathResult['moves'][number]['from']): THREE.Vector3 {
-  return new THREE.Vector3(point.x, point.z, point.y)
+  return new THREE.Vector3(...toolpathPointToWorldTuple(point))
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -334,24 +335,6 @@ function buildToolpathOverlay(
       continue
     }
 
-    const positions = new Float32Array(moves.length * 2 * 3)
-    let offset = 0
-    for (const move of moves) {
-      const from = toolpathPointToWorld(move.from)
-      const to = toolpathPointToWorld(move.to)
-      positions[offset] = from.x
-      positions[offset + 1] = from.y
-      positions[offset + 2] = from.z
-      positions[offset + 3] = to.x
-      positions[offset + 4] = to.y
-      positions[offset + 5] = to.z
-      offset += 6
-    }
-
-    const geometry = new THREE.BufferGeometry()
-    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3))
-    geometry.computeBoundingSphere()
-
     const material = new THREE.LineBasicMaterial({
       color: layer.color,
       transparent: true,
@@ -360,7 +343,13 @@ function buildToolpathOverlay(
       depthTest: false,
     })
 
-    objects.push(new THREE.LineSegments(geometry, material))
+    for (const chunk of buildToolpathLinePositionChunks(moves)) {
+      const geometry = new THREE.BufferGeometry()
+      geometry.setAttribute('position', new THREE.BufferAttribute(chunk.positions, 3))
+      geometry.computeBoundingSphere()
+
+      objects.push(new THREE.LineSegments(geometry, material))
+    }
   }
 
   if (emphasized && visibility.directions) {

--- a/src/components/viewport3d/toolpathOverlay.test.ts
+++ b/src/components/viewport3d/toolpathOverlay.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for 3D viewport toolpath overlay helpers.
+ *
+ * Run with: npx tsx src/components/viewport3d/toolpathOverlay.test.ts
+ */
+
+import type { ToolpathMove } from '../../engine/toolpaths/types'
+import {
+  buildToolpathLinePositionChunks,
+  toolpathPointToWorldTuple,
+} from './toolpathOverlay'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function makeMove(index: number): ToolpathMove {
+  return {
+    kind: 'cut',
+    from: { x: index, y: index + 10, z: index + 20 },
+    to: { x: index + 0.5, y: index + 10.5, z: index + 20.5 },
+  }
+}
+
+function assertArrayEquals(actual: number[], expected: number[], message: string): void {
+  assert(actual.length === expected.length, `${message}: expected length ${expected.length}, got ${actual.length}`)
+  for (let i = 0; i < expected.length; i += 1) {
+    assert(Math.abs(actual[i] - expected[i]) <= 1e-9, `${message}: index ${i}, expected ${expected[i]}, got ${actual[i]}`)
+  }
+}
+
+function testPointMapping(): void {
+  console.log('Testing toolpath point maps Z to 3D vertical axis...')
+  assertArrayEquals(
+    toolpathPointToWorldTuple({ x: 1, y: 2, z: 3 }),
+    [1, 3, 2],
+    'world tuple',
+  )
+}
+
+function testChunkedLinePositions(): void {
+  console.log('Testing toolpath line positions are chunked and mapped...')
+  const moves = [0, 1, 2, 3, 4].map(makeMove)
+  const chunks = buildToolpathLinePositionChunks(moves, 2)
+
+  assert(chunks.length === 3, `expected 3 chunks, got ${chunks.length}`)
+  assert(chunks[0].segmentCount === 2, `expected first chunk to have 2 segments, got ${chunks[0].segmentCount}`)
+  assert(chunks[1].segmentCount === 2, `expected second chunk to have 2 segments, got ${chunks[1].segmentCount}`)
+  assert(chunks[2].segmentCount === 1, `expected third chunk to have 1 segment, got ${chunks[2].segmentCount}`)
+
+  assertArrayEquals(
+    Array.from(chunks[0].positions.slice(0, 12)),
+    [
+      0, 20, 10,
+      0.5, 20.5, 10.5,
+      1, 21, 11,
+      1.5, 21.5, 11.5,
+    ],
+    'first chunk positions',
+  )
+}
+
+function testEmptyMovesDoNotAllocateChunks(): void {
+  console.log('Testing empty toolpath line positions produce no chunks...')
+  const chunks = buildToolpathLinePositionChunks([], 2)
+  assert(chunks.length === 0, `expected no chunks, got ${chunks.length}`)
+}
+
+testPointMapping()
+testChunkedLinePositions()
+testEmptyMovesDoNotAllocateChunks()
+
+console.log('toolpathOverlay tests passed')

--- a/src/components/viewport3d/toolpathOverlay.ts
+++ b/src/components/viewport3d/toolpathOverlay.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ToolpathMove, ToolpathPoint } from '../../engine/toolpaths/types'
+
+export const DEFAULT_TOOLPATH_LINE_SEGMENTS_PER_CHUNK = 16384
+
+export interface ToolpathLinePositionChunk {
+  positions: Float32Array
+  segmentCount: number
+}
+
+export function toolpathPointToWorldTuple(point: ToolpathPoint): [number, number, number] {
+  return [point.x, point.z, point.y]
+}
+
+export function buildToolpathLinePositionChunks(
+  moves: readonly ToolpathMove[],
+  maxSegmentsPerChunk = DEFAULT_TOOLPATH_LINE_SEGMENTS_PER_CHUNK,
+): ToolpathLinePositionChunk[] {
+  if (moves.length === 0) {
+    return []
+  }
+
+  const segmentLimit = Math.max(1, Math.floor(maxSegmentsPerChunk))
+  const chunks: ToolpathLinePositionChunk[] = []
+
+  for (let start = 0; start < moves.length; start += segmentLimit) {
+    const chunkMoves = moves.slice(start, start + segmentLimit)
+    const positions = new Float32Array(chunkMoves.length * 2 * 3)
+    let offset = 0
+
+    for (const move of chunkMoves) {
+      const from = toolpathPointToWorldTuple(move.from)
+      const to = toolpathPointToWorldTuple(move.to)
+      positions[offset] = from[0]
+      positions[offset + 1] = from[1]
+      positions[offset + 2] = from[2]
+      positions[offset + 3] = to[0]
+      positions[offset + 4] = to[1]
+      positions[offset + 5] = to[2]
+      offset += 6
+    }
+
+    chunks.push({
+      positions,
+      segmentCount: chunkMoves.length,
+    })
+  }
+
+  return chunks
+}


### PR DESCRIPTION
## Summary

- Chunk dense 3D toolpath overlay line buffers to avoid Chrome ANGLE Metal rendering corruption on large toolpath layers.
- Factor toolpath overlay position-buffer generation into a pure helper and cover its coordinate mapping/chunking with a focused test.
- Archive the approved plan: `planning/archive/CHROME_TOOLPATH_LINE_RENDERING_Plan.md`.

## Verification

- `npx tsx src/components/viewport3d/toolpathOverlay.test.ts`
- `npm run build`

## Manual Check

- Verified by user in Chrome and Safari with `work/Old-man-simple.camj` after tuning chunk size to 16,384 segments.
