### PR TITLE
Snap waterline ring entries across levels

### DIFF
--- a/planning/archive/WATERLINE_ENTRY_SNAP_Plan.md
+++ b/planning/archive/WATERLINE_ENTRY_SNAP_Plan.md
@@ -1,0 +1,43 @@
+---
+status: Done
+created: 2026-05-30
+---
+
+# Waterline Entry Snap Plan
+
+## Goal
+
+Fix waterline finishing so adjacent closed rings in the same column keep same-XY entry alignment when their starts are only slightly shifted by slicing, offsetting, or simplification. The user-visible outcome is fewer unnecessary safe-Z retract, rapid, and plunge cycles while descending vertical or near-vertical waterline walls.
+
+## Approach
+
+- Keep the existing waterline column clustering and top-to-bottom machining flow in `finishSurfaceWaterline.ts`.
+- After closed contour direction is resolved and the ring is rotated near the current endpoint, detect when the selected entry is within a small, bounded snap tolerance of the previous ring endpoint.
+- For matching closed rings, insert or snap the first contour point so the emitted entry point exactly matches the previous XY before calling `transitionToCutEntry(..., maxLinkDistance = 0)`.
+- Tie the tolerance to the waterline stepover/tool scale, with a conservative cap, so it absorbs numerical drift without moving real entry points across meaningful geometry.
+- Preserve existing safety behavior for open contours, protected-region splits, intersecting-add forced retracts, and projected adaptive waterline paths.
+
+## Files affected
+
+- `src/engine/toolpaths/finishSurfaceWaterline.ts` — add the bounded closed-ring entry snapping helper and apply it in the column descent path.
+- `src/engine/toolpaths/finishSurface.test.ts` — add a regression for stacked waterline rings that should descend with direct plunges rather than safe-Z round trips.
+- `planning/INDEX.md` — register this plan while active.
+- `planning/archive/WATERLINE_ENTRY_SNAP_Plan.md` — archive after implementation and build verification.
+
+## Tests
+
+- Add or update a focused finish-surface waterline test that builds a vertical-wall pocket/cylinder style imported mesh with multiple waterline levels and asserts adjacent same-column closed rings emit direct plunge moves between levels.
+- Assert the regression does not contain a retract/rapid/plunge cycle between the adjacent closed rings being tested.
+- Run `npx tsx src/engine/toolpaths/finishSurface.test.ts`.
+- Run `npm run build`.
+
+## Open questions / risks
+
+- The snap tolerance needs to be large enough to handle Clipper/simplification drift but capped tightly enough that it cannot visibly distort a ring or hide a genuine XY transition.
+- Existing intersecting-add wall protection intentionally forces retracts near add-feature walls; this work should not override that safety path.
+
+## Out of scope
+
+- Changing waterline column clustering or nearest-column ordering.
+- Changing adaptive waterline refinement, containing-add classification, or UI quality controls.
+- Broad toolpath transition behavior outside waterline closed-ring column descent.

--- a/src/engine/toolpaths/finishSurface.test.ts
+++ b/src/engine/toolpaths/finishSurface.test.ts
@@ -10,6 +10,7 @@ import { defaultTool, newProject, rectProfile, type Operation, type Project, typ
 import { normalizeProject, useProjectStore } from '../../store/projectStore'
 import { convertProjectUnits } from '../../utils/units'
 import { generateFinishSurfaceToolpath, maxContourGap } from './finishSurface'
+import { snapClosedContourEntryToAnchor } from './finishSurfaceWaterline'
 import { generateRoughSurfaceToolpath } from './roughSurface'
 import { toClipperPath, normalizeWinding, DEFAULT_CLIPPER_SCALE, applyContourDirectionBySide, isClockwise, normalizeToolForProject } from './geometry'
 import { loadSTLTransformedGeometry } from '../csg'
@@ -1782,6 +1783,27 @@ function testWaterlineConventionalWindsOppositeOfClimb(): void {
   }
 }
 
+function testWaterlineSnapsDriftedClosedRingEntryToPreviousEndpoint(): void {
+  console.log('Testing waterline snaps drifted closed-ring entries to previous XY...')
+  const previousEndpoint = { x: 6.5, y: 3.5 }
+  const contour: Point[] = [
+    { x: 6.503, y: 3.498 },
+    { x: 13.5, y: 3.5 },
+    { x: 13.5, y: 6.5 },
+    { x: 6.5, y: 6.5 },
+  ]
+
+  const snapped = snapClosedContourEntryToAnchor(contour, previousEndpoint, 0.01)
+  assert(snapped.length === contour.length + 1,
+    `expected snap to insert an exact entry point, got ${snapped.length} points`)
+  assert(snapped[0].x === previousEndpoint.x && snapped[0].y === previousEndpoint.y,
+    `expected snapped entry to equal previous endpoint, got (${snapped[0].x}, ${snapped[0].y})`)
+  assert(snapped[1] === contour[0], 'expected original contour geometry to be preserved after inserted entry')
+
+  const unsnapped = snapClosedContourEntryToAnchor(contour, previousEndpoint, 0.001)
+  assert(unsnapped === contour, 'expected contour outside tolerance to remain unchanged')
+}
+
 // ── Run all tests ────────────────────────────────────────────────────────
 
 testFinishSurfaceCoversLowerTopPlateau()
@@ -1829,6 +1851,7 @@ testApplyContourDirectionBySideReversesOpenPolylinesWhenNeeded()
 testApplyContourDirectionBySideAcceptsNaturalWindingHint()
 testWaterlineClimbWindsCorrectlyOnBothSides()
 testWaterlineConventionalWindsOppositeOfClimb()
+testWaterlineSnapsDriftedClosedRingEntryToPreviousEndpoint()
 
 function testWaterlineFinishesOneColumnBeforeNext(): void {
   console.log('Testing waterline finishes one column top-to-bottom before moving to the next...')

--- a/src/engine/toolpaths/finishSurface.test.ts
+++ b/src/engine/toolpaths/finishSurface.test.ts
@@ -1794,11 +1794,11 @@ function testWaterlineSnapsDriftedClosedRingEntryToPreviousEndpoint(): void {
   ]
 
   const snapped = snapClosedContourEntryToAnchor(contour, previousEndpoint, 0.01)
-  assert(snapped.length === contour.length + 1,
-    `expected snap to insert an exact entry point, got ${snapped.length} points`)
+  assert(snapped.length === contour.length,
+    `expected snap to replace the entry point, got ${snapped.length} points`)
   assert(snapped[0].x === previousEndpoint.x && snapped[0].y === previousEndpoint.y,
     `expected snapped entry to equal previous endpoint, got (${snapped[0].x}, ${snapped[0].y})`)
-  assert(snapped[1] === contour[0], 'expected original contour geometry to be preserved after inserted entry')
+  assert(snapped[1] === contour[1], 'expected snap to preserve the rest of the contour vertices')
 
   const unsnapped = snapClosedContourEntryToAnchor(contour, previousEndpoint, 0.001)
   assert(unsnapped === contour, 'expected contour outside tolerance to remain unchanged')
@@ -1928,19 +1928,48 @@ function testWaterlineColumnDescentReusesSameXYWithPlunge(): void {
   // the same XY. Each such plunge is one column-step that did not retract to
   // safe Z. With column ordering + ring rotation, most Z transitions inside
   // a column should be of this kind.
+  type Col = 'outer' | 'pocket' | 'other'
+  const classifyPoint = (point: { x: number; y: number }): Col => {
+    if (point.x < 0 || point.x > 20 || point.y < 0 || point.y > 10) return 'outer'
+    if (point.x > 5.5 && point.x < 14.5 && point.y > 2.5 && point.y < 7.5) return 'pocket'
+    return 'other'
+  }
+  const safeZ = Math.max(...result.moves.flatMap((move) => [move.from.z, move.to.z]))
   let columnPlunges = 0
+  let sameColumnSafeZRoundTrips = 0
   const eps = 1e-3
   for (let i = 0; i < result.moves.length; i += 1) {
     const m = result.moves[i]
-    if (m.kind !== 'plunge') continue
-    // A "column plunge" lands directly from a previous cut Z (m.from.z is well
-    // below safeZ — i.e., not coming from the safe-Z lane).
-    if (m.from.z > 10 - eps) continue
-    if (m.from.z - m.to.z <= 0) continue
-    columnPlunges += 1
+    if (m.kind === 'plunge') {
+      // A "column plunge" lands directly from a previous cut Z (m.from.z is well
+      // below safeZ — i.e., not coming from the safe-Z lane).
+      if (m.from.z <= safeZ - eps && m.from.z - m.to.z > 0) {
+        columnPlunges += 1
+      }
+      continue
+    }
+
+    if (m.kind !== 'rapid' || m.from.z >= safeZ - eps || m.to.z < safeZ - eps) continue
+    const previousCut = result.moves.slice(0, i).findLast((candidate) => candidate.kind === 'cut')
+    const nextPlungeIndex = result.moves.findIndex((candidate, index) => (
+      index > i && candidate.kind === 'plunge'
+    ))
+    if (!previousCut || nextPlungeIndex < 0) continue
+    const nextPlunge = result.moves[nextPlungeIndex]
+    if (nextPlunge.kind !== 'plunge' || nextPlunge.to.z >= previousCut.to.z - eps) continue
+
+    const nextCut = result.moves.slice(nextPlungeIndex + 1).find((candidate) => candidate.kind === 'cut')
+    if (!nextCut) continue
+    const previousColumn = classifyPoint(previousCut.to)
+    const nextColumn = classifyPoint(nextCut.from)
+    if (previousColumn !== 'other' && previousColumn === nextColumn) {
+      sameColumnSafeZRoundTrips += 1
+    }
   }
   assert(columnPlunges >= 1,
     `expected at least one column-descent plunge (cut-Z to cut-Z), got ${columnPlunges}; column ordering is not reusing XY between Z levels`)
+  assert(sameColumnSafeZRoundTrips === 0,
+    `expected no safe-Z retract/rapid/plunge cycles between adjacent rings in the same column, got ${sameColumnSafeZRoundTrips}`)
 }
 
 testWaterlineFinishesOneColumnBeforeNext()

--- a/src/engine/toolpaths/finishSurfaceWaterline.ts
+++ b/src/engine/toolpaths/finishSurfaceWaterline.ts
@@ -1051,7 +1051,7 @@ export function snapClosedContourEntryToAnchor(
     return contour
   }
 
-  return [{ x: anchor.x, y: anchor.y }, ...contour]
+  return [{ x: anchor.x, y: anchor.y }, ...contour.slice(1)]
 }
 
 function toProjectedCutMoves(

--- a/src/engine/toolpaths/finishSurfaceWaterline.ts
+++ b/src/engine/toolpaths/finishSurfaceWaterline.ts
@@ -1033,6 +1033,27 @@ function projectedContourStartPoint(
   return { x: first.x, y: first.y, z: zAtPoint(first) }
 }
 
+export function snapClosedContourEntryToAnchor(
+  contour: Array<{ x: number; y: number }>,
+  anchor: { x: number; y: number } | null,
+  tolerance: number,
+): Array<{ x: number; y: number }> {
+  if (contour.length < 3 || anchor === null || tolerance <= 0) {
+    return contour
+  }
+
+  const first = contour[0]
+  const distance = Math.hypot(first.x - anchor.x, first.y - anchor.y)
+  if (distance <= 1e-9) {
+    return contour
+  }
+  if (distance > tolerance) {
+    return contour
+  }
+
+  return [{ x: anchor.x, y: anchor.y }, ...contour]
+}
+
 function toProjectedCutMoves(
   contour: Array<{ x: number; y: number }>,
   closed: boolean,
@@ -1530,6 +1551,14 @@ export function generateFinishSurfaceWaterline(
 
   const depthWarning = checkMaxCutDepthWarning(tool, Math.abs(modelTopZ - effectiveBottom))
   if (depthWarning) warnings.push(depthWarning)
+  const maxEntrySnapTolerance = Math.max(
+    waterlineLengthEpsilon,
+    Math.min(tool.radius * 0.25, convertLength(0.25, 'mm', project.meta.units)),
+  )
+  const entrySnapTolerance = Math.min(
+    Math.max(waterlineLengthEpsilon, stepoverDistance * 0.5),
+    maxEntrySnapTolerance,
+  )
 
   // Intersecting-add proximity test for plunge safety. Build the union of
   // all intersecting-add footprints once, then for each ring entry test
@@ -1710,13 +1739,8 @@ export function generateFinishSurfaceWaterline(
         const isClosed = pathClosed[i] && contour.length >= 3
 
         if (isClosed && currentPosition) {
-          // TODO: For vertical-wall pockets (e.g. round pocket), rings at different Z
-          // levels should share the same XY start point, enabling direct plunge descent.
-          // Currently, floating-point drift in Clipper offset or simplification can shift
-          // the nearest vertex slightly between levels, breaking XY alignment and causing
-          // unnecessary retract+plunge cycles mid-column. Consider snapping the entry
-          // point to the previous ring's endpoint when distance is below stepover/2.
           contour = rotateContourToNearestEntry(contour, { x: currentPosition.x, y: currentPosition.y })
+          contour = snapClosedContourEntryToAnchor(contour, currentPosition, entrySnapTolerance)
         }
 
         const meshBoundaryPaths = intersectingAdds.length > 0 ? sliceMeshOnlyAtZ(ringEntry.z) : []


### PR DESCRIPTION
## Summary
- Add bounded snapping for closed waterline ring entries so adjacent same-column levels can keep exact same-XY direct plunges
- Snap the rotated entry vertex in place when it is within tolerance, avoiding an extra short entry segment
- Add regression coverage for drifted closed-ring entry snapping and same-column waterline descents that must not round-trip through safe Z
- Archive the completed plan: planning/archive/WATERLINE_ENTRY_SNAP_Plan.md

Closes #121

## Verification
- npx tsx src/engine/toolpaths/finishSurface.test.ts
- npm run build