### PR TITLE
Optimize feature-first toolpath block ordering

### DIFF
--- a/planning/archive/FEATURE_FIRST_BLOCK_ORDERING_Plan.md
+++ b/planning/archive/FEATURE_FIRST_BLOCK_ORDERING_Plan.md
@@ -1,0 +1,44 @@
+---
+status: Done
+created: 2026-05-29
+---
+
+# Feature-First Block Ordering Plan
+
+## Goal
+
+Optimize `feature_first` toolpath output so per-feature blocks are still completed one feature at a time, but the concatenated block order follows nearest travel from the previous block endpoint instead of blindly preserving target feature order. This should reduce unnecessary safe-Z rapid travel for pocket, edge-route, V-carve, and V-carve-recursive operations that share the multi-feature merge path.
+
+## Approach
+
+- Add a deterministic nearest-neighbor ordering pass in `multiFeature.ts` for generated per-feature `ToolpathResult` blocks.
+- Use each block's first and last meaningful move positions to score travel from the current endpoint, preserving original order as the tie-breaker.
+- Keep the core `feature_first` behavior intact: all moves from a feature block remain contiguous and are not interleaved with other features.
+- Normalize the concatenated block transition if needed so the first move of a reordered block starts from the previous block endpoint rather than relying on stale `from` coordinates from its isolated generation.
+- Route pocket-specific merging through the same ordered block list while preserving warning, bounds, clamp, and `stepLevels` aggregation behavior.
+
+## Files affected
+
+- `src/engine/toolpaths/multiFeature.ts` — add shared block ordering/transition helpers and apply them in `mergeToolpathResults` / `mergePocketToolpathResults`.
+- `src/engine/toolpaths/toolpaths.test.ts` — add focused tests for non-spatial target order in pocket and edge feature-first operations, and update merge expectations where ordered output changes.
+
+## Tests
+
+- Add or update structural tests in `src/engine/toolpaths/toolpaths.test.ts` to verify:
+  - `feature_first` still keeps each feature's full depth/pass block contiguous.
+  - non-spatial target feature order is reordered by nearest block travel.
+  - deterministic tie-breaking falls back to original target order when distances match.
+  - pocket `stepLevels` aggregation remains deduped and sorted after block ordering.
+- Run `npm run build` before completing the work.
+
+## Open questions / risks
+
+- Rewriting a block's first move `from` coordinate may change exact move output snapshots/expectations, but it should better represent the actual machine state after reordering.
+- V-carve and V-carve-recursive use the shared merge path, so the implementation should avoid assumptions specific to pocket/edge move shapes.
+
+## Out of scope
+
+- Changing level-first behavior.
+- Interleaving passes between features.
+- Optimizing within a single feature block.
+- Changing G-code post-processing or machine-origin behavior.

--- a/src/engine/toolpaths/edge.ts
+++ b/src/engine/toolpaths/edge.ts
@@ -307,7 +307,7 @@ export function generateEdgeRouteToolpath(project: Project, operation: Operation
     const parts = perFeatureOperations(operation, project).map((subOp) =>
       generateEdgeRouteToolpathSingle(project, subOp),
     )
-    return mergeToolpathResults(operation.id, parts)
+    return mergeToolpathResults(operation.id, parts, { orderBlocks: 'nearest' })
   }
   return generateEdgeRouteToolpathSingle(project, operation)
 }

--- a/src/engine/toolpaths/multiFeature.ts
+++ b/src/engine/toolpaths/multiFeature.ts
@@ -15,7 +15,18 @@
  */
 
 import type { Operation, Project } from '../../types/project'
-import type { PocketToolpathResult, ToolpathBounds, ToolpathResult } from './types'
+import type { PocketToolpathResult, ToolpathBounds, ToolpathPoint, ToolpathResult } from './types'
+
+interface MergeToolpathOptions {
+  orderBlocks?: 'input' | 'nearest'
+}
+
+interface IndexedToolpathPart<T extends ToolpathResult> {
+  part: T
+  originalIndex: number
+  start: ToolpathPoint
+  end: ToolpathPoint
+}
 
 export function perFeatureOperations(operation: Operation, project?: Project): Operation[] {
   if (operation.target.source !== 'features') return [operation]
@@ -52,8 +63,96 @@ function mergeBounds(a: ToolpathBounds | null, b: ToolpathBounds | null): Toolpa
   }
 }
 
-export function mergeToolpathResults(operationId: string, parts: ToolpathResult[]): ToolpathResult {
-  const moves = parts.flatMap((part) => part.moves)
+function blockStart(part: ToolpathResult): ToolpathPoint | null {
+  const firstMove = part.moves[0]
+  if (!firstMove) return null
+  if (firstMove.kind === 'rapid') return firstMove.to
+  return firstMove.from
+}
+
+function blockEnd(part: ToolpathResult): ToolpathPoint | null {
+  return part.moves.at(-1)?.to ?? null
+}
+
+function xyDistanceSquared(a: ToolpathPoint, b: ToolpathPoint): number {
+  const dx = b.x - a.x
+  const dy = b.y - a.y
+  return dx * dx + dy * dy
+}
+
+function samePoint(a: ToolpathPoint, b: ToolpathPoint): boolean {
+  return a.x === b.x && a.y === b.y && a.z === b.z
+}
+
+function orderPartsByNearestBlock<T extends ToolpathResult>(parts: T[]): T[] {
+  const blocks = parts.reduce<IndexedToolpathPart<T>[]>((acc, part, originalIndex) => {
+    const start = blockStart(part)
+    const end = blockEnd(part)
+    if (start && end) acc.push({ part, originalIndex, start, end })
+    return acc
+  }, [])
+  if (blocks.length <= 1) return parts
+
+  const ordered: IndexedToolpathPart<T>[] = [blocks[0]]
+  const remaining = blocks.slice(1)
+  let current = blocks[0].end
+
+  while (remaining.length > 0) {
+    let bestIndex = 0
+    let bestDistance = xyDistanceSquared(current, remaining[0].start)
+    for (let i = 1; i < remaining.length; i += 1) {
+      const distance = xyDistanceSquared(current, remaining[i].start)
+      if (
+        distance < bestDistance
+        || (distance === bestDistance && remaining[i].originalIndex < remaining[bestIndex].originalIndex)
+      ) {
+        bestIndex = i
+        bestDistance = distance
+      }
+    }
+
+    const [next] = remaining.splice(bestIndex, 1)
+    ordered.push(next)
+    current = next.end
+  }
+
+  return ordered.map((block) => block.part)
+}
+
+function mergeMoves(parts: ToolpathResult[], normalizeTransitions: boolean): ToolpathResult['moves'] {
+  if (!normalizeTransitions) return parts.flatMap((part) => part.moves)
+
+  const moves: ToolpathResult['moves'] = []
+  let previousEnd: ToolpathPoint | null = null
+
+  for (const part of parts) {
+    if (part.moves.length === 0) continue
+
+    const [firstMove, ...remainingMoves] = part.moves
+    if (previousEnd && !samePoint(previousEnd, firstMove.from)) {
+      if (firstMove.kind === 'rapid') {
+        moves.push({ ...firstMove, from: previousEnd })
+      } else {
+        moves.push({ kind: 'rapid', from: previousEnd, to: firstMove.from })
+        moves.push(firstMove)
+      }
+    } else {
+      moves.push(firstMove)
+    }
+    moves.push(...remainingMoves)
+    previousEnd = part.moves.at(-1)?.to ?? previousEnd
+  }
+
+  return moves
+}
+
+export function mergeToolpathResults(
+  operationId: string,
+  parts: ToolpathResult[],
+  options: MergeToolpathOptions = {},
+): ToolpathResult {
+  const orderedParts = options.orderBlocks === 'nearest' ? orderPartsByNearestBlock(parts) : parts
+  const moves = mergeMoves(orderedParts, options.orderBlocks === 'nearest')
   const warnings = parts.flatMap((part) => part.warnings)
   const bounds = parts.reduce<ToolpathBounds | null>((acc, part) => mergeBounds(acc, part.bounds), null)
   const collidingClampIds = Array.from(
@@ -71,8 +170,9 @@ export function mergeToolpathResults(operationId: string, parts: ToolpathResult[
 export function mergePocketToolpathResults(
   operationId: string,
   parts: PocketToolpathResult[],
+  options: MergeToolpathOptions = {},
 ): PocketToolpathResult {
-  const base = mergeToolpathResults(operationId, parts)
+  const base = mergeToolpathResults(operationId, parts, options)
   const stepLevels = Array.from(new Set(parts.flatMap((part) => part.stepLevels)))
     .sort((a, b) => b - a)
   return { ...base, stepLevels }

--- a/src/engine/toolpaths/pocket.ts
+++ b/src/engine/toolpaths/pocket.ts
@@ -1062,7 +1062,7 @@ export function generatePocketToolpath(project: Project, operation: Operation): 
     const parts = perFeatureOperations(operation, project).map((subOp) =>
       generatePocketToolpathSingle(project, subOp),
     )
-    return mergePocketToolpathResults(operation.id, parts)
+    return mergePocketToolpathResults(operation.id, parts, { orderBlocks: 'nearest' })
   }
   return generatePocketToolpathSingle(project, operation)
 }

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -249,6 +249,16 @@ function cutZsByFeatureCluster(moves: ToolpathMove[], pivotX: number): { leftZs:
   return { leftZs, rightZs }
 }
 
+function cutClusterSequence(moves: ToolpathMove[], classifyX: (x: number) => string): string[] {
+  const sequence: string[] = []
+  for (const move of cutMoves(moves)) {
+    const cluster = classifyX((move.from.x + move.to.x) / 2)
+    const previous = sequence[sequence.length - 1]
+    if (previous !== cluster) sequence.push(cluster)
+  }
+  return sequence
+}
+
 function movesEqual(a: ToolpathMove[], b: ToolpathMove[]): boolean {
   if (a.length !== b.length) return false
   for (let i = 0; i < a.length; i += 1) {
@@ -347,6 +357,50 @@ function testMergeToolpathResults() {
   assert(mergedPocket.stepLevels.length === 3, 'stepLevels deduped')
   assert(mergedPocket.stepLevels[0] === -2 && mergedPocket.stepLevels[2] === -6, 'stepLevels sorted descending')
 
+  const partNear: ToolpathResult = {
+    operationId: 'sub-near',
+    moves: [
+      { kind: 'rapid', from: { x: 12, y: 0, z: 5 }, to: { x: 12, y: 0, z: 5 } },
+      { kind: 'cut', from: { x: 12, y: 0, z: -2 }, to: { x: 14, y: 0, z: -2 } },
+    ],
+    warnings: [],
+    bounds: null,
+  }
+  const partFar: ToolpathResult = {
+    operationId: 'sub-far',
+    moves: [
+      { kind: 'rapid', from: { x: 100, y: 0, z: 5 }, to: { x: 100, y: 0, z: 5 } },
+      { kind: 'cut', from: { x: 100, y: 0, z: -2 }, to: { x: 110, y: 0, z: -2 } },
+    ],
+    warnings: [],
+    bounds: null,
+  }
+  const ordered = mergeToolpathResults('op-parent', [partA, partFar, partNear], { orderBlocks: 'nearest' })
+  assert(ordered.moves.length === 5, 'nearest merge concatenates all moves')
+  assert(ordered.moves[1].kind === 'rapid' && ordered.moves[1].to.x === 12, 'nearest merge chooses near block before far block')
+  assert(ordered.moves[1].from.x === 10, 'nearest merge normalizes next block rapid from previous endpoint')
+
+  const tieLeft: ToolpathResult = {
+    operationId: 'sub-left',
+    moves: [{ kind: 'rapid', from: { x: 0, y: 0, z: 5 }, to: { x: 0, y: 0, z: 5 } }],
+    warnings: [],
+    bounds: null,
+  }
+  const tieRight: ToolpathResult = {
+    operationId: 'sub-right',
+    moves: [{ kind: 'rapid', from: { x: 20, y: 0, z: 5 }, to: { x: 20, y: 0, z: 5 } }],
+    warnings: [],
+    bounds: null,
+  }
+  const tieAnchor: ToolpathResult = {
+    operationId: 'sub-anchor',
+    moves: [{ kind: 'cut', from: { x: 9, y: 0, z: -2 }, to: { x: 10, y: 0, z: -2 } }],
+    warnings: [],
+    bounds: null,
+  }
+  const tied = mergeToolpathResults('op-parent', [tieAnchor, tieRight, tieLeft], { orderBlocks: 'nearest' })
+  assert(tied.moves[1].to.x === 20, 'nearest merge preserves original order for equal-distance ties')
+
   console.log('mergeToolpathResults: PASSED')
 }
 
@@ -427,6 +481,35 @@ function testPocketFeatureFirstOrder() {
   }
 
   console.log('pocket feature_first: PASSED')
+}
+
+function testPocketFeatureFirstNearestBlockOrder() {
+  console.log('Testing pocket feature_first nearest block ordering...')
+
+  const tool = makeFlatEndmill('t1', 4)
+  const featA = makePocketFeature('a', 0, 0, 10, 10, 0, -4)
+  const featB = makePocketFeature('b', 30, 0, 10, 10, 0, -4)
+  const featC = makePocketFeature('c', 200, 0, 10, 10, 0, -4)
+  const project = baseProject([tool], [featA, featB, featC])
+  const operation = makePocketOp({
+    kind: 'pocket',
+    target: { source: 'features', featureIds: ['a', 'c', 'b'] },
+    toolRef: 't1',
+    stepdown: 2,
+    machiningOrder: 'feature_first',
+  })
+
+  const result = generatePocketToolpath(project, operation)
+  const sequence = cutClusterSequence(result.moves, (x) => {
+    if (x < 20) return 'a'
+    if (x < 100) return 'b'
+    return 'c'
+  })
+
+  assert(sequence.join(',') === 'a,b,c', `expected nearest feature block order a,b,c, got ${sequence.join(',')}`)
+  assert(cutZTransitions(result.moves).length === 6, 'three feature blocks retain two depth passes each')
+
+  console.log('pocket feature_first nearest block ordering: PASSED')
 }
 
 function testPocketSingleFeatureParity() {
@@ -570,6 +653,34 @@ function testEdgeInsideLevelFirstVsFeatureFirst() {
   assert(tFeature.length === 4, `feature_first: expected 4 Z transitions, got ${tFeature.length} (${tFeature.join(',')})`)
 
   console.log('edge_route_inside ordering: PASSED')
+}
+
+function testEdgeInsideFeatureFirstNearestBlockOrder() {
+  console.log('Testing edge_route_inside feature_first nearest block ordering...')
+
+  const tool = makeFlatEndmill('t1', 4)
+  const featA = makePocketFeature('a', 0, 0, 20, 20, 0, -4)
+  const featB = makePocketFeature('b', 40, 0, 20, 20, 0, -4)
+  const featC = makePocketFeature('c', 200, 0, 20, 20, 0, -4)
+  const project = baseProject([tool], [featA, featB, featC])
+  const operation = makePocketOp({
+    kind: 'edge_route_inside',
+    target: { source: 'features', featureIds: ['a', 'c', 'b'] },
+    toolRef: 't1',
+    machiningOrder: 'feature_first',
+  })
+
+  const result = generateEdgeRouteToolpath(project, operation)
+  const sequence = cutClusterSequence(result.moves, (x) => {
+    if (x < 30) return 'a'
+    if (x < 100) return 'b'
+    return 'c'
+  })
+
+  assert(sequence.join(',') === 'a,b,c', `expected nearest feature block order a,b,c, got ${sequence.join(',')}`)
+  assert(cutZTransitions(result.moves).length === 6, 'three edge feature blocks retain two depth passes each')
+
+  console.log('edge_route_inside feature_first nearest block ordering: PASSED')
 }
 
 function testEdgeInsideRegionClipsAtBoundary() {
@@ -999,12 +1110,14 @@ try {
   testMergeToolpathResults()
   testPocketLevelFirstOrder()
   testPocketFeatureFirstOrder()
+  testPocketFeatureFirstNearestBlockOrder()
   testPocketSingleFeatureParity()
   testPocketRejectsRegionOnlyTarget()
   testPocketRegionClipsMachiningArea()
   testPocketRestRegionsFindUnreachableArea()
   testPocketRestRegionsFindCornerCusps()
   testEdgeInsideLevelFirstVsFeatureFirst()
+  testEdgeInsideFeatureFirstNearestBlockOrder()
   testEdgeInsideRegionClipsAtBoundary()
   testEdgeOutsideAcceptsModelSilhouette()
   testEdgeOutsideUsesStoredModelSilhouettePaths()

--- a/src/engine/toolpaths/vcarve.ts
+++ b/src/engine/toolpaths/vcarve.ts
@@ -126,7 +126,7 @@ export function generateVCarveToolpath(project: Project, operation: Operation): 
     const parts = perFeatureOperations(operation, project).map((subOp) =>
       generateVCarveToolpathSingle(project, subOp),
     )
-    return mergeToolpathResults(operation.id, parts)
+    return mergeToolpathResults(operation.id, parts, { orderBlocks: 'nearest' })
   }
   return generateVCarveToolpathSingle(project, operation)
 }

--- a/src/engine/toolpaths/vcarveRecursive.ts
+++ b/src/engine/toolpaths/vcarveRecursive.ts
@@ -2797,7 +2797,7 @@ export function generateVCarveRecursiveToolpath(project: Project, operation: Ope
     const parts = perFeatureOperations(operation, project).map((subOp) =>
       generateVCarveRecursiveToolpathSingle(project, subOp),
     )
-    return mergeToolpathResults(operation.id, parts)
+    return mergeToolpathResults(operation.id, parts, { orderBlocks: 'nearest' })
   }
   return generateVCarveRecursiveToolpathSingle(project, operation)
 }


### PR DESCRIPTION
## Summary
- Add nearest-neighbor ordering for feature-first toolpath result blocks while preserving contiguous per-feature blocks
- Normalize reordered block transitions so the next block starts from the previous endpoint
- Apply the ordering to pocket, edge-route, V-carve, and recursive V-carve feature-first generation
- Archive the completed plan: planning/archive/FEATURE_FIRST_BLOCK_ORDERING_Plan.md

Closes #120

## Verification
- npx tsx src/engine/toolpaths/toolpaths.test.ts
- npm run build