### PR TITLE
Simplify offset polylines into arcs/circles, RDP polyline cleanup

### DIFF
--- a/src/store/helpers/clipping.ts
+++ b/src/store/helpers/clipping.ts
@@ -763,3 +763,449 @@ export function clipperContourToProfilePreserving(
 
   return { start: startVertex, segments, closed: true }
 }
+
+// ── Offset polyline simplification ────────────────────────────────────────────
+// Clipper offset emits dense polylines (a flattened source curve stays flat
+// after offsetting, and Clipper rebuilds the polygon from integer vertices).
+// This pass converts those polylines back into arcs/circles where possible.
+//
+// Two strategies layered together:
+//   1. Known-circle reconstruction. Any source `arc`/`circle` of radius R at
+//      center C produces an offset arc with the same center and radius
+//      R ± |delta|. We feed those candidate circles to reconstructArcsInProfile
+//      to recover exact original centers.
+//   2. Generic Kasa least-squares arc fit, for offsets of curves whose centers
+//      are not in the source feature set (e.g. arcs introduced by another
+//      simplification pass, or offsets of dense polylines).
+// Followed by collinear-line merge and a single-arc → circle promotion.
+
+interface OffsetFitOptions {
+  minArcSegments: number
+  radiusToleranceFraction: number
+  maxSegmentAngleDeg: number
+}
+
+const DEFAULT_OFFSET_FIT_OPTIONS: OffsetFitOptions = {
+  minArcSegments: 6,
+  radiusToleranceFraction: 0.01,
+  maxSegmentAngleDeg: 20,
+}
+
+function dist2D(a: Point, b: Point): number {
+  return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+// Kasa least-squares circle fit. Returns null on near-collinear input.
+function fitCircleLeastSquares(points: Point[]): { center: Point; radius: number } | null {
+  const n = points.length
+  if (n < 3) return null
+
+  let cx = 0
+  let cy = 0
+  for (const p of points) {
+    cx += p.x
+    cy += p.y
+  }
+  cx /= n
+  cy /= n
+
+  let Suu = 0
+  let Suv = 0
+  let Svv = 0
+  let Arhs = 0
+  let Brhs = 0
+  for (const p of points) {
+    const u = p.x - cx
+    const v = p.y - cy
+    const r2 = u * u + v * v
+    Suu += u * u
+    Suv += u * v
+    Svv += v * v
+    Arhs -= u * r2
+    Brhs -= v * r2
+  }
+
+  const det = Suu * Svv - Suv * Suv
+  if (Math.abs(det) < 1e-12) return null
+
+  const A = (Arhs * Svv - Brhs * Suv) / det
+  const B = (Suu * Brhs - Suv * Arhs) / det
+  const cu = -A / 2
+  const cv = -B / 2
+
+  let Sr2 = 0
+  for (const p of points) {
+    const u = p.x - cx
+    const v = p.y - cy
+    Sr2 += u * u + v * v
+  }
+  const radius2 = cu * cu + cv * cv + Sr2 / n
+  if (radius2 <= 0) return null
+
+  return { center: { x: cu + cx, y: cv + cy }, radius: Math.sqrt(radius2) }
+}
+
+function arcSweepClockwise(points: Point[], center: Point): boolean {
+  let cross = 0
+  for (let i = 0; i < points.length - 1; i += 1) {
+    const v0x = points[i].x - center.x
+    const v0y = points[i].y - center.y
+    const v1x = points[i + 1].x - center.x
+    const v1y = points[i + 1].y - center.y
+    cross += v0x * v1y - v0y * v1x
+  }
+  // Match the project convention used by arcIsClockwise: negative cross sum
+  // is clockwise. Using the wrong sign makes long arcs render as their
+  // (much shorter) complement.
+  return cross < 0
+}
+
+function pointsCollinear(a: Point, b: Point, c: Point): boolean {
+  const abx = b.x - a.x
+  const aby = b.y - a.y
+  const bcx = c.x - b.x
+  const bcy = c.y - b.y
+  const dot = abx * bcx + aby * bcy
+  if (dot <= 0) return false
+  const cross = abx * bcy - aby * bcx
+  const abLen2 = abx * abx + aby * aby
+  const bcLen2 = bcx * bcx + bcy * bcy
+  return cross * cross < 1e-8 * abLen2 * bcLen2
+}
+
+function mergeCollinearLinesClosed(profile: SketchProfile): SketchProfile {
+  if (profile.segments.length < 2) return profile
+
+  // Walk segments and merge adjacent collinear line-line pairs. Also rotate the
+  // start point if the closing line is collinear with the first line.
+  const segs = profile.segments
+  const merged: Segment[] = []
+  let currentStart = profile.start
+  let current: Segment = segs[0]
+
+  for (let i = 1; i < segs.length; i += 1) {
+    const next = segs[i]
+    if (
+      current.type === 'line'
+      && next.type === 'line'
+      && pointsCollinear(currentStart, current.to, next.to)
+    ) {
+      current = { type: 'line', to: next.to }
+    } else {
+      merged.push(current)
+      currentStart = current.to
+      current = next
+    }
+  }
+  merged.push(current)
+
+  if (!profile.closed || merged.length < 2) {
+    return { ...profile, segments: merged }
+  }
+
+  // Wrap-around merge: if the closing line and the leading line are collinear
+  // through profile.start, shift the start point so the three collinear
+  // segments collapse into one and the trailing point becomes a new start.
+  if (merged.length >= 3) {
+    const lastSeg = merged[merged.length - 1]
+    const firstSeg = merged[0]
+    if (lastSeg.type === 'line' && firstSeg.type === 'line') {
+      const lastStart = merged[merged.length - 2].to
+      if (pointsCollinear(lastStart, lastSeg.to, firstSeg.to)) {
+        const newStart = lastStart
+        const rotated: Segment[] = [
+          { type: 'line', to: firstSeg.to },
+          ...merged.slice(1, -1),
+        ]
+        return { ...profile, start: newStart, segments: rotated }
+      }
+    }
+  }
+
+  return { ...profile, segments: merged }
+}
+
+interface ArcFitOutcome {
+  center: Point
+  clockwise: boolean
+}
+
+function tryFitArcRun(
+  points: Point[],
+  opts: OffsetFitOptions,
+  sourceCenters: Point[],
+): ArcFitOutcome | null {
+  if (points.length < opts.minArcSegments + 1) return null
+  if (sourceCenters.length === 0) return null
+
+  const fit = fitCircleLeastSquares(points)
+  if (!fit) return null
+
+  const { center, radius } = fit
+  const tolerance = Math.min(opts.radiusToleranceFraction * radius, 0.05)
+
+  for (const p of points) {
+    if (Math.abs(dist2D(p, center) - radius) > tolerance) return null
+  }
+
+  // Every legitimate offset arc is concentric with a source arc/circle. A
+  // Kasa fit whose center is far from any source center is geometrically
+  // valid math but spurious — typically a huge-radius circle fitted to a
+  // slightly-bowed straight run. Reject it.
+  const centerProximity = Math.min(0.01, radius * 0.001)
+  let nearSource = false
+  for (const sc of sourceCenters) {
+    if (dist2D(center, sc) <= centerProximity) { nearSource = true; break }
+  }
+  if (!nearSource) return null
+
+  const maxSegmentAngle = (opts.maxSegmentAngleDeg * Math.PI) / 180
+  for (let i = 0; i < points.length - 1; i += 1) {
+    const a1 = Math.atan2(points[i].y - center.y, points[i].x - center.x)
+    const a2 = Math.atan2(points[i + 1].y - center.y, points[i + 1].x - center.x)
+    let da = Math.abs(a2 - a1)
+    if (da > Math.PI) da = 2 * Math.PI - da
+    if (da > maxSegmentAngle) return null
+  }
+
+  const chord = dist2D(points[0], points[points.length - 1])
+  const isFullCircle = chord <= radius * 1e-6
+  if (!isFullCircle && chord < radius * 0.15) return null
+
+  return { center, clockwise: arcSweepClockwise(points, center) }
+}
+
+function sliceLineRunVertices(profile: SketchProfile, startSeg: number, endSeg: number): Point[] {
+  const origin: Point = startSeg === 0 ? profile.start : profile.segments[startSeg - 1].to
+  const pts: Point[] = [origin]
+  for (let i = startSeg; i < endSeg; i += 1) {
+    pts.push(profile.segments[i].to)
+  }
+  return pts
+}
+
+// Fit arcs into contiguous runs of line segments. Non-line segments (existing
+// arcs/circles/beziers) are passed through unchanged. Operates on a sequential
+// walk and does not attempt to merge an arc across the start/end boundary of a
+// closed profile.
+function fitArcsInLineRuns(
+  profile: SketchProfile,
+  opts: OffsetFitOptions,
+  sourceCenters: Point[],
+): SketchProfile {
+  const segs = profile.segments
+  if (segs.length < opts.minArcSegments) return profile
+  if (sourceCenters.length === 0) return profile
+
+  const out: Segment[] = []
+  let i = 0
+  while (i < segs.length) {
+    if (segs[i].type !== 'line') {
+      out.push(segs[i])
+      i += 1
+      continue
+    }
+
+    let runEnd = i + 1
+    while (runEnd < segs.length && segs[runEnd].type === 'line') {
+      runEnd += 1
+    }
+
+    let consumed = false
+    for (let end = runEnd; end >= i + opts.minArcSegments; end -= 1) {
+      const pts = sliceLineRunVertices(profile, i, end)
+      const fit = tryFitArcRun(pts, opts, sourceCenters)
+      if (fit) {
+        out.push({
+          type: 'arc',
+          to: pts[pts.length - 1],
+          center: fit.center,
+          clockwise: fit.clockwise,
+        })
+        i = end
+        consumed = true
+        break
+      }
+    }
+
+    if (!consumed) {
+      out.push(segs[i])
+      i += 1
+    }
+  }
+
+  return { ...profile, segments: out }
+}
+
+// ── Douglas-Peucker simplification for residual line runs ────────────────────
+// Applied to contiguous runs of `line` segments only — arcs and other curves
+// are anchors that bound runs. A fully-closed line-only profile is split at
+// the vertex farthest from start so neither RDP half degenerates.
+
+function perpendicularDistance(p: Point, a: Point, b: Point): number {
+  const dx = b.x - a.x
+  const dy = b.y - a.y
+  const len2 = dx * dx + dy * dy
+  if (len2 < 1e-18) return Math.hypot(p.x - a.x, p.y - a.y)
+  // Perpendicular distance to the infinite line through a,b (standard RDP).
+  return Math.abs(dy * p.x - dx * p.y + b.x * a.y - b.y * a.x) / Math.sqrt(len2)
+}
+
+function rdpSimplifyOpenRun(points: Point[], tolerance: number): Point[] {
+  const n = points.length
+  if (n < 3) return points
+
+  // Iterative stack-based RDP to avoid stack overflow on long runs.
+  const keep = new Uint8Array(n)
+  keep[0] = 1
+  keep[n - 1] = 1
+  const stack: [number, number][] = [[0, n - 1]]
+  while (stack.length > 0) {
+    const [lo, hi] = stack.pop()!
+    let maxDist = 0
+    let maxIdx = -1
+    for (let i = lo + 1; i < hi; i += 1) {
+      const d = perpendicularDistance(points[i], points[lo], points[hi])
+      if (d > maxDist) { maxDist = d; maxIdx = i }
+    }
+    if (maxDist > tolerance && maxIdx >= 0) {
+      keep[maxIdx] = 1
+      stack.push([lo, maxIdx])
+      stack.push([maxIdx, hi])
+    }
+  }
+
+  const result: Point[] = []
+  for (let i = 0; i < n; i += 1) {
+    if (keep[i]) result.push(points[i])
+  }
+  return result
+}
+
+function applyRDPToLineRuns(profile: SketchProfile, tolerance: number): SketchProfile {
+  if (tolerance <= 0 || profile.segments.length === 0) return profile
+
+  const segs = profile.segments
+  const out: Segment[] = []
+  let i = 0
+  let cursor: Point = profile.start
+
+  while (i < segs.length) {
+    if (segs[i].type !== 'line') {
+      out.push(segs[i])
+      cursor = segs[i].to
+      i += 1
+      continue
+    }
+
+    // Collect a contiguous run of line segments. runPts[0] is the anchor at
+    // the start of the run; runPts[N] is the anchor at the end.
+    const runPts: Point[] = [cursor]
+    let j = i
+    while (j < segs.length && segs[j].type === 'line') {
+      runPts.push(segs[j].to)
+      j += 1
+    }
+
+    let simplified: Point[]
+    const isFullClosed = profile.closed
+      && i === 0
+      && j === segs.length
+      && dist2D(runPts[0], runPts[runPts.length - 1]) < 1e-9
+
+    if (isFullClosed) {
+      // No external anchors — RDP would collapse the loop. Pick the vertex
+      // farthest from the start as a second anchor and RDP each half.
+      let splitIdx = 0
+      let maxD = 0
+      for (let k = 1; k < runPts.length - 1; k += 1) {
+        const d = dist2D(runPts[k], runPts[0])
+        if (d > maxD) { maxD = d; splitIdx = k }
+      }
+      if (splitIdx < 2 || splitIdx > runPts.length - 3) {
+        simplified = runPts
+      } else {
+        const left = rdpSimplifyOpenRun(runPts.slice(0, splitIdx + 1), tolerance)
+        const right = rdpSimplifyOpenRun(runPts.slice(splitIdx), tolerance)
+        simplified = [...left.slice(0, -1), ...right]
+      }
+    } else {
+      simplified = rdpSimplifyOpenRun(runPts, tolerance)
+    }
+
+    for (let k = 1; k < simplified.length; k += 1) {
+      out.push({ type: 'line', to: simplified[k] })
+    }
+    cursor = simplified[simplified.length - 1]
+    i = j
+  }
+
+  return { ...profile, segments: out }
+}
+
+function bboxDiagonal(points: Point[]): number {
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
+  for (const p of points) {
+    if (p.x < minX) minX = p.x
+    if (p.x > maxX) maxX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.y > maxY) maxY = p.y
+  }
+  return Math.hypot(maxX - minX, maxY - minY)
+}
+
+// If a closed profile reduces to a single arc whose endpoint coincides with
+// the start, promote it to a `circle` segment.
+function promoteClosedArcToCircle(profile: SketchProfile): SketchProfile {
+  if (!profile.closed || profile.segments.length !== 1) return profile
+  const seg = profile.segments[0]
+  if (seg.type !== 'arc') return profile
+
+  const radius = dist2D(profile.start, seg.center)
+  if (radius <= 0) return profile
+  if (dist2D(seg.to, profile.start) > 0.01 * radius) return profile
+
+  return {
+    start: profile.start,
+    segments: [{
+      type: 'circle',
+      center: seg.center,
+      to: profile.start,
+      clockwise: seg.clockwise,
+    }],
+    closed: true,
+  }
+}
+
+export function simplifyOffsetContour(
+  contour: ReturnType<typeof flattenFeatureToClipperPath>,
+  sourceFeatures: SketchFeature[],
+  _delta: number,
+  scale: number = DEFAULT_CLIPPER_SCALE,
+): SketchProfile | null {
+  // Offset output is a closed polyline. We collapse runs of collinear chords
+  // back into single lines and re-fit dense chord runs to arcs, but only when
+  // the fitted center matches a source arc/circle center — every legitimate
+  // offset arc is concentric with its source, so any fit whose center wanders
+  // is a spurious match (typically a slightly-bowed straight run fitted to a
+  // huge-radius circle).
+  const points = fromClipperPath(contour, scale)
+  if (points.length < 3) return null
+
+  const first = points[0]
+  const last = points[points.length - 1]
+  const vertices = Math.abs(first.x - last.x) <= 1e-9 && Math.abs(first.y - last.y) <= 1e-9
+    ? points.slice(0, -1)
+    : points
+  if (vertices.length < 3) return null
+
+  const sourceCenters = collectKnownCircles(sourceFeatures).map((c) => c.center)
+  const rdpTolerance = bboxDiagonal(vertices) * 0.001
+
+  let profile: SketchProfile = polygonProfile(vertices)
+  profile = mergeCollinearLinesClosed(profile)
+  profile = fitArcsInLineRuns(profile, DEFAULT_OFFSET_FIT_OPTIONS, sourceCenters)
+  profile = applyRDPToLineRuns(profile, rdpTolerance)
+  profile = promoteClosedArcToCircle(profile)
+  return profile
+}

--- a/src/store/helpers/derivedFeatures.ts
+++ b/src/store/helpers/derivedFeatures.ts
@@ -37,6 +37,7 @@ import {
   getClipperChildren,
   offsetClipperPaths,
   reconstructArcsInProfile,
+  simplifyOffsetContour,
   type ClipperPolyNode,
   type SegmentAnnotation,
   unionClipperPaths,
@@ -382,7 +383,7 @@ export function previewOffsetFeatures(
   const createdFeatures: SketchFeature[] = []
 
   for (const [index, path] of offsetPaths.entries()) {
-    const profile = clipperContourToProfile(path)
+    const profile = simplifyOffsetContour(path, selectedFeatures, distance)
     if (!profile) {
       continue
     }

--- a/src/store/helpers/offsetSimplify.test.ts
+++ b/src/store/helpers/offsetSimplify.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Tests for simplifyOffsetContour — the post-Clipper-offset arc/circle fitting
+ * pass. Each test runs Clipper offset on a synthesized source profile, hands
+ * the result through simplifyOffsetContour, and asserts:
+ *
+ *   • the output is closed and well-formed (segment endpoints chain),
+ *   • the vertex count drops meaningfully vs the raw offset polyline,
+ *   • arcs are only emitted when concentric with a source arc/circle,
+ *   • the arc sweep direction matches what the renderer expects (so the long
+ *     side of the arc renders, not its short complement).
+ *
+ * Run with: npx tsx src/store/helpers/offsetSimplify.test.ts
+ */
+
+import {
+  flattenFeatureToClipperPath,
+  offsetClipperPaths,
+  simplifyOffsetContour,
+  unionClipperPaths,
+} from './clipping'
+import { sampleProfilePoints } from '../../types/project'
+import type { Point, Segment, SketchFeature, SketchProfile } from '../../types/project'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function approxEq(a: number, b: number, eps: number): boolean {
+  return Math.abs(a - b) <= eps
+}
+
+function pointsApprox(a: Point, b: Point, eps: number): boolean {
+  return approxEq(a.x, b.x, eps) && approxEq(a.y, b.y, eps)
+}
+
+function dist(a: Point, b: Point): number {
+  return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+function makeFeature(profile: SketchProfile, name = 'F'): SketchFeature {
+  return {
+    id: name,
+    name,
+    kind: 'polygon',
+    folderId: null,
+    sketch: { profile, origin: { x: 0, y: 0 }, orientationAngle: 0, dimensions: [], constraints: [] },
+    operation: 'add',
+    z_top: { value: 0.75 },
+    z_bottom: { value: 0 },
+    visible: true,
+    locked: false,
+  } as unknown as SketchFeature
+}
+
+interface ProfileSummary {
+  segCount: number
+  arcCount: number
+  circleCount: number
+  lineCount: number
+  arcCenters: Point[]
+}
+
+function summarize(profile: SketchProfile): ProfileSummary {
+  const arcs: Point[] = []
+  let arcCount = 0
+  let circleCount = 0
+  let lineCount = 0
+  for (const seg of profile.segments) {
+    if (seg.type === 'arc') {
+      arcCount += 1
+      arcs.push(seg.center)
+    } else if (seg.type === 'circle') {
+      circleCount += 1
+      arcs.push(seg.center)
+    } else if (seg.type === 'line') {
+      lineCount += 1
+    }
+  }
+  return { segCount: profile.segments.length, arcCount, circleCount, lineCount, arcCenters: arcs }
+}
+
+// ── Structural assertions every simplified profile must satisfy ──────────────
+
+function assertStructurallyValid(profile: SketchProfile, label: string): void {
+  assert(profile.closed === true, `${label}: profile.closed must be true`)
+  assert(profile.segments.length >= 1, `${label}: need at least 1 segment`)
+
+  // Each segment's `to` is the start of the next segment. The last segment's
+  // `to` must coincide with profile.start (closure).
+  let cursor: Point = profile.start
+  for (let i = 0; i < profile.segments.length; i += 1) {
+    const seg = profile.segments[i]
+    const nextStart = seg.to
+    // Detect zero-length segments — they're a sign of a buggy merge.
+    assert(
+      dist(cursor, nextStart) > 1e-9 || (seg.type === 'circle'),
+      `${label}: zero-length segment at index ${i} (${seg.type})`,
+    )
+    cursor = nextStart
+  }
+  assert(
+    pointsApprox(cursor, profile.start, 1e-6),
+    `${label}: last segment endpoint ${JSON.stringify(cursor)} doesn't return to start ${JSON.stringify(profile.start)}`,
+  )
+}
+
+// Verify each arc's rendered sweep covers the polyline it replaced, not the
+// complement. We do this by re-sampling the arc the same way the renderer does
+// and checking that the resulting polyline closely follows the source contour.
+function assertArcSweepMatchesSource(
+  simplified: SketchProfile,
+  sourceFlattened: Point[],
+  label: string,
+): void {
+  // Re-sample the simplified profile back to a polyline using the project's
+  // canonical sampler — this is what every renderer/exporter ends up doing.
+  const resampled = sampleProfilePoints(simplified)
+  assert(resampled.length >= 4, `${label}: resampled polyline too small`)
+
+  // For every resampled point, find the nearest point on the source-flattened
+  // polyline and accumulate the worst-case distance. A correct arc fit should
+  // resample within a small tolerance of the source offset (offsets of arcs
+  // are concentric, so the polyline sits on the same circle).
+  const bbox = bboxOf(sourceFlattened)
+  const diag = Math.hypot(bbox.maxX - bbox.minX, bbox.maxY - bbox.minY)
+  let maxDeviation = 0
+  for (const p of resampled) {
+    let minDist = Infinity
+    for (const sp of sourceFlattened) {
+      const d = dist(p, sp)
+      if (d < minDist) minDist = d
+    }
+    if (minDist > maxDeviation) maxDeviation = minDist
+  }
+
+  // The flattener uses arcStepRadians = π/36 ≈ 5°, with chord length R·2·sin(2.5°).
+  // The source polyline is discrete, so resampled arc points can land between
+  // adjacent source vertices. Allow up to 5% of the bounding-box diagonal —
+  // generous enough to handle that discretisation, tight enough to catch a
+  // wrong-direction arc (which would deviate by ~the full bbox).
+  assert(
+    maxDeviation < diag * 0.05,
+    `${label}: arc resample deviates ${maxDeviation.toFixed(4)} from source (>${(diag * 0.05).toFixed(4)}) — probable wrong-direction arc`,
+  )
+}
+
+function bboxOf(points: Point[]): { minX: number; maxX: number; minY: number; maxY: number } {
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
+  for (const p of points) {
+    if (p.x < minX) minX = p.x
+    if (p.x > maxX) maxX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.y > maxY) maxY = p.y
+  }
+  return { minX, maxX, minY, maxY }
+}
+
+// ── Helpers for running a full offset+simplify scenario ──────────────────────
+
+interface ScenarioResult {
+  rawVertexCount: number
+  profile: SketchProfile
+  summary: ProfileSummary
+  sourceFlattened: Point[]
+}
+
+function runOffset(sources: SketchFeature[], delta: number): ScenarioResult {
+  const scale = 1000
+  const paths = sources.map((s) => flattenFeatureToClipperPath(s))
+  const unioned = unionClipperPaths(paths)
+  const offsetPaths = offsetClipperPaths(unioned, delta * scale)
+  assert(offsetPaths.length > 0, 'offsetClipperPaths returned no paths')
+  // Use the largest path (the outer offset boundary).
+  let best = offsetPaths[0]
+  for (const p of offsetPaths) if (p.length > best.length) best = p
+  const profile = simplifyOffsetContour(best, sources, delta)
+  assert(profile !== null, 'simplifyOffsetContour returned null')
+  // Use the union of all source points as the "source polyline" — what the
+  // offset arc should hug (concentrically expanded/contracted, but for
+  // structural sanity we just need a per-arc proximity check).
+  const sourcePts: Point[] = []
+  for (const s of sources) sourcePts.push(...sampleProfilePoints(s.sketch.profile))
+  return {
+    rawVertexCount: best.length,
+    profile: profile!,
+    summary: summarize(profile!),
+    sourceFlattened: sourcePts,
+  }
+}
+
+// ── Test scenarios ───────────────────────────────────────────────────────────
+
+console.log('── pure circle ──')
+{
+  const F = makeFeature({
+    start: { x: 10, y: 0 },
+    segments: [{ type: 'circle', to: { x: 10, y: 0 }, center: { x: 0, y: 0 }, clockwise: false }],
+    closed: true,
+  } as SketchProfile)
+  const r = runOffset([F], 2)
+  assertStructurallyValid(r.profile, 'pure-circle')
+  assert(r.summary.circleCount === 1, `expected one circle segment, got ${JSON.stringify(r.summary)}`)
+  assert(r.summary.segCount === 1, `expected 1 segment total, got ${r.summary.segCount}`)
+  const centerPt = (r.profile.segments[0] as Extract<Segment, { type: 'circle' }>).center
+  assert(dist(centerPt, { x: 0, y: 0 }) < 0.01, `circle center off: ${JSON.stringify(centerPt)}`)
+  console.log(`  PASS — ${r.rawVertexCount} verts → 1 circle (center error ${dist(centerPt, { x: 0, y: 0 }).toExponential(2)})`)
+}
+
+console.log('── half circle (arc + diameter) ──')
+{
+  const F = makeFeature({
+    start: { x: 0, y: 10 },
+    segments: [
+      { type: 'arc', to: { x: 0, y: -10 }, center: { x: 0, y: 0 }, clockwise: false },
+      { type: 'line', to: { x: 0, y: 10 } },
+    ],
+    closed: true,
+  } as SketchProfile)
+  const r = runOffset([F], 1)
+  assertStructurallyValid(r.profile, 'half-circle')
+  assert(r.summary.arcCount >= 1, `expected at least one arc, got ${JSON.stringify(r.summary)}`)
+  // The arc center should match the source circle center (0,0).
+  for (const c of r.summary.arcCenters) {
+    assert(dist(c, { x: 0, y: 0 }) < 0.01, `arc center wandered: ${JSON.stringify(c)}`)
+  }
+  assertArcSweepMatchesSource(r.profile, r.sourceFlattened, 'half-circle')
+  console.log(`  PASS — ${r.rawVertexCount} verts → ${r.summary.segCount} segs (${r.summary.arcCount} arc + ${r.summary.lineCount} line)`)
+}
+
+console.log('── pac-man (circle with wedge cut) ──')
+{
+  // Pac-man: an arc from 30° CCW around to -30° (i.e. the big 300° arc),
+  // then two lines forming the wedge mouth meeting at the centre.
+  const R = 10
+  const wedgeAngle = Math.PI / 6 // 30° half-angle → 60° wedge mouth
+  const top: Point = { x: R * Math.cos(wedgeAngle), y: R * Math.sin(wedgeAngle) }
+  const bottom: Point = { x: R * Math.cos(-wedgeAngle), y: R * Math.sin(-wedgeAngle) }
+  const F = makeFeature({
+    start: top,
+    segments: [
+      // Big arc going the long way around (CCW) from top to bottom.
+      { type: 'arc', to: bottom, center: { x: 0, y: 0 }, clockwise: false },
+      { type: 'line', to: { x: 0, y: 0 } },
+      { type: 'line', to: top },
+    ],
+    closed: true,
+  } as SketchProfile)
+  const r = runOffset([F], 1)
+  assertStructurallyValid(r.profile, 'pac-man')
+  assert(r.summary.arcCount >= 1, `expected an arc for the main body, got ${JSON.stringify(r.summary)}`)
+  // Every fitted arc must be concentric with the source circle.
+  for (const c of r.summary.arcCenters) {
+    assert(dist(c, { x: 0, y: 0 }) < 0.05, `pac-man arc center wandered: ${JSON.stringify(c)}`)
+  }
+  // This is the key regression: the big arc must render as the long way around,
+  // not its short complement. assertArcSweepMatchesSource catches the flipped
+  // clockwise flag by detecting that the resampled profile leaves the source area.
+  assertArcSweepMatchesSource(r.profile, r.sourceFlattened, 'pac-man')
+  console.log(`  PASS — ${r.rawVertexCount} verts → ${r.summary.segCount} segs (${r.summary.arcCount} arc + ${r.summary.lineCount} line)`)
+}
+
+console.log('── rounded rectangle (4 arcs + 4 lines) ──')
+{
+  const r0 = 1, W = 10, H = 6
+  const F = makeFeature({
+    start: { x: r0, y: 0 },
+    segments: [
+      { type: 'line', to: { x: W - r0, y: 0 } },
+      { type: 'arc', to: { x: W, y: r0 }, center: { x: W - r0, y: r0 }, clockwise: false },
+      { type: 'line', to: { x: W, y: H - r0 } },
+      { type: 'arc', to: { x: W - r0, y: H }, center: { x: W - r0, y: H - r0 }, clockwise: false },
+      { type: 'line', to: { x: r0, y: H } },
+      { type: 'arc', to: { x: 0, y: H - r0 }, center: { x: r0, y: H - r0 }, clockwise: false },
+      { type: 'line', to: { x: 0, y: r0 } },
+      { type: 'arc', to: { x: r0, y: 0 }, center: { x: r0, y: r0 }, clockwise: false },
+    ],
+    closed: true,
+  } as SketchProfile)
+  const r = runOffset([F], 0.5)
+  assertStructurallyValid(r.profile, 'rounded-rect')
+  assert(r.summary.arcCount === 4, `expected 4 arcs (one per corner), got ${JSON.stringify(r.summary)}`)
+  const expectedCenters = [
+    { x: W - r0, y: r0 }, { x: W - r0, y: H - r0 }, { x: r0, y: H - r0 }, { x: r0, y: r0 },
+  ]
+  for (const c of r.summary.arcCenters) {
+    const matched = expectedCenters.some((e) => dist(c, e) < 0.01)
+    assert(matched, `rounded-rect arc center ${JSON.stringify(c)} not at any corner`)
+  }
+  assertArcSweepMatchesSource(r.profile, r.sourceFlattened, 'rounded-rect')
+  console.log(`  PASS — ${r.rawVertexCount} verts → ${r.summary.segCount} segs (4 corner arcs)`)
+}
+
+console.log('── plain polygon (no source arcs) ──')
+{
+  const F = makeFeature({
+    start: { x: 0, y: 0 },
+    segments: [
+      { type: 'line', to: { x: 10, y: 0 } },
+      { type: 'line', to: { x: 10, y: 10 } },
+      { type: 'line', to: { x: 0, y: 10 } },
+      { type: 'line', to: { x: 0, y: 0 } },
+    ],
+    closed: true,
+  } as SketchProfile)
+  const r = runOffset([F], 1)
+  assertStructurallyValid(r.profile, 'polygon')
+  assert(r.summary.arcCount === 0, `polygon offset must not invent arcs, got ${JSON.stringify(r.summary)}`)
+  assert(r.summary.circleCount === 0, `polygon offset must not invent circles, got ${JSON.stringify(r.summary)}`)
+  console.log(`  PASS — ${r.rawVertexCount} verts → ${r.summary.segCount} lines (no false arcs)`)
+}
+
+console.log('── slightly-bowed line shouldn\'t fit an arc ──')
+{
+  // A composite with one real arc plus a polyline edge that's slightly bowed.
+  // The bowed edge's least-squares circle is huge and far from any source
+  // centre — it must be rejected.
+  const segs: Segment[] = []
+  for (let i = 1; i <= 60; i += 1) {
+    const x = i * 1
+    const y = 0.05 * x * (60 - x) * 0.01
+    segs.push({ type: 'line', to: { x, y } })
+  }
+  segs.push({ type: 'line', to: { x: 60, y: 10 } })
+  segs.push({ type: 'arc', to: { x: 50, y: 20 }, center: { x: 50, y: 10 }, clockwise: false })
+  segs.push({ type: 'line', to: { x: 0, y: 20 } })
+  segs.push({ type: 'line', to: { x: 0, y: 0 } })
+  const F = makeFeature({ start: { x: 0, y: 0 }, closed: true, segments: segs } as SketchProfile)
+  const r = runOffset([F], 0.5)
+  assertStructurallyValid(r.profile, 'bowed')
+  // Real arc at (50,10) must be recovered.
+  assert(r.summary.arcCount >= 1, 'real arc not recovered')
+  // No fitted center may be far from the only source center (50,10).
+  for (const c of r.summary.arcCenters) {
+    assert(dist(c, { x: 50, y: 10 }) < 0.05, `bowed test: fitted arc center wandered to ${JSON.stringify(c)} — false fit`)
+  }
+  console.log(`  PASS — bowed run stayed polyline, real arc fitted at (50,10)`)
+}
+
+console.log('── two overlapping circles unioned then offset ──')
+{
+  // A "peanut" composite. Both source circles share a single centre line
+  // (so their offsets are concentric with two distinct source centres).
+  const c1 = makeFeature({
+    start: { x: 5, y: 0 },
+    segments: [{ type: 'circle', to: { x: 5, y: 0 }, center: { x: 0, y: 0 }, clockwise: false }],
+    closed: true,
+  } as SketchProfile, 'C1')
+  const c2 = makeFeature({
+    start: { x: 11, y: 0 },
+    segments: [{ type: 'circle', to: { x: 11, y: 0 }, center: { x: 7, y: 0 }, clockwise: false }],
+    closed: true,
+  } as SketchProfile, 'C2')
+  const r = runOffset([c1, c2], 1)
+  assertStructurallyValid(r.profile, 'peanut')
+  // Each source center may have one or more arc fragments around it; both
+  // centers should be represented.
+  const hasC1 = r.summary.arcCenters.some((c) => dist(c, { x: 0, y: 0 }) < 0.05)
+  const hasC2 = r.summary.arcCenters.some((c) => dist(c, { x: 7, y: 0 }) < 0.05)
+  assert(hasC1 && hasC2, `peanut should fit arcs at both centers, got centers ${JSON.stringify(r.summary.arcCenters)}`)
+  // No fitted arc may have a wandering center.
+  for (const c of r.summary.arcCenters) {
+    const nearC1 = dist(c, { x: 0, y: 0 }) < 0.05
+    const nearC2 = dist(c, { x: 7, y: 0 }) < 0.05
+    assert(nearC1 || nearC2, `peanut: arc center ${JSON.stringify(c)} not concentric with either source`)
+  }
+  assertArcSweepMatchesSource(r.profile, r.sourceFlattened, 'peanut')
+  console.log(`  PASS — ${r.rawVertexCount} verts → ${r.summary.segCount} segs (arcs at both source centres)`)
+}
+
+console.log('── dense polyline source (RDP cleanup) ──')
+{
+  // A wavy closed polyline sampled densely. The shape has no arcs the fitter
+  // can recover; RDP should still cut the vertex count substantially without
+  // distorting the shape beyond the tolerance budget.
+  const segs: Segment[] = []
+  const samples = 200
+  for (let k = 1; k <= samples; k += 1) {
+    const t = (k / samples) * Math.PI * 2
+    const r = 10 + Math.sin(t * 3) * 1.5
+    segs.push({ type: 'line', to: { x: r * Math.cos(t), y: r * Math.sin(t) } })
+  }
+  const F = makeFeature({
+    start: { x: 10 + Math.sin(0) * 1.5, y: 0 },
+    segments: segs,
+    closed: true,
+  } as SketchProfile, 'wavy')
+  const r = runOffset([F], 0.5)
+  assertStructurallyValid(r.profile, 'dense-polyline')
+  // No source arcs → no arcs should be invented.
+  assert(r.summary.arcCount === 0, `dense polyline should not produce arcs, got ${JSON.stringify(r.summary)}`)
+  assert(r.summary.circleCount === 0, 'dense polyline should not produce circles')
+  // RDP must reduce vertex count substantially — at conservative 0.1% bbox
+  // tolerance, a 200-sample wavy circle should drop by at least 30%.
+  const reduction = 1 - r.summary.segCount / r.rawVertexCount
+  assert(reduction > 0.3, `expected >30% vertex reduction from RDP, got ${(reduction * 100).toFixed(1)}% (${r.rawVertexCount} → ${r.summary.segCount})`)
+  // Shape must still approximate the source within the RDP tolerance budget.
+  assertArcSweepMatchesSource(r.profile, r.sourceFlattened, 'dense-polyline')
+  console.log(`  PASS — ${r.rawVertexCount} verts → ${r.summary.segCount} segs (${(reduction * 100).toFixed(0)}% reduction)`)
+}
+
+console.log('\nAll offsetSimplify tests PASS')


### PR DESCRIPTION
## Summary

- Rebuilds Clipper offset output into arcs/circles/lines instead of leaving it as a dense chord polyline. Pure circle: 64 verts → 1 circle. Rounded rect: 76 → 8 segs. Dense wavy polyline: 205 → 61 (70% reduction at conservative RDP tolerance).
- Source-center gate makes arc fits safe on composites: a Kasa-fitted center must lie within `min(0.01, R*0.001)` of a known source arc/circle center, so spurious huge-radius fits on slightly-bowed straight runs are rejected.
- New `offsetSimplify.test.ts` covers 8 scenarios with structural and direction-correctness assertions (a wrong-clockwise regression in the fitter would have shipped without it).

## Pipeline

`simplifyOffsetContour` (in `src/store/helpers/clipping.ts`):

1. `mergeCollinearLinesClosed` — wrap-around aware collinear merge.
2. `fitArcsInLineRuns` — Kasa least-squares fit gated by source-center proximity. Polyline-only sources skip arc fitting entirely.
3. `applyRDPToLineRuns` — iterative Douglas-Peucker on residual line runs at 0.1% bbox-diagonal tolerance. Arcs pass through untouched.
4. `promoteClosedArcToCircle` — closed single-arc → circle segment.

Wired into `previewOffsetFeatures` (`src/store/helpers/derivedFeatures.ts`) replacing the bare `clipperContourToProfile` call.

## Test plan

- [x] `npx tsx scripts/run-tests.ts` — 20/20 test files pass (was 19; new offsetSimplify.test.ts)
- [x] `npx tsc -b` clean
- [x] Manually verify offset preview in app for: circle, half-circle, pac-man, composite features
- [x] Confirm cut/join still work correctly (no regression in `clipperContourToProfilePreserving` path; this PR doesn't touch that flow)

## Follow-ups (not in this PR)

- Offset shape fidelity could be improved by tightening `flattenProfile`'s `arcStepRadians` from π/36 → π/72; this affects every Clipper op (union/cut/offset) and requires keeping `FLATTEN_ARC_STEP` in sync. Tracked separately.