### PR TITLE
Fix operation example images 404ing on the web deploy

### DIFF
--- a/src/components/cam/OperationAddMenu.tsx
+++ b/src/components/cam/OperationAddMenu.tsx
@@ -140,7 +140,7 @@ export function OperationAddMenu({
                         </div>
                       ) : (
                         <img
-                          src={`/operation-examples/${description.exampleImageName}`}
+                          src={`${import.meta.env.BASE_URL}operation-examples/${description.exampleImageName}`}
                           alt={`${description.title} example`}
                           className="cam-operation-details__image"
                           onError={() => setImageErrors((prev) => new Set(prev).add(button.kind))}


### PR DESCRIPTION
## Summary
- `OperationAddMenu.tsx` rendered example PNGs with `src="/operation-examples/<file>.png"`. On the deployed website the app is served from `https://purecutcnc.github.io/app/`, so the leading `/` resolves to the site root and the request 404s.
- The files themselves are deployed correctly under `/app/operation-examples/` by `.github/workflows/deploy.yml` (vite copies `public/` into `dist/`, the workflow propagates it). The bug is purely the URL.
- Prefixed the src with `import.meta.env.BASE_URL`, matching the pattern already used by `Icon.tsx` and `useIconIds.ts`. The path becomes `./operation-examples/<file>.png`, which resolves correctly on both web (`/app/operation-examples/...`) and Tauri (`tauri://localhost/operation-examples/...`).

## Impact on shipped builds
- **Web**: broken before, fixed after this deploys.
- **Desktop (Tauri)**: unaffected. The bundle is served at the protocol root, so `/operation-examples/...` happened to resolve. After the fix, BASE_URL is `./` in that context and still resolves correctly. No emergency desktop release needed — the fix rides along on the next normal release.

## Test plan
- [x] `npm run build` clean (23 tests passed).
- [x] Confirmed bundle output contains `src:\`./operation-examples/${name}\``.
- [ ] Once deployed, open the operation Add menu on https://purecutcnc.github.io/app/ and expand a card — the example image should render.