### PR TITLE
Keep context menus inside viewport

### DIFF
--- a/planning/archive/CONTEXT_MENU_VISIBILITY_Plan.md
+++ b/planning/archive/CONTEXT_MENU_VISIBILITY_Plan.md
@@ -1,0 +1,36 @@
+---
+status: Done
+created: 2026-05-29
+---
+
+# Context Menu Visibility Plan
+
+## Goal
+
+Keep the feature/tree context menu fully visible and selectable when it opens near the bottom or right edge of the viewport. The current positioning uses fixed size guesses, so the taller feature menu can extend below the window and hide actions.
+
+## Approach
+
+- Replace the hardcoded `window.innerHeight - 300` / width guess positioning with measured menu placement.
+- Store the resolved menu position in component state and update it after the menu renders, using the actual `getBoundingClientRect()` size plus a small viewport padding.
+- Recompute the position when the menu changes and on window resize while the menu is open.
+- Add a CSS max-height / overflow fallback so the menu remains usable even on very short viewports.
+
+## Files affected
+
+- `src/App.tsx` — measure the context menu and clamp its fixed position inside the viewport.
+- `src/styles/layout.css` — add viewport-height overflow protection for the context menu.
+
+## Tests
+
+- Run `npm run build` after implementation.
+- Manual check: open the feature context menu near the bottom and right edges of the sketch canvas and confirm all items remain visible or scrollable.
+
+## Open questions / risks
+
+None.
+
+## Out of scope
+
+- Redesigning context menu contents, grouping, or visual style.
+- Changing feature tree, tab, or clamp context menu actions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useTransition } from 'react'
 import { CAMPanel } from './components/cam/CAMPanel'
 import { SketchCanvas, type SketchCanvasHandle } from './components/canvas/SketchCanvas'
 import { applyClampWarnings, applyTabsToEdgeRoute, applyTabWarnings, generateDrillingToolpath, generateEdgeRouteToolpath, generateFinishSurfaceCleanupToolpath, generateFinishSurfaceToolpath, generateFollowLineToolpath, generatePocketToolpath, generateRoughSurfaceToolpath, generateSurfaceCleanToolpath, generateVCarveToolpath, generateVCarveRecursiveToolpath } from './engine/toolpaths'
@@ -43,6 +43,11 @@ interface TreeContextMenuState {
   primaryId: string
   x: number
   y: number
+}
+
+interface MenuPosition {
+  left: number
+  top: number
 }
 
 interface ToolpathCacheEntry {
@@ -113,6 +118,28 @@ type ToolbarOrientation = 'top' | 'left'
 const TOOLBAR_ORIENTATION_STORAGE_KEY = 'camcam.toolbarOrientation'
 const DEPTH_LEGEND_COLLAPSED_STORAGE_KEY = 'camcam.depthLegendCollapsed'
 const TOOLBAR_LEFT_BREAKPOINT = 920
+const CONTEXT_MENU_VIEWPORT_PADDING = 8
+const CONTEXT_MENU_INITIAL_WIDTH = 188
+const CONTEXT_MENU_INITIAL_HEIGHT = 300
+
+function clampMenuPosition(
+  x: number,
+  y: number,
+  menuWidth: number,
+  menuHeight: number,
+  viewportWidth: number,
+  viewportHeight: number,
+): MenuPosition {
+  const minLeft = CONTEXT_MENU_VIEWPORT_PADDING
+  const minTop = CONTEXT_MENU_VIEWPORT_PADDING
+  const maxLeft = Math.max(minLeft, viewportWidth - menuWidth - CONTEXT_MENU_VIEWPORT_PADDING)
+  const maxTop = Math.max(minTop, viewportHeight - menuHeight - CONTEXT_MENU_VIEWPORT_PADDING)
+
+  return {
+    left: Math.min(Math.max(x, minLeft), maxLeft),
+    top: Math.min(Math.max(y, minTop), maxTop),
+  }
+}
 
 function App() {
   const [centerTab, setCenterTab] = useState<'sketch' | 'preview3d' | 'simulation'>('sketch')
@@ -130,6 +157,7 @@ function App() {
   ))
   const [workspaceLayout, setWorkspaceLayout] = useState<'lcr' | 'lc' | 'c' | 'cr'>('lcr')
   const [treeContextMenu, setTreeContextMenu] = useState<TreeContextMenuState | null>(null)
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null)
   const [selectedOperationId, setSelectedOperationId] = useState<string | null>(null)
   const [simulationDetailCells, setSimulationDetailCells] = useState(280)
   const [isSimulationPending, startSimulationTransition] = useTransition()
@@ -716,11 +744,13 @@ function App() {
         return
       }
       setTreeContextMenu(null)
+      setMenuPosition(null)
     }
 
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
         setTreeContextMenu(null)
+        setMenuPosition(null)
       }
     }
 
@@ -775,19 +805,23 @@ function App() {
     const featureIds = nextSelection.selectedFeatureIds.includes(featureId)
       ? nextSelection.selectedFeatureIds
       : [featureId]
+    setMenuPosition(null)
     setTreeContextMenu({ entityType: 'feature', ids: featureIds, primaryId: featureId, x, y })
   }
 
   function openClampContextMenu(clampId: string, x: number, y: number) {
+    setMenuPosition(null)
     setTreeContextMenu({ entityType: 'clamp', ids: [clampId], primaryId: clampId, x, y })
   }
 
   function openTabContextMenu(tabId: string, x: number, y: number) {
+    setMenuPosition(null)
     setTreeContextMenu({ entityType: 'tab', ids: [tabId], primaryId: tabId, x, y })
   }
 
   function closeTreeContextMenu() {
     setTreeContextMenu(null)
+    setMenuPosition(null)
   }
 
   function handleEditSketch(featureId: string) {
@@ -904,13 +938,6 @@ function App() {
     closeTreeContextMenu()
   }
 
-  const menuPosition = treeContextMenu
-    ? {
-        left: Math.min(treeContextMenu.x, window.innerWidth - 188),
-        top: Math.min(treeContextMenu.y, window.innerHeight - 300),
-      }
-    : null
-
   const menuHasMultipleSelection = treeContextMenu?.entityType === 'feature' && (treeContextMenu?.ids.length ?? 0) > 1
   const menuCanUseAsStock =
     treeContextMenu?.entityType === 'feature' &&
@@ -924,6 +951,59 @@ function App() {
     treeContextMenu?.entityType === 'feature' && (treeContextMenu?.ids.some((featureId) =>
       project.features.some((feature) => feature.id === featureId && feature.locked)
     ) ?? false)
+  const fallbackMenuPosition = treeContextMenu
+    ? clampMenuPosition(
+        treeContextMenu.x,
+        treeContextMenu.y,
+        CONTEXT_MENU_INITIAL_WIDTH,
+        CONTEXT_MENU_INITIAL_HEIGHT,
+        window.innerWidth,
+        window.innerHeight,
+      )
+    : null
+  const resolvedMenuPosition = menuPosition ?? fallbackMenuPosition
+
+  const updateTreeContextMenuPosition = useCallback(() => {
+    if (!treeContextMenu || !menuRef.current) {
+      return
+    }
+
+    const rect = menuRef.current.getBoundingClientRect()
+    const nextPosition = clampMenuPosition(
+      treeContextMenu.x,
+      treeContextMenu.y,
+      rect.width,
+      rect.height,
+      window.innerWidth,
+      window.innerHeight,
+    )
+    setMenuPosition((previous) => (
+      previous?.left === nextPosition.left && previous.top === nextPosition.top
+        ? previous
+        : nextPosition
+    ))
+  }, [treeContextMenu])
+
+  useLayoutEffect(() => {
+    updateTreeContextMenuPosition()
+  }, [
+    updateTreeContextMenuPosition,
+    menuFeature,
+    menuTab,
+    menuClamp,
+    menuHasMultipleSelection,
+    menuCanUseAsStock,
+    menuHasLockedSelection,
+  ])
+
+  useEffect(() => {
+    if (!treeContextMenu) {
+      return
+    }
+
+    window.addEventListener('resize', updateTreeContextMenuPosition)
+    return () => window.removeEventListener('resize', updateTreeContextMenuPosition)
+  }, [treeContextMenu, updateTreeContextMenuPosition])
 
   const collapsedDepthLegend = centerTab === 'sketch' && depthLegendCollapsed ? (
     <button
@@ -1104,11 +1184,11 @@ function App() {
         </div>
       )}
 
-      {treeContextMenu && menuPosition && (menuFeature || menuTab || menuClamp) ? (
+      {treeContextMenu && resolvedMenuPosition && (menuFeature || menuTab || menuClamp) ? (
         <div
           ref={menuRef}
           className="feature-context-menu"
-          style={menuPosition}
+          style={resolvedMenuPosition}
           onContextMenu={(event) => event.preventDefault()}
         >
           {menuFeature ? (

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2245,6 +2245,8 @@
   position: fixed;
   z-index: 1000;
   min-width: 168px;
+  max-height: calc(100vh - 16px);
+  max-height: calc(100dvh - 16px);
   padding: 4px;
   border-radius: 10px;
   border: 1px solid rgba(94, 121, 142, 0.72);
@@ -2254,6 +2256,8 @@
     inset 0 1px 0 rgba(255, 255, 255, 0.04);
   display: grid;
   gap: 1px;
+  box-sizing: border-box;
+  overflow-y: auto;
 }
 
 .feature-context-menu__separator {
@@ -3504,4 +3508,3 @@
 .cam-add-menu--vertical::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.2);
 }
-


### PR DESCRIPTION
## Summary
- measure rendered context menu size and clamp it inside the viewport
- reset and recompute menu coordinates on open, close, and resize
- add a max-height/scroll fallback for very short viewports

## Verification
- npm run build
- npx eslint src/App.tsx (0 errors; one existing unrelated warning at App.tsx:398)
- npm run lint still fails repo-wide because of existing unrelated lint errors outside this change

Archived plan: planning/archive/CONTEXT_MENU_VISIBILITY_Plan.md