### PR TITLE
Arm operation highlight on tap so touch users get A1.3 feedback

### DIFF
--- a/src/components/cam/OperationAddMenu.tsx
+++ b/src/components/cam/OperationAddMenu.tsx
@@ -32,7 +32,7 @@ interface OperationAddMenuProps {
   operationSupportsPass: (kind: OperationKind) => boolean
   onChooseOperation: (kind: OperationKind) => void
   onAddOperation: (kind: OperationKind, mode: 'rough' | 'finish' | 'pair') => void
-  /** A1.3: arm a kind (on hover) so the canvas highlights its compatible features. */
+  /** A1.3: arm a kind (on hover or tap-expand) so the canvas highlights its compatible features. */
   onHighlightOperation?: (kind: OperationKind | null) => void
 }
 
@@ -88,7 +88,14 @@ export function OperationAddMenu({
                     className={`cam-operation-label-btn ${isExpanded ? 'cam-operation-label-btn--expanded' : ''}`}
                     type="button"
                     title={button.hint ?? (isExpanded ? `Collapse ${button.label} info` : `Expand ${button.label} info`)}
-                    onClick={() => setExpandedOperationKind(isExpanded ? null : button.kind)}
+                    onClick={() => {
+                      // A1.5: arm the highlight on tap too, so touch users (no
+                      // hover) get the same compatible-feature highlight. Kept
+                      // armed on collapse — it matches hover (the pointer is
+                      // still on the row) and clears when the menu closes.
+                      setExpandedOperationKind(isExpanded ? null : button.kind)
+                      onHighlightOperation?.(button.kind)
+                    }}
                   >
                     <span className="cam-operation-label">{button.label}</span>
                     <Icon id="chevron-down" size={12} />


### PR DESCRIPTION
## Summary

Closes out the last code gap in **A1.5** (tablet cross-checks for the P0/P1 UX surfaces, deferred from the archived `UX_REVIEW_P1_Plan.md`).

The A1.3 compatible-feature canvas highlight in `OperationAddMenu` was armed only via `onMouseEnter`/`onMouseLeave`, so on touch it worked only incidentally (via emulated mouse events). Tapping an operation row now also arms the highlight deterministically:

- Tap (expand or collapse) calls `onHighlightOperation(kind)` for that row.
- Kept armed on collapse — matches hover semantics (the pointer is still on the row) and avoids a desktop regression where collapsing while hovering would clear the highlight.
- Clears as before when the menu closes/unmounts, or when another row is hovered/tapped.

Desktop hover behavior is unchanged.

## A1.5 audit (rest already satisfied)

- Empty-state overlay, disclosure sections, inline validity hints — plain buttons / inline text, touch-fine.
- Feature quick-ops menu — always-visible per-row `⋯` button mirrors right-click.
- Tablet drawer Properties scroll — fixed in #138.
- No user-facing tablet capability over-claims found.

## Testing

- `npm run build` (tsc + structural tests + vite) passes clean.