### PR TITLE
Docs: close UX P1 A1.2 as already done

### DIFF
--- a/planning/archive/UX_REVIEW_P1_Plan.md
+++ b/planning/archive/UX_REVIEW_P1_Plan.md
@@ -32,6 +32,17 @@ Make the app's own model obvious so a first-time user doesn't have to learn inte
 
 ### A1.2 — Standardize multi-step interactions on workflow panels
 
+> **CLOSED AS ALREADY DONE (audit 2026-06-09).** The audit found all 13 armed
+> multi-step flows (placement, creation, move/copy, resize/rotate/mirror,
+> offset, join, cut, constraint, sketch edit, tape, dimension placement,
+> dimension delete) already use `CanvasWorkflowPanel` with step label,
+> instruction, confirm/cancel, and numeric inputs. Backdrop move/resize/rotate
+> route through `pendingMove`/`pendingTransform` and are covered by those
+> panels. The migration was completed during the tablet UX work (commit
+> `4fbacb6` "convert last old-style banner to workflow panel") before this
+> plan was written; the remaining `sketch-banner-warning` elements are
+> informational, not interactive. No code change required.
+
 - Make `CanvasWorkflowPanel` / `useCanvasWorkflowPanel` the single pattern for every armed multi-step action (placement, move/copy/resize/rotate/offset/mirror, join, cut, constraint placement, dimension/tape tools).
 - Each panel must answer the five questions: step label, instruction, confirm, cancel, and current numeric inputs/constraints. Audit the pending-action flows in the store and `SketchCanvas.tsx` for any that still rely on canvas-only banners or keyboard-only paths and migrate them.
 - This is the largest P1 item; scope it as an audit + incremental migration (one PR per cluster of actions), not a single rewrite.


### PR DESCRIPTION
## What

Doc-only change. Marks the **A1.2** item (standardize multi-step interactions on `CanvasWorkflowPanel`) in the archived UX P1 plan as **already done**, with the audit conclusion inline.

## Why

A1.2 was deferred from [#138](https://github.com/PureCutCNC/purecutcnc/pull/138) as a follow-up "audit + incremental migration." Auditing `SketchCanvas.tsx` and the store's pending-action state found there is nothing to migrate — all 13 armed multi-step flows already use `CanvasWorkflowPanel`:

> placement, creation, move/copy, resize/rotate/mirror, offset, join, cut, constraint, sketch edit, tape measure, dimension placement, dimension delete

Each panel answers the five questions (step label, instruction, confirm, cancel, numeric inputs). Backdrop move/resize/rotate route through `pendingMove`/`pendingTransform` and are covered by those panels. The remaining `sketch-banner-warning` elements are informational, not interactive.

The migration actually completed during the earlier tablet UX work (commit `4fbacb6`, "convert last old-style banner to workflow panel") — before the P1 plan was written, so the plan item was stale on arrival.

## Change

- One annotation block added to `planning/archive/UX_REVIEW_P1_Plan.md` recording the audit outcome.

No code changes. No build impact.