### PR TITLE
Measure & dimensions: feature + visual-pass polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1918,9 +1918,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1938,9 +1935,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1958,9 +1952,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1978,9 +1969,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1998,9 +1986,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1918,6 +1918,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1935,6 +1938,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1952,6 +1958,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1969,6 +1978,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1986,6 +1998,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [

--- a/planning/INDEX.md
+++ b/planning/INDEX.md
@@ -11,6 +11,7 @@ Every task: write a plan from [`TEMPLATE.md`](TEMPLATE.md) → register it under
 ## Pending approval
 
 - [IMPORTED_MODEL_OUTLINE_COLORS_Plan.md](IMPORTED_MODEL_OUTLINE_COLORS_Plan.md) — add orange outline for imported 3D models in sketch view, add missing region + imported-model entries to feature color legend
+- [MEASURE_DIMENSIONS_Plan.md](MEASURE_DIMENSIONS_Plan.md) — tape-measure tool (transient distance readout) + permanent CAD dimensions (aligned/horizontal/vertical/radius/diameter/angle) anchored to geometry so they auto-update when features move/change
 
 ## In progress
 

--- a/planning/INDEX.md
+++ b/planning/INDEX.md
@@ -11,9 +11,10 @@ Every task: write a plan from [`TEMPLATE.md`](TEMPLATE.md) → register it under
 ## Pending approval
 
 - [IMPORTED_MODEL_OUTLINE_COLORS_Plan.md](IMPORTED_MODEL_OUTLINE_COLORS_Plan.md) — add orange outline for imported 3D models in sketch view, add missing region + imported-model entries to feature color legend
-- [MEASURE_DIMENSIONS_Plan.md](MEASURE_DIMENSIONS_Plan.md) — tape-measure tool (transient distance readout) + permanent CAD dimensions (aligned/horizontal/vertical/radius/diameter/angle) anchored to geometry so they auto-update when features move/change
 
 ## In progress
+
+- [MEASURE_DIMENSIONS_Plan.md](MEASURE_DIMENSIONS_Plan.md) — tape-measure tool (transient distance readout) + permanent CAD dimensions (aligned/horizontal/vertical/radius/diameter/angle) anchored to geometry so they auto-update when features move/change
 
 - [WATERLINE_ADAPTIVE_REFINEMENT_Plan.md](WATERLINE_ADAPTIVE_REFINEMENT_Plan.md) — improve imported-model waterline finishing by inserting bounded intermediate contour levels when adjacent bands have small Z separation but large XY drift
 - [WATERLINE_CONTAINING_ADD_FIX_Plan.md](WATERLINE_CONTAINING_ADD_FIX_Plan.md) — fix waterline finish emitting no paths when containing/base add features are mistaken for intersecting walls

--- a/planning/MEASURE_DIMENSIONS_HANDOVER.md
+++ b/planning/MEASURE_DIMENSIONS_HANDOVER.md
@@ -1,0 +1,81 @@
+# Measure & Dimensions — Handover
+
+**Branch:** `claude/measure-dimensions-design-oXJuu` (pushed to origin)
+**Status:** Feature implemented end-to-end; build green (`npm run build` = tsc + 22 tests + vite). Not yet PR'd. Plan still `In progress` at `planning/MEASURE_DIMENSIONS_Plan.md`.
+**Design doc:** `planning/MEASURE_DIMENSIONS_Plan.md` (read its "Implementation notes" section for as-built deviations).
+
+## What the feature does
+
+1. **Tape measure** — transient tool. Click point A (snaps to geometry), live readout of distance + Δx + Δy + angle, click B to freeze; next click starts a new measurement. Esc/Done exits. Never persisted, never in undo history.
+2. **Permanent dimensions** — aligned/parallel, horizontal, vertical, radius, diameter, angle. Stored as **anchors** (references to a feature's vertex/midpoint/center, the stock, or the origin) — *not* frozen coordinates — so value + graphics recompute live and follow geometry when it moves/edits. Select by clicking, drag the line to reposition (offset), delete via the delete tool or select + Delete key. Dangling (anchored feature deleted) → drawn muted with a ⚠ marker, not auto-removed.
+3. **Delete tool** — trash button arms "click a dimension to delete" mode (hover highlights red, stays armed for multiple, Esc/Done exits).
+4. **Global show/hide** — `project.meta.showDimensions` (persisted in `.camj`), toggled from the toolbar; gates rendering + hit-testing.
+
+## Commits on the branch (oldest→newest)
+
+```
+60fc7f0 design plan
+65ead66 confirmed v1 scope decisions
+7460e0f data model, pure logic, snap provenance, store
+40819c7 canvas rendering, interaction, toolbar
+a8deeb1 plan as-built notes
+21e45cc global show/hide toggle + toolbar icons
+0ff3cbb desktop toolbar controls
+1eb564c delete tool + instruction popups
+```
+
+## Architecture / key files
+
+**Data model** — `src/types/project.ts`
+- `DimensionAnnotation`, `DimensionAnchor`, `AnchorTarget`, `DimensionType`.
+- New `Project.annotations: DimensionAnnotation[]` (distinct from the pre-existing parametric `Project.dimensions` map — do not confuse them).
+- New `ProjectMeta.showDimensions: boolean`.
+- A dimension never stores its measured value; value is computed live from anchors.
+
+**Pure logic (unit-tested)** — `src/sketch/dimensions.ts` + `src/sketch/dimensions.test.ts`
+- `resolveAnchor(anchor, project): Point | null` (null = dangling)
+- `measureValue(dim, project)`, `dimensionLayout(dim, project)`, `offsetForCursor(dim, project, cursor)`, `dimensionLabelText(...)`, `isDimensionDangling(...)`, `angleBetween(...)`.
+- Feature profiles are world coords (see `project.ts` `stockFromFeature` comment), so anchor indices match `profileVertices`/`segments` exactly — this is why auto-update is correct.
+
+**Snap provenance** — `src/components/canvas/snappingHelpers.ts`
+- `ResolvedSnap`/`SnapCandidate` gained optional `anchor?: DimensionAnchor`; `addProfileSnapCandidates` takes a `source: AnchorTarget | null`. Stock/features/origin carry provenance; tabs/clamps deferred (null). Purely additive.
+
+**Units** — `src/utils/units.ts`
+- `convertProjectUnits` converts `annotations` (free-anchor points, offset, labelOffset; angle/anchored refs untouched). Added `formatAngle`. Round-trip tested in `src/utils/units.test.ts`.
+
+**Store** — `src/store/`
+- `slices/dimensionsSlice.ts` — persistent `addDimensionAnnotation`/`updateDimensionAnnotation`/`deleteDimensionAnnotation`/`selectAnnotation` (history-tracked).
+- `slices/dimensionToolSlice.ts` — transient tools: `tapeMeasure`, `pendingDimension`, `dimensionDeleteArmed` + their actions (`startTapeMeasure`, `tapeMeasureClick`, `clearTapeMeasure`, `startDimensionTool`, `setPendingDimensionType`, `pendingDimensionPick`, `cancelPendingDimension`, `setDimensionDeleteArmed`). Not in history.
+- Wired in `projectStore.ts`; `normalizeProject` defaults `annotations: []` and `showDimensions: true` (legacy `.camj` safe). New top-level state fields: `selectedAnnotationId`, `tapeMeasure`, `pendingDimension`, `dimensionDeleteArmed`. Action signatures in `store/types.ts`.
+
+**Rendering + interaction** — `src/components/canvas/`
+- `dimensionRendering.ts` — `drawDimensions` (extension/dimension lines, arrowheads, labels, angle arcs; selected=blue, delete-hover=red, dangling=muted ⚠), `drawTapeMeasure`, `drawPendingDimensionPreview`, `pickDimensionAt`.
+- `SketchCanvas.tsx` — draw layer (gated on `showDimensions`); click handling for tape/placement/delete/select; drag-to-reposition offset (begin/move/up + pointer-leave commit); Esc/Delete keys; `CanvasWorkflowPanel` instruction popups (tape / placement / delete) using `useCanvasWorkflowPanel`.
+
+**Toolbar UI**
+- Desktop: `src/components/layout/Toolbar.tsx` — `MeasureActions` group (tape, 6 dimension types, delete-trash, show/hide-eye) wired via `useToolbarState`; rendered in both `CreationToolbar` (vertical) and combined `Toolbar`.
+- Tablet: `src/components/layout/DimensionPopover.tsx` — rendered in `TopCommandBar.tsx` next to `SnapPopover` (tablet-only; the snap popover does NOT exist on desktop — that was a correction made during development).
+
+**Icons** — added `measure`, `dim-aligned/-horizontal/-vertical/-radius/-diameter/-angle`, `dim-visibility` to `src/assets/icons.camj`; regenerated `public/icons.svg` via `npm run sync-icons`. (Generator was a throwaway script at `/tmp/add-icons.mjs` — not in repo; edit `icons.camj` in-app or re-run sync if regenerating.)
+
+## Build / verify
+
+```
+npm run build   # icons + tsc + 22 tests + vite — currently green
+npm test        # structural tests only
+```
+Tests added: `src/sketch/dimensions.test.ts`, `src/utils/units.test.ts`.
+
+## Known limitations / suggested follow-ups
+
+- **Not visually verified in-app** — logic/rendering math are unit-tested, but no one has clicked through tape/placement/delete/drag in a running app. First local step: `npm run dev` and exercise each tool (desktop left toolbar + tablet popover).
+- **Per-dimension visibility** — `DimensionAnnotation.visible` is honored by the renderer but has no per-item UI (only the global toggle). A feature-tree/list entry would close this.
+- **textOverride / precisionOverride** fields exist on the model but have no editing UI yet (double-click-to-edit-label was scoped but not built).
+- **Tabs/clamps** are not yet snappable dimension anchor targets (v1: features + stock + origin).
+- **3D viewport / G-code / simulation** intentionally ignore dimensions (annotations are inert).
+- **Radius/diameter** dimensions aren't drag-repositionable (offset not cursor-driven for those); label sits at midpoint.
+- **Lint**: repo has a pre-existing lint baseline with errors (not gating the build); the measure/dimension files are lint-clean except inheriting SketchCanvas/Toolbar pre-existing warnings.
+
+## To open the PR (when ready)
+
+Per `AGENTS.md`: `git mv planning/MEASURE_DIMENSIONS_Plan.md planning/archive/`, set its frontmatter `status: Done`, remove its entry from `planning/INDEX.md`, then open the PR linking the archived plan.

--- a/planning/MEASURE_DIMENSIONS_Plan.md
+++ b/planning/MEASURE_DIMENSIONS_Plan.md
@@ -289,19 +289,21 @@ Rendering and pointer interaction in `SketchCanvas.tsx` are validated manually
 
 ## Open questions / risks
 
-1. **Dimension types for v1.** Proposed set: aligned/parallel, horizontal,
-   vertical, radius, diameter, angle. Is that the right scope, or should any be
-   cut/added (e.g. ordinate, baseline/chain) for the first pass?
-2. **Behaviour when an anchored feature is deleted.** Proposed: keep the dimension
-   as *dangling* (drawn muted, with a warning) rather than auto-deleting it, so a
-   delete is non-destructive and re-anchorable. Acceptable, or should deleting a
-   feature also delete its dimensions?
-3. **Tape-measure readout content.** Proposed: distance + Δx + Δy + angle. Too
-   much — just the straight distance — or right?
+**Resolved (confirmed by user 2026-06-02):**
+
+1. **Dimension types for v1.** ✅ Full set — aligned/parallel, horizontal,
+   vertical, radius, diameter, angle.
+2. **Behaviour when an anchored feature is deleted.** ✅ Keep the dimension as
+   *dangling* (drawn muted, with a warning); deleting a feature is non-destructive
+   to its dimensions, which can be re-anchored or deleted.
+3. **Tape-measure readout content.** ✅ Distance + Δx + Δy + angle.
+
+**Still open (sensible defaults proposed; speak up to change):**
+
 4. **Circle default.** When dimensioning a circle, default to diameter (Ø) or
-   radius (R)? (Both available; this is just the default.)
-5. **Anchor targets in v1.** Proposed: features + stock + machine origin. Should
-   tabs/clamps be snappable dimension targets now, or is "later" fine?
+   radius (R)? (Both available; this is just the default. Proposed: diameter.)
+5. **Anchor targets in v1.** Proposed: features + stock + machine origin; tabs and
+   clamps come later. OK to defer tabs/clamps?
 6. **3D / export.** Confirm dimensions stay 2D-sketch-only and are excluded from
    the 3D viewport and any export in v1.
 7. **Field name.** Confirm the new top-level field is `annotations` (kept distinct

--- a/planning/MEASURE_DIMENSIONS_Plan.md
+++ b/planning/MEASURE_DIMENSIONS_Plan.md
@@ -235,6 +235,27 @@ Annotations are drawing-only. They are ignored by toolpath generation, G-code
 export, the 3D viewport, and simulation in v1. The engine never reads
 `project.annotations`.
 
+## Implementation notes (deviations from the original design)
+
+Captured as built, per the AGENTS mid-flight-update rule:
+
+- **Selection state** is held as a top-level store field `selectedAnnotationId`
+  (plus `tapeMeasure` / `pendingDimension` transient tools) rather than nested in
+  `SelectionState`. This avoids touching the feature-selection sanitize logic and
+  keeps annotation selection isolated.
+- **Toolbar surface**: instead of a button group inside `CreationActions`, the
+  tools live in a self-contained `DimensionPopover` (mirrors `SnapPopover`)
+  rendered in `TopCommandBar`. It exposes a tape-measure toggle and a
+  dimension-type picker (aligned/horizontal/vertical/radius/diameter/angle).
+- **Icon**: the popover uses a small inline SVG ruler glyph, so no change to the
+  `icons.camj` → `icons.svg` build pipeline was required.
+- **Layout offset model**: horizontal/vertical dimension lines are offset from the
+  measured points' *midpoint* (not min/max), which makes drag-to-reposition
+  natural and keeps the offset a single signed scalar.
+- Added `formatAngle` to `src/utils/units.ts` for degree labels.
+- After committing a dimension the placement tool deactivates (one dimension per
+  activation); re-pick a type to place another.
+
 ## Files affected
 
 - `src/types/project.ts` — add `DimensionAnnotation`, `DimensionAnchor`,
@@ -258,11 +279,10 @@ export, the 3D viewport, and simulation in v1. The engine never reads
 - `src/store/projectStore.ts` — wire the new slices into the store.
 - `src/utils/units.ts` — convert `annotations` in `convertProjectUnits`; add
   `formatAngle` if not present.
-- `src/components/layout/Toolbar.tsx` — Measure tool group + buttons.
-- `src/assets/icons.camj` (+ regenerate `public/icons.svg` via `npm run sync-icons`)
-  — `measure` and `dimension` icons.
-- `INDEX.md` files: `src/sketch/`, `src/components/canvas/`, `src/store/slices/`
-  updated for the new files (per the maintenance rule).
+- *(new)* `src/components/layout/DimensionPopover.tsx` — tape toggle + dimension
+  type picker; rendered from `src/components/layout/TopCommandBar.tsx`.
+- `INDEX.md` files: `src/store/INDEX.md` and `src/components/INDEX.md` updated for
+  the new files (per the maintenance rule).
 
 ## Tests
 

--- a/planning/MEASURE_DIMENSIONS_Plan.md
+++ b/planning/MEASURE_DIMENSIONS_Plan.md
@@ -247,8 +247,15 @@ Captured as built, per the AGENTS mid-flight-update rule:
   tools live in a self-contained `DimensionPopover` (mirrors `SnapPopover`)
   rendered in `TopCommandBar`. It exposes a tape-measure toggle and a
   dimension-type picker (aligned/horizontal/vertical/radius/diameter/angle).
-- **Icon**: the popover uses a small inline SVG ruler glyph, so no change to the
-  `icons.camj` → `icons.svg` build pipeline was required.
+- **Icons**: added `measure` + `dim-aligned`/`dim-horizontal`/`dim-vertical`/
+  `dim-radius`/`dim-diameter`/`dim-angle` to `src/assets/icons.camj` and
+  regenerated `public/icons.svg` via `npm run sync-icons`. The popover button and
+  type picker use these via the `Icon` component.
+- **Global show/hide**: `project.meta.showDimensions` (defaults true, persists in
+  `.camj`) gates rendering and hit-testing of all dimensions; toggled from the
+  Measure popover. `setShowDimensions` store action mirrors `setShowFeatureInfo`.
+  Per-dimension visibility (`DimensionAnnotation.visible`) is honored by the
+  renderer but has no dedicated per-item UI yet (future: feature-tree entries).
 - **Layout offset model**: horizontal/vertical dimension lines are offset from the
   measured points' *midpoint* (not min/max), which makes drag-to-reposition
   natural and keeps the offset a single signed scalar.

--- a/planning/MEASURE_DIMENSIONS_Plan.md
+++ b/planning/MEASURE_DIMENSIONS_Plan.md
@@ -1,0 +1,319 @@
+---
+status: Draft   # Draft → Approved → In progress → Done | Abandoned
+created: 2026-06-02
+---
+
+# Measure & Dimensions Plan
+
+## Goal
+
+Give users two related measuring capabilities on the 2D sketch canvas:
+
+1. **Tape measure** — a transient tool that reports the distance (plus dx/dy and
+   angle) between two snapped points. The readout persists on screen until the
+   next click starts a fresh measurement; nothing is saved to the project.
+2. **Permanent dimensions** — standard CAD dimension annotations (aligned/parallel,
+   horizontal, vertical, radius, diameter, angle) that are **anchored to the
+   geometry they were placed on**. When the underlying feature is edited, moved,
+   or its sketch changes, the dimension value and graphics update automatically.
+
+The user-visible outcome: a "Measure" tool group in the sketch toolbar, a live
+tape-measure readout, and persistent dimension annotations that behave like a
+real CAD drawing — they follow their geometry and survive save/load.
+
+## Background — what the codebase already gives us
+
+- **Rendering primitives exist.** `src/components/canvas/measurements.ts` already
+  draws dimension-style labels (`drawMeasurementLabel`), line lengths
+  (`drawLineLengthMeasurement`), radii (`drawArcRadiusMeasurement`,
+  `drawRadiusMeasurement`), and angles (`drawAngleMeasurement`). The permanent-
+  dimension renderer is largely an extension of these, not a from-scratch effort.
+- **Transient multi-click tools have a pattern.** `pendingAdd` in
+  `src/store/types.ts` + `src/store/slices/pendingAddSlice.ts` (e.g.
+  `startAddPolygonPlacement` / `addPendingPolygonPoint` / `completePendingPolygon`)
+  is the template for the placement flow. These are transient UI state and are
+  **not** in undo history.
+- **Snapping is centralized.** `resolveSketchSnap` in
+  `src/components/canvas/snappingHelpers.ts` already produces a snapped world
+  point from stock / features / tabs / clamps / origin.
+- **The label-as-hit-target pattern exists.** Constraints already register
+  per-frame hit rectangles (`constraintLabelRectsRef`) so labels are clickable;
+  dimensions reuse this approach.
+
+### The one hard problem: snaps have no provenance
+
+`ResolvedSnap` (snappingHelpers.ts:46) returns only `rawPoint`, `point`, and
+`mode`. It does **not** record *which* feature / segment / vertex produced the
+snap. A permanent dimension that must follow moved geometry cannot store a frozen
+coordinate — it must store a **reference** to the geometry and re-resolve the
+world point every frame. So the central new mechanic is: **extend the snap
+pipeline to carry provenance, and store that provenance (an "anchor") on the
+dimension.** The dimension's numeric value is then always computed live from the
+resolved anchors and is never stored stale.
+
+### Naming note (collision)
+
+`Project.dimensions` already exists as `Record<string, NamedDimension>` — the
+**parametric** named-dimension table used by `z_top`/`z_bottom`. This is unrelated
+to drawing dimensions. To avoid confusion we introduce a **new** top-level field
+`annotations: DimensionAnnotation[]` rather than overloading `dimensions`.
+
+## Approach
+
+### 1. Data model (`src/types/project.ts`)
+
+A dimension stores *anchors*, *type*, and *placement* — never the measured value
+(value is computed live, guaranteeing auto-update).
+
+```ts
+// A reference to a live point in the scene. Resolves to a world Point each frame.
+export type DimensionAnchor =
+  | { kind: 'free'; point: Point }                                  // unattached, fixed world point
+  | { kind: 'vertex'; target: AnchorTarget; vertexIndex: number }   // profile vertex
+  | { kind: 'midpoint'; target: AnchorTarget; segmentIndex: number }
+  | { kind: 'center'; target: AnchorTarget; segmentIndex: number }  // arc / circle centre
+  | { kind: 'origin' }                                              // machine origin
+
+// What a non-free anchor points at. v1: features + stock. (tabs/clamps: see open Qs)
+export type AnchorTarget =
+  | { source: 'feature'; featureId: string }
+  | { source: 'stock' }
+
+export type DimensionType =
+  | 'aligned'     // true distance, dimension line parallel to the two points
+  | 'horizontal'  // |Δx| between two points
+  | 'vertical'    // |Δy| between two points
+  | 'radius'      // R of an arc/circle
+  | 'diameter'    // Ø of an arc/circle
+  | 'angle'       // angle at a vertex between two rays
+
+export interface DimensionAnnotation {
+  id: string                    // 'dim0001' via nextUniqueGeneratedId(project, 'dim')
+  type: DimensionType
+  a: DimensionAnchor            // primary anchor (linear start / arc reference / angle vertex)
+  b?: DimensionAnchor           // second anchor (linear end / angle ray-1)
+  c?: DimensionAnchor           // third anchor (angle ray-2)
+  offset: number                // perpendicular distance of dimension line from the
+                                // measured points, world units; sign chooses the side
+  labelOffset?: number          // optional slide of the text along the dimension line
+  textOverride?: string | null  // optional manual label text (value still computed for tooltip)
+  precisionOverride?: number | null
+  visible: boolean
+  locked: boolean
+}
+
+export interface Project {
+  // ...existing fields...
+  annotations: DimensionAnnotation[]   // NEW, additive
+}
+```
+
+`normalizeProject` defaults `annotations` to `[]` so existing `.camj` files load
+unchanged (format is additive; no version bump needed).
+
+### 2. Pure geometry/value module (`src/sketch/dimensions.ts`, new)
+
+All testable logic lives here, **out of React**, so it is covered by the
+`src/**/*.test.ts` structural suite:
+
+- `resolveAnchor(anchor, project): Point | null` — returns the live world point,
+  or `null` when the reference is dangling (feature deleted, index out of range).
+  Must use the **same** profile-world-point helpers the snapper/renderer use
+  (`profileVertices`, `anchorPointForIndex`, `segmentMidpoint`, segment `center`)
+  so a dimension and its snap always agree.
+- `measureValue(dim, project): number | null` — computes the live value:
+  aligned = `hypot(Δ)`, horizontal = `|Δx|`, vertical = `|Δy|`,
+  radius = distance(center, edge), diameter = `2 × radius`, angle = angle at `a`
+  between rays to `b` and `c`.
+- `dimensionGeometry(dim, project): {...} | null` — pure layout: extension
+  (witness) line endpoints, dimension-line endpoints (offset applied along the
+  measured normal), arrowhead anchor points, and label anchor + rotation. The
+  canvas renderer consumes this; keeping it pure makes the offset math testable.
+
+A dimension whose `measureValue`/`dimensionGeometry` returns `null` is **dangling**
+and is drawn in a muted warning style (mirrors the `is_invalid` convention already
+used on constraints).
+
+### 3. Snap provenance (`src/components/canvas/snappingHelpers.ts`)
+
+Extend `SnapCandidate` and `ResolvedSnap` with an optional `anchor?:
+DimensionAnchor` describing the candidate's source. `addProfileSnapCandidates`
+gains a `source: AnchorTarget | null` parameter (callers already iterate per
+feature/stock, so the owning identity is in scope) and attaches:
+
+- `point` snaps → `{ kind: 'vertex', target, vertexIndex }`
+- `midpoint` snaps → `{ kind: 'midpoint', target, segmentIndex }`
+- `center` snaps → `{ kind: 'center', target, segmentIndex }`
+- origin snap → `{ kind: 'origin' }`
+- `grid`/`line`/`perpendicular` (no stable geometry identity) → no anchor; the
+  dimension tool records these as `{ kind: 'free', point }`.
+
+This change is **purely additive** to the snap result; existing callers ignore the
+new field, so drawing/snapping behaviour is unchanged for everything else.
+
+### 4. Tape measure (transient, no persistence)
+
+New transient store state (sibling of `pendingAdd`, **not** in history), e.g.
+`tapeMeasure: { first: { point: Point } | null; last: { a: Point; b: Point } | null }`
+with actions `startTapeMeasure`, `tapeMeasureClick(point)`, `clearTapeMeasure`.
+
+Behaviour: activate the tape tool → first click sets A (snapped) → moving shows a
+live readout (distance, Δx, Δy, angle) anchored near the cursor using
+`drawLineLengthMeasurement` + a small multi-line label → second click freezes the
+A–B measurement, which stays drawn until the next click starts a new one. `Esc` or
+switching tools clears it. Tape never touches `project` and never records anchors.
+
+### 5. Permanent-dimension placement tool
+
+Add a `pendingDimension` transient tool (mirrors `pendingAdd`) in
+`src/store/types.ts` + a new `src/store/slices/dimensionToolSlice.ts`:
+
+```ts
+type PendingDimensionTool = {
+  type: DimensionType
+  a: DimensionAnchor | null
+  b: DimensionAnchor | null
+  c: DimensionAnchor | null
+  session: number
+}
+```
+
+Flow for a linear dimension: pick the type (or use an "auto" mode that infers
+radius/diameter when the first click lands on an arc/circle, linear otherwise) →
+click A → click B → move to choose side/offset → click to commit via
+`addDimensionAnnotation`. Each click runs `resolveSketchSnap`; the resolved
+`anchor` (or `{ kind:'free' }`) is captured. Angle dimensions take three clicks
+(vertex, ray-1, ray-2).
+
+### 6. Persistent store actions (history-tracked)
+
+In a new `src/store/slices/dimensionsSlice.ts`, following the tabs/clamps action
+shape (clone-to-history, bump `meta.modified`, no-op guard):
+
+- `addDimensionAnnotation(partial): string` (returns new id)
+- `updateDimensionAnnotation(id, patch)`
+- `deleteDimensionAnnotation(id)`
+
+When a feature is deleted we **do not** silently drop its dimensions — they become
+dangling and render in the warning style so the user can re-anchor or delete them
+(non-destructive; see open question 2).
+
+### 7. Selection & editing
+
+Add `selectedAnnotationId` / `hoveredAnnotationId` to `SelectionState`
+(`src/store/types.ts`). The canvas registers per-frame dimension hit rects
+(`dimensionHitRectsRef`, modelled on `constraintLabelRectsRef`). Interactions:
+hover highlights; click selects; drag the dimension line changes `offset` (and
+drag along it sets `labelOffset`); double-click the label edits `textOverride` /
+precision; `Delete` removes it.
+
+### 8. Rendering (`src/components/canvas/dimensionRendering.ts`, new)
+
+`drawDimensions(ctx, project, vt, units, selection)` iterates
+`project.annotations`, calls the pure `dimensionGeometry`, and draws witness lines,
+the dimension line with arrowheads, and the label (reusing `drawMeasurementLabel`).
+A new draw layer is added to the `SketchCanvas` draw loop after features (near the
+existing constraint/measurement layers). Because geometry is resolved live each
+frame, moving/editing a feature updates its dimensions for free.
+
+### 9. Toolbar, icons, units, wiring
+
+- **Toolbar** (`src/components/layout/Toolbar.tsx`): add a "Measure" group with a
+  tape-measure button and a dimension button (with a small type sub-menu / cycle),
+  wired through the existing `togglePlacement` pattern.
+- **Icons**: add `measure` and `dimension` features to
+  `src/assets/icons.camj`, then `npm run sync-icons`.
+- **Units** (`src/utils/units.ts`): extend `convertProjectUnits` to convert
+  `annotations` — `free` anchor points, `offset`, and `labelOffset` are world
+  lengths and must convert; anchored points resolve from geometry and need no
+  conversion; `angle` values are unitless. Display always goes through
+  `formatLength` / a new `formatAngle` at render time.
+
+### 10. Explicitly inert in the engine
+
+Annotations are drawing-only. They are ignored by toolpath generation, G-code
+export, the 3D viewport, and simulation in v1. The engine never reads
+`project.annotations`.
+
+## Files affected
+
+- `src/types/project.ts` — add `DimensionAnnotation`, `DimensionAnchor`,
+  `AnchorTarget`, `DimensionType`; add `annotations` to `Project`; default it in
+  `normalizeProject`.
+- *(new)* `src/sketch/dimensions.ts` — pure `resolveAnchor`, `measureValue`,
+  `dimensionGeometry`.
+- *(new)* `src/sketch/dimensions.test.ts` — unit tests for the above.
+- `src/components/canvas/snappingHelpers.ts` — add `anchor` provenance to
+  `SnapCandidate`/`ResolvedSnap`; thread `source` into `addProfileSnapCandidates`.
+- *(new)* `src/components/canvas/dimensionRendering.ts` — `drawDimensions(...)`.
+- `src/components/canvas/measurements.ts` — small shared helpers (arrowheads,
+  multi-line readout label) if needed; reuse existing label drawing.
+- `src/components/canvas/SketchCanvas.tsx` — new draw layer, tape + dimension tool
+  click/move handling, dimension hit-testing/selection/drag-edit, `Esc` handling.
+- `src/store/types.ts` — `PendingDimensionTool`, `tapeMeasure` state,
+  `annotations`-related selection fields, new action signatures on `ProjectStore`.
+- *(new)* `src/store/slices/dimensionsSlice.ts` — add/update/delete (history).
+- *(new)* `src/store/slices/dimensionToolSlice.ts` — transient tape + pending
+  dimension tool actions.
+- `src/store/projectStore.ts` — wire the new slices into the store.
+- `src/utils/units.ts` — convert `annotations` in `convertProjectUnits`; add
+  `formatAngle` if not present.
+- `src/components/layout/Toolbar.tsx` — Measure tool group + buttons.
+- `src/assets/icons.camj` (+ regenerate `public/icons.svg` via `npm run sync-icons`)
+  — `measure` and `dimension` icons.
+- `INDEX.md` files: `src/sketch/`, `src/components/canvas/`, `src/store/slices/`
+  updated for the new files (per the maintenance rule).
+
+## Tests
+
+Engine/pure logic gets unit tests (required by AGENTS.md):
+
+- **`src/sketch/dimensions.test.ts`**
+  - `resolveAnchor`: correct world point for `vertex` / `midpoint` / `center` /
+    `origin` / `free`; returns `null` for missing feature and out-of-range index;
+    a resolved vertex anchor **moves** when the feature's sketch origin/geometry
+    changes (the core auto-update guarantee).
+  - `measureValue`: correct numbers for aligned / horizontal / vertical / radius /
+    diameter / angle on known fixtures; `null` when an anchor is dangling.
+  - `dimensionGeometry`: offset sign places the dimension line on the expected
+    side; witness/arrow endpoints are correct for a simple horizontal case.
+- **units**: `convertProjectUnits` round-trips a project containing `annotations`
+  (free point, offset, labelOffset) between mm↔inch; angle values unchanged.
+- **store**: `addDimensionAnnotation` / `updateDimensionAnnotation` /
+  `deleteDimensionAnnotation` mutate correctly, bump `meta.modified`, and
+  participate in undo/redo; `normalizeProject` defaults `annotations` to `[]` for a
+  legacy project object lacking the field.
+
+Rendering and pointer interaction in `SketchCanvas.tsx` are validated manually
+(no canvas test harness exists today).
+
+## Open questions / risks
+
+1. **Dimension types for v1.** Proposed set: aligned/parallel, horizontal,
+   vertical, radius, diameter, angle. Is that the right scope, or should any be
+   cut/added (e.g. ordinate, baseline/chain) for the first pass?
+2. **Behaviour when an anchored feature is deleted.** Proposed: keep the dimension
+   as *dangling* (drawn muted, with a warning) rather than auto-deleting it, so a
+   delete is non-destructive and re-anchorable. Acceptable, or should deleting a
+   feature also delete its dimensions?
+3. **Tape-measure readout content.** Proposed: distance + Δx + Δy + angle. Too
+   much — just the straight distance — or right?
+4. **Circle default.** When dimensioning a circle, default to diameter (Ø) or
+   radius (R)? (Both available; this is just the default.)
+5. **Anchor targets in v1.** Proposed: features + stock + machine origin. Should
+   tabs/clamps be snappable dimension targets now, or is "later" fine?
+6. **3D / export.** Confirm dimensions stay 2D-sketch-only and are excluded from
+   the 3D viewport and any export in v1.
+7. **Field name.** Confirm the new top-level field is `annotations` (kept distinct
+   from the existing parametric `dimensions` map).
+
+## Out of scope
+
+- Toolpath/G-code/3D/simulation awareness of dimensions — annotations are inert.
+- Tolerances, GD&T symbols, dimension styles/themes, leader notes, and free text
+  annotations (the `annotations` array is named to leave room for these later, but
+  only `DimensionAnnotation` ships now).
+- Ordinate/baseline/chain dimension families (unless pulled in via open question 1).
+- Auto-dimensioning / one-click "dimension this feature" automation.
+- Dragging a dimension to *drive* geometry (these are read-only annotations, not
+  constraints).

--- a/planning/MEASURE_DIMENSIONS_Plan.md
+++ b/planning/MEASURE_DIMENSIONS_Plan.md
@@ -1,5 +1,5 @@
 ---
-status: Draft   # Draft → Approved → In progress → Done | Abandoned
+status: In progress   # Draft → Approved → In progress → Done | Abandoned
 created: 2026-06-02
 ---
 

--- a/public/icons.svg
+++ b/public/icons.svg
@@ -447,4 +447,46 @@
     <path d="M 9 10 L 9 12" />
     <path d="M 9 2.0277876989464443 L 9 3" />
   </symbol>
+  <symbol id="measure" viewBox="0 0 24 24">
+    <path d="M 2 8 L 22 8 L 22 16 L 2 16 L 2 8 Z" />
+    <path d="M 6 8 L 6 12" />
+    <path d="M 10 8 L 10 13" />
+    <path d="M 14 8 L 14 12" />
+    <path d="M 18 8 L 18 13" />
+  </symbol>
+  <symbol id="dim-aligned" viewBox="0 0 24 24">
+    <path d="M 5 19 L 19 5" />
+    <path d="M 9.2 17.6 L 5 19 L 6.4 14.8" />
+    <path d="M 17.6 9.2 L 19 5 L 14.8 6.4" />
+  </symbol>
+  <symbol id="dim-horizontal" viewBox="0 0 24 24">
+    <path d="M 4 7 L 4 17" />
+    <path d="M 20 7 L 20 17" />
+    <path d="M 4 12 L 20 12" />
+    <path d="M 8 9 L 4 12 L 8 15" />
+    <path d="M 16 9 L 20 12 L 16 15" />
+  </symbol>
+  <symbol id="dim-vertical" viewBox="0 0 24 24">
+    <path d="M 7 4 L 17 4" />
+    <path d="M 7 20 L 17 20" />
+    <path d="M 12 4 L 12 20" />
+    <path d="M 9 8 L 12 4 L 15 8" />
+    <path d="M 9 16 L 12 20 L 15 16" />
+  </symbol>
+  <symbol id="dim-radius" viewBox="0 0 24 24">
+    <path d="M 21 12 A 9 9 0 1 0 3 12 A 9 9 0 1 0 21 12 Z" />
+    <path d="M 12 12 L 21 12" />
+    <path d="M 18 10 L 21 12 L 18 14" />
+  </symbol>
+  <symbol id="dim-diameter" viewBox="0 0 24 24">
+    <path d="M 21 12 A 9 9 0 1 0 3 12 A 9 9 0 1 0 21 12 Z" />
+    <path d="M 3 12 L 21 12" />
+    <path d="M 6 10 L 3 12 L 6 14" />
+    <path d="M 18 10 L 21 12 L 18 14" />
+  </symbol>
+  <symbol id="dim-angle" viewBox="0 0 24 24">
+    <path d="M 5 18 L 21 18" />
+    <path d="M 5 18 L 17 5" />
+    <path d="M 12 18 L 11.4 15.2 L 9.8 12.9" />
+  </symbol>
 </svg>

--- a/public/icons.svg
+++ b/public/icons.svg
@@ -489,4 +489,8 @@
     <path d="M 5 18 L 17 5" />
     <path d="M 12 18 L 11.4 15.2 L 9.8 12.9" />
   </symbol>
+  <symbol id="dim-visibility" viewBox="0 0 24 24">
+    <path d="M 3 12 C 9 6, 15 6, 21 12 C 15 18, 9 18, 3 12 Z" />
+    <path d="M 15 12 A 3 3 0 1 0 9 12 A 3 3 0 1 0 15 12 Z" />
+  </symbol>
 </svg>

--- a/public/icons.svg
+++ b/public/icons.svg
@@ -493,4 +493,10 @@
     <path d="M 3 12 C 9 6, 15 6, 21 12 C 15 18, 9 18, 3 12 Z" />
     <path d="M 15 12 A 3 3 0 1 0 9 12 A 3 3 0 1 0 15 12 Z" />
   </symbol>
+  <symbol id="tape-measure" viewBox="0 0 24 24">
+    <path d="M 13 12 A 6 6 0 1 0 1 12 A 6 6 0 1 0 13 12 Z" />
+    <path d="M 9 12 A 2 2 0 1 0 5 12 A 2 2 0 1 0 9 12 Z" />
+    <path d="M 13 10 L 22 10 L 22 14 L 13 14 L 13 10 Z" />
+    <path d="M 22 8 L 22 16" />
+  </symbol>
 </svg>

--- a/src/assets/icons.camj
+++ b/src/assets/icons.camj
@@ -22610,6 +22610,1143 @@
       "visible": false,
       "locked": false,
       "text": null
+    },
+    {
+      "id": "icon_measure_0",
+      "name": "measure_shape_0",
+      "kind": "composite",
+      "folderId": "folder_measure",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 2,
+            "y": 8
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 22,
+                "y": 8
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 22,
+                "y": 16
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 2,
+                "y": 16
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 2,
+                "y": 8
+              }
+            }
+          ],
+          "closed": true
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_measure_1",
+      "name": "measure_shape_1",
+      "kind": "composite",
+      "folderId": "folder_measure",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 6,
+            "y": 8
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 6,
+                "y": 12
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_measure_2",
+      "name": "measure_shape_2",
+      "kind": "composite",
+      "folderId": "folder_measure",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 10,
+            "y": 8
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 10,
+                "y": 13
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_measure_3",
+      "name": "measure_shape_3",
+      "kind": "composite",
+      "folderId": "folder_measure",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 14,
+            "y": 8
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 14,
+                "y": 12
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_measure_4",
+      "name": "measure_shape_4",
+      "kind": "composite",
+      "folderId": "folder_measure",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 18,
+            "y": 8
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 18,
+                "y": 13
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-aligned_0",
+      "name": "dim-aligned_shape_0",
+      "kind": "composite",
+      "folderId": "folder_dim-aligned",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 5,
+            "y": 19
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 19,
+                "y": 5
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-aligned_1",
+      "name": "dim-aligned_shape_1",
+      "kind": "composite",
+      "folderId": "folder_dim-aligned",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 9.2,
+            "y": 17.6
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 5,
+                "y": 19
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 6.4,
+                "y": 14.8
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-aligned_2",
+      "name": "dim-aligned_shape_2",
+      "kind": "composite",
+      "folderId": "folder_dim-aligned",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 17.6,
+            "y": 9.2
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 19,
+                "y": 5
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 14.8,
+                "y": 6.4
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-horizontal_0",
+      "name": "dim-horizontal_shape_0",
+      "kind": "composite",
+      "folderId": "folder_dim-horizontal",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 4,
+            "y": 7
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 4,
+                "y": 17
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-horizontal_1",
+      "name": "dim-horizontal_shape_1",
+      "kind": "composite",
+      "folderId": "folder_dim-horizontal",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 20,
+            "y": 7
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 20,
+                "y": 17
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-horizontal_2",
+      "name": "dim-horizontal_shape_2",
+      "kind": "composite",
+      "folderId": "folder_dim-horizontal",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 4,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 20,
+                "y": 12
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-horizontal_3",
+      "name": "dim-horizontal_shape_3",
+      "kind": "composite",
+      "folderId": "folder_dim-horizontal",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 8,
+            "y": 9
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 4,
+                "y": 12
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 8,
+                "y": 15
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-horizontal_4",
+      "name": "dim-horizontal_shape_4",
+      "kind": "composite",
+      "folderId": "folder_dim-horizontal",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 16,
+            "y": 9
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 20,
+                "y": 12
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 16,
+                "y": 15
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-vertical_0",
+      "name": "dim-vertical_shape_0",
+      "kind": "composite",
+      "folderId": "folder_dim-vertical",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 7,
+            "y": 4
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 17,
+                "y": 4
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-vertical_1",
+      "name": "dim-vertical_shape_1",
+      "kind": "composite",
+      "folderId": "folder_dim-vertical",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 7,
+            "y": 20
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 17,
+                "y": 20
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-vertical_2",
+      "name": "dim-vertical_shape_2",
+      "kind": "composite",
+      "folderId": "folder_dim-vertical",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 12,
+            "y": 4
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 12,
+                "y": 20
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-vertical_3",
+      "name": "dim-vertical_shape_3",
+      "kind": "composite",
+      "folderId": "folder_dim-vertical",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 9,
+            "y": 8
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 12,
+                "y": 4
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 15,
+                "y": 8
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-vertical_4",
+      "name": "dim-vertical_shape_4",
+      "kind": "composite",
+      "folderId": "folder_dim-vertical",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 9,
+            "y": 16
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 12,
+                "y": 20
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 15,
+                "y": 16
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-radius_0",
+      "name": "dim-radius_shape_0",
+      "kind": "composite",
+      "folderId": "folder_dim-radius",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 21,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "circle",
+              "center": {
+                "x": 12,
+                "y": 12
+              },
+              "to": {
+                "x": 21,
+                "y": 12
+              },
+              "clockwise": true
+            }
+          ],
+          "closed": true
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-radius_1",
+      "name": "dim-radius_shape_1",
+      "kind": "composite",
+      "folderId": "folder_dim-radius",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 12,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 21,
+                "y": 12
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-radius_2",
+      "name": "dim-radius_shape_2",
+      "kind": "composite",
+      "folderId": "folder_dim-radius",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 18,
+            "y": 10
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 21,
+                "y": 12
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 18,
+                "y": 14
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-diameter_0",
+      "name": "dim-diameter_shape_0",
+      "kind": "composite",
+      "folderId": "folder_dim-diameter",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 21,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "circle",
+              "center": {
+                "x": 12,
+                "y": 12
+              },
+              "to": {
+                "x": 21,
+                "y": 12
+              },
+              "clockwise": true
+            }
+          ],
+          "closed": true
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-diameter_1",
+      "name": "dim-diameter_shape_1",
+      "kind": "composite",
+      "folderId": "folder_dim-diameter",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 3,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 21,
+                "y": 12
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-diameter_2",
+      "name": "dim-diameter_shape_2",
+      "kind": "composite",
+      "folderId": "folder_dim-diameter",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 6,
+            "y": 10
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 3,
+                "y": 12
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 6,
+                "y": 14
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-diameter_3",
+      "name": "dim-diameter_shape_3",
+      "kind": "composite",
+      "folderId": "folder_dim-diameter",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 18,
+            "y": 10
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 21,
+                "y": 12
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 18,
+                "y": 14
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-angle_0",
+      "name": "dim-angle_shape_0",
+      "kind": "composite",
+      "folderId": "folder_dim-angle",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 5,
+            "y": 18
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 21,
+                "y": 18
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-angle_1",
+      "name": "dim-angle_shape_1",
+      "kind": "composite",
+      "folderId": "folder_dim-angle",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 5,
+            "y": 18
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 17,
+                "y": 5
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-angle_2",
+      "name": "dim-angle_shape_2",
+      "kind": "composite",
+      "folderId": "folder_dim-angle",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 12,
+            "y": 18
+          },
+          "segments": [
+            {
+              "type": "line",
+              "to": {
+                "x": 11.4,
+                "y": 15.2
+              }
+            },
+            {
+              "type": "line",
+              "to": {
+                "x": 9.8,
+                "y": 12.9
+              }
+            }
+          ],
+          "closed": false
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
     }
   ],
   "featureFolders": [
@@ -23027,6 +24164,41 @@
       "id": "fd0082",
       "name": "constraint",
       "collapsed": true
+    },
+    {
+      "id": "folder_measure",
+      "name": "measure",
+      "collapsed": true
+    },
+    {
+      "id": "folder_dim-aligned",
+      "name": "dim-aligned",
+      "collapsed": true
+    },
+    {
+      "id": "folder_dim-horizontal",
+      "name": "dim-horizontal",
+      "collapsed": true
+    },
+    {
+      "id": "folder_dim-vertical",
+      "name": "dim-vertical",
+      "collapsed": true
+    },
+    {
+      "id": "folder_dim-radius",
+      "name": "dim-radius",
+      "collapsed": true
+    },
+    {
+      "id": "folder_dim-diameter",
+      "name": "dim-diameter",
+      "collapsed": true
+    },
+    {
+      "id": "folder_dim-angle",
+      "name": "dim-angle",
+      "collapsed": true
     }
   ],
   "featureTree": [
@@ -23361,6 +24533,34 @@
     {
       "type": "folder",
       "folderId": "fd0082"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_measure"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_dim-aligned"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_dim-horizontal"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_dim-vertical"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_dim-radius"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_dim-diameter"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_dim-angle"
     }
   ],
   "global_constraints": [],

--- a/src/assets/icons.camj
+++ b/src/assets/icons.camj
@@ -23849,6 +23849,109 @@
       "visible": false,
       "locked": false,
       "text": null
+    },
+    {
+      "id": "icon_tape-measure_0",
+      "name": "tape-measure_shape_0",
+      "kind": "composite",
+      "folderId": "folder_tape-measure",
+      "sketch": {
+        "profile": {
+          "start": { "x": 13, "y": 12 },
+          "segments": [
+            { "type": "circle", "center": { "x": 7, "y": 12 }, "to": { "x": 13, "y": 12 }, "clockwise": true }
+          ],
+          "closed": true
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_tape-measure_1",
+      "name": "tape-measure_shape_1",
+      "kind": "composite",
+      "folderId": "folder_tape-measure",
+      "sketch": {
+        "profile": {
+          "start": { "x": 9, "y": 12 },
+          "segments": [
+            { "type": "circle", "center": { "x": 7, "y": 12 }, "to": { "x": 9, "y": 12 }, "clockwise": true }
+          ],
+          "closed": true
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_tape-measure_2",
+      "name": "tape-measure_shape_2",
+      "kind": "composite",
+      "folderId": "folder_tape-measure",
+      "sketch": {
+        "profile": {
+          "start": { "x": 13, "y": 10 },
+          "segments": [
+            { "type": "line", "to": { "x": 22, "y": 10 } },
+            { "type": "line", "to": { "x": 22, "y": 14 } },
+            { "type": "line", "to": { "x": 13, "y": 14 } },
+            { "type": "line", "to": { "x": 13, "y": 10 } }
+          ],
+          "closed": true
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_tape-measure_3",
+      "name": "tape-measure_shape_3",
+      "kind": "composite",
+      "folderId": "folder_tape-measure",
+      "sketch": {
+        "profile": {
+          "start": { "x": 22, "y": 8 },
+          "segments": [
+            { "type": "line", "to": { "x": 22, "y": 16 } }
+          ],
+          "closed": false
+        },
+        "origin": { "x": 0, "y": 0 },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
     }
   ],
   "featureFolders": [
@@ -24306,6 +24409,11 @@
       "id": "folder_dim-visibility",
       "name": "dim-visibility",
       "collapsed": true
+    },
+    {
+      "id": "folder_tape-measure",
+      "name": "tape-measure",
+      "collapsed": true
     }
   ],
   "featureTree": [
@@ -24672,6 +24780,10 @@
     {
       "type": "folder",
       "folderId": "folder_dim-visibility"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_tape-measure"
     }
   ],
   "global_constraints": [],

--- a/src/assets/icons.camj
+++ b/src/assets/icons.camj
@@ -23747,6 +23747,108 @@
       "visible": false,
       "locked": false,
       "text": null
+    },
+    {
+      "id": "icon_dim-visibility_0",
+      "name": "dim-visibility_shape_0",
+      "kind": "composite",
+      "folderId": "folder_dim-visibility",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 3,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "bezier",
+              "control1": {
+                "x": 9,
+                "y": 6
+              },
+              "control2": {
+                "x": 15,
+                "y": 6
+              },
+              "to": {
+                "x": 21,
+                "y": 12
+              }
+            },
+            {
+              "type": "bezier",
+              "control1": {
+                "x": 15,
+                "y": 18
+              },
+              "control2": {
+                "x": 9,
+                "y": 18
+              },
+              "to": {
+                "x": 3,
+                "y": 12
+              }
+            }
+          ],
+          "closed": true
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
+    },
+    {
+      "id": "icon_dim-visibility_1",
+      "name": "dim-visibility_shape_1",
+      "kind": "composite",
+      "folderId": "folder_dim-visibility",
+      "sketch": {
+        "profile": {
+          "start": {
+            "x": 15,
+            "y": 12
+          },
+          "segments": [
+            {
+              "type": "circle",
+              "center": {
+                "x": 12,
+                "y": 12
+              },
+              "to": {
+                "x": 15,
+                "y": 12
+              },
+              "clockwise": true
+            }
+          ],
+          "closed": true
+        },
+        "origin": {
+          "x": 0,
+          "y": 0
+        },
+        "orientationAngle": 0,
+        "dimensions": [],
+        "constraints": []
+      },
+      "operation": "add",
+      "z_top": 0,
+      "z_bottom": -1,
+      "visible": false,
+      "locked": false,
+      "text": null
     }
   ],
   "featureFolders": [
@@ -24199,6 +24301,11 @@
       "id": "folder_dim-angle",
       "name": "dim-angle",
       "collapsed": true
+    },
+    {
+      "id": "folder_dim-visibility",
+      "name": "dim-visibility",
+      "collapsed": true
     }
   ],
   "featureTree": [
@@ -24561,6 +24668,10 @@
     {
       "type": "folder",
       "folderId": "folder_dim-angle"
+    },
+    {
+      "type": "folder",
+      "folderId": "folder_dim-visibility"
     }
   ],
   "global_constraints": [],

--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -13,7 +13,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 - `useIconIds.ts` — hook listing available icon IDs
 
 ## Subfolders (by area)
-- `canvas/` — 2D sketch canvas: drawing, snapping, panning/zoom, pointer handling
+- `canvas/` — 2D sketch canvas: drawing, snapping, panning/zoom, pointer handling. Dimension annotations + tape measure render via `canvas/dimensionRendering.ts` (pure geometry in `sketch/dimensions.ts`)
 - `viewport3d/` — Three.js 3D preview of the CSG-derived model, including toolpath overlay helpers
 - `simulation/` — voxel toolpath simulation viewport and playback controls
 - `cam/` — CAM panels (tools, operations, parameters)

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -56,7 +56,7 @@ import type { DimensionEditState, OperationDimEdit } from './manualEntry'
 import { resolveSketchSnap } from './snappingHelpers'
 import type { ResolvedSnap } from './snappingHelpers'
 import { drawDimensions, drawPendingDimensionPreview, drawTapeMeasure, pickDimensionAt } from './dimensionRendering'
-import { offsetForCursor } from '../../sketch/dimensions'
+import { circleEdgeAnchorFromPoint, offsetForCursor } from '../../sketch/dimensions'
 import {
   drawFeature,
   drawMoveGuide,
@@ -597,7 +597,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     const t = pendingDimension.type
     const n = dimensionPickedCount
     if (t === 'radius' || t === 'diameter') {
-      return n === 0 ? 'Click the circle / arc center' : n === 1 ? 'Click a point on the edge' : 'Click to place'
+      return n === 0 ? 'Click the circle / arc center' : 'Click a point on the edge'
     }
     if (t === 'angle') {
       return n === 0 ? 'Click the vertex'
@@ -3478,6 +3478,38 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       const anchor: DimensionAnchor = resolvedSnap.anchor ?? { kind: 'free', point: resolvedSnap.point }
       const need = pendingDim.type === 'angle' ? 3 : 2
       const picked = [pendingDim.a, pendingDim.b, pendingDim.c].filter(Boolean).length
+      // Radius/diameter have no cursor-driven offset (line is always center→edge),
+      // so commit immediately on the final anchor click instead of asking for an
+      // extra "click to place" step.
+      const isRadial = pendingDim.type === 'radius' || pendingDim.type === 'diameter'
+      // For radius/diameter the first click MUST identify a circle/arc center —
+      // otherwise the dimension would be measured between arbitrary points and
+      // the value would be meaningless. Silently ignore non-center clicks; the
+      // CanvasWorkflowPanel already says "Click the circle / arc center".
+      if (isRadial && picked === 0 && anchor.kind !== 'center') {
+        return
+      }
+      if (isRadial && picked === need - 1) {
+        // If the edge click landed off-circle (or via a non-anchored snap), but
+        // anchor a pins the circle's center, project onto that circle and store
+        // an angle-relative anchor so the dim direction follows the feature.
+        const edgeAnchor =
+          anchor.kind === 'free' && pendingDim.a
+            ? (circleEdgeAnchorFromPoint(anchor.point, pendingDim.a, project) ?? anchor)
+            : anchor
+        addDimensionAnnotation({
+          type: pendingDim.type,
+          a: pendingDim.a!,
+          b: edgeAnchor,
+          offset: 0,
+          visible: true,
+          locked: false,
+          textOverride: null,
+          precisionOverride: null,
+        })
+        cancelPendingDimension()
+        return
+      }
       if (picked < need) {
         pendingDimensionPick(anchor)
         return
@@ -5911,7 +5943,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           )}
         >
           <div className="canvas-workflow-panel__summary">
-            Click points to anchor the dimension to geometry — it follows when features move. Esc to cancel.
+            Click points to anchor the dimension to geometry. Esc to cancel.
           </div>
         </CanvasWorkflowPanel>
       )}

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -331,11 +331,13 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     pendingConstraint,
     tapeMeasure,
     pendingDimension,
+    dimensionDeleteArmed,
     selectedAnnotationId,
     tapeMeasureClick,
     clearTapeMeasure,
     pendingDimensionPick,
     cancelPendingDimension,
+    setDimensionDeleteArmed,
     addDimensionAnnotation,
     updateDimensionAnnotation,
     deleteDimensionAnnotation,
@@ -443,7 +445,9 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const copyCountDraftRef = useRef(copyCountDraft)
   const tapeMeasureRef = useRef(tapeMeasure)
   const pendingDimensionRef = useRef(pendingDimension)
+  const dimensionDeleteArmedRef = useRef(dimensionDeleteArmed)
   const selectedAnnotationIdRef = useRef(selectedAnnotationId)
+  const deleteHoverDimIdRef = useRef<string | null>(null)
 
   projectRef.current = project
   selectionRef.current = selection
@@ -463,7 +467,9 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   copyCountDraftRef.current = copyCountDraft
   tapeMeasureRef.current = tapeMeasure
   pendingDimensionRef.current = pendingDimension
+  dimensionDeleteArmedRef.current = dimensionDeleteArmed
   selectedAnnotationIdRef.current = selectedAnnotationId
+  if (!dimensionDeleteArmed) deleteHoverDimIdRef.current = null
   dimensionEditRef.current = dimensionEdit
   constraintEditRef.current = constraintEdit
 
@@ -557,6 +563,50 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     canvasRef,
     clearTransientCanvasState,
   })
+
+  // ── Measure & dimension workflow panels (instruction popups) ──
+  const dimensionPickedCount = pendingDimension
+    ? [pendingDimension.a, pendingDimension.b, pendingDimension.c].filter(Boolean).length
+    : 0
+  const tapeWorkflowPanel = useCanvasWorkflowPanel({
+    open: !!tapeMeasure,
+    phaseKey: tapeMeasure?.first ? 'second' : 'first',
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+  const dimensionWorkflowPanel = useCanvasWorkflowPanel({
+    open: !!pendingDimension,
+    phaseKey: pendingDimension ? `${pendingDimension.type}:${dimensionPickedCount}` : null,
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+  const dimensionDeleteWorkflowPanel = useCanvasWorkflowPanel({
+    open: dimensionDeleteArmed,
+    phaseKey: 'delete',
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+  const dimensionTitle = pendingDimension
+    ? `${pendingDimension.type.charAt(0).toUpperCase()}${pendingDimension.type.slice(1)} dimension`
+    : ''
+  const dimensionStep = (() => {
+    if (!pendingDimension) return ''
+    const t = pendingDimension.type
+    const n = dimensionPickedCount
+    if (t === 'radius' || t === 'diameter') {
+      return n === 0 ? 'Click the circle / arc center' : n === 1 ? 'Click a point on the edge' : 'Click to place'
+    }
+    if (t === 'angle') {
+      return n === 0 ? 'Click the vertex'
+        : n === 1 ? 'Click the first ray point'
+        : n === 2 ? 'Click the second ray point'
+        : 'Click to place'
+    }
+    return n === 0 ? 'Click the first point' : n === 1 ? 'Click the second point' : 'Click to set the offset'
+  })()
 
   function updateActiveSnap(nextSnap: ResolvedSnap | null) {
     activeSnapRef.current = nextSnap?.mode ? nextSnap : null
@@ -1048,7 +1098,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   // Redraw when measure/dimension transient state changes.
   useEffect(() => {
     scheduleDraw()
-  }, [tapeMeasure, pendingDimension, selectedAnnotationId, project.annotations])
+  }, [tapeMeasure, pendingDimension, dimensionDeleteArmed, selectedAnnotationId, project.annotations])
 
   useEffect(() => {
     scheduleDraw()
@@ -1978,7 +2028,10 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     // Permanent dimension annotations — resolved live so they follow geometry.
     // Hidden entirely when the project-level show-dimensions flag is off.
     if (project.meta.showDimensions) {
-      drawDimensions(ctx, project, vt, project.meta.units, { selectedId: selectedAnnotationIdRef.current })
+      drawDimensions(ctx, project, vt, project.meta.units, {
+        selectedId: selectedAnnotationIdRef.current,
+        deleteHoverId: dimensionDeleteArmedRef.current ? deleteHoverDimIdRef.current : null,
+      })
     }
 
     // Transient tape measure overlay.
@@ -2686,7 +2739,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     }
 
     // Measure/dimension placement is handled on click — don't start marquee here.
-    if (event.button === 0 && !pendingAddRef.current && (tapeMeasureRef.current || pendingDimensionRef.current)) {
+    if (event.button === 0 && !pendingAddRef.current && (tapeMeasureRef.current || pendingDimensionRef.current || dimensionDeleteArmedRef.current)) {
       return
     }
 
@@ -2808,6 +2861,16 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     const world = canvasToWorld(point.cx, point.cy, vt)
     livePointerWorldRef.current = world
     const sketchEditTool = selection.sketchEditTool
+
+    // ── Delete-dimension mode: highlight the dimension under the cursor ──
+    if (dimensionDeleteArmedRef.current) {
+      const hit = project.meta.showDimensions ? pickDimensionAt(project, vt, point, 8) : null
+      if (hit !== deleteHoverDimIdRef.current) {
+        deleteHoverDimIdRef.current = hit
+        scheduleDraw()
+      }
+      return
+    }
 
     // ── Dragging a dimension: update its offset to follow the cursor ──
     if (draggingDimensionIdRef.current) {
@@ -3390,6 +3453,18 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       excludeActiveEditGeometry: constraintRefPickingClick,
     })
     const pickedPoint = requiresResolvedSnapForPointPick() && !resolvedSnap.mode ? null : resolvedSnap.point
+
+    // ── Delete-dimension mode: click a dimension to remove it (stays armed) ──
+    if (!pendingAdd && dimensionDeleteArmedRef.current) {
+      if (project.meta.showDimensions) {
+        const hit = pickDimensionAt(project, vt, point, 8)
+        if (hit) {
+          deleteDimensionAnnotation(hit)
+          deleteHoverDimIdRef.current = null
+        }
+      }
+      return
+    }
 
     // ── Tape measure: each click sets/advances the transient measurement ──
     if (!pendingAdd && tapeMeasureRef.current) {
@@ -4202,6 +4277,11 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     if (event.key === 'Escape' && pendingDimensionRef.current) {
       event.preventDefault()
       cancelPendingDimension()
+      return
+    }
+    if (event.key === 'Escape' && dimensionDeleteArmedRef.current) {
+      event.preventDefault()
+      setDimensionDeleteArmed(false)
       return
     }
     if ((event.key === 'Delete' || event.key === 'Backspace') && selectedAnnotationIdRef.current) {
@@ -5801,6 +5881,54 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
               )}
             </>
           )}
+        </CanvasWorkflowPanel>
+      )}
+      {tapeMeasure && (
+        <CanvasWorkflowPanel
+          title="Tape measure"
+          step={tapeMeasure.first ? 'Click the second point' : 'Click the first point'}
+          position={tapeWorkflowPanel.position}
+          panelRef={tapeWorkflowPanel.panelRef}
+          handleProps={tapeWorkflowPanel.handleProps}
+          actions={(
+            <button type="button" className="tablet-cmd-btn tablet-cmd-btn--cancel" onClick={() => { clearTapeMeasure(); tapeWorkflowPanel.focusCanvasAfterAction() }}>Done</button>
+          )}
+        >
+          <div className="canvas-workflow-panel__summary">
+            Snaps to geometry. The measurement stays until your next click — Esc or Done to exit.
+          </div>
+        </CanvasWorkflowPanel>
+      )}
+      {pendingDimension && (
+        <CanvasWorkflowPanel
+          title={dimensionTitle}
+          step={dimensionStep}
+          position={dimensionWorkflowPanel.position}
+          panelRef={dimensionWorkflowPanel.panelRef}
+          handleProps={dimensionWorkflowPanel.handleProps}
+          actions={(
+            <button type="button" className="tablet-cmd-btn tablet-cmd-btn--cancel" onClick={() => { cancelPendingDimension(); dimensionWorkflowPanel.focusCanvasAfterAction() }}>Cancel</button>
+          )}
+        >
+          <div className="canvas-workflow-panel__summary">
+            Click points to anchor the dimension to geometry — it follows when features move. Esc to cancel.
+          </div>
+        </CanvasWorkflowPanel>
+      )}
+      {dimensionDeleteArmed && (
+        <CanvasWorkflowPanel
+          title="Delete dimension"
+          step="Click a dimension to delete"
+          position={dimensionDeleteWorkflowPanel.position}
+          panelRef={dimensionDeleteWorkflowPanel.panelRef}
+          handleProps={dimensionDeleteWorkflowPanel.handleProps}
+          actions={(
+            <button type="button" className="tablet-cmd-btn tablet-cmd-btn--confirm" onClick={() => { setDimensionDeleteArmed(false); dimensionDeleteWorkflowPanel.focusCanvasAfterAction() }}>Done</button>
+          )}
+        >
+          <div className="canvas-workflow-panel__summary">
+            Click each dimension you want to remove. Esc or Done to finish.
+          </div>
         </CanvasWorkflowPanel>
       )}
       {editModeActive && (

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -55,6 +55,8 @@ import {
 import type { DimensionEditState, OperationDimEdit } from './manualEntry'
 import { resolveSketchSnap } from './snappingHelpers'
 import type { ResolvedSnap } from './snappingHelpers'
+import { drawDimensions, drawPendingDimensionPreview, drawTapeMeasure, pickDimensionAt } from './dimensionRendering'
+import { offsetForCursor } from '../../sketch/dimensions'
 import {
   drawFeature,
   drawMoveGuide,
@@ -104,7 +106,7 @@ import {
   profileVertices,
   rectProfile,
 } from '../../types/project'
-import type { Clamp, Point, SketchFeature, Tab } from '../../types/project'
+import type { Clamp, DimensionAnchor, DimensionAnnotation, Point, SketchFeature, Tab } from '../../types/project'
 import { formatLength, parseLengthInput } from '../../utils/units'
 import { useAxisLock, lockModeGuideColor } from '../../sketch/useAxisLock'
 import { useCanvasGestures } from '../../sketch/useCanvasGestures'
@@ -268,6 +270,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const suppressClickRef = useRef(false)
   const originPreviewPointRef = useRef<PendingPreviewPoint | null>(null)
   const activeSnapRef = useRef<ResolvedSnap | null>(null)
+  const draggingDimensionIdRef = useRef<string | null>(null)
   const sketchEditPreviewRef = useRef<SketchEditPreviewPoint | null>(null)
   const pendingSketchExtensionRef = useRef<PendingSketchExtension | null>(null)
   const pendingSketchFilletRef = useRef<PendingSketchFillet | null>(null)
@@ -326,6 +329,17 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     pendingOffset,
     pendingShapeAction,
     pendingConstraint,
+    tapeMeasure,
+    pendingDimension,
+    selectedAnnotationId,
+    tapeMeasureClick,
+    clearTapeMeasure,
+    pendingDimensionPick,
+    cancelPendingDimension,
+    addDimensionAnnotation,
+    updateDimensionAnnotation,
+    deleteDimensionAnnotation,
+    selectAnnotation,
     creationTarget,
     selection,
     selectFeature,
@@ -427,6 +441,9 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const collidingClampIdsRef = useRef(collidingClampIds)
   const snapSettingsRef = useRef(snapSettings)
   const copyCountDraftRef = useRef(copyCountDraft)
+  const tapeMeasureRef = useRef(tapeMeasure)
+  const pendingDimensionRef = useRef(pendingDimension)
+  const selectedAnnotationIdRef = useRef(selectedAnnotationId)
 
   projectRef.current = project
   selectionRef.current = selection
@@ -444,6 +461,9 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   collidingClampIdsRef.current = collidingClampIds
   snapSettingsRef.current = snapSettings
   copyCountDraftRef.current = copyCountDraft
+  tapeMeasureRef.current = tapeMeasure
+  pendingDimensionRef.current = pendingDimension
+  selectedAnnotationIdRef.current = selectedAnnotationId
   dimensionEditRef.current = dimensionEdit
   constraintEditRef.current = constraintEdit
 
@@ -1024,6 +1044,11 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       onActiveSnapModeChange?.(null)
     }
   }, [onActiveSnapModeChange])
+
+  // Redraw when measure/dimension transient state changes.
+  useEffect(() => {
+    scheduleDraw()
+  }, [tapeMeasure, pendingDimension, selectedAnnotationId, project.annotations])
 
   useEffect(() => {
     scheduleDraw()
@@ -1950,6 +1975,23 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       }
     }
 
+    // Permanent dimension annotations — resolved live so they follow geometry.
+    drawDimensions(ctx, project, vt, project.meta.units, { selectedId: selectedAnnotationIdRef.current })
+
+    // Transient tape measure overlay.
+    const tape = tapeMeasureRef.current
+    if (tape) {
+      const liveTapePoint = activeSnapRef.current?.point ?? livePointerWorldRef.current
+      drawTapeMeasure(ctx, tape, liveTapePoint, vt, project.meta.units)
+    }
+
+    // In-progress permanent dimension: preview from picked anchors to cursor.
+    const pendingDim = pendingDimensionRef.current
+    if (pendingDim) {
+      const livePreviewPoint = activeSnapRef.current?.point ?? livePointerWorldRef.current
+      drawPendingDimensionPreview(ctx, pendingDim, livePreviewPoint, vt, project, project.meta.units)
+    }
+
     drawSnapIndicator(ctx, activeSnapRef.current, vt)
   }
 
@@ -2640,6 +2682,11 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       return
     }
 
+    // Measure/dimension placement is handled on click — don't start marquee here.
+    if (event.button === 0 && !pendingAddRef.current && (tapeMeasureRef.current || pendingDimensionRef.current)) {
+      return
+    }
+
     if (selection.mode === 'sketch_edit' && selection.sketchEditTool) {
       return
     }
@@ -2651,6 +2698,27 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
     const vt = computeViewTransform(project.stock, canvas.width, canvas.height, viewState)
     const world = canvasToWorld(point.cx, point.cy, vt)
+
+    // ── Begin dragging a dimension annotation to reposition it ──
+    if (
+      event.button === 0 && selection.mode === 'feature'
+      && !pendingAddRef.current && !pendingMoveRef.current && !pendingTransformRef.current
+      && !pendingOffset && !pendingShapeAction && !pendingConstraintRef.current
+      && !tapeMeasureRef.current && !pendingDimensionRef.current
+    ) {
+      const hitDim = pickDimensionAt(project, vt, point, 8)
+      if (hitDim) {
+        const dim = project.annotations.find((d) => d.id === hitDim)
+        if (dim && !dim.locked && offsetForCursor(dim, project, world) !== null) {
+          selectAnnotation(hitDim)
+          draggingDimensionIdRef.current = hitDim
+          beginHistoryTransaction()
+          suppressClickRef.current = true
+          return
+        }
+      }
+    }
+
     const control = hitEditableControl(point)
     const hitClampId = findHitClampId(world, project.clamps)
     const hitTabId = findHitTabId(world, project.tabs)
@@ -2737,6 +2805,19 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     livePointerWorldRef.current = world
     const sketchEditTool = selection.sketchEditTool
 
+    // ── Dragging a dimension: update its offset to follow the cursor ──
+    if (draggingDimensionIdRef.current) {
+      const dim = project.annotations.find((d) => d.id === draggingDimensionIdRef.current)
+      if (dim) {
+        const off = offsetForCursor(dim, project, world)
+        if (off !== null) {
+          updateDimensionAnnotation(dim.id, { offset: off })
+        }
+      }
+      scheduleDraw()
+      return
+    }
+
     if (touchDragPendingRef.current) {
       const pending = touchDragPendingRef.current
       const dx = point.cx - pending.canvasPoint.cx
@@ -2807,6 +2888,8 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         || !!pendingMove
         || !!pendingTransform
         || !!pendingOffset
+        || !!tapeMeasureRef.current
+        || !!pendingDimensionRef.current
         || (selection.mode === 'sketch_edit' && (sketchEditTool === 'add_point' || sketchEditTool === 'fillet'))
         || isDraggingNodeRef.current
         || constraintPicking
@@ -3130,6 +3213,13 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       return
     }
 
+    if (draggingDimensionIdRef.current) {
+      draggingDimensionIdRef.current = null
+      commitHistoryTransaction()
+      scheduleDraw()
+      return
+    }
+
     const canvas = canvasRef.current
     const project = projectRef.current
     const selection = selectionRef.current
@@ -3206,6 +3296,11 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     }
     longPressStartRef.current = null
     touchDragPendingRef.current = null
+
+    if (draggingDimensionIdRef.current) {
+      draggingDimensionIdRef.current = null
+      commitHistoryTransaction()
+    }
 
     const pendingAdd = pendingAddRef.current
     const pendingMove = pendingMoveRef.current
@@ -3291,6 +3386,67 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       excludeActiveEditGeometry: constraintRefPickingClick,
     })
     const pickedPoint = requiresResolvedSnapForPointPick() && !resolvedSnap.mode ? null : resolvedSnap.point
+
+    // ── Tape measure: each click sets/advances the transient measurement ──
+    if (!pendingAdd && tapeMeasureRef.current) {
+      tapeMeasureClick(resolvedSnap.point)
+      return
+    }
+
+    // ── Permanent dimension placement ──
+    const pendingDim = pendingAdd ? null : pendingDimensionRef.current
+    if (pendingDim) {
+      const anchor: DimensionAnchor = resolvedSnap.anchor ?? { kind: 'free', point: resolvedSnap.point }
+      const need = pendingDim.type === 'angle' ? 3 : 2
+      const picked = [pendingDim.a, pendingDim.b, pendingDim.c].filter(Boolean).length
+      if (picked < need) {
+        pendingDimensionPick(anchor)
+        return
+      }
+      // All anchors picked → this click chooses the offset and commits.
+      const temp: DimensionAnnotation = {
+        id: '__commit__',
+        type: pendingDim.type,
+        a: pendingDim.a!,
+        b: pendingDim.b ?? undefined,
+        c: pendingDim.c ?? undefined,
+        offset: 0,
+        visible: true,
+        locked: false,
+        textOverride: null,
+        precisionOverride: null,
+      }
+      const off = offsetForCursor(temp, project, world) ?? 0
+      addDimensionAnnotation({
+        type: pendingDim.type,
+        a: pendingDim.a!,
+        b: pendingDim.b ?? undefined,
+        c: pendingDim.c ?? undefined,
+        offset: off,
+        visible: true,
+        locked: false,
+        textOverride: null,
+        precisionOverride: null,
+      })
+      cancelPendingDimension()
+      return
+    }
+
+    // ── Select an existing dimension annotation (plain select mode) ──
+    if (
+      selection.mode === 'feature'
+      && !pendingAdd && !pendingMove && !pendingTransform && !pendingOffset
+      && !pendingShapeAction && !pendingConstraint
+    ) {
+      const hitDim = pickDimensionAt(project, vt, point, 8)
+      if (hitDim) {
+        selectAnnotation(hitDim)
+        return
+      }
+      if (selectedAnnotationIdRef.current) {
+        selectAnnotation(null)
+      }
+    }
 
     if (pendingConstraint && !pendingConstraint.anchor) {
       if (!pickedPoint) {
@@ -4031,6 +4187,23 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     const pendingOffset = pendingOffsetRef.current
     const pendingShapeAction = pendingShapeActionRef.current
     const viewState = viewStateRef.current
+
+    // ── Measure & dimension tools ──
+    if (event.key === 'Escape' && tapeMeasureRef.current) {
+      event.preventDefault()
+      clearTapeMeasure()
+      return
+    }
+    if (event.key === 'Escape' && pendingDimensionRef.current) {
+      event.preventDefault()
+      cancelPendingDimension()
+      return
+    }
+    if ((event.key === 'Delete' || event.key === 'Backspace') && selectedAnnotationIdRef.current) {
+      event.preventDefault()
+      deleteDimensionAnnotation(selectedAnnotationIdRef.current)
+      return
+    }
 
     if (event.key === 'Tab' && pendingAdd) {
       const currentEdit = dimensionEditRef.current

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -1976,7 +1976,10 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     }
 
     // Permanent dimension annotations — resolved live so they follow geometry.
-    drawDimensions(ctx, project, vt, project.meta.units, { selectedId: selectedAnnotationIdRef.current })
+    // Hidden entirely when the project-level show-dimensions flag is off.
+    if (project.meta.showDimensions) {
+      drawDimensions(ctx, project, vt, project.meta.units, { selectedId: selectedAnnotationIdRef.current })
+    }
 
     // Transient tape measure overlay.
     const tape = tapeMeasureRef.current
@@ -2705,6 +2708,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       && !pendingAddRef.current && !pendingMoveRef.current && !pendingTransformRef.current
       && !pendingOffset && !pendingShapeAction && !pendingConstraintRef.current
       && !tapeMeasureRef.current && !pendingDimensionRef.current
+      && project.meta.showDimensions
     ) {
       const hitDim = pickDimensionAt(project, vt, point, 8)
       if (hitDim) {
@@ -3437,6 +3441,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       selection.mode === 'feature'
       && !pendingAdd && !pendingMove && !pendingTransform && !pendingOffset
       && !pendingShapeAction && !pendingConstraint
+      && project.meta.showDimensions
     ) {
       const hitDim = pickDimensionAt(project, vt, point, 8)
       if (hitDim) {

--- a/src/components/canvas/dimensionRendering.ts
+++ b/src/components/canvas/dimensionRendering.ts
@@ -124,9 +124,10 @@ export function drawDimensions(
   project: Project,
   vt: ViewTransform,
   units: Units,
-  opts?: { selectedId?: string | null },
+  opts?: { selectedId?: string | null; deleteHoverId?: string | null },
 ): void {
   const selectedId = opts?.selectedId ?? null
+  const deleteHoverId = opts?.deleteHoverId ?? null
   const lenFmt = fmtLen(units)
 
   for (const dim of project.annotations) {
@@ -154,7 +155,9 @@ export function drawDimensions(
     const value = measureValue(dim, project)
     if (value === null) continue
     const labelText = dimensionLabelText(dim, value, lenFmt, formatAngle)
-    const color = dim.id === selectedId ? SELECTED_COLOR : LINE_COLOR
+    const color = dim.id === deleteHoverId
+      ? WARNING_COLOR
+      : dim.id === selectedId ? SELECTED_COLOR : LINE_COLOR
     drawLayout(ctx, layout, vt, units, labelText, color)
   }
 }

--- a/src/components/canvas/dimensionRendering.ts
+++ b/src/components/canvas/dimensionRendering.ts
@@ -237,8 +237,11 @@ export function drawPendingDimensionPreview(
   const picked = [pending.a, pending.b, pending.c].filter(Boolean).length
 
   if (picked < need) {
-    // Rubber-band from the last picked anchor to the cursor.
-    const last = c ?? b ?? a
+    // Rubber-band to the cursor from the most relevant anchor: for angle
+    // dimensions both rays emanate from the vertex (a), so always anchor there
+    // once it is picked. For other types the trailing line just follows the
+    // most recently placed anchor.
+    const last = pending.type === 'angle' ? (a ?? c ?? b) : (c ?? b ?? a)
     if (last && livePoint) {
       ctx.save()
       ctx.strokeStyle = ACTIVE_COLOR

--- a/src/components/canvas/dimensionRendering.ts
+++ b/src/components/canvas/dimensionRendering.ts
@@ -1,0 +1,312 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Canvas rendering + hit-testing for permanent dimension annotations and the
+ * transient tape measure. Pure geometry/value logic lives in
+ * `src/sketch/dimensions.ts`; this module turns a layout into pixels.
+ */
+
+import type { Point, Project } from '../../types/project'
+import type { Units } from '../../utils/units'
+import { formatAngle, formatLength } from '../../utils/units'
+import {
+  dimensionLabelText,
+  dimensionLayout,
+  isDimensionDangling,
+  measureValue,
+  offsetForCursor,
+  resolveAnchor,
+} from '../../sketch/dimensions'
+import type { DimensionLayout } from '../../sketch/dimensions'
+import type { DimensionAnnotation, DimensionAnchor } from '../../types/project'
+import { drawMeasurementLabel } from './measurements'
+import { worldToCanvas } from './viewTransform'
+import type { CanvasPoint, ViewTransform } from './viewTransform'
+
+const ACTIVE_COLOR = 'rgba(239, 188, 122, 0.95)'
+const LINE_COLOR = 'rgba(180, 200, 224, 0.85)'
+const EXT_COLOR = 'rgba(180, 200, 224, 0.45)'
+const SELECTED_COLOR = 'rgba(120, 200, 255, 0.98)'
+const WARNING_COLOR = 'rgba(240, 120, 120, 0.9)'
+const ARROW_PX = 7
+
+function fmtLen(units: Units): (v: number) => string {
+  return (v: number) => formatLength(v, units)
+}
+
+function lineTo(ctx: CanvasRenderingContext2D, a: CanvasPoint, b: CanvasPoint): void {
+  ctx.beginPath()
+  ctx.moveTo(a.cx, a.cy)
+  ctx.lineTo(b.cx, b.cy)
+  ctx.stroke()
+}
+
+/** Draw a filled arrowhead at `tip`, pointing away from `from`. */
+function drawArrow(ctx: CanvasRenderingContext2D, tip: CanvasPoint, from: CanvasPoint, color: string): void {
+  const dx = tip.cx - from.cx
+  const dy = tip.cy - from.cy
+  const len = Math.hypot(dx, dy)
+  if (len < 1e-3) return
+  const ux = dx / len
+  const uy = dy / len
+  const baseX = tip.cx - ux * ARROW_PX
+  const baseY = tip.cy - uy * ARROW_PX
+  const nx = -uy
+  const ny = ux
+  const half = ARROW_PX * 0.42
+  ctx.fillStyle = color
+  ctx.beginPath()
+  ctx.moveTo(tip.cx, tip.cy)
+  ctx.lineTo(baseX + nx * half, baseY + ny * half)
+  ctx.lineTo(baseX - nx * half, baseY - ny * half)
+  ctx.closePath()
+  ctx.fill()
+}
+
+function drawLayout(
+  ctx: CanvasRenderingContext2D,
+  layout: DimensionLayout,
+  vt: ViewTransform,
+  units: Units,
+  labelText: string,
+  color: string,
+): void {
+  const start = worldToCanvas(layout.lineStart, vt)
+  const end = worldToCanvas(layout.lineEnd, vt)
+
+  // Extension/witness lines
+  ctx.strokeStyle = EXT_COLOR
+  ctx.lineWidth = 1
+  for (const [from, to] of layout.extensions) {
+    lineTo(ctx, worldToCanvas(from, vt), worldToCanvas(to, vt))
+  }
+
+  // Dimension line
+  ctx.strokeStyle = color
+  ctx.lineWidth = 1.25
+  if (layout.type === 'angle' && layout.vertex && layout.startAngle !== undefined && layout.endAngle !== undefined) {
+    const vc = worldToCanvas(layout.vertex, vt)
+    const radiusPx = Math.hypot(start.cx - vc.cx, start.cy - vc.cy)
+    let delta = layout.endAngle - layout.startAngle
+    while (delta <= -Math.PI) delta += Math.PI * 2
+    while (delta > Math.PI) delta -= Math.PI * 2
+    ctx.beginPath()
+    ctx.arc(vc.cx, vc.cy, radiusPx, layout.startAngle, layout.startAngle + delta, delta < 0)
+    ctx.stroke()
+  } else {
+    lineTo(ctx, start, end)
+    drawArrow(ctx, start, end, color)
+    drawArrow(ctx, end, start, color)
+  }
+
+  const labelCanvas = worldToCanvas(layout.labelPos, vt)
+  drawMeasurementLabel(ctx, labelText, labelCanvas.cx, labelCanvas.cy, layout.labelAngle)
+  void units
+}
+
+/** Draw all persistent dimension annotations. */
+export function drawDimensions(
+  ctx: CanvasRenderingContext2D,
+  project: Project,
+  vt: ViewTransform,
+  units: Units,
+  opts?: { selectedId?: string | null },
+): void {
+  const selectedId = opts?.selectedId ?? null
+  const lenFmt = fmtLen(units)
+
+  for (const dim of project.annotations) {
+    if (!dim.visible) continue
+
+    if (isDimensionDangling(dim, project)) {
+      // Dangling: draw a warning marker at whatever anchor still resolves.
+      const fallback = resolveAnchor(dim.a, project)
+        ?? (dim.b ? resolveAnchor(dim.b, project) : null)
+      if (fallback) {
+        const c = worldToCanvas(fallback, vt)
+        ctx.strokeStyle = WARNING_COLOR
+        ctx.fillStyle = WARNING_COLOR
+        ctx.lineWidth = 1.5
+        ctx.beginPath()
+        ctx.arc(c.cx, c.cy, 5, 0, Math.PI * 2)
+        ctx.stroke()
+        drawMeasurementLabel(ctx, '⚠ dim', c.cx + 22, c.cy, 0)
+      }
+      continue
+    }
+
+    const layout = dimensionLayout(dim, project)
+    if (!layout) continue
+    const value = measureValue(dim, project)
+    if (value === null) continue
+    const labelText = dimensionLabelText(dim, value, lenFmt, formatAngle)
+    const color = dim.id === selectedId ? SELECTED_COLOR : LINE_COLOR
+    drawLayout(ctx, layout, vt, units, labelText, color)
+  }
+}
+
+/** Draw the transient tape-measure overlay (in-progress + frozen). */
+export function drawTapeMeasure(
+  ctx: CanvasRenderingContext2D,
+  tape: { first: Point | null; frozen: { a: Point; b: Point } | null },
+  livePoint: Point | null,
+  vt: ViewTransform,
+  units: Units,
+): void {
+  const drawSpan = (a: Point, b: Point, dashed: boolean): void => {
+    const ca = worldToCanvas(a, vt)
+    const cb = worldToCanvas(b, vt)
+    ctx.save()
+    ctx.strokeStyle = ACTIVE_COLOR
+    ctx.lineWidth = 1.25
+    if (dashed) ctx.setLineDash([5, 4])
+    lineTo(ctx, ca, cb)
+    ctx.restore()
+    drawArrow(ctx, ca, cb, ACTIVE_COLOR)
+    drawArrow(ctx, cb, ca, ACTIVE_COLOR)
+
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const dist = Math.hypot(dx, dy)
+    const angle = Math.abs((Math.atan2(dy, dx) * 180) / Math.PI)
+    const text = `${formatLength(dist, units)}  ·  Δx ${formatLength(Math.abs(dx), units)}  Δy ${formatLength(Math.abs(dy), units)}  ·  ${formatAngle(angle)}`
+    const mid = { cx: (ca.cx + cb.cx) / 2, cy: (ca.cy + cb.cy) / 2 }
+    drawMeasurementLabel(ctx, text, mid.cx, mid.cy - 16, 0)
+  }
+
+  if (tape.frozen) {
+    drawSpan(tape.frozen.a, tape.frozen.b, false)
+  }
+  if (tape.first && livePoint) {
+    drawSpan(tape.first, livePoint, true)
+  } else if (tape.first) {
+    const c = worldToCanvas(tape.first, vt)
+    ctx.fillStyle = ACTIVE_COLOR
+    ctx.beginPath()
+    ctx.arc(c.cx, c.cy, 4, 0, Math.PI * 2)
+    ctx.fill()
+  }
+}
+
+/**
+ * Preview the in-progress permanent-dimension placement. Draws picked anchor
+ * dots, a rubber-band to the cursor while collecting anchors, and — once enough
+ * anchors are picked — a live preview of the dimension with the cursor-driven
+ * offset (the offset-pick phase).
+ */
+export function drawPendingDimensionPreview(
+  ctx: CanvasRenderingContext2D,
+  pending: { type: DimensionAnnotation['type']; a: DimensionAnchor | null; b: DimensionAnchor | null; c: DimensionAnchor | null },
+  livePoint: Point | null,
+  vt: ViewTransform,
+  project: Project,
+  units: Units,
+): void {
+  const dot = (p: Point): void => {
+    const c = worldToCanvas(p, vt)
+    ctx.fillStyle = ACTIVE_COLOR
+    ctx.beginPath()
+    ctx.arc(c.cx, c.cy, 4, 0, Math.PI * 2)
+    ctx.fill()
+  }
+  const a = pending.a ? resolveAnchor(pending.a, project) : null
+  const b = pending.b ? resolveAnchor(pending.b, project) : null
+  const c = pending.c ? resolveAnchor(pending.c, project) : null
+  if (a) dot(a)
+  if (b) dot(b)
+  if (c) dot(c)
+
+  const need = pending.type === 'angle' ? 3 : 2
+  const picked = [pending.a, pending.b, pending.c].filter(Boolean).length
+
+  if (picked < need) {
+    // Rubber-band from the last picked anchor to the cursor.
+    const last = c ?? b ?? a
+    if (last && livePoint) {
+      ctx.save()
+      ctx.strokeStyle = ACTIVE_COLOR
+      ctx.lineWidth = 1
+      ctx.setLineDash([5, 4])
+      lineTo(ctx, worldToCanvas(last, vt), worldToCanvas(livePoint, vt))
+      ctx.restore()
+    }
+    return
+  }
+
+  // Offset-pick phase: synthesize a temp dimension and preview it at the cursor.
+  if (!livePoint) return
+  const temp: DimensionAnnotation = {
+    id: '__preview__',
+    type: pending.type,
+    a: pending.a!,
+    b: pending.b ?? undefined,
+    c: pending.c ?? undefined,
+    offset: 0,
+    visible: true,
+    locked: false,
+    textOverride: null,
+    precisionOverride: null,
+  }
+  const offset = offsetForCursor(temp, project, livePoint)
+  if (offset !== null) temp.offset = offset
+  const layout = dimensionLayout(temp, project)
+  const value = measureValue(temp, project)
+  if (layout && value !== null) {
+    drawLayout(ctx, layout, vt, units, dimensionLabelText(temp, value, fmtLen(units), formatAngle), ACTIVE_COLOR)
+  }
+}
+
+/**
+ * Hit-test the dimension annotations at a canvas point. Returns the id of the
+ * nearest dimension whose line or label is within `tolerancePx`, or null.
+ */
+export function pickDimensionAt(
+  project: Project,
+  vt: ViewTransform,
+  point: CanvasPoint,
+  tolerancePx = 8,
+): string | null {
+  let bestId: string | null = null
+  let bestDist = tolerancePx
+
+  for (const dim of project.annotations) {
+    if (!dim.visible) continue
+    const layout = dimensionLayout(dim, project)
+    if (!layout) continue
+    const a = worldToCanvas(layout.lineStart, vt)
+    const b = worldToCanvas(layout.lineEnd, vt)
+    const dLine = distanceToSegment(point, a, b)
+    const labelC = worldToCanvas(layout.labelPos, vt)
+    const dLabel = Math.hypot(point.cx - labelC.cx, point.cy - labelC.cy)
+    const d = Math.min(dLine, dLabel)
+    if (d <= bestDist) {
+      bestDist = d
+      bestId = dim.id
+    }
+  }
+  return bestId
+}
+
+function distanceToSegment(p: CanvasPoint, a: CanvasPoint, b: CanvasPoint): number {
+  const dx = b.cx - a.cx
+  const dy = b.cy - a.cy
+  const lenSq = dx * dx + dy * dy
+  if (lenSq < 1e-6) return Math.hypot(p.cx - a.cx, p.cy - a.cy)
+  let t = ((p.cx - a.cx) * dx + (p.cy - a.cy) * dy) / lenSq
+  t = Math.max(0, Math.min(1, t))
+  return Math.hypot(p.cx - (a.cx + t * dx), p.cy - (a.cy + t * dy))
+}

--- a/src/components/canvas/snappingHelpers.ts
+++ b/src/components/canvas/snappingHelpers.ts
@@ -16,7 +16,7 @@
 
 import type { SnapMode, SnapSettings } from '../../sketch/snapping'
 import { profileVertices, rectProfile } from '../../types/project'
-import type { Point, Project, SketchProfile } from '../../types/project'
+import type { AnchorTarget, DimensionAnchor, Point, Project, SketchProfile } from '../../types/project'
 import { distance2 } from './hitTest'
 import {
   nearestPointOnPolyline,
@@ -41,6 +41,10 @@ interface SnapCandidate {
   priority: number
   guide?: SnapGuide
   perpendicularSegment?: { a: Point; b: Point }
+  // Provenance: what geometry produced this snap, so a dimension placed here can
+  // anchor to it and follow the geometry when it moves. Absent for grid/line/
+  // perpendicular snaps (no stable geometry identity).
+  anchor?: DimensionAnchor
 }
 
 export interface ResolvedSnap {
@@ -49,6 +53,8 @@ export interface ResolvedSnap {
   mode: SnapMode | null
   guide?: SnapGuide
   perpendicularSegment?: { a: Point; b: Point }
+  /** Anchor describing the snapped geometry, when the snap has stable identity. */
+  anchor?: DimensionAnchor
 }
 
 function distanceToCanvas(a: { cx: number; cy: number }, b: { cx: number; cy: number }): number {
@@ -84,6 +90,7 @@ function pushSnapCandidate(
   point: Point,
   guide?: SnapGuide,
   perpendicularSegment?: { a: Point; b: Point },
+  anchor?: DimensionAnchor,
 ) {
   const distancePx = distanceToCanvas(worldToCanvas(rawPoint, vt), worldToCanvas(point, vt))
   if (distancePx > snapRadiusPx) {
@@ -97,6 +104,7 @@ function pushSnapCandidate(
     priority: snapPriority(mode),
     guide,
     perpendicularSegment,
+    anchor,
   })
 }
 
@@ -108,11 +116,15 @@ function addProfileSnapCandidates(
   snapRadiusPx: number,
   activeModes: Set<SnapMode>,
   referencePoint: Point | null,
+  source: AnchorTarget | null = null,
 ) {
   const vertices = profileVertices(profile)
   if (activeModes.has('point')) {
-    for (const vertex of vertices) {
-      pushSnapCandidate(candidates, rawPoint, vt, snapRadiusPx, 'point', vertex)
+    for (let v = 0; v < vertices.length; v += 1) {
+      const anchor: DimensionAnchor | undefined = source
+        ? { kind: 'vertex', target: source, vertexIndex: v }
+        : undefined
+      pushSnapCandidate(candidates, rawPoint, vt, snapRadiusPx, 'point', vertices[v], undefined, undefined, anchor)
     }
   }
 
@@ -121,11 +133,17 @@ function addProfileSnapCandidates(
     const segment = profile.segments[index]
 
     if (activeModes.has('midpoint')) {
-      pushSnapCandidate(candidates, rawPoint, vt, snapRadiusPx, 'midpoint', segmentMidpoint(start, segment))
+      const anchor: DimensionAnchor | undefined = source
+        ? { kind: 'midpoint', target: source, segmentIndex: index }
+        : undefined
+      pushSnapCandidate(candidates, rawPoint, vt, snapRadiusPx, 'midpoint', segmentMidpoint(start, segment), undefined, undefined, anchor)
     }
 
     if (activeModes.has('center') && (segment.type === 'arc' || segment.type === 'circle')) {
-      pushSnapCandidate(candidates, rawPoint, vt, snapRadiusPx, 'center', segment.center)
+      const anchor: DimensionAnchor | undefined = source
+        ? { kind: 'center', target: source, segmentIndex: index }
+        : undefined
+      pushSnapCandidate(candidates, rawPoint, vt, snapRadiusPx, 'center', segment.center, undefined, undefined, anchor)
     }
 
     if (!activeModes.has('line') && !(activeModes.has('perpendicular') && referencePoint)) {
@@ -228,13 +246,13 @@ export function resolveSketchSnap(input: {
     pushSnapCandidate(candidates, rawPoint, vt, snapRadiusPx, 'grid', gridPoint)
   }
 
-  addProfileSnapCandidates(candidates, project.stock.profile, rawPoint, vt, snapRadiusPx, activeModes, referencePoint)
+  addProfileSnapCandidates(candidates, project.stock.profile, rawPoint, vt, snapRadiusPx, activeModes, referencePoint, { source: 'stock' })
 
   for (const feature of project.features) {
     if (!feature.visible || feature.id === excludeFeatureId) {
       continue
     }
-    addProfileSnapCandidates(candidates, feature.sketch.profile, rawPoint, vt, snapRadiusPx, activeModes, referencePoint)
+    addProfileSnapCandidates(candidates, feature.sketch.profile, rawPoint, vt, snapRadiusPx, activeModes, referencePoint, { source: 'feature', featureId: feature.id })
   }
 
   for (const tab of project.tabs) {
@@ -252,7 +270,7 @@ export function resolveSketchSnap(input: {
   }
 
   if (activeModes.has('point') && project.origin.visible) {
-    pushSnapCandidate(candidates, rawPoint, vt, snapRadiusPx, 'point', { x: project.origin.x, y: project.origin.y })
+    pushSnapCandidate(candidates, rawPoint, vt, snapRadiusPx, 'point', { x: project.origin.x, y: project.origin.y }, undefined, undefined, { kind: 'origin' })
   }
 
   if (candidates.length === 0) {
@@ -271,5 +289,6 @@ export function resolveSketchSnap(input: {
     mode: best.mode,
     guide: best.guide,
     perpendicularSegment: best.perpendicularSegment,
+    anchor: best.anchor,
   }
 }

--- a/src/components/canvas/snappingHelpers.ts
+++ b/src/components/canvas/snappingHelpers.ts
@@ -81,6 +81,13 @@ function snapValue(value: number, step: number): number {
   return Math.round(value / step) * step
 }
 
+function normalizeAngle(rad: number): number {
+  let v = rad
+  while (v <= -Math.PI) v += Math.PI * 2
+  while (v > Math.PI) v -= Math.PI * 2
+  return v
+}
+
 function pushSnapCandidate(
   candidates: SnapCandidate[],
   rawPoint: Point,
@@ -153,6 +160,15 @@ function addProfileSnapCandidates(
     if (segment.type === 'line') {
       if (activeModes.has('line')) {
         const projected = projectPointOntoSegment(rawPoint, start, segment.to)
+        const dx = segment.to.x - start.x
+        const dy = segment.to.y - start.y
+        const lenSq = dx * dx + dy * dy
+        const t = lenSq > 1e-9
+          ? Math.max(0, Math.min(1, ((projected.x - start.x) * dx + (projected.y - start.y) * dy) / lenSq))
+          : 0
+        const anchor: DimensionAnchor | undefined = source
+          ? { kind: 'segmentPoint', target: source, segmentIndex: index, t }
+          : undefined
         pushSnapCandidate(
           candidates,
           rawPoint,
@@ -161,6 +177,8 @@ function addProfileSnapCandidates(
           'line',
           projected,
           { kind: 'projection', from: rawPoint, to: projected },
+          undefined,
+          anchor,
         )
       }
       if (activeModes.has('perpendicular') && referencePoint) {
@@ -183,6 +201,18 @@ function addProfileSnapCandidates(
 
     if (activeModes.has('line')) {
       const projected = nearestPointOnPolyline(rawPoint, polyline)
+      const anchor: DimensionAnchor | undefined =
+        source && (segment.type === 'arc' || segment.type === 'circle')
+          ? {
+              kind: 'circleEdge',
+              target: source,
+              segmentIndex: index,
+              relativeAngle: normalizeAngle(
+                Math.atan2(projected.y - segment.center.y, projected.x - segment.center.x)
+                  - Math.atan2(start.y - segment.center.y, start.x - segment.center.x),
+              ),
+            }
+          : undefined
       pushSnapCandidate(
         candidates,
         rawPoint,
@@ -191,6 +221,8 @@ function addProfileSnapCandidates(
         'line',
         projected,
         { kind: 'projection', from: rawPoint, to: projected },
+        undefined,
+        anchor,
       )
     }
 

--- a/src/components/layout/DimensionPopover.tsx
+++ b/src/components/layout/DimensionPopover.tsx
@@ -41,10 +41,12 @@ export function DimensionPopover() {
   const showDimensions = useProjectStore((s) => s.project.meta.showDimensions)
   const setShowDimensions = useProjectStore((s) => s.setShowDimensions)
   const dimensionCount = useProjectStore((s) => s.project.annotations.length)
+  const dimensionDeleteArmed = useProjectStore((s) => s.dimensionDeleteArmed)
+  const setDimensionDeleteArmed = useProjectStore((s) => s.setDimensionDeleteArmed)
 
   const tapeActive = tapeMeasure !== null
   const dimType = pendingDimension?.type ?? null
-  const anyActive = tapeActive || pendingDimension !== null
+  const anyActive = tapeActive || pendingDimension !== null || dimensionDeleteArmed
 
   useEffect(() => {
     if (!open) return
@@ -108,6 +110,15 @@ export function DimensionPopover() {
               onClick={() => setShowDimensions(!showDimensions)}
             >
               {showDimensions ? 'Dimensions shown' : 'Dimensions hidden'}
+            </button>
+            <button
+              className={`snap-popover-enable-btn ${dimensionDeleteArmed ? 'snap-popover-enable-btn--active' : ''}`}
+              type="button"
+              aria-pressed={dimensionDeleteArmed}
+              disabled={dimensionCount === 0}
+              onClick={() => setDimensionDeleteArmed(!dimensionDeleteArmed)}
+            >
+              {dimensionDeleteArmed ? 'Click a dimension…' : 'Delete dimension'}
             </button>
           </div>
           <div className="snap-popover-grid">

--- a/src/components/layout/DimensionPopover.tsx
+++ b/src/components/layout/DimensionPopover.tsx
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { useProjectStore } from '../../store/projectStore'
+import type { DimensionType } from '../../types/project'
+
+const DIMENSION_TYPES: { type: DimensionType; label: string; hint: string }[] = [
+  { type: 'aligned', label: 'Aligned', hint: 'Parallel distance between two points' },
+  { type: 'horizontal', label: 'Horizontal', hint: 'Horizontal distance (Δx)' },
+  { type: 'vertical', label: 'Vertical', hint: 'Vertical distance (Δy)' },
+  { type: 'radius', label: 'Radius', hint: 'Radius of an arc/circle' },
+  { type: 'diameter', label: 'Diameter', hint: 'Diameter of an arc/circle' },
+  { type: 'angle', label: 'Angle', hint: 'Angle at a vertex between two points' },
+]
+
+/** Small inline ruler glyph so we don't depend on the icon sprite pipeline. */
+function RulerGlyph() {
+  return (
+    <svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6}>
+      <rect x={2.5} y={7} width={19} height={10} rx={1.5} />
+      <path d="M6.5 7v3M10 7v4M13.5 7v3M17 7v4" />
+    </svg>
+  )
+}
+
+export function DimensionPopover() {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  const tapeMeasure = useProjectStore((s) => s.tapeMeasure)
+  const pendingDimension = useProjectStore((s) => s.pendingDimension)
+  const startTapeMeasure = useProjectStore((s) => s.startTapeMeasure)
+  const clearTapeMeasure = useProjectStore((s) => s.clearTapeMeasure)
+  const startDimensionTool = useProjectStore((s) => s.startDimensionTool)
+  const cancelPendingDimension = useProjectStore((s) => s.cancelPendingDimension)
+
+  const tapeActive = tapeMeasure !== null
+  const dimType = pendingDimension?.type ?? null
+  const anyActive = tapeActive || pendingDimension !== null
+
+  useEffect(() => {
+    if (!open) return
+    function handlePointerDown(event: PointerEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  function toggleTape() {
+    if (tapeActive) clearTapeMeasure()
+    else startTapeMeasure()
+  }
+
+  function pickType(type: DimensionType) {
+    if (dimType === type) cancelPendingDimension()
+    else startDimensionTool(type)
+  }
+
+  return (
+    <div className="snap-popover-host" ref={containerRef}>
+      <div className="toolbar-action">
+        <button
+          className={`toolbar-icon-btn ${anyActive ? 'toolbar-icon-btn--active' : ''}`}
+          type="button"
+          aria-label="Measure and dimensions"
+          aria-expanded={open}
+          onClick={() => setOpen((prev) => !prev)}
+        >
+          <RulerGlyph />
+        </button>
+        <span className="toolbar-tooltip toolbar-tooltip--bottom" role="tooltip">
+          Measure &amp; dimensions
+        </span>
+      </div>
+      {open && (
+        <div className="snap-popover" role="menu">
+          <div className="snap-popover-header">
+            <button
+              className={`snap-popover-enable-btn ${tapeActive ? 'snap-popover-enable-btn--active' : ''}`}
+              type="button"
+              onClick={toggleTape}
+            >
+              {tapeActive ? 'Tape measure on' : 'Tape measure'}
+            </button>
+          </div>
+          <div className="snap-popover-grid">
+            {DIMENSION_TYPES.map(({ type, label, hint }) => {
+              const active = dimType === type
+              return (
+                <button
+                  key={type}
+                  className={`snap-popover-item ${active ? 'snap-popover-item--active' : ''}`}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={active}
+                  aria-label={hint}
+                  title={hint}
+                  onClick={() => pickType(type)}
+                >
+                  <span className="snap-popover-item-label">{label}</span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/layout/DimensionPopover.tsx
+++ b/src/components/layout/DimensionPopover.tsx
@@ -15,27 +15,18 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
+import { Icon } from '../Icon'
 import { useProjectStore } from '../../store/projectStore'
 import type { DimensionType } from '../../types/project'
 
-const DIMENSION_TYPES: { type: DimensionType; label: string; hint: string }[] = [
-  { type: 'aligned', label: 'Aligned', hint: 'Parallel distance between two points' },
-  { type: 'horizontal', label: 'Horizontal', hint: 'Horizontal distance (Δx)' },
-  { type: 'vertical', label: 'Vertical', hint: 'Vertical distance (Δy)' },
-  { type: 'radius', label: 'Radius', hint: 'Radius of an arc/circle' },
-  { type: 'diameter', label: 'Diameter', hint: 'Diameter of an arc/circle' },
-  { type: 'angle', label: 'Angle', hint: 'Angle at a vertex between two points' },
+const DIMENSION_TYPES: { type: DimensionType; icon: string; label: string; hint: string }[] = [
+  { type: 'aligned', icon: 'dim-aligned', label: 'Aligned', hint: 'Parallel distance between two points' },
+  { type: 'horizontal', icon: 'dim-horizontal', label: 'Horizontal', hint: 'Horizontal distance (Δx)' },
+  { type: 'vertical', icon: 'dim-vertical', label: 'Vertical', hint: 'Vertical distance (Δy)' },
+  { type: 'radius', icon: 'dim-radius', label: 'Radius', hint: 'Radius of an arc/circle' },
+  { type: 'diameter', icon: 'dim-diameter', label: 'Diameter', hint: 'Diameter of an arc/circle' },
+  { type: 'angle', icon: 'dim-angle', label: 'Angle', hint: 'Angle at a vertex between two points' },
 ]
-
-/** Small inline ruler glyph so we don't depend on the icon sprite pipeline. */
-function RulerGlyph() {
-  return (
-    <svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6}>
-      <rect x={2.5} y={7} width={19} height={10} rx={1.5} />
-      <path d="M6.5 7v3M10 7v4M13.5 7v3M17 7v4" />
-    </svg>
-  )
-}
 
 export function DimensionPopover() {
   const [open, setOpen] = useState(false)
@@ -47,6 +38,9 @@ export function DimensionPopover() {
   const clearTapeMeasure = useProjectStore((s) => s.clearTapeMeasure)
   const startDimensionTool = useProjectStore((s) => s.startDimensionTool)
   const cancelPendingDimension = useProjectStore((s) => s.cancelPendingDimension)
+  const showDimensions = useProjectStore((s) => s.project.meta.showDimensions)
+  const setShowDimensions = useProjectStore((s) => s.setShowDimensions)
+  const dimensionCount = useProjectStore((s) => s.project.annotations.length)
 
   const tapeActive = tapeMeasure !== null
   const dimType = pendingDimension?.type ?? null
@@ -90,7 +84,7 @@ export function DimensionPopover() {
           aria-expanded={open}
           onClick={() => setOpen((prev) => !prev)}
         >
-          <RulerGlyph />
+          <Icon id="measure" />
         </button>
         <span className="toolbar-tooltip toolbar-tooltip--bottom" role="tooltip">
           Measure &amp; dimensions
@@ -106,9 +100,18 @@ export function DimensionPopover() {
             >
               {tapeActive ? 'Tape measure on' : 'Tape measure'}
             </button>
+            <button
+              className={`snap-popover-enable-btn ${showDimensions ? 'snap-popover-enable-btn--active' : ''}`}
+              type="button"
+              aria-pressed={showDimensions}
+              title={dimensionCount > 0 ? `${dimensionCount} dimension${dimensionCount === 1 ? '' : 's'}` : 'No dimensions yet'}
+              onClick={() => setShowDimensions(!showDimensions)}
+            >
+              {showDimensions ? 'Dimensions shown' : 'Dimensions hidden'}
+            </button>
           </div>
           <div className="snap-popover-grid">
-            {DIMENSION_TYPES.map(({ type, label, hint }) => {
+            {DIMENSION_TYPES.map(({ type, icon, label, hint }) => {
               const active = dimType === type
               return (
                 <button
@@ -121,6 +124,7 @@ export function DimensionPopover() {
                   title={hint}
                   onClick={() => pickType(type)}
                 >
+                  <Icon id={icon} />
                   <span className="snap-popover-item-label">{label}</span>
                 </button>
               )

--- a/src/components/layout/DimensionPopover.tsx
+++ b/src/components/layout/DimensionPopover.tsx
@@ -19,13 +19,13 @@ import { Icon } from '../Icon'
 import { useProjectStore } from '../../store/projectStore'
 import type { DimensionType } from '../../types/project'
 
-const DIMENSION_TYPES: { type: DimensionType; icon: string; label: string; hint: string }[] = [
-  { type: 'aligned', icon: 'dim-aligned', label: 'Aligned', hint: 'Parallel distance between two points' },
-  { type: 'horizontal', icon: 'dim-horizontal', label: 'Horizontal', hint: 'Horizontal distance (Δx)' },
-  { type: 'vertical', icon: 'dim-vertical', label: 'Vertical', hint: 'Vertical distance (Δy)' },
-  { type: 'radius', icon: 'dim-radius', label: 'Radius', hint: 'Radius of an arc/circle' },
-  { type: 'diameter', icon: 'dim-diameter', label: 'Diameter', hint: 'Diameter of an arc/circle' },
-  { type: 'angle', icon: 'dim-angle', label: 'Angle', hint: 'Angle at a vertex between two points' },
+const DIMENSION_TYPES: { type: DimensionType; icon: string; hint: string }[] = [
+  { type: 'aligned', icon: 'dim-aligned', hint: 'Aligned dimension' },
+  { type: 'horizontal', icon: 'dim-horizontal', hint: 'Horizontal dimension' },
+  { type: 'vertical', icon: 'dim-vertical', hint: 'Vertical dimension' },
+  { type: 'radius', icon: 'dim-radius', hint: 'Radius dimension' },
+  { type: 'diameter', icon: 'dim-diameter', hint: 'Diameter dimension' },
+  { type: 'angle', icon: 'dim-angle', hint: 'Angle dimension' },
 ]
 
 export function DimensionPopover() {
@@ -94,35 +94,41 @@ export function DimensionPopover() {
       </div>
       {open && (
         <div className="snap-popover" role="menu">
-          <div className="snap-popover-header">
+          <div className="snap-popover-grid snap-popover-grid--icon-only" style={{ gridTemplateColumns: 'repeat(3, 1fr)' }}>
             <button
-              className={`snap-popover-enable-btn ${tapeActive ? 'snap-popover-enable-btn--active' : ''}`}
+              className={`snap-popover-item ${tapeActive ? 'snap-popover-item--active' : ''}`}
               type="button"
+              aria-label="Tape measure"
+              aria-pressed={tapeActive}
+              title={tapeActive ? 'Stop tape measure' : 'Tape measure'}
               onClick={toggleTape}
             >
-              {tapeActive ? 'Tape measure on' : 'Tape measure'}
+              <Icon id="tape-measure" />
             </button>
             <button
-              className={`snap-popover-enable-btn ${showDimensions ? 'snap-popover-enable-btn--active' : ''}`}
+              className={`snap-popover-item ${showDimensions ? 'snap-popover-item--active' : ''}`}
               type="button"
+              aria-label="Show or hide dimensions"
               aria-pressed={showDimensions}
-              title={dimensionCount > 0 ? `${dimensionCount} dimension${dimensionCount === 1 ? '' : 's'}` : 'No dimensions yet'}
+              title={dimensionCount > 0
+                ? `${showDimensions ? 'Hide' : 'Show'} dimensions (${dimensionCount})`
+                : 'Show/hide dimensions'}
               onClick={() => setShowDimensions(!showDimensions)}
             >
-              {showDimensions ? 'Dimensions shown' : 'Dimensions hidden'}
+              <Icon id={showDimensions ? 'eye' : 'eye-off'} />
             </button>
             <button
-              className={`snap-popover-enable-btn ${dimensionDeleteArmed ? 'snap-popover-enable-btn--active' : ''}`}
+              className={`snap-popover-item ${dimensionDeleteArmed ? 'snap-popover-item--active' : ''}`}
               type="button"
+              aria-label="Delete dimension"
               aria-pressed={dimensionDeleteArmed}
               disabled={dimensionCount === 0}
+              title={dimensionDeleteArmed ? 'Click a dimension to delete' : 'Delete dimension'}
               onClick={() => setDimensionDeleteArmed(!dimensionDeleteArmed)}
             >
-              {dimensionDeleteArmed ? 'Click a dimension…' : 'Delete dimension'}
+              <Icon id="trash" />
             </button>
-          </div>
-          <div className="snap-popover-grid">
-            {DIMENSION_TYPES.map(({ type, icon, label, hint }) => {
+            {DIMENSION_TYPES.map(({ type, icon, hint }) => {
               const active = dimType === type
               return (
                 <button
@@ -136,7 +142,6 @@ export function DimensionPopover() {
                   onClick={() => pickType(type)}
                 >
                   <Icon id={icon} />
-                  <span className="snap-popover-item-label">{label}</span>
                 </button>
               )
             })}

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -22,6 +22,7 @@ import { TextToolDialog } from '../project/TextToolDialog'
 import { featureHasClosedGeometry } from '../../text'
 import type { SnapMode, SnapSettings } from '../../sketch/snapping'
 import type { CreationTarget, FeatureAlignment, FeatureDistribution, SketchEditTool } from '../../store/types'
+import type { DimensionType } from '../../types/project'
 import { useProjectStore } from '../../store/projectStore'
 import type { TextToolConfig } from '../../text'
 import { useFileActions } from '../../platform/useFileActions'
@@ -135,6 +136,13 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
     cancelPendingOffset,
     cancelPendingShapeAction,
     selection,
+    tapeMeasure,
+    pendingDimension,
+    startTapeMeasure,
+    clearTapeMeasure,
+    startDimensionTool,
+    cancelPendingDimension,
+    setShowDimensions,
   } = useProjectStore()
 
   const [editingName, setEditingName] = useState(false)
@@ -185,6 +193,28 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
   function confirmTextTool(config: TextToolConfig) {
     startAddTextPlacement(config)
     setShowTextDialog(false)
+  }
+
+  function handleTapeMeasure() {
+    if (tapeMeasure) {
+      clearTapeMeasure()
+      return
+    }
+    if (pendingAdd) cancelPendingAdd()
+    startTapeMeasure()
+  }
+
+  function handleDimensionType(type: DimensionType) {
+    if (pendingDimension?.type === type) {
+      cancelPendingDimension()
+      return
+    }
+    if (pendingAdd) cancelPendingAdd()
+    startDimensionTool(type)
+  }
+
+  function handleToggleShowDimensions() {
+    setShowDimensions(!project.meta.showDimensions)
   }
 
   const selectedFeatureIds = selection.mode === 'feature' ? selection.selectedFeatureIds : []
@@ -418,6 +448,13 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
     handleSpline: () => togglePlacement('spline', startAddSplinePlacement),
     handleComposite: () => togglePlacement('composite', startAddCompositePlacement),
     handleTextTool,
+    tapeActive: tapeMeasure !== null,
+    pendingDimensionType: pendingDimension?.type ?? null,
+    showDimensions: project.meta.showDimensions,
+    dimensionCount: project.annotations.length,
+    handleTapeMeasure,
+    handleDimensionType,
+    handleToggleShowDimensions,
     creationTarget,
     setCreationTarget,
     confirmTextTool,
@@ -1175,6 +1212,66 @@ function SnapActions({
   )
 }
 
+const DIMENSION_TOOLS: { type: DimensionType; icon: string; label: string }[] = [
+  { type: 'aligned', icon: 'dim-aligned', label: 'Aligned dimension' },
+  { type: 'horizontal', icon: 'dim-horizontal', label: 'Horizontal dimension' },
+  { type: 'vertical', icon: 'dim-vertical', label: 'Vertical dimension' },
+  { type: 'radius', icon: 'dim-radius', label: 'Radius dimension' },
+  { type: 'diameter', icon: 'dim-diameter', label: 'Diameter dimension' },
+  { type: 'angle', icon: 'dim-angle', label: 'Angle dimension' },
+]
+
+function MeasureActions({
+  tapeActive,
+  pendingDimensionType,
+  showDimensions,
+  dimensionCount,
+  tooltipSide,
+  onTapeMeasure,
+  onDimensionType,
+  onToggleShowDimensions,
+}: {
+  tapeActive: boolean
+  pendingDimensionType: DimensionType | null
+  showDimensions: boolean
+  dimensionCount: number
+  tooltipSide?: 'bottom' | 'right'
+  onTapeMeasure: () => void
+  onDimensionType: (type: DimensionType) => void
+  onToggleShowDimensions: () => void
+}) {
+  return (
+    <div className="toolbar-group">
+      <ToolbarActionButton
+        icon="measure"
+        label={tapeActive ? 'Tape measure (on)' : 'Tape measure'}
+        active={tapeActive}
+        tooltipSide={tooltipSide}
+        onClick={onTapeMeasure}
+      />
+      {DIMENSION_TOOLS.map(({ type, icon, label }) => (
+        <ToolbarActionButton
+          key={type}
+          icon={icon}
+          label={label}
+          active={pendingDimensionType === type}
+          tooltipSide={tooltipSide}
+          onClick={() => onDimensionType(type)}
+        />
+      ))}
+      <ToolbarActionButton
+        icon="dim-visibility"
+        label={dimensionCount === 0
+          ? 'Show/hide dimensions'
+          : showDimensions ? `Hide dimensions (${dimensionCount})` : `Show dimensions (${dimensionCount})`}
+        active={showDimensions}
+        tooltipSide={tooltipSide}
+        onClick={onToggleShowDimensions}
+      />
+    </div>
+  )
+}
+
 function ToolbarDialog({
   showNewProjectDialog,
   showImportDialog,
@@ -1290,6 +1387,16 @@ export function CreationToolbar({
           onSpline={toolbar.handleSpline}
           onComposite={toolbar.handleComposite}
           onText={toolbar.handleTextTool}
+        />
+        <MeasureActions
+          tapeActive={toolbar.tapeActive}
+          pendingDimensionType={toolbar.pendingDimensionType}
+          showDimensions={toolbar.showDimensions}
+          dimensionCount={toolbar.dimensionCount}
+          tooltipSide={layout === 'vertical' ? 'right' : 'bottom'}
+          onTapeMeasure={toolbar.handleTapeMeasure}
+          onDimensionType={toolbar.handleDimensionType}
+          onToggleShowDimensions={toolbar.handleToggleShowDimensions}
         />
         <ShapeToolActions
           pendingShapeAction={toolbar.pendingShapeAction?.kind ?? null}
@@ -1421,6 +1528,15 @@ export function Toolbar({
           onSpline={toolbar.handleSpline}
           onComposite={toolbar.handleComposite}
           onText={toolbar.handleTextTool}
+        />
+        <MeasureActions
+          tapeActive={toolbar.tapeActive}
+          pendingDimensionType={toolbar.pendingDimensionType}
+          showDimensions={toolbar.showDimensions}
+          dimensionCount={toolbar.dimensionCount}
+          onTapeMeasure={toolbar.handleTapeMeasure}
+          onDimensionType={toolbar.handleDimensionType}
+          onToggleShowDimensions={toolbar.handleToggleShowDimensions}
         />
         <ShapeToolActions
           pendingShapeAction={toolbar.pendingShapeAction?.kind ?? null}

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -142,6 +142,8 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
     clearTapeMeasure,
     startDimensionTool,
     cancelPendingDimension,
+    dimensionDeleteArmed,
+    setDimensionDeleteArmed,
     setShowDimensions,
   } = useProjectStore()
 
@@ -215,6 +217,11 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
 
   function handleToggleShowDimensions() {
     setShowDimensions(!project.meta.showDimensions)
+  }
+
+  function handleDeleteDimension() {
+    if (pendingAdd) cancelPendingAdd()
+    setDimensionDeleteArmed(!dimensionDeleteArmed)
   }
 
   const selectedFeatureIds = selection.mode === 'feature' ? selection.selectedFeatureIds : []
@@ -450,10 +457,12 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
     handleTextTool,
     tapeActive: tapeMeasure !== null,
     pendingDimensionType: pendingDimension?.type ?? null,
+    dimensionDeleteArmed,
     showDimensions: project.meta.showDimensions,
     dimensionCount: project.annotations.length,
     handleTapeMeasure,
     handleDimensionType,
+    handleDeleteDimension,
     handleToggleShowDimensions,
     creationTarget,
     setCreationTarget,
@@ -1224,20 +1233,24 @@ const DIMENSION_TOOLS: { type: DimensionType; icon: string; label: string }[] = 
 function MeasureActions({
   tapeActive,
   pendingDimensionType,
+  dimensionDeleteArmed,
   showDimensions,
   dimensionCount,
   tooltipSide,
   onTapeMeasure,
   onDimensionType,
+  onDeleteDimension,
   onToggleShowDimensions,
 }: {
   tapeActive: boolean
   pendingDimensionType: DimensionType | null
+  dimensionDeleteArmed: boolean
   showDimensions: boolean
   dimensionCount: number
   tooltipSide?: 'bottom' | 'right'
   onTapeMeasure: () => void
   onDimensionType: (type: DimensionType) => void
+  onDeleteDimension: () => void
   onToggleShowDimensions: () => void
 }) {
   return (
@@ -1259,6 +1272,14 @@ function MeasureActions({
           onClick={() => onDimensionType(type)}
         />
       ))}
+      <ToolbarActionButton
+        icon="trash"
+        label={dimensionDeleteArmed ? 'Delete dimension (click one)' : 'Delete dimension'}
+        active={dimensionDeleteArmed}
+        disabled={dimensionCount === 0}
+        tooltipSide={tooltipSide}
+        onClick={onDeleteDimension}
+      />
       <ToolbarActionButton
         icon="dim-visibility"
         label={dimensionCount === 0
@@ -1391,11 +1412,13 @@ export function CreationToolbar({
         <MeasureActions
           tapeActive={toolbar.tapeActive}
           pendingDimensionType={toolbar.pendingDimensionType}
+          dimensionDeleteArmed={toolbar.dimensionDeleteArmed}
           showDimensions={toolbar.showDimensions}
           dimensionCount={toolbar.dimensionCount}
           tooltipSide={layout === 'vertical' ? 'right' : 'bottom'}
           onTapeMeasure={toolbar.handleTapeMeasure}
           onDimensionType={toolbar.handleDimensionType}
+          onDeleteDimension={toolbar.handleDeleteDimension}
           onToggleShowDimensions={toolbar.handleToggleShowDimensions}
         />
         <ShapeToolActions
@@ -1532,10 +1555,12 @@ export function Toolbar({
         <MeasureActions
           tapeActive={toolbar.tapeActive}
           pendingDimensionType={toolbar.pendingDimensionType}
+          dimensionDeleteArmed={toolbar.dimensionDeleteArmed}
           showDimensions={toolbar.showDimensions}
           dimensionCount={toolbar.dimensionCount}
           onTapeMeasure={toolbar.handleTapeMeasure}
           onDimensionType={toolbar.handleDimensionType}
+          onDeleteDimension={toolbar.handleDeleteDimension}
           onToggleShowDimensions={toolbar.handleToggleShowDimensions}
         />
         <ShapeToolActions

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -145,6 +145,8 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
     dimensionDeleteArmed,
     setDimensionDeleteArmed,
     setShowDimensions,
+    selectedAnnotationId,
+    deleteDimensionAnnotation,
   } = useProjectStore()
 
   const [editingName, setEditingName] = useState(false)
@@ -221,6 +223,13 @@ function useToolbarState(onZoomToModel: () => void, onImportComplete?: () => voi
 
   function handleDeleteDimension() {
     if (pendingAdd) cancelPendingAdd()
+    // If a dimension is already selected, just delete it — no need to arm the
+    // pick-a-dimension mode for a second click.
+    if (selectedAnnotationId) {
+      deleteDimensionAnnotation(selectedAnnotationId)
+      if (dimensionDeleteArmed) setDimensionDeleteArmed(false)
+      return
+    }
     setDimensionDeleteArmed(!dimensionDeleteArmed)
   }
 
@@ -1221,13 +1230,13 @@ function SnapActions({
   )
 }
 
-const DIMENSION_TOOLS: { type: DimensionType; icon: string; label: string }[] = [
-  { type: 'aligned', icon: 'dim-aligned', label: 'Aligned dimension' },
-  { type: 'horizontal', icon: 'dim-horizontal', label: 'Horizontal dimension' },
-  { type: 'vertical', icon: 'dim-vertical', label: 'Vertical dimension' },
-  { type: 'radius', icon: 'dim-radius', label: 'Radius dimension' },
-  { type: 'diameter', icon: 'dim-diameter', label: 'Diameter dimension' },
-  { type: 'angle', icon: 'dim-angle', label: 'Angle dimension' },
+const DIMENSION_TYPE_OPTIONS: PopoverMenuOption<DimensionType>[] = [
+  { value: 'aligned', icon: 'dim-aligned', label: 'Aligned dimension' },
+  { value: 'horizontal', icon: 'dim-horizontal', label: 'Horizontal dimension' },
+  { value: 'vertical', icon: 'dim-vertical', label: 'Vertical dimension' },
+  { value: 'radius', icon: 'dim-radius', label: 'Radius dimension' },
+  { value: 'diameter', icon: 'dim-diameter', label: 'Diameter dimension' },
+  { value: 'angle', icon: 'dim-angle', label: 'Angle dimension' },
 ]
 
 function MeasureActions({
@@ -1253,25 +1262,34 @@ function MeasureActions({
   onDeleteDimension: () => void
   onToggleShowDimensions: () => void
 }) {
+  // Reflect a pending dimension placement in the popover trigger so the user
+  // can see which type is in progress without expanding the menu.
+  const activeDimOption = pendingDimensionType
+    ? DIMENSION_TYPE_OPTIONS.find((option) => option.value === pendingDimensionType) ?? null
+    : null
+  const triggerIcon = activeDimOption?.icon ?? 'measure'
+  const triggerLabelClosed = activeDimOption
+    ? `Cancel ${activeDimOption.label.toLowerCase()}`
+    : 'Add dimension'
   return (
     <div className="toolbar-group">
       <ToolbarActionButton
-        icon="measure"
+        icon="tape-measure"
         label={tapeActive ? 'Tape measure (on)' : 'Tape measure'}
         active={tapeActive}
         tooltipSide={tooltipSide}
         onClick={onTapeMeasure}
       />
-      {DIMENSION_TOOLS.map(({ type, icon, label }) => (
-        <ToolbarActionButton
-          key={type}
-          icon={icon}
-          label={label}
-          active={pendingDimensionType === type}
-          tooltipSide={tooltipSide}
-          onClick={() => onDimensionType(type)}
-        />
-      ))}
+      <ToolbarPopoverMenu
+        triggerIcon={triggerIcon}
+        triggerLabelOpen="Close dimension menu"
+        triggerLabelClosed={triggerLabelClosed}
+        enabled
+        tooltipSide={tooltipSide}
+        columns={3}
+        options={DIMENSION_TYPE_OPTIONS}
+        onSelect={onDimensionType}
+      />
       <ToolbarActionButton
         icon="trash"
         label={dimensionDeleteArmed ? 'Delete dimension (click one)' : 'Delete dimension'}
@@ -1281,7 +1299,7 @@ function MeasureActions({
         onClick={onDeleteDimension}
       />
       <ToolbarActionButton
-        icon="dim-visibility"
+        icon={showDimensions ? 'eye' : 'eye-off'}
         label={dimensionCount === 0
           ? 'Show/hide dimensions'
           : showDimensions ? `Hide dimensions (${dimensionCount})` : `Show dimensions (${dimensionCount})`}
@@ -1367,6 +1385,17 @@ export function GlobalToolbar({
           onToggleSnapEnabled={onToggleSnapEnabled}
           onToggleSnapMode={onToggleSnapMode}
         />
+        <MeasureActions
+          tapeActive={toolbar.tapeActive}
+          pendingDimensionType={toolbar.pendingDimensionType}
+          dimensionDeleteArmed={toolbar.dimensionDeleteArmed}
+          showDimensions={toolbar.showDimensions}
+          dimensionCount={toolbar.dimensionCount}
+          onTapeMeasure={toolbar.handleTapeMeasure}
+          onDimensionType={toolbar.handleDimensionType}
+          onDeleteDimension={toolbar.handleDeleteDimension}
+          onToggleShowDimensions={toolbar.handleToggleShowDimensions}
+        />
       </div>
       <ToolbarDialog
         showNewProjectDialog={toolbar.showNewProjectDialog}
@@ -1408,18 +1437,6 @@ export function CreationToolbar({
           onSpline={toolbar.handleSpline}
           onComposite={toolbar.handleComposite}
           onText={toolbar.handleTextTool}
-        />
-        <MeasureActions
-          tapeActive={toolbar.tapeActive}
-          pendingDimensionType={toolbar.pendingDimensionType}
-          dimensionDeleteArmed={toolbar.dimensionDeleteArmed}
-          showDimensions={toolbar.showDimensions}
-          dimensionCount={toolbar.dimensionCount}
-          tooltipSide={layout === 'vertical' ? 'right' : 'bottom'}
-          onTapeMeasure={toolbar.handleTapeMeasure}
-          onDimensionType={toolbar.handleDimensionType}
-          onDeleteDimension={toolbar.handleDeleteDimension}
-          onToggleShowDimensions={toolbar.handleToggleShowDimensions}
         />
         <ShapeToolActions
           pendingShapeAction={toolbar.pendingShapeAction?.kind ?? null}
@@ -1540,6 +1557,17 @@ export function Toolbar({
           onToggleSnapEnabled={onToggleSnapEnabled}
           onToggleSnapMode={onToggleSnapMode}
         />
+        <MeasureActions
+          tapeActive={toolbar.tapeActive}
+          pendingDimensionType={toolbar.pendingDimensionType}
+          dimensionDeleteArmed={toolbar.dimensionDeleteArmed}
+          showDimensions={toolbar.showDimensions}
+          dimensionCount={toolbar.dimensionCount}
+          onTapeMeasure={toolbar.handleTapeMeasure}
+          onDimensionType={toolbar.handleDimensionType}
+          onDeleteDimension={toolbar.handleDeleteDimension}
+          onToggleShowDimensions={toolbar.handleToggleShowDimensions}
+        />
         <CreationActions
           pendingShape={toolbar.pendingAdd?.shape ?? null}
           creationTarget={toolbar.creationTarget}
@@ -1551,17 +1579,6 @@ export function Toolbar({
           onSpline={toolbar.handleSpline}
           onComposite={toolbar.handleComposite}
           onText={toolbar.handleTextTool}
-        />
-        <MeasureActions
-          tapeActive={toolbar.tapeActive}
-          pendingDimensionType={toolbar.pendingDimensionType}
-          dimensionDeleteArmed={toolbar.dimensionDeleteArmed}
-          showDimensions={toolbar.showDimensions}
-          dimensionCount={toolbar.dimensionCount}
-          onTapeMeasure={toolbar.handleTapeMeasure}
-          onDimensionType={toolbar.handleDimensionType}
-          onDeleteDimension={toolbar.handleDeleteDimension}
-          onToggleShowDimensions={toolbar.handleToggleShowDimensions}
         />
         <ShapeToolActions
           pendingShapeAction={toolbar.pendingShapeAction?.kind ?? null}

--- a/src/components/layout/TopCommandBar.tsx
+++ b/src/components/layout/TopCommandBar.tsx
@@ -6,6 +6,7 @@ import { ImportGeometryDialog } from '../project/ImportGeometryDialog'
 import { NewProjectDialog } from '../project/NewProjectDialog'
 import type { SnapMode, SnapSettings } from '../../sketch/snapping'
 import { SnapPopover } from './SnapPopover'
+import { DimensionPopover } from './DimensionPopover'
 
 interface TopCommandBarProps {
   centerTab: 'sketch' | 'preview3d' | 'simulation'
@@ -198,6 +199,7 @@ export function TopCommandBar({
             onToggleSnapEnabled={onToggleSnapEnabled}
             onToggleSnapMode={onToggleSnapMode}
           />
+          <DimensionPopover />
           <button
             className="top-cmd-btn top-cmd-btn--operations"
             type="button"

--- a/src/sketch/dimensions.test.ts
+++ b/src/sketch/dimensions.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Run with: npx tsx src/sketch/dimensions.test.ts
+ */
+
+import {
+  circleProfile,
+  newProject,
+  rectProfile,
+} from '../types/project'
+import type {
+  DimensionAnnotation,
+  Project,
+  SketchFeature,
+  SketchProfile,
+} from '../types/project'
+import {
+  angleBetween,
+  dimensionLayout,
+  isDimensionDangling,
+  measureValue,
+  resolveAnchor,
+} from './dimensions'
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error('FAIL: ' + msg)
+}
+
+function approx(a: number, b: number, eps = 1e-6): boolean {
+  return Math.abs(a - b) <= eps
+}
+
+function makeFeature(id: string, profile: SketchProfile): SketchFeature {
+  return {
+    id,
+    name: id,
+    kind: 'polygon',
+    folderId: null,
+    sketch: {
+      profile,
+      origin: { x: 0, y: 0 },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+    operation: 'add',
+    z_top: 10,
+    z_bottom: 0,
+    visible: true,
+    locked: false,
+  }
+}
+
+function projectWith(features: SketchFeature[]): Project {
+  const base = newProject('dim-test', 'mm')
+  return { ...base, features }
+}
+
+// A 10×6 rectangle whose corners are well-known.
+const rect = rectProfile(0, 0, 10, 6)
+const rectFeature = makeFeature('f0001', rect)
+
+function makeDim(partial: Partial<DimensionAnnotation> & Pick<DimensionAnnotation, 'type' | 'a'>): DimensionAnnotation {
+  return {
+    id: 'dim0001',
+    offset: 2,
+    visible: true,
+    locked: false,
+    textOverride: null,
+    precisionOverride: null,
+    ...partial,
+  }
+}
+
+// ── resolveAnchor ───────────────────────────────────────────
+{
+  const project = projectWith([rectFeature])
+  const target = { source: 'feature' as const, featureId: 'f0001' }
+
+  // rectProfile vertices: (0,0) (10,0) (10,6) (0,6)
+  const v0 = resolveAnchor({ kind: 'vertex', target, vertexIndex: 0 }, project)
+  assert(!!v0 && approx(v0.x, 0) && approx(v0.y, 0), 'vertex 0 = (0,0)')
+  const v2 = resolveAnchor({ kind: 'vertex', target, vertexIndex: 2 }, project)
+  assert(!!v2 && approx(v2.x, 10) && approx(v2.y, 6), 'vertex 2 = (10,6)')
+
+  // segment 0 is the bottom edge (0,0)->(10,0); midpoint (5,0)
+  const mid = resolveAnchor({ kind: 'midpoint', target, segmentIndex: 0 }, project)
+  assert(!!mid && approx(mid.x, 5) && approx(mid.y, 0), 'midpoint of bottom edge = (5,0)')
+
+  // origin + free
+  const origin = resolveAnchor({ kind: 'origin' }, project)
+  assert(!!origin && approx(origin.x, project.origin.x) && approx(origin.y, project.origin.y), 'origin anchor resolves')
+  const free = resolveAnchor({ kind: 'free', point: { x: 3, y: 7 } }, project)
+  assert(!!free && approx(free.x, 3) && approx(free.y, 7), 'free anchor resolves to its point')
+
+  console.log('resolveAnchor PASS')
+}
+
+// ── center anchor on a circle ───────────────────────────────
+{
+  const circleFeature = makeFeature('f0002', circleProfile(4, 5, 3))
+  const project = projectWith([circleFeature])
+  const target = { source: 'feature' as const, featureId: 'f0002' }
+  const center = resolveAnchor({ kind: 'center', target, segmentIndex: 0 }, project)
+  assert(!!center && approx(center.x, 4) && approx(center.y, 5), 'circle center = (4,5)')
+  // a center anchor on a line segment is invalid
+  const badCenter = resolveAnchor({ kind: 'center', target: { source: 'feature', featureId: 'f0001' }, segmentIndex: 0 }, projectWith([rectFeature]))
+  assert(badCenter === null, 'center on a non-arc segment is null')
+  console.log('center anchor PASS')
+}
+
+// ── dangling references ─────────────────────────────────────
+{
+  const project = projectWith([rectFeature])
+  const missing = resolveAnchor({ kind: 'vertex', target: { source: 'feature', featureId: 'nope' }, vertexIndex: 0 }, project)
+  assert(missing === null, 'missing feature → null')
+  const outOfRange = resolveAnchor({ kind: 'vertex', target: { source: 'feature', featureId: 'f0001' }, vertexIndex: 99 }, project)
+  assert(outOfRange === null, 'out-of-range vertex → null')
+  console.log('dangling references PASS')
+}
+
+// ── auto-update when geometry moves ─────────────────────────
+{
+  const target = { source: 'feature' as const, featureId: 'f0001' }
+  const before = projectWith([rectFeature])
+  const movedFeature = makeFeature('f0001', rectProfile(100, 100, 10, 6)) // translated +100,+100
+  const after = projectWith([movedFeature])
+  const anchor = { kind: 'vertex' as const, target, vertexIndex: 0 }
+
+  const p0Before = resolveAnchor(anchor, before)!
+  const p0After = resolveAnchor(anchor, after)!
+  assert(approx(p0Before.x, 0) && approx(p0After.x, 100) && approx(p0After.y, 100),
+    'vertex anchor follows the feature when its profile moves')
+  console.log('auto-update PASS')
+}
+
+// ── measureValue for each type ──────────────────────────────
+{
+  const project = projectWith([rectFeature])
+  const target = { source: 'feature' as const, featureId: 'f0001' }
+  const v0 = { kind: 'vertex' as const, target, vertexIndex: 0 } // (0,0)
+  const v2 = { kind: 'vertex' as const, target, vertexIndex: 2 } // (10,6)
+
+  const aligned = makeDim({ type: 'aligned', a: v0, b: v2 })
+  assert(approx(measureValue(aligned, project)!, Math.hypot(10, 6)), 'aligned = hypot(10,6)')
+
+  const horizontal = makeDim({ type: 'horizontal', a: v0, b: v2 })
+  assert(approx(measureValue(horizontal, project)!, 10), 'horizontal = 10')
+
+  const vertical = makeDim({ type: 'vertical', a: v0, b: v2 })
+  assert(approx(measureValue(vertical, project)!, 6), 'vertical = 6')
+
+  // radius/diameter on a circle: center (4,5), edge at start (4+3,5)=(7,5)
+  const circleFeature = makeFeature('f0003', circleProfile(4, 5, 3))
+  const cproject = projectWith([circleFeature])
+  const ctarget = { source: 'feature' as const, featureId: 'f0003' }
+  const center = { kind: 'center' as const, target: ctarget, segmentIndex: 0 }
+  const edge = { kind: 'vertex' as const, target: ctarget, vertexIndex: 0 }
+  const radius = makeDim({ type: 'radius', a: center, b: edge })
+  assert(approx(measureValue(radius, cproject)!, 3), 'radius = 3')
+  const diameter = makeDim({ type: 'diameter', a: center, b: edge })
+  assert(approx(measureValue(diameter, cproject)!, 6), 'diameter = 6')
+
+  // angle: vertex (0,0), rays to (1,0) and (0,1) → 90°
+  const angle = makeDim({
+    type: 'angle',
+    a: { kind: 'free', point: { x: 0, y: 0 } },
+    b: { kind: 'free', point: { x: 1, y: 0 } },
+    c: { kind: 'free', point: { x: 0, y: 1 } },
+  })
+  assert(approx(measureValue(angle, project)!, 90), 'angle = 90°')
+  assert(approx(angleBetween({ x: 0, y: 0 }, { x: 1, y: 0 }, { x: -1, y: 0 }), 180), 'opposite rays = 180°')
+
+  // dangling dimension → null value
+  const dangling = makeDim({ type: 'horizontal', a: v0, b: { kind: 'vertex', target: { source: 'feature', featureId: 'gone' }, vertexIndex: 0 } })
+  assert(measureValue(dangling, project) === null, 'dangling measure = null')
+  assert(isDimensionDangling(dangling, project), 'isDimensionDangling true')
+
+  console.log('measureValue PASS')
+}
+
+// ── dimensionLayout: offset side + extensions ───────────────
+{
+  const project = projectWith([rectFeature])
+  const target = { source: 'feature' as const, featureId: 'f0001' }
+  const v0 = { kind: 'vertex' as const, target, vertexIndex: 0 } // (0,0)
+  const v1 = { kind: 'vertex' as const, target, vertexIndex: 1 } // (10,0)
+
+  // horizontal with +offset → line sits below (Y-down) at y = max(0,0)+2 = 2
+  const hPos = makeDim({ type: 'horizontal', a: v0, b: v1, offset: 2 })
+  const layoutPos = dimensionLayout(hPos, project)!
+  assert(approx(layoutPos.lineStart.y, 2) && approx(layoutPos.lineEnd.y, 2), 'h+offset line at y=2')
+  assert(layoutPos.extensions.length === 2, 'horizontal has 2 extension lines')
+  assert(approx(layoutPos.extensions[0][0].y, 0) && approx(layoutPos.extensions[0][1].y, 2),
+    'extension runs from measured point (y=0) to dim line (y=2)')
+
+  // negative offset flips to the other side: y = min(0,0) - 2 = -2
+  const hNeg = makeDim({ type: 'horizontal', a: v0, b: v1, offset: -2 })
+  const layoutNeg = dimensionLayout(hNeg, project)!
+  assert(approx(layoutNeg.lineStart.y, -2), 'h-offset line at y=-2')
+
+  // aligned: dimension line parallel, shifted by perpendicular normal
+  const aligned = makeDim({ type: 'aligned', a: v0, b: v1, offset: 3 })
+  const la = dimensionLayout(aligned, project)!
+  // dir = (1,0), normal = (0,1); both endpoints shift +3 in y
+  assert(approx(la.lineStart.y, 3) && approx(la.lineEnd.y, 3), 'aligned shifted by normal*offset')
+  assert(approx(la.value, 10), 'aligned value = 10')
+
+  // dangling layout → null
+  const dangling = makeDim({ type: 'horizontal', a: v0, b: { kind: 'vertex', target: { source: 'feature', featureId: 'gone' }, vertexIndex: 0 } })
+  assert(dimensionLayout(dangling, project) === null, 'dangling layout = null')
+
+  console.log('dimensionLayout PASS')
+}
+
+console.log('\nall dimensions.test.ts assertions passed')

--- a/src/sketch/dimensions.ts
+++ b/src/sketch/dimensions.ts
@@ -148,6 +148,30 @@ export function resolveAnchor(anchor: DimensionAnchor, project: Project): Point 
       return { x: segment.center.x, y: segment.center.y }
     }
 
+    case 'circleEdge': {
+      const profile = profileForTarget(anchor.target, project)
+      if (!profile) return null
+      const segment = profile.segments[anchor.segmentIndex]
+      if (!segment || (segment.type !== 'arc' && segment.type !== 'circle')) return null
+      const start = anchorPointForIndex(profile, anchor.segmentIndex)
+      const radius = Math.hypot(start.x - segment.center.x, start.y - segment.center.y)
+      const baseAngle = Math.atan2(start.y - segment.center.y, start.x - segment.center.x)
+      const a = baseAngle + anchor.relativeAngle
+      return {
+        x: segment.center.x + Math.cos(a) * radius,
+        y: segment.center.y + Math.sin(a) * radius,
+      }
+    }
+
+    case 'segmentPoint': {
+      const profile = profileForTarget(anchor.target, project)
+      if (!profile) return null
+      const segment = profile.segments[anchor.segmentIndex]
+      if (!segment || segment.type !== 'line') return null
+      const start = anchorPointForIndex(profile, anchor.segmentIndex)
+      return lerp(start, segment.to, anchor.t)
+    }
+
     default:
       return null
   }
@@ -174,6 +198,52 @@ export function angleBetween(vertex: Point, p1: Point, p2: Point): number {
   return Math.abs(delta)
 }
 
+/**
+ * If `anchor` is tied to an arc/circle (its center or a point on its edge),
+ * return that segment's true radius (from its stored geometry, not the distance
+ * between two picked points). Used so radius/diameter dimensions show the exact
+ * value instead of a number perturbed by polyline-tessellated edge snaps.
+ */
+function trueRadiusFromCircleAnchor(anchor: DimensionAnchor, project: Project): number | null {
+  if (anchor.kind !== 'center' && anchor.kind !== 'circleEdge') return null
+  const profile = profileForTarget(anchor.target, project)
+  if (!profile) return null
+  const segment = profile.segments[anchor.segmentIndex]
+  if (!segment || (segment.type !== 'arc' && segment.type !== 'circle')) return null
+  const start = anchorPointForIndex(profile, anchor.segmentIndex)
+  return Math.hypot(start.x - segment.center.x, start.y - segment.center.y)
+}
+
+/**
+ * If `centerAnchor` is a `center` anchor on an arc/circle, build a `circleEdge`
+ * anchor for the picked world point. The point's exact distance to the center
+ * doesn't matter — only the angle is captured, so the resulting anchor sits on
+ * the true circle and rotates/translates with the feature.
+ */
+export function circleEdgeAnchorFromPoint(
+  point: Point,
+  centerAnchor: DimensionAnchor,
+  project: Project,
+): DimensionAnchor | null {
+  if (centerAnchor.kind !== 'center') return null
+  const profile = profileForTarget(centerAnchor.target, project)
+  if (!profile) return null
+  const segment = profile.segments[centerAnchor.segmentIndex]
+  if (!segment || (segment.type !== 'arc' && segment.type !== 'circle')) return null
+  const start = anchorPointForIndex(profile, centerAnchor.segmentIndex)
+  const baseAngle = Math.atan2(start.y - segment.center.y, start.x - segment.center.x)
+  const pickedAngle = Math.atan2(point.y - segment.center.y, point.x - segment.center.x)
+  let rel = pickedAngle - baseAngle
+  while (rel <= -Math.PI) rel += Math.PI * 2
+  while (rel > Math.PI) rel -= Math.PI * 2
+  return {
+    kind: 'circleEdge',
+    target: centerAnchor.target,
+    segmentIndex: centerAnchor.segmentIndex,
+    relativeAngle: rel,
+  }
+}
+
 /** Live measured value, or `null` if any required anchor is dangling. */
 export function measureValue(dim: DimensionAnnotation, project: Project): number | null {
   const a = resolveAnchor(dim.a, project)
@@ -198,12 +268,14 @@ export function measureValue(dim: DimensionAnnotation, project: Project): number
     case 'radius': {
       const b = dim.b ? resolveAnchor(dim.b, project) : null
       if (!b) return null
-      return dist(a, b)
+      const trueR = trueRadiusFromCircleAnchor(dim.a, project) ?? (dim.b ? trueRadiusFromCircleAnchor(dim.b, project) : null)
+      return trueR ?? dist(a, b)
     }
     case 'diameter': {
       const b = dim.b ? resolveAnchor(dim.b, project) : null
       if (!b) return null
-      return dist(a, b) * 2
+      const trueR = trueRadiusFromCircleAnchor(dim.a, project) ?? (dim.b ? trueRadiusFromCircleAnchor(dim.b, project) : null)
+      return trueR !== null ? trueR * 2 : dist(a, b) * 2
     }
     case 'angle': {
       const b = dim.b ? resolveAnchor(dim.b, project) : null
@@ -327,17 +399,21 @@ export function dimensionLayout(dim: DimensionAnnotation, project: Project): Dim
   if (dim.type === 'radius' || dim.type === 'diameter') {
     const edge = resolveAnchor(dim.b!, project)!
     const dir = normalize({ x: edge.x - a.x, y: edge.y - a.y })
-    // For diameter, draw straight across the circle through the center.
+    // Trim the dimension line to the true boundary (radius == value, diameter
+    // spans value across the center). When the value is derived purely from
+    // dist(a, b) this is a no-op; when a center anchor pinned the true radius,
+    // the line snaps to the actual circle instead of the picked-off-edge point.
+    const radius = dim.type === 'diameter' ? value / 2 : value
     const lineStart = dim.type === 'diameter'
-      ? { x: a.x - dir.x * (value / 2), y: a.y - dir.y * (value / 2) }
+      ? { x: a.x - dir.x * radius, y: a.y - dir.y * radius }
       : { x: a.x, y: a.y }
-    const lineEnd = edge
+    const lineEnd = { x: a.x + dir.x * radius, y: a.y + dir.y * radius }
     const mid = lerp(lineStart, lineEnd, 0.5)
     return {
       type: dim.type,
       value,
       from: a,
-      to: edge,
+      to: lineEnd,
       lineStart,
       lineEnd,
       extensions: [],

--- a/src/sketch/dimensions.ts
+++ b/src/sketch/dimensions.ts
@@ -285,9 +285,9 @@ export function dimensionLayout(dim: DimensionAnnotation, project: Project): Dim
   }
 
   if (dim.type === 'horizontal') {
+    // Dimension line is horizontal, placed `offset` from the points' mid Y.
     const b = resolveAnchor(dim.b!, project)!
-    const anchorY = offset >= 0 ? Math.max(a.y, b.y) : Math.min(a.y, b.y)
-    const yLine = anchorY + offset
+    const yLine = (a.y + b.y) / 2 + offset
     const lineStart = { x: a.x, y: yLine }
     const lineEnd = { x: b.x, y: yLine }
     const mid = lerp(lineStart, lineEnd, 0.5)
@@ -305,9 +305,9 @@ export function dimensionLayout(dim: DimensionAnnotation, project: Project): Dim
   }
 
   if (dim.type === 'vertical') {
+    // Dimension line is vertical, placed `offset` from the points' mid X.
     const b = resolveAnchor(dim.b!, project)!
-    const anchorX = offset >= 0 ? Math.max(a.x, b.x) : Math.min(a.x, b.x)
-    const xLine = anchorX + offset
+    const xLine = (a.x + b.x) / 2 + offset
     const lineStart = { x: xLine, y: a.y }
     const lineEnd = { x: xLine, y: b.y }
     const mid = lerp(lineStart, lineEnd, 0.5)
@@ -373,6 +373,38 @@ export function dimensionLayout(dim: DimensionAnnotation, project: Project): Dim
     startAngle,
     endAngle,
   }
+}
+
+/**
+ * Compute the `offset` value that would place a dimension's line at the given
+ * world cursor position. Used while dragging a dimension to reposition it.
+ * Returns `null` for types whose offset is not cursor-driven (radius/diameter).
+ */
+export function offsetForCursor(dim: DimensionAnnotation, project: Project, cursor: Point): number | null {
+  const a = resolveAnchor(dim.a, project)
+  if (!a) return null
+
+  if (dim.type === 'aligned') {
+    const b = dim.b ? resolveAnchor(dim.b, project) : null
+    if (!b) return null
+    const dir = normalize({ x: b.x - a.x, y: b.y - a.y })
+    const nrm = { x: -dir.y, y: dir.x }
+    return (cursor.x - a.x) * nrm.x + (cursor.y - a.y) * nrm.y
+  }
+  if (dim.type === 'horizontal') {
+    const b = dim.b ? resolveAnchor(dim.b, project) : null
+    if (!b) return null
+    return cursor.y - (a.y + b.y) / 2
+  }
+  if (dim.type === 'vertical') {
+    const b = dim.b ? resolveAnchor(dim.b, project) : null
+    if (!b) return null
+    return cursor.x - (a.x + b.x) / 2
+  }
+  if (dim.type === 'angle') {
+    return Math.hypot(cursor.x - a.x, cursor.y - a.y)
+  }
+  return null
 }
 
 /**

--- a/src/sketch/dimensions.ts
+++ b/src/sketch/dimensions.ts
@@ -1,0 +1,399 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pure geometry/value logic for measure & dimension annotations.
+ *
+ * Everything here is framework-free so it can be unit-tested by the structural
+ * suite. The canvas renderer (components/canvas/dimensionRendering.ts) consumes
+ * `dimensionLayout`; the store/tooling consume `resolveAnchor`/`measureValue`.
+ *
+ * Coordinates are project/world coordinates (Y grows downward — see
+ * ARCHITECTURE.md §6). Feature profiles are already stored in world coordinates
+ * (see project.ts `stockFromFeature`), so an anchor resolves by indexing into the
+ * live profile — which is exactly why a dimension follows its geometry when the
+ * feature is edited or moved.
+ */
+
+import {
+  profileVertices,
+} from '../types/project'
+import type {
+  AnchorTarget,
+  DimensionAnchor,
+  DimensionAnnotation,
+  DimensionType,
+  Point,
+  Project,
+  Segment,
+  SketchProfile,
+} from '../types/project'
+
+// ────────────────────────────────────────────────────────────
+// Small pure geometry helpers (kept local to avoid depending on
+// the canvas layer, which carries rendering imports).
+// ────────────────────────────────────────────────────────────
+
+function lerp(a: Point, b: Point, t: number): Point {
+  return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t }
+}
+
+function bezierPoint(p0: Point, c1: Point, c2: Point, p1: Point, t: number): Point {
+  const u = 1 - t
+  const w0 = u * u * u
+  const w1 = 3 * u * u * t
+  const w2 = 3 * u * t * t
+  const w3 = t * t * t
+  return {
+    x: w0 * p0.x + w1 * c1.x + w2 * c2.x + w3 * p1.x,
+    y: w0 * p0.y + w1 * c1.y + w2 * c2.y + w3 * p1.y,
+  }
+}
+
+/** Start point (anchor) of the segment at `index` within a profile. */
+function anchorPointForIndex(profile: SketchProfile, index: number): Point {
+  if (index <= 0) return profile.start
+  const seg = profile.segments[index - 1]
+  if (!seg) return profile.start
+  if (seg.type === 'circle') return profile.start
+  return seg.to
+}
+
+/** Midpoint of a segment (arc/circle use the mid-sweep point on the curve). */
+function segmentMidpoint(start: Point, segment: Segment): Point {
+  if (segment.type === 'line') {
+    return lerp(start, segment.to, 0.5)
+  }
+  if (segment.type === 'bezier') {
+    return bezierPoint(start, segment.control1, segment.control2, segment.to, 0.5)
+  }
+
+  // arc / circle: point at the mid sweep angle
+  const center = segment.center
+  const radius = Math.hypot(start.x - center.x, start.y - center.y)
+  const startAngle = Math.atan2(start.y - center.y, start.x - center.x)
+  let sweep: number
+  if (segment.type === 'circle') {
+    sweep = segment.clockwise ? -Math.PI * 2 : Math.PI * 2
+  } else {
+    const endAngle = Math.atan2(segment.to.y - center.y, segment.to.x - center.x)
+    sweep = endAngle - startAngle
+    if (segment.clockwise && sweep > 0) sweep -= Math.PI * 2
+    else if (!segment.clockwise && sweep < 0) sweep += Math.PI * 2
+  }
+  const midAngle = startAngle + sweep / 2
+  return { x: center.x + Math.cos(midAngle) * radius, y: center.y + Math.sin(midAngle) * radius }
+}
+
+// ────────────────────────────────────────────────────────────
+// Anchor resolution
+// ────────────────────────────────────────────────────────────
+
+function profileForTarget(target: AnchorTarget, project: Project): SketchProfile | null {
+  if (target.source === 'stock') {
+    return project.stock.profile
+  }
+  const feature = project.features.find((f) => f.id === target.featureId)
+  return feature ? feature.sketch.profile : null
+}
+
+/**
+ * Resolve an anchor to a live world point, or `null` when the reference is
+ * dangling (feature deleted, index out of range). A `null` result marks the
+ * whole dimension as invalid and is drawn in a warning style.
+ */
+export function resolveAnchor(anchor: DimensionAnchor, project: Project): Point | null {
+  switch (anchor.kind) {
+    case 'free':
+      return anchor.point
+
+    case 'origin':
+      return { x: project.origin.x, y: project.origin.y }
+
+    case 'vertex': {
+      const profile = profileForTarget(anchor.target, project)
+      if (!profile) return null
+      const vertices = profileVertices(profile)
+      const point = vertices[anchor.vertexIndex]
+      return point ? { x: point.x, y: point.y } : null
+    }
+
+    case 'midpoint': {
+      const profile = profileForTarget(anchor.target, project)
+      if (!profile) return null
+      const segment = profile.segments[anchor.segmentIndex]
+      if (!segment) return null
+      const start = anchorPointForIndex(profile, anchor.segmentIndex)
+      return segmentMidpoint(start, segment)
+    }
+
+    case 'center': {
+      const profile = profileForTarget(anchor.target, project)
+      if (!profile) return null
+      const segment = profile.segments[anchor.segmentIndex]
+      if (!segment || (segment.type !== 'arc' && segment.type !== 'circle')) return null
+      return { x: segment.center.x, y: segment.center.y }
+    }
+
+    default:
+      return null
+  }
+}
+
+// ────────────────────────────────────────────────────────────
+// Value computation
+// ────────────────────────────────────────────────────────────
+
+function dist(a: Point, b: Point): number {
+  return Math.hypot(b.x - a.x, b.y - a.y)
+}
+
+/**
+ * Angle in degrees at `vertex` between the rays to `p1` and `p2`, normalized to
+ * the (0, 360) interior-style range as an absolute magnitude in [0, 180].
+ */
+export function angleBetween(vertex: Point, p1: Point, p2: Point): number {
+  const a1 = Math.atan2(p1.y - vertex.y, p1.x - vertex.x)
+  const a2 = Math.atan2(p2.y - vertex.y, p2.x - vertex.x)
+  let delta = (a2 - a1) * (180 / Math.PI)
+  while (delta <= -180) delta += 360
+  while (delta > 180) delta -= 360
+  return Math.abs(delta)
+}
+
+/** Live measured value, or `null` if any required anchor is dangling. */
+export function measureValue(dim: DimensionAnnotation, project: Project): number | null {
+  const a = resolveAnchor(dim.a, project)
+  if (!a) return null
+
+  switch (dim.type) {
+    case 'aligned': {
+      const b = dim.b ? resolveAnchor(dim.b, project) : null
+      if (!b) return null
+      return dist(a, b)
+    }
+    case 'horizontal': {
+      const b = dim.b ? resolveAnchor(dim.b, project) : null
+      if (!b) return null
+      return Math.abs(b.x - a.x)
+    }
+    case 'vertical': {
+      const b = dim.b ? resolveAnchor(dim.b, project) : null
+      if (!b) return null
+      return Math.abs(b.y - a.y)
+    }
+    case 'radius': {
+      const b = dim.b ? resolveAnchor(dim.b, project) : null
+      if (!b) return null
+      return dist(a, b)
+    }
+    case 'diameter': {
+      const b = dim.b ? resolveAnchor(dim.b, project) : null
+      if (!b) return null
+      return dist(a, b) * 2
+    }
+    case 'angle': {
+      const b = dim.b ? resolveAnchor(dim.b, project) : null
+      const c = dim.c ? resolveAnchor(dim.c, project) : null
+      if (!b || !c) return null
+      return angleBetween(a, b, c)
+    }
+    default:
+      return null
+  }
+}
+
+/** True if the dimension cannot be measured (any anchor dangling). */
+export function isDimensionDangling(dim: DimensionAnnotation, project: Project): boolean {
+  return measureValue(dim, project) === null
+}
+
+// ────────────────────────────────────────────────────────────
+// Layout (pure geometry for the renderer)
+// ────────────────────────────────────────────────────────────
+
+export interface DimensionLayout {
+  type: DimensionType
+  value: number
+  /** The two resolved measured points (for angle: the two rays' endpoints). */
+  from: Point
+  to: Point
+  /** Endpoints of the drawn dimension line. */
+  lineStart: Point
+  lineEnd: Point
+  /** Witness/extension lines, each `[atMeasuredPoint, atDimensionLine]`. */
+  extensions: Array<[Point, Point]>
+  /** Label anchor and rotation (radians, world space). */
+  labelPos: Point
+  labelAngle: number
+  /** Angle-dimension extras. */
+  vertex?: Point
+  startAngle?: number
+  endAngle?: number
+}
+
+function normalize(v: Point): Point {
+  const len = Math.hypot(v.x, v.y)
+  if (len <= 1e-9) return { x: 1, y: 0 }
+  return { x: v.x / len, y: v.y / len }
+}
+
+/**
+ * Compute the full drawing layout for a dimension, or `null` if it is dangling.
+ * Pure: depends only on resolved anchors + the stored `offset`/`labelOffset`.
+ */
+export function dimensionLayout(dim: DimensionAnnotation, project: Project): DimensionLayout | null {
+  const value = measureValue(dim, project)
+  if (value === null) return null
+  const a = resolveAnchor(dim.a, project)
+  if (!a) return null
+  const offset = dim.offset
+  const labelOffset = dim.labelOffset ?? 0
+
+  if (dim.type === 'aligned') {
+    const b = resolveAnchor(dim.b!, project)!
+    const dir = normalize({ x: b.x - a.x, y: b.y - a.y })
+    const nrm = { x: -dir.y, y: dir.x }
+    const shift = { x: nrm.x * offset, y: nrm.y * offset }
+    const lineStart = { x: a.x + shift.x, y: a.y + shift.y }
+    const lineEnd = { x: b.x + shift.x, y: b.y + shift.y }
+    const mid = lerp(lineStart, lineEnd, 0.5)
+    return {
+      type: dim.type,
+      value,
+      from: a,
+      to: b,
+      lineStart,
+      lineEnd,
+      extensions: [[a, lineStart], [b, lineEnd]],
+      labelPos: { x: mid.x + dir.x * labelOffset, y: mid.y + dir.y * labelOffset },
+      labelAngle: Math.atan2(dir.y, dir.x),
+    }
+  }
+
+  if (dim.type === 'horizontal') {
+    const b = resolveAnchor(dim.b!, project)!
+    const anchorY = offset >= 0 ? Math.max(a.y, b.y) : Math.min(a.y, b.y)
+    const yLine = anchorY + offset
+    const lineStart = { x: a.x, y: yLine }
+    const lineEnd = { x: b.x, y: yLine }
+    const mid = lerp(lineStart, lineEnd, 0.5)
+    return {
+      type: dim.type,
+      value,
+      from: a,
+      to: b,
+      lineStart,
+      lineEnd,
+      extensions: [[a, lineStart], [b, lineEnd]],
+      labelPos: { x: mid.x + labelOffset, y: yLine },
+      labelAngle: 0,
+    }
+  }
+
+  if (dim.type === 'vertical') {
+    const b = resolveAnchor(dim.b!, project)!
+    const anchorX = offset >= 0 ? Math.max(a.x, b.x) : Math.min(a.x, b.x)
+    const xLine = anchorX + offset
+    const lineStart = { x: xLine, y: a.y }
+    const lineEnd = { x: xLine, y: b.y }
+    const mid = lerp(lineStart, lineEnd, 0.5)
+    return {
+      type: dim.type,
+      value,
+      from: a,
+      to: b,
+      lineStart,
+      lineEnd,
+      extensions: [[a, lineStart], [b, lineEnd]],
+      labelPos: { x: xLine, y: mid.y + labelOffset },
+      labelAngle: Math.PI / 2,
+    }
+  }
+
+  if (dim.type === 'radius' || dim.type === 'diameter') {
+    const edge = resolveAnchor(dim.b!, project)!
+    const dir = normalize({ x: edge.x - a.x, y: edge.y - a.y })
+    // For diameter, draw straight across the circle through the center.
+    const lineStart = dim.type === 'diameter'
+      ? { x: a.x - dir.x * (value / 2), y: a.y - dir.y * (value / 2) }
+      : { x: a.x, y: a.y }
+    const lineEnd = edge
+    const mid = lerp(lineStart, lineEnd, 0.5)
+    return {
+      type: dim.type,
+      value,
+      from: a,
+      to: edge,
+      lineStart,
+      lineEnd,
+      extensions: [],
+      labelPos: { x: mid.x + dir.x * labelOffset, y: mid.y + dir.y * labelOffset },
+      labelAngle: Math.atan2(dir.y, dir.x),
+    }
+  }
+
+  // angle
+  const b = resolveAnchor(dim.b!, project)!
+  const c = resolveAnchor(dim.c!, project)!
+  const vertex = a
+  const r1 = Math.hypot(b.x - vertex.x, b.y - vertex.y)
+  const r2 = Math.hypot(c.x - vertex.x, c.y - vertex.y)
+  const radius = Math.max(Math.abs(offset), Math.min(r1, r2) * 0.6, 1e-6)
+  const startAngle = Math.atan2(b.y - vertex.y, b.x - vertex.x)
+  const endAngle = Math.atan2(c.y - vertex.y, c.x - vertex.x)
+  let delta = endAngle - startAngle
+  while (delta <= -Math.PI) delta += Math.PI * 2
+  while (delta > Math.PI) delta -= Math.PI * 2
+  const midAngle = startAngle + delta / 2
+  return {
+    type: dim.type,
+    value,
+    from: b,
+    to: c,
+    lineStart: { x: vertex.x + Math.cos(startAngle) * radius, y: vertex.y + Math.sin(startAngle) * radius },
+    lineEnd: { x: vertex.x + Math.cos(endAngle) * radius, y: vertex.y + Math.sin(endAngle) * radius },
+    extensions: [],
+    labelPos: { x: vertex.x + Math.cos(midAngle) * (radius + labelOffset), y: vertex.y + Math.sin(midAngle) * (radius + labelOffset) },
+    labelAngle: 0,
+    vertex,
+    startAngle,
+    endAngle,
+  }
+}
+
+/**
+ * Format the value text for a dimension's label (without unit conversion — the
+ * caller supplies a formatter so this stays framework/units-agnostic).
+ */
+export function dimensionLabelText(
+  dim: DimensionAnnotation,
+  value: number,
+  formatLength: (v: number) => string,
+  formatAngle: (deg: number) => string,
+): string {
+  if (dim.textOverride) return dim.textOverride
+  switch (dim.type) {
+    case 'radius':
+      return `R ${formatLength(value)}`
+    case 'diameter':
+      return `Ø ${formatLength(value)}`
+    case 'angle':
+      return formatAngle(value)
+    default:
+      return formatLength(value)
+  }
+}

--- a/src/store/INDEX.md
+++ b/src/store/INDEX.md
@@ -12,6 +12,8 @@ Zustand store. The single source of truth for the current `.camj` project. **All
   - `pendingActionsSlice.ts` — queue of deferred ops awaiting user confirmation
   - `pendingAddSlice.ts` — in-progress feature being drawn but not yet committed
   - `pendingCompletionSlice.ts` — partially-completed sketches awaiting closure
+  - `dimensionsSlice.ts` — persistent dimension annotations (`project.annotations`): add/update/delete + selection (history-tracked)
+  - `dimensionToolSlice.ts` — transient measure tools: tape measure + in-progress permanent-dimension placement (not persisted, not in history)
 - `helpers/` — pure helpers used by the store
   - `clipping.ts` — clipper-lib wrappers (handles the integer scaling factor): profile↔Clipper-path conversion, boolean/offset execution, and overlap predicates. Arc/curve reconstruction of Clipper output lives in `engine/toolpaths/arcReconstruction.ts`.
   - `derivedFeatures.ts` — computes derived features from the feature tree

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -122,6 +122,8 @@ import { createPendingAddSlice } from './slices/pendingAddSlice'
 import { createPendingActionsSlice } from './slices/pendingActionsSlice'
 import { createPendingCompletionSlice } from './slices/pendingCompletionSlice'
 import { createSelectionSlice, emptySelection, sanitizeSelection } from './slices/selectionSlice'
+import { createDimensionsSlice } from './slices/dimensionsSlice'
+import { createDimensionToolSlice } from './slices/dimensionToolSlice'
 import { propagateConstraintsOnTranslate, propagateConstraintsOnRotate, rederiveConstraintGeometry, inferSemanticIndices, validateConstraintsOnFeature, solveFeatureTranslation, type ConstraintInput, type FeatureOffset } from '../sketch/constraintSolver'
 import type {
   PendingAddTool,
@@ -2880,6 +2882,7 @@ export function normalizeProject(project: Project): Project {
     ...project,
     meta,
     modelAssets,
+    annotations: project.annotations ?? [],
     stock: {
       ...project.stock,
       profile: {
@@ -2932,6 +2935,7 @@ function instantiateProjectTemplate(template?: Project, name?: string): Project 
     },
     backdrop: null,
     dimensions: {},
+    annotations: [],
     modelAssets: {},
     features: [],
     featureFolders: [],
@@ -3147,6 +3151,8 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
     resolveOpenCompositeDraftSegments,
     cloneSegment,
   }),
+  ...createDimensionsSlice(set, get, { cloneProject }),
+  ...createDimensionToolSlice(set, get),
 
   // ── Project ──────────────────────────────────────────────
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -2862,6 +2862,7 @@ export function normalizeProject(project: Project): Project {
   const meta = {
     ...project.meta,
     showFeatureInfo: project.meta.showFeatureInfo ?? true,
+    showDimensions: project.meta.showDimensions ?? true,
     maxTravelZ: project.meta.maxTravelZ ?? defaultMaxTravelZ(project.meta.units),
     operationClearanceZ: project.meta.operationClearanceZ ?? defaultOperationClearanceZ(project.meta.units),
     clampClearanceXY: project.meta.clampClearanceXY ?? defaultClampClearanceXY(project.meta.units),
@@ -3207,6 +3208,32 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
         meta: {
           ...s.project.meta,
           ...patch,
+          modified: new Date().toISOString(),
+        },
+      }
+      if (projectsEqual(nextProject, s.project)) {
+        return {}
+      }
+      if (s.history.transactionStart) {
+        return { project: nextProject }
+      }
+      return {
+        project: nextProject,
+        history: {
+          past: [...s.history.past, cloneProject(s.project)].slice(-100),
+          future: [],
+          transactionStart: null,
+        },
+      }
+    }),
+
+  setShowDimensions: (visible) =>
+    set((s) => {
+      const nextProject = {
+        ...s.project,
+        meta: {
+          ...s.project.meta,
+          showDimensions: visible,
           modified: new Date().toISOString(),
         },
       }

--- a/src/store/projectStoreTransform.test.ts
+++ b/src/store/projectStoreTransform.test.ts
@@ -182,6 +182,7 @@ endsolid tri
     origin: { name: 'Origin', x: 0, y: 0, z: 5, visible: true },
     backdrop: null,
     dimensions: {},
+    annotations: [],
     modelAssets: {},
     features: [makeFeature('stl')].map((feature) => ({
       ...feature,

--- a/src/store/projectStoreTransform.test.ts
+++ b/src/store/projectStoreTransform.test.ts
@@ -170,6 +170,7 @@ endsolid tri
       modified: '2026-01-01T00:00:00.000Z',
       units: 'mm',
       showFeatureInfo: true,
+      showDimensions: true,
       maxTravelZ: 10,
       operationClearanceZ: 3,
       clampClearanceXY: 2,

--- a/src/store/slices/dimensionToolSlice.ts
+++ b/src/store/slices/dimensionToolSlice.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Transient measure/dimension tool state. None of this is persisted to .camj
+ * or recorded in undo history — it is purely in-flight interaction state.
+ */
+
+import type { StateCreator } from 'zustand'
+import { nextPlacementSession } from '../helpers/ids'
+import type { DimensionAnchor, DimensionType } from '../../types/project'
+import type { PendingDimensionTool, ProjectStore } from '../types'
+
+export type DimensionToolSlice = Pick<
+  ProjectStore,
+  | 'tapeMeasure'
+  | 'pendingDimension'
+  | 'startTapeMeasure'
+  | 'tapeMeasureClick'
+  | 'clearTapeMeasure'
+  | 'startDimensionTool'
+  | 'setPendingDimensionType'
+  | 'pendingDimensionPick'
+  | 'cancelPendingDimension'
+>
+
+/** Anchors required before a dimension of the given type can be committed. */
+function requiredAnchors(type: DimensionType): 2 | 3 {
+  return type === 'angle' ? 3 : 2
+}
+
+/** Clears all other in-flight placement tools so the measure tools are exclusive. */
+function clearOtherTools(): Partial<ProjectStore> {
+  return {
+    pendingAdd: null,
+    pendingMove: null,
+    pendingTransform: null,
+    pendingOffset: null,
+    pendingShapeAction: null,
+    pendingConstraint: null,
+  }
+}
+
+export function createDimensionToolSlice(
+  set: Parameters<StateCreator<ProjectStore>>[0],
+  _get: Parameters<StateCreator<ProjectStore>>[1],
+): DimensionToolSlice {
+  void _get
+  return {
+    tapeMeasure: null,
+    pendingDimension: null,
+
+    startTapeMeasure: () =>
+      set(() => ({
+        ...clearOtherTools(),
+        pendingDimension: null,
+        tapeMeasure: { first: null, frozen: null },
+      })),
+
+    tapeMeasureClick: (point) =>
+      set((s) => {
+        const tape = s.tapeMeasure
+        if (!tape) {
+          return { tapeMeasure: { first: { ...point }, frozen: null } }
+        }
+        if (!tape.first) {
+          // Begin a fresh measurement (also the path after a frozen one).
+          return { tapeMeasure: { first: { ...point }, frozen: null } }
+        }
+        // Second click: freeze the A→B measurement; it shows until the next click.
+        return { tapeMeasure: { first: null, frozen: { a: tape.first, b: { ...point } } } }
+      }),
+
+    clearTapeMeasure: () => set(() => ({ tapeMeasure: null })),
+
+    startDimensionTool: (type) =>
+      set(() => ({
+        ...clearOtherTools(),
+        tapeMeasure: null,
+        pendingDimension: { type, a: null, b: null, c: null, session: nextPlacementSession() },
+      })),
+
+    setPendingDimensionType: (type) =>
+      set((s) => {
+        if (!s.pendingDimension) {
+          return { pendingDimension: { type, a: null, b: null, c: null, session: nextPlacementSession() } }
+        }
+        // Switching type resets accumulated anchors to avoid mismatched arity.
+        return { pendingDimension: { ...s.pendingDimension, type, a: null, b: null, c: null } }
+      }),
+
+    pendingDimensionPick: (anchor: DimensionAnchor) =>
+      set((s) => {
+        const tool = s.pendingDimension
+        if (!tool) return {}
+        const need = requiredAnchors(tool.type)
+        let next: PendingDimensionTool
+        if (!tool.a) {
+          next = { ...tool, a: anchor }
+        } else if (!tool.b) {
+          next = { ...tool, b: anchor }
+        } else if (need === 3 && !tool.c) {
+          next = { ...tool, c: anchor }
+        } else {
+          return {}
+        }
+        return { pendingDimension: next }
+      }),
+
+    cancelPendingDimension: () => set(() => ({ pendingDimension: null })),
+  }
+}

--- a/src/store/slices/dimensionToolSlice.ts
+++ b/src/store/slices/dimensionToolSlice.ts
@@ -26,6 +26,7 @@ export type DimensionToolSlice = Pick<
   ProjectStore,
   | 'tapeMeasure'
   | 'pendingDimension'
+  | 'dimensionDeleteArmed'
   | 'startTapeMeasure'
   | 'tapeMeasureClick'
   | 'clearTapeMeasure'
@@ -33,6 +34,7 @@ export type DimensionToolSlice = Pick<
   | 'setPendingDimensionType'
   | 'pendingDimensionPick'
   | 'cancelPendingDimension'
+  | 'setDimensionDeleteArmed'
 >
 
 /** Anchors required before a dimension of the given type can be committed. */
@@ -60,11 +62,13 @@ export function createDimensionToolSlice(
   return {
     tapeMeasure: null,
     pendingDimension: null,
+    dimensionDeleteArmed: false,
 
     startTapeMeasure: () =>
       set(() => ({
         ...clearOtherTools(),
         pendingDimension: null,
+        dimensionDeleteArmed: false,
         tapeMeasure: { first: null, frozen: null },
       })),
 
@@ -88,6 +92,7 @@ export function createDimensionToolSlice(
       set(() => ({
         ...clearOtherTools(),
         tapeMeasure: null,
+        dimensionDeleteArmed: false,
         pendingDimension: { type, a: null, b: null, c: null, session: nextPlacementSession() },
       })),
 
@@ -119,5 +124,12 @@ export function createDimensionToolSlice(
       }),
 
     cancelPendingDimension: () => set(() => ({ pendingDimension: null })),
+
+    setDimensionDeleteArmed: (armed) =>
+      set(() =>
+        armed
+          ? { ...clearOtherTools(), tapeMeasure: null, pendingDimension: null, dimensionDeleteArmed: true }
+          : { dimensionDeleteArmed: false },
+      ),
   }
 }

--- a/src/store/slices/dimensionsSlice.ts
+++ b/src/store/slices/dimensionsSlice.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { StateCreator } from 'zustand'
+import type { Project } from '../../types/project'
+import { nextUniqueGeneratedId } from '../helpers/ids'
+import type { ProjectStore } from '../types'
+
+export interface DimensionsSliceDependencies {
+  cloneProject: (project: Project) => Project
+}
+
+export type DimensionsSlice = Pick<
+  ProjectStore,
+  | 'selectedAnnotationId'
+  | 'addDimensionAnnotation'
+  | 'updateDimensionAnnotation'
+  | 'deleteDimensionAnnotation'
+  | 'selectAnnotation'
+>
+
+export function createDimensionsSlice(
+  set: Parameters<StateCreator<ProjectStore>>[0],
+  get: Parameters<StateCreator<ProjectStore>>[1],
+  deps: DimensionsSliceDependencies,
+): DimensionsSlice {
+  const { cloneProject } = deps
+
+  /** Build a history-aware state patch for a project mutation. */
+  function commit(s: ProjectStore, nextProject: Project): Partial<ProjectStore> {
+    const project = { ...nextProject, meta: { ...nextProject.meta, modified: new Date().toISOString() } }
+    if (s.history.transactionStart) {
+      return { project }
+    }
+    return {
+      project,
+      history: {
+        past: [...s.history.past, cloneProject(s.project)].slice(-100),
+        future: [],
+        transactionStart: null,
+      },
+    }
+  }
+
+  return {
+    selectedAnnotationId: null,
+
+    addDimensionAnnotation: (annotation) => {
+      const id = nextUniqueGeneratedId(get().project, 'dim')
+      set((s) => ({
+        ...commit(s, {
+          ...s.project,
+          annotations: [...s.project.annotations, { ...annotation, id }],
+        }),
+        selectedAnnotationId: id,
+      }))
+      return id
+    },
+
+    updateDimensionAnnotation: (id, patch) =>
+      set((s) => {
+        const exists = s.project.annotations.some((a) => a.id === id)
+        if (!exists) return {}
+        return commit(s, {
+          ...s.project,
+          annotations: s.project.annotations.map((a) => (a.id === id ? { ...a, ...patch, id: a.id } : a)),
+        })
+      }),
+
+    deleteDimensionAnnotation: (id) =>
+      set((s) => {
+        if (!s.project.annotations.some((a) => a.id === id)) return {}
+        return {
+          ...commit(s, {
+            ...s.project,
+            annotations: s.project.annotations.filter((a) => a.id !== id),
+          }),
+          selectedAnnotationId: s.selectedAnnotationId === id ? null : s.selectedAnnotationId,
+        }
+      }),
+
+    selectAnnotation: (id) =>
+      set(() => ({ selectedAnnotationId: id })),
+  }
+}

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -20,6 +20,9 @@ import type { SnapMode } from '../sketch/snapping'
 import type {
   BackdropImage,
   Clamp,
+  DimensionAnchor,
+  DimensionAnnotation,
+  DimensionType,
   FeatureFolder,
   FeatureTreeEntry,
   GridSettings,
@@ -117,6 +120,29 @@ export type PendingAddTool =
 export type CompositeSegmentMode = 'line' | 'arc' | 'spline'
 export type CreationTarget = 'feature' | 'region'
 
+/**
+ * Transient tape-measure state. Not persisted, not in undo history.
+ * `first` is the anchored start of an in-progress measurement; `frozen` is the
+ * last completed A→B measurement, shown until the next click starts a new one.
+ */
+export interface TapeMeasureState {
+  first: Point | null
+  frozen: { a: Point; b: Point } | null
+}
+
+/**
+ * Transient permanent-dimension placement tool. Anchors accumulate as the user
+ * clicks (a, then b, then c for angles); the canvas then enters an offset-pick
+ * phase and commits via `addDimensionAnnotation`. Not in undo history.
+ */
+export interface PendingDimensionTool {
+  type: DimensionType
+  a: DimensionAnchor | null
+  b: DimensionAnchor | null
+  c: DimensionAnchor | null
+  session: number
+}
+
 export interface PendingMoveTool {
   mode: 'move' | 'copy'
   entityType: 'feature' | 'clamp' | 'tab' | 'backdrop'
@@ -197,6 +223,11 @@ export interface ProjectStore {
   backdropImageLoading: boolean
   sketchEditSession: SketchEditSession | null
   pendingConstraint: PendingConstraint | null
+  // ---- Measure & dimensions (transient tool state, not persisted) ----
+  tapeMeasure: TapeMeasureState | null
+  pendingDimension: PendingDimensionTool | null
+  /** Currently selected dimension annotation, or null. Not in undo history. */
+  selectedAnnotationId: string | null
   history: ProjectHistory
 
   // ---- Session state (not persisted in .camj) ----
@@ -244,6 +275,22 @@ export interface ProjectStore {
   beginHistoryTransaction: () => void
   commitHistoryTransaction: () => void
   cancelHistoryTransaction: () => void
+
+  // ---- Measure & dimensions ----
+  /** Persistent dimension annotation actions (history-tracked). */
+  addDimensionAnnotation: (annotation: Omit<DimensionAnnotation, 'id'>) => string
+  updateDimensionAnnotation: (id: string, patch: Partial<DimensionAnnotation>) => void
+  deleteDimensionAnnotation: (id: string) => void
+  selectAnnotation: (id: string | null) => void
+  /** Transient tape-measure tool. */
+  startTapeMeasure: () => void
+  tapeMeasureClick: (point: Point) => void
+  clearTapeMeasure: () => void
+  /** Transient permanent-dimension placement tool. */
+  startDimensionTool: (type: DimensionType) => void
+  setPendingDimensionType: (type: DimensionType) => void
+  pendingDimensionPick: (anchor: DimensionAnchor) => void
+  cancelPendingDimension: () => void
 
   setStock: (stock: Stock) => void
   setStockSourceFeature: (featureId: string | null) => void

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -247,6 +247,7 @@ export interface ProjectStore {
   createNewProject: (template?: Project, name?: string) => void
   setProjectName: (name: string) => void
   setShowFeatureInfo: (visible: boolean) => void
+  setShowDimensions: (visible: boolean) => void
   setProjectClearances: (patch: Partial<Pick<Project['meta'], 'maxTravelZ' | 'operationClearanceZ' | 'clampClearanceXY' | 'clampClearanceZ'>>) => void
   setOrigin: (origin: Project['origin']) => void
   startPlaceOrigin: () => void

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -226,6 +226,8 @@ export interface ProjectStore {
   // ---- Measure & dimensions (transient tool state, not persisted) ----
   tapeMeasure: TapeMeasureState | null
   pendingDimension: PendingDimensionTool | null
+  /** When true, the next canvas click on a dimension deletes it. */
+  dimensionDeleteArmed: boolean
   /** Currently selected dimension annotation, or null. Not in undo history. */
   selectedAnnotationId: string | null
   history: ProjectHistory
@@ -292,6 +294,8 @@ export interface ProjectStore {
   setPendingDimensionType: (type: DimensionType) => void
   pendingDimensionPick: (anchor: DimensionAnchor) => void
   cancelPendingDimension: () => void
+  /** Transient "click a dimension to delete it" mode. */
+  setDimensionDeleteArmed: (armed: boolean) => void
 
   setStock: (stock: Stock) => void
   setStockSourceFeature: (featureId: string | null) => void

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -892,6 +892,10 @@
   text-overflow: ellipsis;
 }
 
+.snap-popover-grid--icon-only .snap-popover-item {
+  justify-content: center;
+}
+
 /* ── Left drawer (tablet) ──────────────────────────────── */
 
 [data-shell-mode="tablet"] .panel-left,

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -480,6 +480,7 @@ export interface ProjectMeta {
   modified: string
   units: 'mm' | 'inch'
   showFeatureInfo: boolean
+  showDimensions: boolean
   maxTravelZ: number
   operationClearanceZ: number
   clampClearanceXY: number
@@ -1141,6 +1142,7 @@ export function newProject(name = 'Untitled', units: ProjectMeta['units'] = 'inc
       modified: now,
       units,
       showFeatureInfo: true,
+      showDimensions: true,
       maxTravelZ: defaultMaxTravelZ(units),
       operationClearanceZ: defaultOperationClearanceZ(units),
       clampClearanceXY: defaultClampClearanceXY(units),

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -95,6 +95,14 @@ export type DimensionAnchor =
   | { kind: 'vertex'; target: AnchorTarget; vertexIndex: number }   // profile vertex (profileVertices order)
   | { kind: 'midpoint'; target: AnchorTarget; segmentIndex: number }
   | { kind: 'center'; target: AnchorTarget; segmentIndex: number }  // arc / circle centre
+  // Point on an arc/circle boundary identified by an angle (radians) relative
+  // to the segment's radius-handle direction. Lets a radius/diameter dimension
+  // keep its drawn direction when the feature moves, rotates, or resizes.
+  | { kind: 'circleEdge'; target: AnchorTarget; segmentIndex: number; relativeAngle: number }
+  // Point along a straight segment at parameter t∈[0,1]. Lets a line-snap edge
+  // pick on a line segment follow the feature instead of staying frozen in
+  // world space (e.g. angle dimensions whose rays land on a rectangle edge).
+  | { kind: 'segmentPoint'; target: AnchorTarget; segmentIndex: number; t: number }
   | { kind: 'origin' }                                              // machine origin
 
 export type DimensionType =

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -75,6 +75,52 @@ export interface NamedDimension {
 }
 
 // ============================================================
+// Dimension annotations (measure / drawing dimensions)
+//
+// These are *drawing* annotations (distances, radii, angles) shown on the
+// sketch canvas. They are inert: toolpaths, G-code, CSG and simulation ignore
+// them. Distinct from `Project.dimensions` (parametric NamedDimension values
+// that drive feature Z-depths). A dimension never stores its measured value —
+// the value is recomputed live from its anchors so it follows geometry edits.
+// ============================================================
+
+// What a non-free anchor points at. v1: features + stock + machine origin.
+export type AnchorTarget =
+  | { source: 'feature'; featureId: string }
+  | { source: 'stock' }
+
+// A reference to a live point in the scene. Resolves to a world Point each frame.
+export type DimensionAnchor =
+  | { kind: 'free'; point: Point }                                  // unattached, fixed world point
+  | { kind: 'vertex'; target: AnchorTarget; vertexIndex: number }   // profile vertex (profileVertices order)
+  | { kind: 'midpoint'; target: AnchorTarget; segmentIndex: number }
+  | { kind: 'center'; target: AnchorTarget; segmentIndex: number }  // arc / circle centre
+  | { kind: 'origin' }                                              // machine origin
+
+export type DimensionType =
+  | 'aligned'     // true distance, dimension line parallel to the two points
+  | 'horizontal'  // |Δx| between two points
+  | 'vertical'    // |Δy| between two points
+  | 'radius'      // R of an arc/circle (anchor a = center, anchor b = edge)
+  | 'diameter'    // Ø of an arc/circle
+  | 'angle'       // angle at vertex a between rays to b and c
+
+export interface DimensionAnnotation {
+  id: string                    // 'dim0001'
+  type: DimensionType
+  a: DimensionAnchor            // primary anchor (linear start / arc center / angle vertex)
+  b?: DimensionAnchor           // second anchor (linear end / arc edge / angle ray-1)
+  c?: DimensionAnchor           // third anchor (angle ray-2)
+  offset: number                // perpendicular distance of the dimension line from the
+                                // measured points (world units); sign chooses the side
+  labelOffset?: number          // optional slide of the label along the dimension line (world units)
+  textOverride?: string | null  // optional manual label text (value still computed for tooltip)
+  precisionOverride?: number | null
+  visible: boolean
+  locked: boolean
+}
+
+// ============================================================
 // Constraints
 // ============================================================
 
@@ -458,6 +504,7 @@ export interface Project {
   origin: MachineOrigin
   backdrop: BackdropImage | null
   dimensions: Record<string, NamedDimension>
+  annotations: DimensionAnnotation[]
   modelAssets: Record<string, PersistedImportedMesh>
   features: SketchFeature[]
   featureFolders: FeatureFolder[]
@@ -1106,6 +1153,7 @@ export function newProject(name = 'Untitled', units: ProjectMeta['units'] = 'inc
     origin: defaultOrigin(stock),
     backdrop: null,
     dimensions: {},
+    annotations: [],
     modelAssets: {},
     features: [],
     featureFolders: [],

--- a/src/utils/units.test.ts
+++ b/src/utils/units.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Run with: npx tsx src/utils/units.test.ts
+ */
+
+import { newProject } from '../types/project'
+import type { DimensionAnnotation, Project } from '../types/project'
+import { convertProjectUnits } from './units'
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error('FAIL: ' + msg)
+}
+
+function approx(a: number, b: number, eps = 1e-9): boolean {
+  return Math.abs(a - b) <= eps
+}
+
+const MM_PER_INCH = 25.4
+
+const freeDim: DimensionAnnotation = {
+  id: 'dim0001',
+  type: 'aligned',
+  a: { kind: 'free', point: { x: 25.4, y: 50.8 } },
+  b: { kind: 'free', point: { x: 0, y: 0 } },
+  offset: 12.7,
+  labelOffset: 5,
+  textOverride: null,
+  precisionOverride: null,
+  visible: true,
+  locked: false,
+}
+
+const anchoredAngleDim: DimensionAnnotation = {
+  id: 'dim0002',
+  type: 'angle',
+  a: { kind: 'vertex', target: { source: 'feature', featureId: 'f0001' }, vertexIndex: 0 },
+  b: { kind: 'vertex', target: { source: 'feature', featureId: 'f0001' }, vertexIndex: 1 },
+  c: { kind: 'vertex', target: { source: 'feature', featureId: 'f0001' }, vertexIndex: 2 },
+  offset: 25.4,
+  textOverride: null,
+  precisionOverride: null,
+  visible: true,
+  locked: false,
+}
+
+// ── mm → inch conversion of annotations ─────────────────────
+{
+  const base: Project = { ...newProject('units-test', 'mm'), annotations: [freeDim, anchoredAngleDim] }
+  const inch = convertProjectUnits(base, 'inch')
+
+  const a = inch.annotations[0]
+  assert(a.a.kind === 'free' && approx(a.a.point.x, 25.4 / MM_PER_INCH), 'free anchor x converts to inch')
+  assert(a.a.kind === 'free' && approx(a.a.point.y, 50.8 / MM_PER_INCH), 'free anchor y converts to inch')
+  assert(approx(a.offset, 12.7 / MM_PER_INCH), 'offset converts to inch')
+  assert(a.labelOffset !== undefined && approx(a.labelOffset, 5 / MM_PER_INCH), 'labelOffset converts to inch')
+
+  // anchored angle dim: anchors are references (no coords) and stay intact; offset still converts
+  const angle = inch.annotations[1]
+  assert(angle.a.kind === 'vertex' && angle.a.vertexIndex === 0, 'anchored vertex reference unchanged')
+  assert(approx(angle.offset, 25.4 / MM_PER_INCH), 'angle dim offset converts (length)')
+
+  console.log('mm→inch annotation conversion PASS')
+}
+
+// ── round-trip mm → inch → mm is identity ───────────────────
+{
+  const base: Project = { ...newProject('units-test', 'mm'), annotations: [freeDim] }
+  const round = convertProjectUnits(convertProjectUnits(base, 'inch'), 'mm')
+  const a = round.annotations[0]
+  assert(a.a.kind === 'free' && approx(a.a.point.x, 25.4, 1e-7), 'round-trip free x')
+  assert(approx(a.offset, 12.7, 1e-7), 'round-trip offset')
+  assert(a.labelOffset !== undefined && approx(a.labelOffset, 5, 1e-7), 'round-trip labelOffset')
+  console.log('round-trip annotation conversion PASS')
+}
+
+console.log('\nall units.test.ts assertions passed')

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -17,6 +17,8 @@
 import type {
   BackdropImage,
   Clamp,
+  DimensionAnchor,
+  DimensionAnnotation,
   DimensionRef,
   GlobalConstraint,
   GridSettings,
@@ -65,6 +67,13 @@ export function formatLength(
   const maximumFractionDigits = options?.maximumFractionDigits ?? (units === 'inch' ? 4 : 3)
   const fixed = value.toFixed(maximumFractionDigits)
   return fixed.replace(/(\.\d*?[1-9])0+$/u, '$1').replace(/\.0+$/u, '')
+}
+
+export function formatAngle(degrees: number, options?: { maximumFractionDigits?: number }): string {
+  const maximumFractionDigits = options?.maximumFractionDigits ?? 1
+  const fixed = degrees.toFixed(maximumFractionDigits)
+  const trimmed = fixed.replace(/(\.\d*?[1-9])0+$/u, '$1').replace(/\.0+$/u, '')
+  return `${trimmed}°`
 }
 
 function convertPoint(point: Point, from: Units, to: Units): Point {
@@ -158,6 +167,30 @@ function convertLocalConstraint(constraint: LocalConstraint, from: Units, to: Un
   }
 
   return constraint
+}
+
+function convertDimensionAnchor(anchor: DimensionAnchor, from: Units, to: Units): DimensionAnchor {
+  // Only `free` anchors store a literal coordinate; anchored kinds resolve from
+  // geometry at render time and need no conversion.
+  if (anchor.kind === 'free') {
+    return { ...anchor, point: convertPoint(anchor.point, from, to) }
+  }
+  return anchor
+}
+
+function convertDimensionAnnotation(annotation: DimensionAnnotation, from: Units, to: Units): DimensionAnnotation {
+  return {
+    ...annotation,
+    a: convertDimensionAnchor(annotation.a, from, to),
+    b: annotation.b ? convertDimensionAnchor(annotation.b, from, to) : annotation.b,
+    c: annotation.c ? convertDimensionAnchor(annotation.c, from, to) : annotation.c,
+    // offset/labelOffset are world lengths regardless of dimension type. Angle
+    // dimensions carry no length value (it is computed live), so nothing else converts.
+    offset: convertLength(annotation.offset, from, to),
+    labelOffset: annotation.labelOffset === undefined
+      ? annotation.labelOffset
+      : convertLength(annotation.labelOffset, from, to),
+  }
 }
 
 function convertGlobalConstraint(constraint: GlobalConstraint, from: Units, to: Units): GlobalConstraint {
@@ -298,6 +331,7 @@ export function convertProjectUnits(project: Project, toUnits: Units): Project {
         convertNamedDimension(dimension, fromUnits, toUnits),
       ]),
     ),
+    annotations: project.annotations.map((annotation) => convertDimensionAnnotation(annotation, fromUnits, toUnits)),
     features: project.features.map((feature) => convertFeature(feature, fromUnits, toUnits)),
     global_constraints: project.global_constraints.map((constraint) => convertGlobalConstraint(constraint, fromUnits, toUnits)),
     tools: project.tools,


### PR DESCRIPTION
## Summary

This branch lands the **Measure & Dimensions** feature (see `planning/MEASURE_DIMENSIONS_Plan.md`) plus a round of in-app polish from the visual-verification pass.

The feature provides:
- **Tape measure** — transient distance tool with live readout, never persisted.
- **Permanent dimensions** — aligned / horizontal / vertical / radius / diameter / angle, stored as anchored references that follow geometry when it moves or is edited.
- **Delete tool** + **global show/hide** + per-platform toolbar controls.

Earlier commits (already on the branch) build the data model, pure geometry, snap provenance, store wiring, canvas rendering, and the initial toolbar/popover controls. The newer commits on top fold in fixes and refinements from clicking through the feature in the running app.

### Visual-pass changes

- **Toolbar layout.** Moved the measure/dimensions group to the top toolbar next to the snap group. The 6 dimension types collapse into a popover (same pattern as Alignment), so the top toolbar drops from 9 inline buttons to 4 (tape, dim-popover, delete, visibility).
- **Tablet popover.** Redesigned as a uniform 3×3 icon grid. New `tape-measure` icon (case + spool + blade + hook) added to `icons.camj` and regenerated `public/icons.svg`. Show/hide uses `eye` / `eye-off`. Labels removed; tooltips retain context.
- **Radius / diameter correctness.**
  - True radius is pulled from the circle/arc segment when one anchor is a `center`, so the displayed value no longer drifts with polyline-tessellated line snaps.
  - The drawn dimension line is trimmed to the true boundary.
  - Commit happens immediately on the edge click (no ceremonial "click to place"; offset is meaningless for radial dims).
  - The first click is now restricted to an arc/circle `center` — non-center clicks are ignored so users can't produce a meaningless radius between arbitrary points.
- **Anchors that survive feature edits.**
  - New `circleEdge` anchor kind: line-snap on an arc/circle stores the angle relative to the segment's radius handle, so the dim direction follows translations, rotations, and resizes.
  - New `segmentPoint` anchor kind: line-snap on a straight segment stores parameter `t` along that segment, so an angle dimension's ray endpoint stays glued to the picked edge.
- **Angle dim preview.** Rubber-band now anchors at the vertex when the user picks the second ray (was previously rubber-banding from the first ray point).
- **Delete-from-selection.** Clicking the Delete-dimension toolbar button when a dim is already selected deletes it immediately, instead of arming the click-to-delete mode and requiring a second click. (Delete/Backspace key already did this.)
- **Instruction text** for permanent-dim placement trimmed to "Click points to anchor the dimension to geometry. Esc to cancel."

### Lockfile

Restores the libc selectors (gnu/musl) on the Linux Tauri CLI optional packages that were inadvertently dropped on this branch. No code impact.

### Files

- New anchor kinds in `src/types/project.ts`.
- Geometry/value logic + helpers in `src/sketch/dimensions.ts`.
- Snap provenance for line-snaps in `src/components/canvas/snappingHelpers.ts`.
- Canvas placement / preview in `src/components/canvas/SketchCanvas.tsx`, `src/components/canvas/dimensionRendering.ts`.
- Desktop toolbar + tablet popover in `src/components/layout/Toolbar.tsx`, `src/components/layout/DimensionPopover.tsx`, with a small icon-grid centering rule in `src/styles/tablet.css`.
- New `tape-measure` icon in `src/assets/icons.camj` / `public/icons.svg`.

### Build

`npm run build` is green: icons sync + tsc + 22 structural tests + vite.

## Test plan

- [x] Place each dimension type (aligned, horizontal, vertical, radius, diameter, angle) on a feature; values look right.
- [x] Move / rotate / resize the feature — every dim follows, including radius/diameter direction and angle-dim ray endpoints picked via line snap.
- [x] Radius: first click on anything other than the circle center is ignored; first click on a center then any second click anywhere produces a clean radius value and a line trimmed to the boundary.
- [x] Tape measure: works the same as before, no persistence.
- [x] Delete dimension via (a) toolbar with a dim selected, (b) toolbar with nothing selected → armed mode, (c) Delete/Backspace key with a dim selected.
- [x] Global show/hide toggles all dimensions on both desktop and tablet shells.
- [x] Reopen a `.camj` saved before this branch — `annotations: []` and `showDimensions: true` are restored cleanly.

Plan stays `In progress` in `planning/INDEX.md` until the in-app pass is signed off.