### PR TITLE
Fix Windows test runner npx launch

### DIFF
--- a/planning/archive/WINDOWS_TEST_RUNNER_NODE_TSX_Plan.md
+++ b/planning/archive/WINDOWS_TEST_RUNNER_NODE_TSX_Plan.md
@@ -1,0 +1,37 @@
+---
+status: Done
+created: 2026-06-03
+---
+
+# Windows Test Runner Node TSX Plan
+
+## Goal
+
+Fix the remaining Windows CI test-launch failure on PR #134, where spawning `npx.cmd` still fails with `spawnSync npx.cmd EINVAL` before any test file runs.
+
+## Approach
+
+- Stop spawning the `npx`/`npx.cmd` package-manager shim from `scripts/run-tests.ts`.
+- Resolve the installed `tsx` CLI from `node_modules` and launch it with `process.execPath` (`node`) for each test file.
+- Keep the current per-test process isolation and improve launch-error output to name the `node` + `tsx` command path.
+
+## Files affected
+
+- `scripts/run-tests.ts` — replace shim-based child execution with direct `node <tsx-cli> <test-file>` execution.
+- `planning/archive/WINDOWS_TEST_RUNNER_NODE_TSX_Plan.md` — archive this completed follow-up plan after verification.
+- `planning/INDEX.md` — track this plan while active, then remove it when archived.
+
+## Tests
+
+- Run `npm test`.
+- Run `npm run build`.
+- Push to PR #134 so the Windows workflow can verify the actual runner platform.
+
+## Open questions / risks
+
+None. This keeps the same test execution model but removes Windows `.cmd` spawning from the inner loop.
+
+## Out of scope
+
+- Changing individual tests.
+- Changing the GitHub Actions workflow.

--- a/planning/archive/WINDOWS_TEST_RUNNER_Plan.md
+++ b/planning/archive/WINDOWS_TEST_RUNNER_Plan.md
@@ -1,0 +1,35 @@
+---
+status: Done
+created: 2026-06-03
+---
+
+# Windows Test Runner Plan
+
+## Goal
+
+Fix the Windows CI build so `npm test` can execute the discovered TypeScript test files instead of reporting every test as failed with `exit null`.
+
+## Approach
+
+- Update the test runner to invoke `npx` through the platform-specific executable name (`npx.cmd` on Windows, `npx` elsewhere).
+- Preserve current per-file test execution, output, and failure counting.
+- Improve failure reporting for child-process launch errors so future harness failures show the actual spawn error instead of only `exit null`.
+
+## Files affected
+
+- `scripts/run-tests.ts` — make child test execution Windows-compatible and report spawn errors.
+- `planning/INDEX.md` — track this plan while active, then remove it when archived.
+
+## Tests
+
+- Run `npm test` locally to verify the runner still executes all test files on macOS/Linux.
+- Run `npm run build` from the repo root before finishing, per project requirements.
+
+## Open questions / risks
+
+None. The CI failure pattern points at the runner process launch, not the individual tests.
+
+## Out of scope
+
+- Changing individual test files.
+- Changing the Windows release workflow beyond the test runner compatibility fix.

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -9,13 +9,16 @@
 
 import { spawnSync } from 'node:child_process'
 import { existsSync, readdirSync, statSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { dirname, join, relative, resolve } from 'node:path'
 
+const require = createRequire(import.meta.url)
 const here = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(here, '..')
 const srcRoot = join(repoRoot, 'src')
-const npxExecutable = process.platform === 'win32' ? 'npx.cmd' : 'npx'
+const tsxCliPath = require.resolve('tsx/cli')
+const testExecutable = process.execPath
 
 // Tests that are known-failing for reasons unrelated to the build's freshness.
 // Each entry should be paired with a follow-up issue/task tracking its fix.
@@ -58,14 +61,14 @@ for (const file of testFiles) {
     continue
   }
   process.stdout.write(`\n── ${rel} ─────────────────────────\n`)
-  const result = spawnSync(npxExecutable, ['tsx', file], {
+  const result = spawnSync(testExecutable, [tsxCliPath, file], {
     cwd: repoRoot,
     stdio: 'inherit',
   })
   if (result.status !== 0) {
     failed += 1
     if (result.error) {
-      console.error(`run-tests: failed to launch ${npxExecutable}: ${result.error.message}`)
+      console.error(`run-tests: failed to launch ${testExecutable} ${tsxCliPath}: ${result.error.message}`)
     }
     console.error(`run-tests: FAILED ${rel} (exit ${result.status})`)
   }

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -15,6 +15,7 @@ import { dirname, join, relative, resolve } from 'node:path'
 const here = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(here, '..')
 const srcRoot = join(repoRoot, 'src')
+const npxExecutable = process.platform === 'win32' ? 'npx.cmd' : 'npx'
 
 // Tests that are known-failing for reasons unrelated to the build's freshness.
 // Each entry should be paired with a follow-up issue/task tracking its fix.
@@ -57,12 +58,15 @@ for (const file of testFiles) {
     continue
   }
   process.stdout.write(`\n── ${rel} ─────────────────────────\n`)
-  const result = spawnSync('npx', ['tsx', file], {
+  const result = spawnSync(npxExecutable, ['tsx', file], {
     cwd: repoRoot,
     stdio: 'inherit',
   })
   if (result.status !== 0) {
     failed += 1
+    if (result.error) {
+      console.error(`run-tests: failed to launch ${npxExecutable}: ${result.error.message}`)
+    }
     console.error(`run-tests: FAILED ${rel} (exit ${result.status})`)
   }
 }


### PR DESCRIPTION
## Summary
- Use npx.cmd when the test runner launches child tests on Windows
- Keep npx on non-Windows platforms
- Log child-process launch errors so spawn failures show the actual cause
- Archive the completed plan: planning/archive/WINDOWS_TEST_RUNNER_Plan.md

## Verification
- npm test
- npm run build