### PR TITLE
UX P2 A2.1: visual collision & stock-setup overlays

### DIFF
--- a/planning/archive/UX_P2_A2_1_COLLISION_OVERLAYS_Plan.md
+++ b/planning/archive/UX_P2_A2_1_COLLISION_OVERLAYS_Plan.md
@@ -1,0 +1,76 @@
+---
+status: Done
+created: 2026-06-09
+---
+
+# UX Review P2 — A2.1: Visual Collision & Stock-Setup Overlays
+
+> Derived from [`planning/reviews/CONSOLIDATED_REVIEW_2026-06-08.md`](reviews/CONSOLIDATED_REVIEW_2026-06-08.md), section "P2 — A2.1".
+> Depends on no P0/P1 items; independently shippable.
+
+## Goal
+
+Make the collision and setup problems visible directly on the canvas, so a user never has to hunt through text warnings to understand what went wrong. Concretely: highlight the specific toolpath segments that pass through a colliding clamp zone, show the stock outline in amber when a feature exceeds it, add W×H dimension labels to the stock border, and add axis labels ("X" / "Y") to the existing machine-origin marker — all so the digital canvas maps obviously to the physical machine.
+
+## What's already there (context)
+
+- `collidingClampIds` is already computed and propagated to `SketchCanvas`, `Viewport3D`, and `SimulationViewport`.
+- `drawClampFootprint` already renders colliding clamps with a red fill/stroke vs. blue for non-colliding.
+- `applyClampWarnings` (`src/engine/toolpaths/clamps.ts`) already identifies which moves cross into which clamp zones and produces text warnings — but it only surfaces *which clamps* collide (`collidingClampIds`), not *which moves*.
+- `drawOriginMarker` (`src/components/canvas/scenePrimitives.ts`) already draws X/Y axis arrows at the project origin; it's shown when `project.origin.visible`.
+- `profileExceedsStock` is called in `PropertiesPanel.tsx` and shows a text warning — no canvas-level indicator.
+
+## Approach
+
+### 1 — Per-move collision tagging
+
+Extend `ToolpathResult` (`src/engine/toolpaths/types.ts`) with an optional `collidingMoveIndices: number[]` field. In `applyClampWarnings` (`src/engine/toolpaths/clamps.ts`), while iterating moves that cross into unsafe clamp zones, record the move index. No existing callers need to change; the field defaults to `undefined`.
+
+### 2 — Highlight colliding toolpath segments
+
+In `drawToolpath` (`src/components/canvas/previewPrimitives.ts`), when `toolpath.collidingMoveIndices` is non-empty, draw an additional pass over those specific moves in a distinct warning color (amber: `rgba(255, 180, 60, 0.95)`, slightly thicker than the normal cut layer). Draw this on top of the normal toolpath so it's clearly visible.
+
+### 3 — Stock border feedback
+
+In the main `SketchCanvas` draw loop (`src/components/canvas/SketchCanvas.tsx`, draw function around line 1343), compute whether any visible feature exceeds the stock bounds (`profileExceedsStock` already exists in `src/types/project.ts`). If so, stroke the stock outline in amber (`rgba(240, 160, 40, 0.9)`) instead of the normal stock color. Keep the fill neutral; only the border changes.
+
+This computation happens per-frame inside the canvas draw callback (not a React render), so it does not affect re-render frequency.
+
+### 4 — Stock dimension labels
+
+In `drawStockOutline` (or the inline block in the draw loop), after drawing the stock stroke, add two dimension labels at canvas edges: width along the top edge, height along the right edge, both formatted with `formatLength` in the project's units. Use a small semi-transparent pill background (matching the existing constraint-label style) so labels read against the canvas background.
+
+Extract the inline stock-drawing block into a small `drawStockOutline(ctx, stock, vt, exceedsAny)` function in `src/components/canvas/scenePrimitives.ts` to keep the logic tidy.
+
+### 5 — Axis labels on the origin marker
+
+In `drawOriginMarker` (`src/components/canvas/scenePrimitives.ts`), add "X" (red) and "Y" (green) text labels at the arrowhead tips. Labels use `sans-serif 10px` with a dark background pill (same style as the existing origin name label that already appears below the dot).
+
+## Files affected
+
+- `src/engine/toolpaths/types.ts` — add `collidingMoveIndices?: number[]` to `ToolpathResult`.
+- `src/engine/toolpaths/clamps.ts` — populate `collidingMoveIndices` in `applyClampWarnings`.
+- `src/components/canvas/previewPrimitives.ts` — `drawToolpath`: extra pass for colliding moves.
+- `src/components/canvas/scenePrimitives.ts` — extract `drawStockOutline`; extend `drawOriginMarker` with axis labels.
+- `src/components/canvas/SketchCanvas.tsx` — call `drawStockOutline` (with `exceedsAny` flag) instead of the inline stock block; pass computed excess flag.
+
+No changes to `PropertiesPanel.tsx` (its text warning is complementary), engine logic, or data model.
+
+## Tests
+
+- **`collidingMoveIndices` population**: unit test in `src/engine/toolpaths/clamps.test.ts` (or alongside the existing engine tests) that runs `applyClampWarnings` with a fixture project + a toolpath move that crosses a clamp zone below clearance; asserts the colliding move index appears in `collidingMoveIndices`.
+- **No regression on existing warning text**: existing warning string assertions still pass.
+- **Structural/snapshot**: no new component tests needed — the drawing changes are purely canvas-side and already tested at the integration level by the build.
+
+## Open questions / risks
+
+- **Label overlap at small zoom levels**: the stock dimension labels could overlap feature geometry at very high zoom (small stock, many features). Use a minimum scale threshold (don't render labels when the stock viewport-px width is below ~200 px).
+- **`collidingMoveIndices` on adjusted moves**: `applyClampWarnings` can inject extra lift moves (`liftRapidMove`). The indices should refer to positions in the *output* `adjustedMoves` array, not the input — confirm this is what the draw path gets.
+- **Viewport3D / SimulationViewport**: these already colorize colliding clamps; the per-move field is purely 2D-canvas-side for now. 3D toolpath segment coloring is possible but would be a separate 3D renderer change — leave for a follow-up if requested.
+
+## Out of scope
+
+- 3D toolpath segment collision highlights in `Viewport3D` (canvas only for this PR).
+- Changes to collision-detection rules or clearance parameters.
+- Simulation voxel-level collision feedback (that is A3.2 territory).
+- Any toolbar or layout changes (that is A2.2 in a separate PR).

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -65,7 +65,6 @@ import {
   drawPendingSplineLoop,
   drawPreviewProfile,
   drawToolpath,
-  hexToRgba,
   translateProfile,
 } from './previewPrimitives'
 import {
@@ -94,6 +93,7 @@ import {
   drawOriginMarker,
   drawSketchControls,
   drawSketchEditPreviewPoint,
+  drawStockOutline,
   drawTabFootprint,
   hitBackdrop,
 } from './scenePrimitives'
@@ -1340,16 +1340,12 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     }
 
     if (project.stock.visible) {
-      traceProfilePath(ctx, project.stock.profile, vt)
-      ctx.strokeStyle = hexToRgba(project.stock.color, 0.7)
-      ctx.lineWidth = 2
-      ctx.setLineDash([7, 4])
-      ctx.stroke()
-      ctx.setLineDash([])
-
-      traceProfilePath(ctx, project.stock.profile, vt)
-      ctx.fillStyle = hexToRgba(project.stock.color, 0.12)
-      ctx.fill()
+      const anyFeatureExceedsStock = project.features.some(
+        (feature) => feature.visible
+          && feature.kind !== 'text'
+          && profileExceedsStock(feature.sketch.profile, project.stock),
+      )
+      drawStockOutline(ctx, project.stock, vt, project.meta.units, anyFeatureExceedsStock)
     }
 
     if (project.origin.visible) {

--- a/src/components/canvas/previewPrimitives.ts
+++ b/src/components/canvas/previewPrimitives.ts
@@ -559,6 +559,26 @@ export function drawToolpath(
     ctx.globalAlpha = 1
   }
 
+  // Collision warning overlay: segments that cross a clamp zone below required
+  // clearance are re-drawn in amber on top, regardless of layer visibility.
+  if (toolpath.collidingMoveIndices && toolpath.collidingMoveIndices.length > 0) {
+    ctx.beginPath()
+    for (const index of toolpath.collidingMoveIndices) {
+      const move = toolpath.moves[index]
+      if (!move) continue
+      const from = worldToCanvas({ x: move.from.x, y: move.from.y }, vt)
+      const to = worldToCanvas({ x: move.to.x, y: move.to.y }, vt)
+      ctx.moveTo(from.cx, from.cy)
+      ctx.lineTo(to.cx, to.cy)
+    }
+    ctx.strokeStyle = 'rgba(255, 180, 60, 0.95)'
+    ctx.globalAlpha = emphasized ? 1 : 0.55
+    ctx.lineWidth = emphasized ? 3 : 2.2
+    ctx.setLineDash([])
+    ctx.stroke()
+    ctx.globalAlpha = 1
+  }
+
   if (!emphasized || !toolpath.bounds || !visibility.directions) {
     return
   }

--- a/src/components/canvas/scenePrimitives.ts
+++ b/src/components/canvas/scenePrimitives.ts
@@ -17,6 +17,9 @@
 import type { SketchControlRef } from '../../store/types'
 import { getStockBounds, profileVertices, rectProfile } from '../../types/project'
 import type { BackdropImage, Clamp, GridSettings, Point, SketchProfile, Stock, Tab } from '../../types/project'
+import type { Units } from '../../utils/units'
+import { formatLength } from '../../utils/units'
+import { hexToRgba } from './previewPrimitives'
 import { arcControlPoint, anchorPointForIndex, traceProfilePath } from './profilePrimitives'
 import { worldToCanvas } from './viewTransform'
 import type { ViewTransform } from './viewTransform'
@@ -264,6 +267,76 @@ export function drawGrid(
   }
 }
 
+const STOCK_LABEL_MIN_WIDTH_PX = 200
+const STOCK_EXCEEDED_STROKE = 'rgba(240, 160, 40, 0.9)'
+
+function drawStockDimensionLabel(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  cx: number,
+  cy: number,
+): void {
+  ctx.font = '11px sans-serif'
+  const metrics = ctx.measureText(text)
+  const halfW = metrics.width / 2 + 4
+  const halfH = 9
+  ctx.fillStyle = 'rgba(18, 26, 36, 0.85)'
+  ctx.fillRect(cx - halfW, cy - halfH, halfW * 2, halfH * 2)
+  ctx.fillStyle = 'rgba(200, 220, 240, 0.95)'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(text, cx, cy)
+}
+
+export function drawStockOutline(
+  ctx: CanvasRenderingContext2D,
+  stock: Stock,
+  vt: ViewTransform,
+  units: Units,
+  exceeded: boolean,
+): void {
+  traceProfilePath(ctx, stock.profile, vt)
+  ctx.strokeStyle = exceeded ? STOCK_EXCEEDED_STROKE : hexToRgba(stock.color, 0.7)
+  ctx.lineWidth = 2
+  ctx.setLineDash([7, 4])
+  ctx.stroke()
+  ctx.setLineDash([])
+
+  traceProfilePath(ctx, stock.profile, vt)
+  ctx.fillStyle = hexToRgba(stock.color, 0.12)
+  ctx.fill()
+
+  const bounds = getStockBounds(stock)
+  const widthWorld = bounds.maxX - bounds.minX
+  const heightWorld = bounds.maxY - bounds.minY
+  if (widthWorld * vt.scale < STOCK_LABEL_MIN_WIDTH_PX) {
+    return
+  }
+
+  const cornerA = worldToCanvas({ x: bounds.minX, y: bounds.minY }, vt)
+  const cornerB = worldToCanvas({ x: bounds.maxX, y: bounds.maxY }, vt)
+  const minCx = Math.min(cornerA.cx, cornerB.cx)
+  const maxCx = Math.max(cornerA.cx, cornerB.cx)
+  const minCy = Math.min(cornerA.cy, cornerB.cy)
+  const maxCy = Math.max(cornerA.cy, cornerB.cy)
+  const unitSuffix = units === 'inch' ? 'in' : 'mm'
+
+  ctx.save()
+  drawStockDimensionLabel(
+    ctx,
+    `${formatLength(widthWorld, units)} ${unitSuffix}`,
+    (minCx + maxCx) / 2,
+    minCy - 12,
+  )
+  drawStockDimensionLabel(
+    ctx,
+    `${formatLength(heightWorld, units)} ${unitSuffix}`,
+    maxCx + 8 + ctx.measureText(`${formatLength(heightWorld, units)} ${unitSuffix}`).width / 2,
+    (minCy + maxCy) / 2,
+  )
+  ctx.restore()
+}
+
 export function drawClampFootprint(
   ctx: CanvasRenderingContext2D,
   clamp: Clamp,
@@ -353,6 +426,11 @@ export function drawOriginMarker(
   ctx.stroke()
 
   ctx.font = '10px "IBM Plex Mono", "SFMono-Regular", Consolas, monospace'
+  ctx.fillStyle = '#e35b5b'
+  ctx.fillText('X', anchor.cx + axisLength + 4, anchor.cy + 3)
+  ctx.fillStyle = '#63c07a'
+  ctx.fillText('Y', anchor.cx - 3, anchor.cy - axisLength - 4)
+
   ctx.fillStyle = 'rgba(230, 237, 245, 0.95)'
   ctx.fillText(origin.name, anchor.cx + 10, anchor.cy - 8)
   ctx.restore()

--- a/src/engine/toolpaths/INDEX.md
+++ b/src/engine/toolpaths/INDEX.md
@@ -34,6 +34,7 @@ Toolpath generators. Each file owns one strategy. `index.ts` re-exports everythi
 
 ## Tests
 - `toolpaths.test.ts` — broad smoke tests across strategies
+- `clamps.test.ts` — clamp collision warnings, rapid auto-lift, per-move collision tagging
 - `roughSurface.test.ts` / `finishSurface.test.ts` / `finishSurfaceCleanup.test.ts` / `meshSlicing.test.ts` / `vcarveRecursive.test.ts` — strategy-specific
 - arc-reconstruction coverage lives with its store-level callers: `store/helpers/offsetSimplify.test.ts` (offset simplification) and `store/second_cut_test.ts` (segment-preserving boolean reconstruction)
 

--- a/src/engine/toolpaths/clamps.test.ts
+++ b/src/engine/toolpaths/clamps.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for applyClampWarnings — collision detection, auto-lift of
+ * rapids, and per-move collision tagging (collidingMoveIndices).
+ *
+ * Run with: npx tsx src/engine/toolpaths/clamps.test.ts
+ */
+
+import type { Clamp, Project } from '../../types/project'
+import { newProject } from '../../types/project'
+import type { ToolpathMove, ToolpathResult } from './types'
+import { applyClampWarnings } from './clamps'
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// mm project: clampClearanceXY = 2, clampClearanceZ = 5, maxTravelZ = 50.
+// Clamp 10..20 x 10..20, height 5 → expanded rect 8..22 x 8..22, requiredZ 10.
+function makeProjectWithClamp(): Project {
+  const project = newProject('clamp-test', 'mm')
+  const clamp: Clamp = {
+    id: 'clamp-1',
+    name: 'Front clamp',
+    type: 'step_clamp',
+    x: 10,
+    y: 10,
+    w: 10,
+    h: 10,
+    height: 5,
+    visible: true,
+  }
+  project.clamps.push(clamp)
+  return project
+}
+
+function move(kind: ToolpathMove['kind'], fromZ: number, toZ: number, fromX = 0, toX = 40): ToolpathMove {
+  return {
+    kind,
+    from: { x: fromX, y: 15, z: fromZ },
+    to: { x: toX, y: 15, z: toZ },
+  }
+}
+
+function makeResult(moves: ToolpathMove[]): ToolpathResult {
+  return { operationId: 'op-1', moves, warnings: [], bounds: null }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+function testNoClampsReturnsResultUnchanged() {
+  const project = newProject('no-clamps', 'mm')
+  const result = makeResult([move('cut', -1, -1)])
+  const out = applyClampWarnings(project, result)
+  assert(out === result, 'result is returned as-is when project has no clamps')
+  assert(out.collidingMoveIndices === undefined, 'no collidingMoveIndices without clamps')
+  console.log('no clamps → unchanged: PASSED')
+}
+
+function testSafeMoveAboveClearanceNotFlagged() {
+  const project = makeProjectWithClamp()
+  const result = makeResult([move('rapid', 20, 20)])
+  const out = applyClampWarnings(project, result)
+  assert(out === result, 'move above required clearance Z is untouched')
+  console.log('safe move above clearance: PASSED')
+}
+
+function testCollidingCutIsTaggedAndWarned() {
+  const project = makeProjectWithClamp()
+  const result = makeResult([move('cut', -1, -1)])
+  const out = applyClampWarnings(project, result)
+  assert(out.warnings.some((w) => w.includes('Front clamp')), 'warning names the clamp')
+  assert((out.collidingClampIds ?? []).includes('clamp-1'), 'clamp id reported')
+  assert((out.collidingMoveIndices ?? []).length === 1, 'one colliding move tagged')
+  assert((out.collidingMoveIndices ?? [])[0] === 0, 'colliding move index refers to the cut')
+  console.log('colliding cut tagged + warned: PASSED')
+}
+
+function testAutoLiftedRapidIsNotTagged() {
+  const project = makeProjectWithClamp()
+  const result = makeResult([move('rapid', 2, 2)])
+  const out = applyClampWarnings(project, result)
+  assert(out.moves.length === 3, 'rapid is lifted into up/traverse/down moves')
+  assert(out.moves[1].from.z === 10 && out.moves[1].to.z === 10, 'traverse at required clearance Z')
+  assert((out.collidingMoveIndices ?? []).length === 0, 'auto-lifted rapid is resolved, not tagged')
+  assert((out.collidingClampIds ?? []).includes('clamp-1'), 'clamp id still reported for the lift')
+  console.log('auto-lifted rapid not tagged: PASSED')
+}
+
+function testIndicesReferToAdjustedMovesArray() {
+  const project = makeProjectWithClamp()
+  // Move 0: auto-liftable rapid (expands to 3 output moves).
+  // Move 1: colliding cut → lands at output index 3.
+  const result = makeResult([move('rapid', 2, 2), move('cut', -1, -1)])
+  const out = applyClampWarnings(project, result)
+  assert(out.moves.length === 4, 'lifted rapid (3) + cut (1)')
+  assert((out.collidingMoveIndices ?? []).length === 1, 'only the cut is tagged')
+  const index = (out.collidingMoveIndices ?? [])[0]
+  assert(index === 3, `index refers to adjusted array (expected 3, got ${index})`)
+  assert(out.moves[index].kind === 'cut', 'tagged move is the cut')
+  console.log('indices refer to adjusted moves: PASSED')
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+try {
+  testNoClampsReturnsResultUnchanged()
+  testSafeMoveAboveClearanceNotFlagged()
+  testCollidingCutIsTaggedAndWarned()
+  testAutoLiftedRapidIsNotTagged()
+  testIndicesReferToAdjustedMovesArray()
+  console.log('\nAll clamp tests PASSED.')
+} catch (e) {
+  console.error(e)
+  throw e
+}

--- a/src/engine/toolpaths/clamps.ts
+++ b/src/engine/toolpaths/clamps.ts
@@ -211,6 +211,7 @@ export function applyClampWarnings(project: Project, result: ToolpathResult, ope
   const maxTravelZ = Math.max(0, project.meta.maxTravelZ)
   const adjustedMoves: ToolpathMove[] = []
   const collidingClampIds = new Set<string>()
+  const collidingMoveIndices: number[] = []
   const warningCounts = new Map<string, { clamp: Clamp; kind: ToolpathMove['kind']; count: number; minActualZ: number; requiredZ: number }>()
   const travelLimitWarnings = new Set<string>()
 
@@ -247,6 +248,7 @@ export function applyClampWarnings(project: Project, result: ToolpathResult, ope
     }
 
     adjustedMoves.push(move)
+    collidingMoveIndices.push(adjustedMoves.length - 1)
 
     for (const rect of unsafe) {
       const key = `${rect.clamp.id}:${move.kind}`
@@ -284,5 +286,6 @@ export function applyClampWarnings(project: Project, result: ToolpathResult, ope
     warnings,
     bounds: computeBounds(adjustedMoves),
     collidingClampIds: [...collidingClampIds],
+    collidingMoveIndices,
   }
 }

--- a/src/engine/toolpaths/types.ts
+++ b/src/engine/toolpaths/types.ts
@@ -50,6 +50,9 @@ export interface ToolpathResult {
   warnings: string[]
   bounds: ToolpathBounds | null
   collidingClampIds?: string[]
+  /** Indices into `moves` of segments that cross a clamp zone below required
+   *  clearance. Refers to the final (adjusted) moves array. */
+  collidingMoveIndices?: number[]
   /** True when the source operation has debugToolpath enabled. The 3D viewport
    *  renders extra diagnostic markers (source-tag symbols) when this is set. */
   debugToolpath?: boolean


### PR DESCRIPTION
## Summary

P2 item **A2.1** from the consolidated UX review — make collision and setup problems visible on the sketch canvas instead of only in text warnings. Scoped & implemented per [`planning/archive/UX_P2_A2_1_COLLISION_OVERLAYS_Plan.md`](planning/archive/UX_P2_A2_1_COLLISION_OVERLAYS_Plan.md).

## What changed

- **Per-move collision tagging** — `ToolpathResult` gains `collidingMoveIndices`, populated by `applyClampWarnings` for the segments that cross a clamp zone below required clearance. Auto-lifted rapids are resolved, so they are not tagged; indices refer to the final adjusted moves array.
- **Amber toolpath highlight** — `drawToolpath` re-draws colliding segments in amber on top of the normal layers, regardless of layer-visibility toggles (it's a warning).
- **Stock border feedback** — new `drawStockOutline` strokes the stock border amber when any visible feature exceeds stock bounds, and labels the border with **W × H** dimensions (suppressed when the stock is under ~200 px wide on screen).
- **Origin axis labels** — `drawOriginMarker` now labels its arrows **"X"** (red) and **"Y"** (green).

No changes to collision rules, clearance params, region semantics, or toolpath behaviour — presentation only.

## Tests

New `src/engine/toolpaths/clamps.test.ts` (5 cases): no-clamps passthrough, safe move above clearance, colliding cut tagged + warned, auto-lifted rapid not tagged, and indices referring to the *adjusted* moves array. `npm run build` green (tsc + full test suite + vite).

## Manual verification

Driven in the running app (Guitar body example):
- Clamp placed over a slot toolpath → cut segments under it render amber; clamp footprint turns red.
- Stock shrunk so the body exceeds it → border switches olive → amber; undo restores it.
- Stock dimension labels ("20 in" / "15 in") and origin "X"/"Y" labels render correctly.
- No console errors.

## Out of scope

3D toolpath segment collision highlights in `Viewport3D`; simulation voxel-level feedback; toolbar/layout changes (A2.2, separate PR).