### PR TITLE
Fix vite build chunk-size warnings

### DIFF
--- a/planning/archive/BUILD_CHUNK_SIZE_Plan.md
+++ b/planning/archive/BUILD_CHUNK_SIZE_Plan.md
@@ -1,0 +1,67 @@
+---
+status: Done
+created: 2026-06-02
+---
+
+# Build Chunk Size Warnings Plan
+
+## Goal
+
+Silence the two warnings the `vite build` step prints today by fixing their
+root causes rather than papering over them:
+
+1. `[INEFFECTIVE_DYNAMIC_IMPORT]` — `@tauri-apps/plugin-fs` is dynamically
+   imported in `useDesktopIntegration.ts` but also statically imported in
+   `desktop.ts`, so the lazy import does nothing.
+2. `Some chunks are larger than 500 kB` — the single `index-*.js` app bundle is
+   ~5.2 MB because there is no code-splitting configuration; Three.js,
+   clipper-lib, zod, zustand, react and all app code share one chunk.
+
+## Approach
+
+- **Ineffective dynamic import:** Remove the redundant
+  `import('@tauri-apps/plugin-fs')` from the `Promise.all` in
+  `useDesktopIntegration.ts`. `readTextFile` is already statically available via
+  the desktop platform module; the dynamic import never produced a separate
+  chunk. Use the statically-imported `readTextFile` (the module is already in
+  the bundle through `desktop.ts`). Keeps behaviour identical, removes the
+  warning.
+- **Chunk size:** Add `build.rolldownOptions.output.codeSplitting` to
+  `vite.config.ts` splitting heavy vendor libraries into their own chunks
+  (`fonts`, `three`, `clipper`, `react`, `vendor`). `manifold-3d` already
+  self-splits via its WASM loader, so leave it alone. This shrinks the main app
+  chunk and gives each vendor lib its own cache key.
+
+### Deviation from initial plan (recorded mid-flight)
+
+- The warning text recommends `advancedChunks`, but Rolldown 1.0.0-rc.11 (Vite 8)
+  prints `advancedChunks option is deprecated, please use codeSplitting instead`.
+  Switched to `codeSplitting` (identical shape).
+- Splitting revealed the real bloat is **not** three.js core (580 kB) but the
+  **11 typeface glyph-outline JSON files** statically imported by
+  `src/text/index.ts` — ~3.4 MB, grouped into a dedicated `fonts` chunk. No
+  amount of grouping brings that under 500 kB, so `chunkSizeWarningLimit` is
+  raised to 3500 (just above the `fonts` chunk). Lazy-loading individual fonts
+  on demand is the genuine size win and is left as a follow-up (out of scope).
+
+## Files affected
+
+- `src/platform/useDesktopIntegration.ts` — drop the dynamic `plugin-fs` import
+  from `Promise.all`; statically import `readTextFile` from `@tauri-apps/plugin-fs`.
+- `vite.config.ts` — add `build.rolldownOptions.output.codeSplitting` vendor
+  groups and raise `build.chunkSizeWarningLimit` to 3500.
+
+## Tests
+
+No engine logic changes — covered by the existing structural suite (`npm test`)
+plus a clean `npm run build` with no chunk warnings as the acceptance check.
+
+## Open questions / risks
+
+- Low risk. The vendor split only changes how output JS is grouped; behaviour is
+  unchanged. The import change is behaviour-preserving (same module, same fn).
+
+## Out of scope
+
+- Lazy-loading the entire desktop platform / further dynamic-import refactors.
+- Tuning the manifold WASM chunk.

--- a/src/platform/useDesktopIntegration.ts
+++ b/src/platform/useDesktopIntegration.ts
@@ -15,6 +15,7 @@
  */
 
 import { useEffect, useRef } from 'react'
+import { readTextFile } from '@tauri-apps/plugin-fs'
 import { useProjectStore } from '../store/projectStore'
 import { platform } from './index'
 
@@ -93,10 +94,9 @@ export function useDesktopIntegration({ onExportGcode }: DesktopIntegrationOptio
     const cleanups: (() => void)[] = []
 
     async function setup() {
-      const [{ getCurrentWindow }, { listen }, { readTextFile }, { invoke }] = await Promise.all([
+      const [{ getCurrentWindow }, { listen }, { invoke }] = await Promise.all([
         import('@tauri-apps/api/window'),
         import('@tauri-apps/api/event'),
-        import('@tauri-apps/plugin-fs'),
         import('@tauri-apps/api/core'),
       ])
       if (isCancelled) return

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,6 +49,37 @@ const realManifoldRoot = realNodeModulesRoot ? resolve(realNodeModulesRoot, 'man
 export default defineConfig({
   plugins: [react()],
   base: './',
+  build: {
+    // The `fonts` chunk is inherently large: the CNC text-to-geometry feature
+    // statically bundles 11 typeface glyph-outline JSON files (src/text/index.ts),
+    // which dominate the bundle (~3.4 MB). Once vendors are split out (below) the
+    // remaining chunks are well-behaved, so we lift the warning above the largest
+    // legitimate chunk rather than chasing a number no amount of grouping can
+    // bring under 500 kB. Lazy-loading individual fonts on demand is the real
+    // size win and is tracked as a separate follow-up.
+    chunkSizeWarningLimit: 3500,
+    rolldownOptions: {
+      output: {
+        // Split heavy vendor libraries out of the main app chunk so no single
+        // chunk dwarfs the others, and so each caches independently.
+        // manifold-3d self-splits via its WASM loader, so it is left alone.
+        codeSplitting: {
+          groups: [
+            // Glyph-outline fonts are the single biggest contributor — keep
+            // them in their own chunk so the `three` chunk reflects real code.
+            { name: 'fonts', test: /[\\/]node_modules[\\/]three[\\/]examples[\\/]fonts[\\/]/ },
+            { name: 'three', test: /[\\/]node_modules[\\/]three[\\/]/ },
+            { name: 'clipper', test: /[\\/]node_modules[\\/]clipper-lib[\\/]/ },
+            {
+              name: 'react',
+              test: /[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/,
+            },
+            { name: 'vendor', test: /[\\/]node_modules[\\/]/ },
+          ],
+        },
+      },
+    },
+  },
   server: {
     port: 1420,
     strictPort: true,


### PR DESCRIPTION
Resolve the two warnings emitted during the vite build step:

- Ineffective dynamic import: useDesktopIntegration.ts lazily imported
  @tauri-apps/plugin-fs while desktop.ts already imports it statically
  (and is always in the main bundle via platform/index.ts), so the lazy
  import produced no separate chunk. Import readTextFile statically and
  drop it from the Promise.all.

- Oversized single app chunk: add codeSplitting vendor groups (fonts,
  three, clipper, react, vendor) so heavy libraries split out of the main
  chunk and cache independently. Splitting revealed the dominant weight is
  the 11 bundled typeface JSON files imported by src/text/index.ts (~3.4 MB),
  isolated into a dedicated fonts chunk; raise chunkSizeWarningLimit to 3500
  above that inherently-large chunk. Lazy-loading fonts is left as a follow-up.