### PR TITLE
Add operation descriptions and PDF booklets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/three": "^0.183.1",
         "clipper-lib": "^6.4.2",
         "manifold-3d": "^3.3.2",
+        "pdf-lib": "^1.17.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "three": "^0.183.2",
@@ -1556,6 +1557,24 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3964,6 +3983,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3996,6 +4021,24 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/three": "^0.183.1",
     "clipper-lib": "^6.4.2",
     "manifold-3d": "^3.3.2",
+    "pdf-lib": "^1.17.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "three": "^0.183.2",

--- a/planning/INDEX.md
+++ b/planning/INDEX.md
@@ -12,8 +12,6 @@ Every task: write a plan from [`TEMPLATE.md`](TEMPLATE.md) → register it under
 
 ## In progress
 
-- [OPERATION_DESCRIPTION_BOOKLET_Plan.md](OPERATION_DESCRIPTION_BOOKLET_Plan.md) — add operation descriptions, expose them to per-operation G-code headers, and export per-operation PDF booklets
-
 - [MEASURE_DIMENSIONS_Plan.md](MEASURE_DIMENSIONS_Plan.md) — tape-measure tool (transient distance readout) + permanent CAD dimensions (aligned/horizontal/vertical/radius/diameter/angle) anchored to geometry so they auto-update when features move/change
 
 - [WATERLINE_ADAPTIVE_REFINEMENT_Plan.md](WATERLINE_ADAPTIVE_REFINEMENT_Plan.md) — improve imported-model waterline finishing by inserting bounded intermediate contour levels when adjacent bands have small Z separation but large XY drift

--- a/planning/INDEX.md
+++ b/planning/INDEX.md
@@ -10,9 +10,9 @@ Every task: write a plan from [`TEMPLATE.md`](TEMPLATE.md) → register it under
 
 ## Pending approval
 
-- [IMPORTED_MODEL_OUTLINE_COLORS_Plan.md](IMPORTED_MODEL_OUTLINE_COLORS_Plan.md) — add orange outline for imported 3D models in sketch view, add missing region + imported-model entries to feature color legend
-
 ## In progress
+
+- [OPERATION_DESCRIPTION_BOOKLET_Plan.md](OPERATION_DESCRIPTION_BOOKLET_Plan.md) — add operation descriptions, expose them to per-operation G-code headers, and export per-operation PDF booklets
 
 - [MEASURE_DIMENSIONS_Plan.md](MEASURE_DIMENSIONS_Plan.md) — tape-measure tool (transient distance readout) + permanent CAD dimensions (aligned/horizontal/vertical/radius/diameter/angle) anchored to geometry so they auto-update when features move/change
 

--- a/planning/OPERATION_DESCRIPTION_BOOKLET_Plan.md
+++ b/planning/OPERATION_DESCRIPTION_BOOKLET_Plan.md
@@ -1,0 +1,73 @@
+---
+status: In progress
+created: 2026-06-04
+---
+
+# Operation Description + Booklet Export Plan
+
+## Goal
+
+Add richer operation documentation to PureCutCNC by storing a freeform operation description, making that description available to machine-definition G-code templates, and exporting a per-operation PDF booklet that captures the operation setup, selected tool, target features, warnings, and a static sketch-style image of the target geometry with the operation toolpath overlaid.
+
+## Approach
+
+- Add an `Operation.description` field to the project schema, operation defaults, normalization path, duplicate/import flows, and selected-operation UI.
+- Extend machine definitions with a per-operation header template block, distinct from the program-level header that is emitted once per file.
+- Add operation template variables for G-code output: operation name, description, index, kind, pass, target summary, tool number/name, feed/plunge/rpm, and formatted setup values where practical.
+- Sanitize multi-line operation descriptions into controller-safe comment lines using the machine definition comment syntax.
+- Update bundled machine definitions so each operation emits a concise header comment that can include `{operationDescription}`.
+- Add an operation booklet export action from the operations panel.
+- Build a report model from the existing project, operation, tool, generated toolpath, stock envelope, and target feature data.
+- Add a static operation snapshot renderer that reuses existing canvas drawing primitives where possible, especially toolpath rendering, origin markers, tabs, and clamps, but avoids coupling the booklet export to interactive `SketchCanvas` state.
+- Generate a real PDF file using a small client-side PDF dependency, most likely `pdf-lib`, embedding the operation snapshot image and tabular operation/tool/settings data.
+- Include setup-critical text in the PDF overview, including origin Z level and locally generated date/time with timezone offset.
+- Estimate feed-controlled operation time from toolpath move distances and operation feed/plunge definitions, while calling out untimed G0 rapid travel separately because controller rapid speed is not currently modeled.
+- Flow the PDF body in two columns after the header/snapshot to reduce page count while keeping the operation image full-width.
+- Save/export the PDF through the existing platform abstraction, adding binary/blob save support where needed for browser and Tauri desktop.
+
+## Files affected
+
+- `package.json` / `package-lock.json` — add the PDF generation dependency if `pdf-lib` is selected.
+- `src/types/project.ts` — add `Operation.description`.
+- `src/store/projectStore.ts` — default and normalize operation descriptions, preserve them through duplicate/rest/import paths.
+- `src/store/types.ts` — no API shape change expected unless booklet export needs store actions; update if needed.
+- `src/components/cam/CAMPanel.tsx` — add the operation description editor and per-operation booklet export action.
+- `src/components/cam/*.css` or nearby CSS — style the multiline description field and booklet action if existing classes are insufficient.
+- `src/engine/gcode/types.ts` — extend machine definition schema with optional `program.operationHeader`.
+- `src/engine/gcode/postprocessor.ts` — emit per-operation header templates with operation context and safe comment handling.
+- `src/engine/gcode/definitions/*.json` — add operation header templates to bundled machine definitions.
+- `src/engine/gcode/*.test.ts` or new tests — cover operation description/header substitution, multiline comments, and legacy definitions without `operationHeader`.
+- `src/components/export/` — add booklet export dialog or helper surface if it does not fit cleanly in `CAMPanel`.
+- *(new)* `src/engine/operationBooklet/` or `src/export/operationBooklet/` — report model, PDF builder, formatting helpers, and snapshot coordination.
+- *(new or refactored)* `src/components/canvas/operationSnapshot.ts` — render static target geometry + toolpath image to an offscreen canvas using shared drawing primitives.
+- `src/components/canvas/previewPrimitives.ts` — factor reusable drawing utilities only if needed for static snapshot rendering.
+- `src/platform/api.ts`, `src/platform/browser.ts`, `src/platform/tauri.ts` — add binary/blob file export support for PDF.
+- `src/INDEX.md`, `src/engine/INDEX.md`, `src/components/INDEX.md` — update nearby indexes for any new files/folders.
+
+## Tests
+
+- Add G-code postprocessor tests for:
+  - `{operationDescription}` replacement in per-operation headers.
+  - Empty descriptions producing clean output.
+  - Multi-line descriptions emitting safe comment lines.
+  - Legacy/custom machine definitions without `operationHeader` still working.
+- Add operation normalization tests or extend existing project-store tests to confirm old operations receive `description: ''`.
+- Add report-model tests for target feature names, tool details, core operation settings, and warning inclusion.
+- Cover generated timestamp, stock size, target feature-name summaries, origin Z summary, and feed-time estimate formatting in report-model tests.
+- Add PDF builder smoke tests where practical, validating a non-empty PDF byte output and expected metadata/text markers if the library supports inspection.
+- Run `npm run build` before completion.
+
+## Open questions / risks
+
+- The PDF dependency choice should be confirmed during implementation. `pdf-lib` is the likely default because it can generate PDFs in browser and desktop contexts without a server.
+- The static sketch-style image should prioritize reliability over perfect parity with the interactive canvas. Exact visual matching may require factoring additional drawing helpers out of `SketchCanvas`.
+- Very large toolpaths can create dense snapshot images and large PDFs. The first implementation should cap image resolution and draw density enough to keep export responsive.
+- G-code program headers are global while operation descriptions are per-operation, so `{operationDescription}` belongs in a new per-operation header block rather than the existing global `program.header`.
+
+## Out of scope
+
+- Combined shop travelers for all operations in one multi-operation booklet.
+- Editing machine definitions through a dedicated UI beyond whatever existing project settings already support.
+- 3D-rendered PDF snapshots from the Three.js preview.
+- Setup-sheet fields not already represented in the project model, such as clamps/workholding notes independent of operations.
+- Versioned `.camj` migration beyond normal load-time normalization.

--- a/planning/archive/OPERATION_DESCRIPTION_BOOKLET_Plan.md
+++ b/planning/archive/OPERATION_DESCRIPTION_BOOKLET_Plan.md
@@ -1,5 +1,5 @@
 ---
-status: In progress
+status: Done
 created: 2026-06-04
 ---
 
@@ -21,8 +21,9 @@ Add richer operation documentation to PureCutCNC by storing a freeform operation
 - Add a static operation snapshot renderer that reuses existing canvas drawing primitives where possible, especially toolpath rendering, origin markers, tabs, and clamps, but avoids coupling the booklet export to interactive `SketchCanvas` state.
 - Generate a real PDF file using a small client-side PDF dependency, most likely `pdf-lib`, embedding the operation snapshot image and tabular operation/tool/settings data.
 - Include setup-critical text in the PDF overview, including origin Z level and locally generated date/time with timezone offset.
-- Estimate feed-controlled operation time from toolpath move distances and operation feed/plunge definitions, while calling out untimed G0 rapid travel separately because controller rapid speed is not currently modeled.
-- Flow the PDF body in two columns after the header/snapshot to reduce page count while keeping the operation image full-width.
+- Estimate feed-controlled operation time from toolpath move distances and operation feed/plunge definitions, while calling out feed travel and untimed G0 rapid travel separately because controller rapid speed is not currently modeled.
+- Flow PDF sections top-to-bottom after the header/snapshot, with each tabular section using two label/value columns internally to reduce page count without splitting the page reading order.
+- Polish PDF presentation with a stronger title header, framed snapshot, description callout, section accents, row dividers, and contextual page footers.
 - Save/export the PDF through the existing platform abstraction, adding binary/blob save support where needed for browser and Tauri desktop.
 
 ## Files affected

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1224,6 +1224,7 @@ function App() {
             selectedOperationId={effectiveSelectedOperationId}
             onSelectedOperationIdChange={handleSelectedOperationIdChange}
             onExport={() => setShowExportDialog(true)}
+            generateToolpath={generateToolpathForOperation}
             toolpathWarnings={selectedToolpath?.warnings ?? null}
             generatingOperationIds={generatingOperationIds}
             onOperationHighlightChange={setOperationHighlightKind}

--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -14,7 +14,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 
 ## Subfolders (by area)
 - `common/` — shared cross-panel UI primitives. `DisclosureSection` is the reusable collapsible "Advanced" section (progressive disclosure); its open/collapsed state persists via the pure helpers in `common/disclosureState.ts`.
-- `canvas/` — 2D sketch canvas: drawing, snapping, panning/zoom, pointer handling. Dimension annotations + tape measure render via `canvas/dimensionRendering.ts` (pure geometry in `sketch/dimensions.ts`)
+- `canvas/` — 2D sketch canvas: drawing, snapping, panning/zoom, pointer handling. Dimension annotations + tape measure render via `canvas/dimensionRendering.ts` (pure geometry in `sketch/dimensions.ts`); `canvas/operationSnapshot.ts` renders static operation booklet images.
 - `viewport3d/` — Three.js 3D preview of the CSG-derived model, including toolpath overlay helpers
 - `simulation/` — voxel toolpath simulation viewport and playback controls
 - `cam/` — CAM panels (tools, operations, parameters)

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -24,6 +24,7 @@ import { OperationAddMenu } from './OperationAddMenu'
 import { DisclosureSection } from '../common/DisclosureSection'
 import type {
   DrillType,
+  Operation,
   OperationKind,
   OperationPass,
   PocketPattern,
@@ -32,6 +33,11 @@ import type {
   Tool,
   ToolType,
 } from '../../types/project'
+import type { ToolpathResult } from '../../engine/toolpaths'
+import { normalizeToolForProject } from '../../engine/toolpaths/geometry'
+import { createOperationBookletPdf } from '../../engine/operationBooklet'
+import { renderOperationSnapshotPng } from '../canvas/operationSnapshot'
+import { platform } from '../../platform'
 import { featureHasClosedGeometry } from '../../text'
 import { getOperationAddHint, operationKindLabel, operationRequiresClosedProfiles, operationTargetsRegion } from './operationValidity'
 import { convertToolUnits, formatLength, parseLengthInput } from '../../utils/units'
@@ -44,6 +50,7 @@ interface CAMPanelProps {
   selectedOperationId: string | null
   onSelectedOperationIdChange: (operationId: string | null) => void
   onExport: () => void
+  generateToolpath: (operation: Operation) => ToolpathResult | null
   toolpathWarnings?: string[] | null
   generatingOperationIds?: Set<string>
   /** A1.3: arm an operation kind (on hover in the Add menu) for the canvas highlight. */
@@ -80,6 +87,34 @@ function DraftTextInput({ value, onCommit }: DraftTextInputProps) {
           return
         }
 
+        if (event.key === 'Escape') {
+          reset(event.currentTarget)
+          event.currentTarget.blur()
+        }
+      }}
+    />
+  )
+}
+
+function DraftTextArea({ value, onCommit }: DraftTextInputProps) {
+  function reset(element: HTMLTextAreaElement) {
+    element.value = value
+  }
+
+  function commit(element: HTMLTextAreaElement) {
+    if (element.value !== value) {
+      onCommit(element.value)
+    } else {
+      reset(element)
+    }
+  }
+
+  return (
+    <textarea
+      defaultValue={value}
+      spellCheck
+      onBlur={(event) => commit(event.currentTarget)}
+      onKeyDown={(event) => {
         if (event.key === 'Escape') {
           reset(event.currentTarget)
           event.currentTarget.blur()
@@ -539,6 +574,7 @@ export function CAMPanel({
   selectedOperationId: selectedOperationIdProp,
   onSelectedOperationIdChange,
   onExport,
+  generateToolpath,
   toolpathWarnings,
   generatingOperationIds,
   onOperationHighlightChange,
@@ -562,6 +598,11 @@ export function CAMPanel({
     operationId: string
     text: string
   } | null>(null)
+  const [bookletExportMessage, setBookletExportMessage] = useState<{
+    operationId: string
+    text: string
+  } | null>(null)
+  const [exportingBookletOperationId, setExportingBookletOperationId] = useState<string | null>(null)
   const shellMode = useShellMode()
   const tabletShell = isTabletMode(shellMode)
   const [dragOperationId, setDragOperationId] = useState<string | null>(null)
@@ -1010,6 +1051,50 @@ export function CAMPanel({
     autoPlaceTabsForOperation(selectedOperation.id)
   }
 
+  async function handleExportBooklet() {
+    if (!selectedOperation) {
+      return
+    }
+
+    setExportingBookletOperationId(selectedOperation.id)
+    setBookletExportMessage({ operationId: selectedOperation.id, text: 'Building booklet...' })
+
+    try {
+      const toolpath = generateToolpath(selectedOperation)
+      const toolRecord = selectedOperation.toolRef
+        ? project.tools.find((tool) => tool.id === selectedOperation.toolRef) ?? null
+        : null
+      const tool = toolRecord ? normalizeToolForProject(toolRecord, project) : null
+      const snapshotPng = await renderOperationSnapshotPng(project, selectedOperation, toolpath)
+      const pdfBytes = await createOperationBookletPdf({
+        project,
+        operation: selectedOperation,
+        tool,
+        toolpath,
+        snapshotPng,
+      })
+      const safeProjectName = project.meta.name.trim().replace(/[^a-z0-9_-]+/gi, '_').replace(/^_+|_+$/g, '') || 'project'
+      const safeOperationName = selectedOperation.name.trim().replace(/[^a-z0-9_-]+/gi, '_').replace(/^_+|_+$/g, '') || 'operation'
+      const exportedPath = await platform.saveBinaryFile(
+        `${safeProjectName}_${safeOperationName}_booklet`,
+        pdfBytes,
+        'pdf',
+        'application/pdf',
+      )
+      setBookletExportMessage({
+        operationId: selectedOperation.id,
+        text: exportedPath ? `Booklet exported: ${exportedPath}` : 'Booklet export cancelled',
+      })
+    } catch (error) {
+      setBookletExportMessage({
+        operationId: selectedOperation.id,
+        text: error instanceof Error ? error.message : 'Failed to export booklet',
+      })
+    } finally {
+      setExportingBookletOperationId(null)
+    }
+  }
+
   return (
     <div className="cam-panel">
       {mode === 'operations' ? (
@@ -1227,6 +1312,13 @@ export function CAMPanel({
                     <span>Name</span>
                     <DraftTextInput value={selectedOperation.name} onCommit={(value) => updateOperation(selectedOperation.id, { name: value })} />
                   </label>
+                  <label className="properties-field properties-field--textarea">
+                    <span>Description</span>
+                    <DraftTextArea
+                      value={selectedOperation.description ?? ''}
+                      onCommit={(value) => updateOperation(selectedOperation.id, { description: value })}
+                    />
+                  </label>
                   <label className="properties-field">
                     <span>Kind</span>
                     <input type="text" value={operationKindLabel(selectedOperation.kind)} readOnly />
@@ -1276,6 +1368,20 @@ export function CAMPanel({
                       <span>Regions limit where this operation may cut — not shapes to machine.</span>
                     </div>
                   ) : null}
+                  <div className="properties-field">
+                    <span>Booklet</span>
+                    <button
+                      className="feat-btn"
+                      type="button"
+                      onClick={handleExportBooklet}
+                      disabled={exportingBookletOperationId === selectedOperation.id}
+                    >
+                      {exportingBookletOperationId === selectedOperation.id ? 'Exporting...' : 'Export PDF'}
+                    </button>
+                    {bookletExportMessage?.operationId === selectedOperation.id ? (
+                      <span className="cam-field-message">{bookletExportMessage.text}</span>
+                    ) : null}
+                  </div>
                   <div className="properties-field">
                     <span>Target Source</span>
                     <button

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -1369,20 +1369,6 @@ export function CAMPanel({
                     </div>
                   ) : null}
                   <div className="properties-field">
-                    <span>Booklet</span>
-                    <button
-                      className="feat-btn"
-                      type="button"
-                      onClick={handleExportBooklet}
-                      disabled={exportingBookletOperationId === selectedOperation.id}
-                    >
-                      {exportingBookletOperationId === selectedOperation.id ? 'Exporting...' : 'Export PDF'}
-                    </button>
-                    {bookletExportMessage?.operationId === selectedOperation.id ? (
-                      <span className="cam-field-message">{bookletExportMessage.text}</span>
-                    ) : null}
-                  </div>
-                  <div className="properties-field">
                     <span>Target Source</span>
                     <button
                       className="feat-btn"
@@ -1411,6 +1397,20 @@ export function CAMPanel({
                       ) : null}
                     </div>
                   ) : null}
+                  <div className="properties-field">
+                    <span>Booklet</span>
+                    <button
+                      className="feat-btn"
+                      type="button"
+                      onClick={handleExportBooklet}
+                      disabled={exportingBookletOperationId === selectedOperation.id}
+                    >
+                      {exportingBookletOperationId === selectedOperation.id ? 'Exporting...' : 'Export PDF'}
+                    </button>
+                    {bookletExportMessage?.operationId === selectedOperation.id ? (
+                      <span className="cam-field-message">{bookletExportMessage.text}</span>
+                    ) : null}
+                  </div>
                   {(selectedOperation.kind === 'edge_route_inside' || selectedOperation.kind === 'edge_route_outside') ? (
                     <div className="properties-field">
                       <span>Tabs</span>

--- a/src/components/canvas/operationSnapshot.ts
+++ b/src/components/canvas/operationSnapshot.ts
@@ -1,0 +1,254 @@
+import { getFeatureGeometryProfiles } from '../../text'
+import { getProfileBounds, rectProfile } from '../../types/project'
+import type { Operation, Project, SketchProfile } from '../../types/project'
+import type { ToolpathResult } from '../../engine/toolpaths'
+import type { ToolpathVisibility } from '../ToolpathVisibilityPanel'
+import { drawToolpath } from './previewPrimitives'
+import { traceProfilePath } from './profilePrimitives'
+import { drawClampFootprint, drawTabFootprint } from './scenePrimitives'
+import { computeFitViewStateForBounds, computeViewTransform } from './viewTransform'
+import { worldToCanvas } from './viewTransform'
+import type { ViewTransform } from './viewTransform'
+
+interface Bounds2D {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+export interface OperationSnapshotOptions {
+  width?: number
+  height?: number
+  pixelRatio?: number
+}
+
+const DEFAULT_WIDTH = 1200
+const DEFAULT_HEIGHT = 760
+const MAX_PIXEL_RATIO = 2
+
+const SNAPSHOT_TOOLPATH_VISIBILITY: ToolpathVisibility = {
+  cuts: true,
+  rapids: true,
+  plunges: true,
+  retractions: true,
+  directions: true,
+}
+
+function includeProfileBounds(bounds: Bounds2D, profile: SketchProfile): Bounds2D {
+  const profileBounds = getProfileBounds(profile)
+  return {
+    minX: Math.min(bounds.minX, profileBounds.minX),
+    minY: Math.min(bounds.minY, profileBounds.minY),
+    maxX: Math.max(bounds.maxX, profileBounds.maxX),
+    maxY: Math.max(bounds.maxY, profileBounds.maxY),
+  }
+}
+
+function includeToolpathBounds(bounds: Bounds2D, toolpath: ToolpathResult | null): Bounds2D {
+  if (!toolpath?.bounds) {
+    return bounds
+  }
+
+  return {
+    minX: Math.min(bounds.minX, toolpath.bounds.minX),
+    minY: Math.min(bounds.minY, toolpath.bounds.minY),
+    maxX: Math.max(bounds.maxX, toolpath.bounds.maxX),
+    maxY: Math.max(bounds.maxY, toolpath.bounds.maxY),
+  }
+}
+
+function includePointBounds(bounds: Bounds2D, point: { x: number; y: number }): Bounds2D {
+  return {
+    minX: Math.min(bounds.minX, point.x),
+    minY: Math.min(bounds.minY, point.y),
+    maxX: Math.max(bounds.maxX, point.x),
+    maxY: Math.max(bounds.maxY, point.y),
+  }
+}
+
+function operationTargetIds(operation: Operation): Set<string> {
+  return operation.target.source === 'features'
+    ? new Set(operation.target.featureIds)
+    : new Set<string>()
+}
+
+function snapshotBounds(project: Project, operation: Operation, toolpath: ToolpathResult | null): Bounds2D {
+  let bounds = includeProfileBounds({
+    minX: Infinity,
+    minY: Infinity,
+    maxX: -Infinity,
+    maxY: -Infinity,
+  }, project.stock.profile)
+
+  const targetIds = operationTargetIds(operation)
+  for (const feature of project.features) {
+    if (!feature.visible && !targetIds.has(feature.id)) {
+      continue
+    }
+    for (const profile of getFeatureGeometryProfiles(feature)) {
+      bounds = includeProfileBounds(bounds, profile)
+    }
+  }
+
+  for (const tab of project.tabs) {
+    if (tab.visible) {
+      bounds = includeProfileBounds(bounds, rectProfile(tab.x, tab.y, tab.w, tab.h))
+    }
+  }
+
+  for (const clamp of project.clamps) {
+    if (clamp.visible) {
+      bounds = includeProfileBounds(bounds, rectProfile(clamp.x, clamp.y, clamp.w, clamp.h))
+    }
+  }
+
+  bounds = includePointBounds(bounds, project.origin)
+
+  return includeToolpathBounds(bounds, toolpath)
+}
+
+function drawProfile(
+  ctx: CanvasRenderingContext2D,
+  profile: SketchProfile,
+  vt: ViewTransform,
+  style: { fill: string; stroke: string; lineWidth: number; dash?: number[] },
+): void {
+  traceProfilePath(ctx, profile, vt)
+  ctx.fillStyle = style.fill
+  ctx.fill()
+  ctx.strokeStyle = style.stroke
+  ctx.lineWidth = style.lineWidth
+  ctx.setLineDash(style.dash ?? [])
+  ctx.stroke()
+  ctx.setLineDash([])
+}
+
+function canvasToPngBytes(canvas: HTMLCanvasElement): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(async (blob) => {
+      if (!blob) {
+        reject(new Error('Failed to render operation booklet snapshot.'))
+        return
+      }
+      resolve(new Uint8Array(await blob.arrayBuffer()))
+    }, 'image/png')
+  })
+}
+
+function drawSnapshotOrigin(
+  ctx: CanvasRenderingContext2D,
+  project: Project,
+  vt: ViewTransform,
+  pixelRatio: number,
+): void {
+  const anchor = worldToCanvas(project.origin, vt)
+  const arm = 22 * pixelRatio
+  const radius = 5 * pixelRatio
+
+  ctx.save()
+  ctx.lineCap = 'round'
+
+  ctx.beginPath()
+  ctx.moveTo(anchor.cx - arm, anchor.cy)
+  ctx.lineTo(anchor.cx + arm, anchor.cy)
+  ctx.moveTo(anchor.cx, anchor.cy - arm)
+  ctx.lineTo(anchor.cx, anchor.cy + arm)
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.96)'
+  ctx.lineWidth = 9 * pixelRatio
+  ctx.stroke()
+
+  ctx.beginPath()
+  ctx.moveTo(anchor.cx - arm, anchor.cy)
+  ctx.lineTo(anchor.cx + arm, anchor.cy)
+  ctx.moveTo(anchor.cx, anchor.cy - arm)
+  ctx.lineTo(anchor.cx, anchor.cy + arm)
+  ctx.strokeStyle = '#1f2937'
+  ctx.lineWidth = 5 * pixelRatio
+  ctx.stroke()
+
+  ctx.beginPath()
+  ctx.arc(anchor.cx, anchor.cy, radius, 0, Math.PI * 2)
+  ctx.fillStyle = '#f97316'
+  ctx.fill()
+  ctx.strokeStyle = '#ffffff'
+  ctx.lineWidth = 2 * pixelRatio
+  ctx.stroke()
+
+  ctx.restore()
+}
+
+export async function renderOperationSnapshotPng(
+  project: Project,
+  operation: Operation,
+  toolpath: ToolpathResult | null,
+  options: OperationSnapshotOptions = {},
+): Promise<Uint8Array> {
+  const pixelRatio = Math.max(1, Math.min(options.pixelRatio ?? window.devicePixelRatio ?? 1, MAX_PIXEL_RATIO))
+  const canvasW = Math.round((options.width ?? DEFAULT_WIDTH) * pixelRatio)
+  const canvasH = Math.round((options.height ?? DEFAULT_HEIGHT) * pixelRatio)
+  const canvas = document.createElement('canvas')
+  canvas.width = canvasW
+  canvas.height = canvasH
+
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    throw new Error('Failed to create operation booklet snapshot canvas.')
+  }
+
+  ctx.fillStyle = '#f6f8fb'
+  ctx.fillRect(0, 0, canvasW, canvasH)
+
+  const viewState = computeFitViewStateForBounds(project.stock, snapshotBounds(project, operation, toolpath), canvasW, canvasH)
+  const vt = computeViewTransform(project.stock, canvasW, canvasH, viewState)
+  const targetIds = operationTargetIds(operation)
+
+  drawProfile(ctx, project.stock.profile, vt, {
+    fill: '#ffffff',
+    stroke: '#9aa8b5',
+    lineWidth: 2 * pixelRatio,
+  })
+
+  for (const feature of project.features) {
+    const isTarget = targetIds.has(feature.id) || operation.target.source === 'stock'
+    const profiles = getFeatureGeometryProfiles(feature)
+    for (const profile of profiles) {
+      drawProfile(ctx, profile, vt, isTarget
+        ? {
+            fill: 'rgba(245, 125, 52, 0.20)',
+            stroke: '#e25f24',
+            lineWidth: 2.4 * pixelRatio,
+          }
+        : {
+            fill: 'rgba(124, 139, 154, 0.10)',
+            stroke: 'rgba(105, 121, 138, 0.54)',
+            lineWidth: 1.2 * pixelRatio,
+            dash: [7 * pixelRatio, 5 * pixelRatio],
+          })
+    }
+  }
+
+  for (const tab of project.tabs) {
+    if (tab.visible) {
+      drawTabFootprint(ctx, tab, vt, false)
+    }
+  }
+
+  for (const clamp of project.clamps) {
+    if (clamp.visible) {
+      drawClampFootprint(ctx, clamp, vt, false, false)
+    }
+  }
+
+  if (toolpath) {
+    drawToolpath(ctx, toolpath, vt, true, SNAPSHOT_TOOLPATH_VISIBILITY)
+  }
+
+  drawSnapshotOrigin(ctx, project, vt, pixelRatio)
+
+  ctx.fillStyle = 'rgba(20, 28, 36, 0.84)'
+  ctx.font = `${Math.round(14 * pixelRatio)}px "IBM Plex Mono", "SFMono-Regular", Consolas, monospace`
+  ctx.fillText(operation.name, 22 * pixelRatio, 30 * pixelRatio)
+
+  return canvasToPngBytes(canvas)
+}

--- a/src/engine/INDEX.md
+++ b/src/engine/INDEX.md
@@ -21,6 +21,7 @@ Pure-logic CAM core. No React, no DOM. Everything here is testable in isolation.
   - `types.ts` — format/option interfaces
   - `assemble.ts` — manifold union → standard Z-up right-handed export mesh
   - `stl.ts` — binary + ASCII STL writers and the `stlExportFormat` entry
+- [operationBooklet/](operationBooklet/INDEX.md) — per-operation report model and PDF booklet generation
 - [simulation/](simulation/INDEX.md) — heightfield-based material removal sim (grid, replay/stepping, GPU heightfield mesh + shaders)
 
 ## Conventions

--- a/src/engine/gcode/definitions/generic.json
+++ b/src/engine/gcode/definitions/generic.json
@@ -30,6 +30,11 @@
       "{unitsCommand}",
       "{wcsCommand}"
     ],
+    "operationHeader": [
+      "( Operation {operationIndex}: {operationName} )",
+      "( Description: {operationDescription} )",
+      "( Tool {toolNumber}: {toolName} )"
+    ],
     "footer": [],
     "commentPrefix": "(",
     "commentSuffix": ")",

--- a/src/engine/gcode/definitions/grbl.json
+++ b/src/engine/gcode/definitions/grbl.json
@@ -29,6 +29,11 @@
       "G17",
       "{unitsCommand}"
     ],
+    "operationHeader": [
+      "; Operation {operationIndex}: {operationName}",
+      "; Description: {operationDescription}",
+      "; Tool {toolNumber}: {toolName}"
+    ],
     "footer": [],
     "commentPrefix": ";",
     "commentSuffix": "",

--- a/src/engine/gcode/definitions/grblhal.json
+++ b/src/engine/gcode/definitions/grblhal.json
@@ -30,6 +30,11 @@
       "{unitsCommand}",
       "{wcsCommand}"
     ],
+    "operationHeader": [
+      "( Operation {operationIndex}: {operationName} )",
+      "( Description: {operationDescription} )",
+      "( Tool {toolNumber}: {toolName} )"
+    ],
     "footer": [
       "M5",
       "G0 G53 Z0"

--- a/src/engine/gcode/definitions/linuxcnc.json
+++ b/src/engine/gcode/definitions/linuxcnc.json
@@ -29,6 +29,11 @@
       "{unitsCommand}",
       "{wcsCommand}"
     ],
+    "operationHeader": [
+      "( Operation {operationIndex}: {operationName} )",
+      "( Description: {operationDescription} )",
+      "( Tool {toolNumber}: {toolName} )"
+    ],
     "footer": [],
     "commentPrefix": "(",
     "commentSuffix": ")",

--- a/src/engine/gcode/definitions/mach3.json
+++ b/src/engine/gcode/definitions/mach3.json
@@ -29,6 +29,11 @@
       "{unitsCommand}",
       "{wcsCommand}"
     ],
+    "operationHeader": [
+      "( Operation {operationIndex}: {operationName} )",
+      "( Description: {operationDescription} )",
+      "( Tool {toolNumber}: {toolName} )"
+    ],
     "footer": [],
     "commentPrefix": "(",
     "commentSuffix": ")",

--- a/src/engine/gcode/postprocessor.test.ts
+++ b/src/engine/gcode/postprocessor.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for machine-definition G-code postprocessing.
+ *
+ * Run with: npx tsx src/engine/gcode/postprocessor.test.ts
+ */
+
+import { defaultTool, newProject } from '../../types/project'
+import type { Operation } from '../../types/project'
+import { normalizeToolForProject } from '../toolpaths/geometry'
+import type { ToolpathResult } from '../toolpaths/types'
+import { runPostProcessor } from './postprocessor'
+import { validateMachineDefinition } from './types'
+import type { MachineDefinition } from './types'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function testDefinition(operationHeader?: string[]): MachineDefinition {
+  return validateMachineDefinition({
+    id: 'test',
+    name: 'Test',
+    description: 'Test controller',
+    builtin: false,
+    fileExtension: 'nc',
+    coordinateSystem: { xAxis: 'X', yAxis: 'Y', zAxis: 'Z' },
+    numberFormat: {
+      decimalPlaces: { mm: 3, inch: 4 },
+      trailingZeros: false,
+      leadingZero: true,
+    },
+    units: { mmCommand: 'G21', inchCommand: 'G20' },
+    program: {
+      header: ['; {programName}', '{unitsCommand}'],
+      ...(operationHeader ? { operationHeader } : {}),
+      footer: [],
+      commentPrefix: ';',
+      commentSuffix: '',
+      lineNumbers: false,
+      lineNumberIncrement: 10,
+    },
+    workCoordinates: { selectCommand: null },
+    motion: {
+      rapidCommand: 'G0',
+      linearCommand: 'G1',
+      cwArcCommand: 'G2',
+      ccwArcCommand: 'G3',
+      arcFormat: 'ij',
+      modalMotion: true,
+    },
+    feedSpeed: {
+      feedCommand: 'F',
+      rpmCommand: 'S',
+      spindleOnCW: 'M3',
+      spindleOnCCW: 'M4',
+      spindleOff: 'M5',
+      inlineWithMotion: true,
+      modalFeedSpeed: true,
+    },
+    toolChange: {
+      commands: ['M0 ; Tool change: {toolName}'],
+      stopSpindleFirst: true,
+      pauseAfterChange: false,
+      pauseCommand: 'M0',
+    },
+    cannedCycles: null,
+    coolant: null,
+    stop: { programEndCommand: 'M30' },
+  })
+}
+
+function fixture(description = 'Pocket the screw bosses'): {
+  operation: Operation
+  toolpath: ToolpathResult
+  tool: ReturnType<typeof normalizeToolForProject>
+} {
+  const project = newProject('Post Test', 'mm')
+  const toolRecord = { ...defaultTool('mm', 1), id: 't1', name: 'Test End Mill' }
+  project.tools = [toolRecord]
+  const operation: Operation = {
+    id: 'op1',
+    name: 'Boss Pocket',
+    description,
+    kind: 'pocket',
+    pass: 'rough',
+    enabled: true,
+    showToolpath: true,
+    debugToolpath: false,
+    target: { source: 'stock' },
+    toolRef: toolRecord.id,
+    stepdown: 1,
+    stepover: 0.4,
+    feed: 600,
+    plungeFeed: 180,
+    rpm: 12000,
+    pocketPattern: 'offset',
+    pocketAngle: 0,
+    stockToLeaveRadial: 0,
+    stockToLeaveAxial: 0,
+    finishWalls: true,
+    finishFloor: true,
+    carveDepth: 1,
+    maxCarveDepth: 1,
+  }
+  return {
+    operation,
+    tool: normalizeToolForProject(toolRecord, project),
+    toolpath: {
+      operationId: operation.id,
+      warnings: [],
+      bounds: null,
+      moves: [
+        { kind: 'rapid', from: { x: 0, y: 0, z: 5 }, to: { x: 1, y: 1, z: 5 } },
+        { kind: 'cut', from: { x: 1, y: 1, z: 5 }, to: { x: 2, y: 1, z: 0 } },
+      ],
+    },
+  }
+}
+
+function runFixture(definition: MachineDefinition, operation: Operation): string {
+  const project = newProject('Post Test', 'mm')
+  const toolRecord = { ...defaultTool('mm', 1), id: 't1', name: 'Test End Mill' }
+  project.tools = [toolRecord]
+  const toolpath: ToolpathResult = {
+    operationId: operation.id,
+    warnings: [],
+    bounds: null,
+    moves: [
+      { kind: 'rapid', from: { x: 0, y: 0, z: 5 }, to: { x: 1, y: 1, z: 5 } },
+      { kind: 'cut', from: { x: 1, y: 1, z: 5 }, to: { x: 2, y: 1, z: 0 } },
+    ],
+  }
+  return runPostProcessor({
+    project,
+    definition,
+    operations: [{
+      operation,
+      tool: normalizeToolForProject(toolRecord, project),
+      toolpath,
+    }],
+    options: {
+      emitToolChanges: true,
+      emitCoolant: false,
+      programName: project.meta.name,
+    },
+  }).gcode
+}
+
+function testOperationHeaderDescription(): void {
+  console.log('Testing operation header description template...')
+  const { operation } = fixture('Clean the inner pocket before finishing')
+  const gcode = runFixture(testDefinition([
+    '; Operation {operationIndex}: {operationName}',
+    '; Description: {operationDescription}',
+    '; Tool {toolNumber}: {toolName}',
+  ]), operation)
+  assert(gcode.includes('; Operation 1: Boss Pocket'), 'operation header should include operation name')
+  assert(gcode.includes('; Description: Clean the inner pocket before finishing'), 'operation header should include description')
+  assert(gcode.includes('; Tool 1:'), 'operation header should include tool number')
+}
+
+function testEmptyDescriptionIsSkipped(): void {
+  console.log('Testing empty operation description header line is skipped...')
+  const { operation } = fixture('')
+  const gcode = runFixture(testDefinition([
+    '; Operation {operationIndex}: {operationName}',
+    '; Description: {operationDescription}',
+  ]), operation)
+  assert(gcode.includes('; Operation 1: Boss Pocket'), 'operation header should still include operation name')
+  assert(!gcode.includes('; Description:'), 'empty description line should not be emitted')
+}
+
+function testMultilineDescription(): void {
+  console.log('Testing multiline operation description header expansion...')
+  const { operation } = fixture('Face datum edge\nLeave tabs untouched (final trim)')
+  const gcode = runFixture(testDefinition([
+    '; Operation {operationIndex}: {operationName}',
+    '; Description: {operationDescription}',
+  ]), operation)
+  assert(gcode.includes('; Description: Face datum edge'), 'first description line should be emitted')
+  assert(gcode.includes('; Description: Leave tabs untouched final trim'), 'second description line should be emitted and sanitized')
+}
+
+function testLegacyDefinitionFallback(): void {
+  console.log('Testing machine definitions without operationHeader still work...')
+  const { operation } = fixture('Ignored by legacy fallback')
+  const gcode = runFixture(testDefinition(), operation)
+  assert(gcode.includes('; Operation: Boss Pocket'), 'legacy fallback should emit operation comment')
+}
+
+testOperationHeaderDescription()
+testEmptyDescriptionIsSkipped()
+testMultilineDescription()
+testLegacyDefinitionFallback()
+console.log('gcode postprocessor tests passed')

--- a/src/engine/gcode/postprocessor.ts
+++ b/src/engine/gcode/postprocessor.ts
@@ -20,6 +20,7 @@ import type {
 } from './types'
 import { projectToMachinePoint, formatGCodeNumber } from './utils'
 import type { ToolpathPoint } from '../toolpaths/types'
+import type { OperationTarget } from '../../types/project'
 
 interface ModalState {
   motionCommand: string | null   // last G0/G1/G2/G3
@@ -30,6 +31,27 @@ interface ModalState {
   currentToolId: string | null
   currentPosition: ToolpathPoint | null
   lineNumber: number
+}
+
+function operationTargetSummary(target: OperationTarget): string {
+  if (target.source === 'stock') {
+    return 'Stock'
+  }
+  return `${target.featureIds.length} feature${target.featureIds.length === 1 ? '' : 's'}`
+}
+
+function safeCommentText(text: string): string {
+  return text
+    .replace(/[()]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function safeCommentLines(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => safeCommentText(line))
+    .filter((line) => line.length > 0)
 }
 
 export function runPostProcessor(input: PostProcessorInput): PostProcessorResult {
@@ -62,6 +84,25 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
 
   const substituteTemplates = (text: string, context: Record<string, string | number>): string => {
     return text.replace(/{(\w+)}/g, (_, key) => context[key] !== undefined ? context[key].toString() : `{${key}}`)
+  }
+
+  const emitTemplateLines = (
+    templates: string[],
+    context: Record<string, string | number>,
+    descriptionLines: string[] = [],
+  ) => {
+    for (const template of templates) {
+      const expanded = template.includes('{operationDescription}')
+        ? descriptionLines.map((descriptionLine) => (
+          substituteTemplates(template, { ...context, operationDescription: descriptionLine })
+        )).join('\n')
+        : substituteTemplates(template, context)
+      for (const line of expanded.split(/\r?\n/)) {
+        if (line.trim().length > 0) {
+          emitLine(line)
+        }
+      }
+    }
   }
 
   const emitMotionLine = (
@@ -142,8 +183,29 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
 
   // 4. Operations
   operations.forEach(({ operation, tool, toolpath }, opIndex) => {
-    // Operation comment
-    emitLine(`${definition.program.commentPrefix} Operation: ${operation.name}${definition.program.commentSuffix}`)
+    const toolNumber = project.tools.findIndex(t => t.id === tool.id) + 1
+    const rpm = operation.rpm || tool.defaultRpm
+    const operationContext = {
+      ...commonContext,
+      operationIndex: opIndex + 1,
+      operationName: safeCommentText(operation.name),
+      operationDescription: safeCommentText(operation.description ?? ''),
+      operationKind: operation.kind,
+      operationPass: operation.pass,
+      operationTarget: operationTargetSummary(operation.target),
+      toolNumber: toolNumber > 0 ? toolNumber : 1,
+      toolName: safeCommentText(tool.name),
+      feed: formatGCodeNumber(operation.feed || tool.defaultFeed, definition, outputUnits),
+      plungeFeed: formatGCodeNumber(operation.plungeFeed || tool.defaultPlungeFeed, definition, outputUnits),
+      rpm: formatGCodeNumber(rpm, definition, outputUnits),
+    }
+    const descriptionLines = safeCommentLines(operation.description ?? '')
+
+    if (definition.program.operationHeader.length > 0) {
+      emitTemplateLines(definition.program.operationHeader, operationContext, descriptionLines)
+    } else {
+      emitLine(`${definition.program.commentPrefix} Operation: ${operationContext.operationName}${definition.program.commentSuffix}`)
+    }
 
     // Tool change
     const toolChanged = state.currentToolId !== tool.id
@@ -153,12 +215,8 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
         state.spindleOn = false
       }
 
-      // Find tool number in original project tools list
-      const toolNumber = project.tools.findIndex(t => t.id === tool.id) + 1
       const toolContext = {
-        ...commonContext,
-        toolNumber: toolNumber > 0 ? toolNumber : 1,
-        toolName: tool.name
+        ...operationContext,
       }
 
       definition.toolChange.commands.forEach(cmd => {
@@ -175,7 +233,6 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
     }
 
     // Spindle On
-    const rpm = operation.rpm || tool.defaultRpm
     if (!state.spindleOn || state.spindleSpeed !== rpm) {
       emitLine(`${definition.feedSpeed.spindleOnCW} ${definition.feedSpeed.rpmCommand}${formatGCodeNumber(rpm, definition, outputUnits)}`)
       state.spindleOn = true

--- a/src/engine/gcode/types.ts
+++ b/src/engine/gcode/types.ts
@@ -53,6 +53,7 @@ export const MachineDefinitionSchema = z.object({
   }),
   program: z.object({
     header: z.array(z.string()),
+    operationHeader: z.array(z.string()).default([]),
     footer: z.array(z.string()),
     commentPrefix: z.string(),
     commentSuffix: z.string(),

--- a/src/engine/operationBooklet/INDEX.md
+++ b/src/engine/operationBooklet/INDEX.md
@@ -1,0 +1,10 @@
+# INDEX — src/engine/operationBooklet/
+
+Per-operation setup-sheet/booklet export logic. This folder stays DOM-free so report and PDF generation can be tested without a browser canvas.
+
+## Files
+
+- `types.ts` — report and input types for operation booklet export.
+- `report.ts` — converts project/operation/tool/toolpath data into a printable report model.
+- `pdf.ts` — builds a PDF byte array from the report model and optional snapshot image.
+- `index.ts` — public exports for the booklet engine.

--- a/src/engine/operationBooklet/index.ts
+++ b/src/engine/operationBooklet/index.ts
@@ -1,0 +1,3 @@
+export * from './pdf'
+export * from './report'
+export * from './types'

--- a/src/engine/operationBooklet/operationBooklet.test.ts
+++ b/src/engine/operationBooklet/operationBooklet.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for operation booklet report and PDF generation.
+ *
+ * Run with: npx tsx src/engine/operationBooklet/operationBooklet.test.ts
+ */
+
+import { defaultTool, newProject, rectProfile } from '../../types/project'
+import type { Operation, Project, SketchFeature } from '../../types/project'
+import { normalizeToolForProject } from '../toolpaths/geometry'
+import type { ToolpathResult } from '../toolpaths/types'
+import { createOperationBookletPdf } from './pdf'
+import { buildOperationBookletReport } from './report'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+function expectedLocalTimestamp(date: Date): string {
+  const timezoneOffsetMinutes = -date.getTimezoneOffset()
+  const offsetSign = timezoneOffsetMinutes >= 0 ? '+' : '-'
+  const absOffsetMinutes = Math.abs(timezoneOffsetMinutes)
+  const offsetHours = Math.floor(absOffsetMinutes / 60)
+  const offsetMinutes = absOffsetMinutes % 60
+  return [
+    `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`,
+    `${pad2(date.getHours())}:${pad2(date.getMinutes())}`,
+    `UTC${offsetSign}${pad2(offsetHours)}:${pad2(offsetMinutes)}`,
+  ].join(' ')
+}
+
+function fixture(): { project: Project; operation: Operation; toolpath: ToolpathResult } {
+  const project = newProject('Booklet Test', 'mm')
+  project.origin = { name: 'Work Zero', x: 2, y: 4, z: 6, visible: true }
+  project.tools = [{ ...defaultTool('mm', 1), id: 't1', name: 'Test End Mill' }]
+  const feature: SketchFeature = {
+    id: 'f-pocket',
+    name: 'Pocket Region',
+    kind: 'rect',
+    folderId: null,
+    sketch: {
+      profile: rectProfile(5, 5, 20, 16),
+      origin: { x: 0, y: 0 },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+    operation: 'subtract',
+    z_top: project.stock.thickness,
+    z_bottom: 0,
+    visible: true,
+    locked: false,
+  }
+  project.features = [feature]
+  const operation: Operation = {
+    id: 'op1',
+    name: 'Rough pocket',
+    description: 'Clear pocket before finish pass',
+    kind: 'pocket',
+    pass: 'rough',
+    enabled: true,
+    showToolpath: true,
+    debugToolpath: false,
+    target: { source: 'features', featureIds: [feature.id] },
+    toolRef: project.tools[0].id,
+    stepdown: 1,
+    stepover: 0.4,
+    feed: 800,
+    plungeFeed: 220,
+    rpm: 14000,
+    pocketPattern: 'offset',
+    pocketAngle: 0,
+    stockToLeaveRadial: 0.2,
+    stockToLeaveAxial: 0,
+    finishWalls: true,
+    finishFloor: true,
+    carveDepth: 1,
+    maxCarveDepth: 1,
+    cutDirection: 'climb',
+    machiningOrder: 'feature_first',
+  }
+  const toolpath: ToolpathResult = {
+    operationId: operation.id,
+    warnings: ['Test warning'],
+    bounds: { minX: 5, minY: 5, minZ: 0, maxX: 25, maxY: 21, maxZ: 5 },
+    moves: [
+      { kind: 'rapid', from: { x: 0, y: 0, z: 5 }, to: { x: 5, y: 5, z: 5 } },
+      { kind: 'plunge', from: { x: 5, y: 5, z: 5 }, to: { x: 5, y: 5, z: 0 } },
+      { kind: 'cut', from: { x: 5, y: 5, z: 0 }, to: { x: 25, y: 5, z: 0 } },
+    ],
+  }
+  return { project, operation, toolpath }
+}
+
+function testReportContent(): void {
+  console.log('Testing operation booklet report content...')
+  const { project, operation, toolpath } = fixture()
+  const generatedAt = new Date('2026-06-04T12:00:00Z')
+  const report = buildOperationBookletReport({
+    project,
+    operation,
+    tool: normalizeToolForProject(project.tools[0], project),
+    toolpath,
+    generatedAt,
+  })
+
+  assert(report.projectName === 'Booklet Test', 'project name should be included')
+  assert(report.operationName === 'Rough pocket', 'operation name should be included')
+  assert(report.operationDescription === 'Clear pocket before finish pass', 'description should be included')
+  assert(report.generatedDate === expectedLocalTimestamp(generatedAt), 'generated date should use local time with offset')
+  assert(report.stockSizeSummary === '100 mm x 80 mm x 20 mm', 'stock size should be included')
+  assert(report.originZSummary === '6 mm', 'origin Z should be included')
+  assert(report.targetSummary === 'Pocket Region', 'target summary should list target feature names')
+  assert(report.targetFeatureNames.includes('Pocket Region'), 'target feature name should be included')
+  assert(report.warnings.includes('Test warning'), 'toolpath warnings should be included')
+  assert(report.settingRows.some((row) => row.label === 'Cut Direction' && row.value === 'Climb'), 'cut direction should be included')
+  assert(report.settingRows.some((row) => row.label === 'Machining Order' && row.value === 'Feature first'), 'machining order should be included')
+  assert(report.toolpathStats.some((row) => row.label === 'Moves' && row.value === '3'), 'toolpath move count should be included')
+  assert(report.toolpathStats.some((row) => row.label === 'Estimated Feed Time' && row.value === '2.9 s (excludes G0 rapid time)'), 'estimated feed time should be included')
+  assert(report.toolpathStats.some((row) => row.label === 'Rapid Travel' && row.value.includes('G0 speed machine-defined')), 'rapid travel should be included')
+  assert(report.toolpathStats.some((row) => row.label === 'Top Z' && row.value === '5 mm'), 'top Z should be included')
+  assert(report.toolpathStats.some((row) => row.label === 'Bottom Z' && row.value === '0 mm'), 'bottom Z should be included')
+}
+
+async function testPdfSmoke(): Promise<void> {
+  console.log('Testing operation booklet PDF smoke output...')
+  const { project, operation, toolpath } = fixture()
+  const pdfBytes = await createOperationBookletPdf({
+    project,
+    operation,
+    tool: normalizeToolForProject(project.tools[0], project),
+    toolpath,
+    generatedAt: new Date('2026-06-04T12:00:00Z'),
+  })
+
+  assert(pdfBytes.byteLength > 500, `expected non-empty PDF, got ${pdfBytes.byteLength} bytes`)
+  const header = new TextDecoder().decode(pdfBytes.slice(0, 5))
+  assert(header === '%PDF-', `expected PDF header, got ${header}`)
+}
+
+testReportContent()
+await testPdfSmoke()
+console.log('operation booklet tests passed')

--- a/src/engine/operationBooklet/operationBooklet.test.ts
+++ b/src/engine/operationBooklet/operationBooklet.test.ts
@@ -89,7 +89,7 @@ function fixture(): { project: Project; operation: Operation; toolpath: Toolpath
     moves: [
       { kind: 'rapid', from: { x: 0, y: 0, z: 5 }, to: { x: 5, y: 5, z: 5 } },
       { kind: 'plunge', from: { x: 5, y: 5, z: 5 }, to: { x: 5, y: 5, z: 0 } },
-      { kind: 'cut', from: { x: 5, y: 5, z: 0 }, to: { x: 25, y: 5, z: 0 } },
+      { kind: 'cut', from: { x: 5, y: 5, z: 0 }, to: { x: 25.1234, y: 5, z: 0 } },
     ],
   }
   return { project, operation, toolpath }
@@ -120,6 +120,7 @@ function testReportContent(): void {
   assert(report.settingRows.some((row) => row.label === 'Machining Order' && row.value === 'Feature first'), 'machining order should be included')
   assert(report.toolpathStats.some((row) => row.label === 'Moves' && row.value === '3'), 'toolpath move count should be included')
   assert(report.toolpathStats.some((row) => row.label === 'Estimated Feed Time' && row.value === '2.9 s (excludes G0 rapid time)'), 'estimated feed time should be included')
+  assert(report.toolpathStats.some((row) => row.label === 'Feed Travel' && row.value === '25.12 mm (feed and plunge moves)'), 'feed travel should be rounded to 2 decimals')
   assert(report.toolpathStats.some((row) => row.label === 'Rapid Travel' && row.value.includes('G0 speed machine-defined')), 'rapid travel should be included')
   assert(report.toolpathStats.some((row) => row.label === 'Top Z' && row.value === '5 mm'), 'top Z should be included')
   assert(report.toolpathStats.some((row) => row.label === 'Bottom Z' && row.value === '0 mm'), 'bottom Z should be included')

--- a/src/engine/operationBooklet/pdf.ts
+++ b/src/engine/operationBooklet/pdf.ts
@@ -8,10 +8,24 @@ const PAGE_HEIGHT = 792
 const MARGIN = 42
 const BODY_SIZE = 9
 const SECTION_SIZE = 11
-const COLUMN_GAP = 24
+const SECTION_COLUMN_GAP = 22
+const ROW_LABEL_WIDTH = 82
+const ROW_LABEL_GAP = 7
 const BODY_TOP = PAGE_HEIGHT - MARGIN
 const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2
-const COLUMN_WIDTH = (CONTENT_WIDTH - COLUMN_GAP) / 2
+const SECTION_COLUMN_WIDTH = (CONTENT_WIDTH - SECTION_COLUMN_GAP) / 2
+const LINE_HEIGHT = BODY_SIZE + 4
+
+const COLORS = {
+  accent: rgb(0.12, 0.34, 0.54),
+  accentSoft: rgb(0.9, 0.95, 0.98),
+  body: rgb(0.1, 0.13, 0.17),
+  border: rgb(0.73, 0.78, 0.83),
+  footer: rgb(0.42, 0.46, 0.5),
+  muted: rgb(0.3, 0.34, 0.39),
+  panel: rgb(0.97, 0.98, 0.99),
+  rowRule: rgb(0.88, 0.91, 0.94),
+}
 
 interface DrawState {
   pdfDoc: PDFDocument
@@ -19,9 +33,6 @@ interface DrawState {
   y: number
   regular: PDFFont
   bold: PDFFont
-  columns: boolean
-  column: 0 | 1
-  columnTopY: number
 }
 
 function pdfSafeText(text: string): string {
@@ -47,31 +58,23 @@ function wrapText(text: string, font: PDFFont, size: number, maxWidth: number): 
   return lines
 }
 
-function currentX(state: DrawState): number {
-  return state.columns && state.column === 1
-    ? MARGIN + COLUMN_WIDTH + COLUMN_GAP
-    : MARGIN
-}
+function truncateToWidth(text: string, font: PDFFont, size: number, maxWidth: number): string {
+  const safe = pdfSafeText(text)
+  if (font.widthOfTextAtSize(safe, size) <= maxWidth) return safe
 
-function currentWidth(state: DrawState): number {
-  return state.columns ? COLUMN_WIDTH : CONTENT_WIDTH
+  const ellipsis = '...'
+  let truncated = safe
+  while (truncated.length > 0 && font.widthOfTextAtSize(`${truncated}${ellipsis}`, size) > maxWidth) {
+    truncated = truncated.slice(0, -1)
+  }
+  return `${truncated}${ellipsis}`
 }
 
 function ensureSpace(state: DrawState, required: number): void {
   if (state.y - required >= MARGIN) return
 
-  if (state.columns && state.column === 0) {
-    state.column = 1
-    state.y = state.columnTopY
-    return
-  }
-
   state.page = state.pdfDoc.addPage([PAGE_WIDTH, PAGE_HEIGHT])
   state.y = BODY_TOP
-  if (state.columns) {
-    state.column = 0
-    state.columnTopY = BODY_TOP
-  }
 }
 
 function drawLine(state: DrawState, text: string, x: number, size = BODY_SIZE, bold = false): void {
@@ -81,67 +84,90 @@ function drawLine(state: DrawState, text: string, x: number, size = BODY_SIZE, b
     y: state.y,
     size,
     font,
-    color: rgb(0.12, 0.14, 0.18),
+    color: COLORS.body,
   })
   state.y -= size + 4
 }
 
 function drawWrapped(state: DrawState, text: string, x: number, width: number, size = BODY_SIZE): void {
-  const effectiveWidth = state.columns ? currentWidth(state) : width
-  const lines = wrapText(text, state.regular, size, effectiveWidth)
+  const lines = wrapText(text, state.regular, size, width)
   ensureSpace(state, lines.length * (size + 4))
-  const effectiveX = state.columns ? currentX(state) : x
   for (const line of lines) {
-    drawLine(state, line, effectiveX, size)
+    drawLine(state, line, x, size)
   }
 }
 
 function drawSection(state: DrawState, title: string): void {
   ensureSpace(state, 28)
-  const x = currentX(state)
-  const width = currentWidth(state)
-  state.y -= 8
-  drawLine(state, title, x, SECTION_SIZE, true)
-  state.page.drawLine({
-    start: { x, y: state.y + 6 },
-    end: { x: x + width, y: state.y + 6 },
-    thickness: 0.5,
-    color: rgb(0.68, 0.72, 0.76),
+  state.y -= 10
+  const titleY = state.y
+  state.page.drawRectangle({
+    x: MARGIN,
+    y: titleY - 1,
+    width: 4,
+    height: SECTION_SIZE + 3,
+    color: COLORS.accent,
   })
+  state.page.drawText(pdfSafeText(title.toUpperCase()), {
+    x: MARGIN + 10,
+    y: titleY,
+    size: SECTION_SIZE,
+    font: state.bold,
+    color: COLORS.accent,
+  })
+  state.y -= SECTION_SIZE + 8
+}
+
+interface PreparedCell {
+  labelLines: string[]
+  valueLines: string[]
+  height: number
+}
+
+function prepareRowCell(state: DrawState, row: OperationBookletRow): PreparedCell {
+  const valueWidth = SECTION_COLUMN_WIDTH - ROW_LABEL_WIDTH - ROW_LABEL_GAP
+  const labelLines = wrapText(row.label, state.bold, BODY_SIZE, ROW_LABEL_WIDTH)
+  const valueLines = wrapText(row.value, state.regular, BODY_SIZE, valueWidth)
+  const lineCount = Math.max(1, labelLines.length, valueLines.length)
+  return {
+    labelLines,
+    valueLines,
+    height: lineCount * LINE_HEIGHT + 6,
+  }
+}
+
+function drawPreparedCell(state: DrawState, cell: PreparedCell, x: number, y: number): void {
+  const valueX = x + ROW_LABEL_WIDTH + ROW_LABEL_GAP
+  for (let index = 0; index < cell.labelLines.length; index += 1) {
+    state.page.drawText(cell.labelLines[index], {
+      x,
+      y: y - index * LINE_HEIGHT,
+      size: BODY_SIZE,
+      font: state.bold,
+      color: COLORS.muted,
+    })
+  }
+  for (let index = 0; index < cell.valueLines.length; index += 1) {
+    state.page.drawText(cell.valueLines[index], {
+      x: valueX,
+      y: y - index * LINE_HEIGHT,
+      size: BODY_SIZE,
+      font: state.regular,
+      color: COLORS.body,
+    })
+  }
 }
 
 function drawRows(state: DrawState, rows: OperationBookletRow[]): void {
-  for (const row of rows) {
-    const width = currentWidth(state)
-    const labelW = state.columns ? 104 : 136
-    const gapW = 8
-    const valueW = width - labelW - gapW
-    const labelLines = wrapText(row.label, state.bold, BODY_SIZE, labelW)
-    const valueLines = wrapText(row.value, state.regular, BODY_SIZE, valueW)
-    const lineCount = Math.max(1, labelLines.length, valueLines.length)
-    ensureSpace(state, lineCount * (BODY_SIZE + 4) + 2)
-    const x = currentX(state)
-    const labelX = x
-    const valueX = x + labelW + gapW
-    for (let index = 0; index < labelLines.length; index += 1) {
-      state.page.drawText(labelLines[index], {
-        x: labelX,
-        y: state.y - index * (BODY_SIZE + 4),
-        size: BODY_SIZE,
-        font: state.bold,
-        color: rgb(0.28, 0.32, 0.36),
-      })
-    }
-    for (let index = 0; index < valueLines.length; index += 1) {
-      state.page.drawText(valueLines[index], {
-        x: valueX,
-        y: state.y - index * (BODY_SIZE + 4),
-        size: BODY_SIZE,
-        font: state.regular,
-        color: rgb(0.12, 0.14, 0.18),
-      })
-    }
-    state.y -= lineCount * (BODY_SIZE + 4) + 2
+  for (let index = 0; index < rows.length; index += 2) {
+    const left = prepareRowCell(state, rows[index])
+    const right = rows[index + 1] ? prepareRowCell(state, rows[index + 1]) : null
+    const rowHeight = Math.max(left.height, right?.height ?? 0)
+    ensureSpace(state, rowHeight)
+    const rowTop = state.y
+    drawPreparedCell(state, left, MARGIN, rowTop)
+    if (right) drawPreparedCell(state, right, MARGIN + SECTION_COLUMN_WIDTH + SECTION_COLUMN_GAP, rowTop)
+    state.y -= rowHeight + 1
   }
 }
 
@@ -152,31 +178,173 @@ function descriptionRows(report: OperationBookletReport): OperationBookletRow[] 
     { label: 'Units', value: report.units },
     { label: 'Stock Size', value: report.stockSizeSummary },
     { label: 'Origin Z', value: report.originZSummary },
-    { label: 'Target', value: report.targetSummary },
   ]
 }
 
-function beginColumns(state: DrawState): void {
-  state.columns = true
-  state.column = 0
-  state.columnTopY = state.y
-}
-
-function drawPageNumbers(pdfDoc: PDFDocument, font: PDFFont): void {
+function drawPageFooters(pdfDoc: PDFDocument, font: PDFFont, report: OperationBookletReport): void {
   const pages = pdfDoc.getPages()
   for (let index = 0; index < pages.length; index += 1) {
     const page = pages[index]
     const label = `Page ${index + 1} of ${pages.length}`
     const size = 8
-    const width = font.widthOfTextAtSize(label, size)
-    page.drawText(label, {
-      x: (PAGE_WIDTH - width) / 2,
+    const footerText = truncateToWidth(`${report.projectName} - ${report.operationName}`, font, size, 300)
+    page.drawLine({
+      start: { x: MARGIN, y: 36 },
+      end: { x: PAGE_WIDTH - MARGIN, y: 36 },
+      thickness: 0.35,
+      color: COLORS.rowRule,
+    })
+    page.drawText(footerText, {
+      x: MARGIN,
       y: 22,
       size,
       font,
-      color: rgb(0.42, 0.46, 0.5),
+      color: COLORS.footer,
+    })
+    page.drawText(label, {
+      x: PAGE_WIDTH - MARGIN - font.widthOfTextAtSize(label, size),
+      y: 22,
+      size,
+      font,
+      color: COLORS.footer,
     })
   }
+}
+
+function drawHeader(state: DrawState, report: OperationBookletReport): void {
+  state.page.drawRectangle({
+    x: 0,
+    y: PAGE_HEIGHT - 16,
+    width: PAGE_WIDTH,
+    height: 16,
+    color: COLORS.accent,
+  })
+
+  const titleLines = wrapText(report.operationName, state.bold, 20, 390)
+  let y = PAGE_HEIGHT - MARGIN - 2
+  for (const line of titleLines.slice(0, 2)) {
+    state.page.drawText(line, {
+      x: MARGIN,
+      y,
+      size: 20,
+      font: state.bold,
+      color: COLORS.body,
+    })
+    y -= 23
+  }
+
+  state.page.drawText('Operation Booklet', {
+    x: MARGIN,
+    y,
+    size: 10,
+    font: state.regular,
+    color: COLORS.muted,
+  })
+
+  const projectLabel = truncateToWidth(report.projectName, state.regular, 9, 160)
+  state.page.drawText(projectLabel, {
+    x: PAGE_WIDTH - MARGIN - state.regular.widthOfTextAtSize(projectLabel, 9),
+    y: PAGE_HEIGHT - MARGIN,
+    size: 9,
+    font: state.regular,
+    color: COLORS.muted,
+  })
+  state.page.drawText(report.generatedDate, {
+    x: PAGE_WIDTH - MARGIN - state.regular.widthOfTextAtSize(report.generatedDate, 8),
+    y: PAGE_HEIGHT - MARGIN - 15,
+    size: 8,
+    font: state.regular,
+    color: COLORS.footer,
+  })
+
+  state.page.drawLine({
+    start: { x: MARGIN, y: y - 12 },
+    end: { x: PAGE_WIDTH - MARGIN, y: y - 12 },
+    thickness: 0.75,
+    color: COLORS.border,
+  })
+  state.y = y - 30
+}
+
+function drawDescriptionBlock(state: DrawState, text: string): void {
+  const lines = wrapText(text, state.regular, 10, CONTENT_WIDTH - 24)
+  const height = lines.length * 14 + 20
+  ensureSpace(state, height + 8)
+  const top = state.y
+  const y = top - height
+
+  state.page.drawRectangle({
+    x: MARGIN,
+    y,
+    width: CONTENT_WIDTH,
+    height,
+    color: COLORS.accentSoft,
+  })
+  state.page.drawRectangle({
+    x: MARGIN,
+    y,
+    width: CONTENT_WIDTH,
+    height,
+    borderColor: COLORS.border,
+    borderWidth: 0.5,
+  })
+
+  let lineY = top - 16
+  for (const line of lines) {
+    state.page.drawText(line, {
+      x: MARGIN + 12,
+      y: lineY,
+      size: 10,
+      font: state.regular,
+      color: COLORS.body,
+    })
+    lineY -= 14
+  }
+  state.y = y - 10
+}
+
+async function drawSnapshotFrame(state: DrawState, input: OperationBookletInput): Promise<void> {
+  if (!input.snapshotPng) return
+
+  const image = await state.pdfDoc.embedPng(input.snapshotPng)
+  const maxW = CONTENT_WIDTH - 20
+  const maxH = 240
+  const scale = Math.min(maxW / image.width, maxH / image.height)
+  const width = image.width * scale
+  const height = image.height * scale
+  const frameHeight = height + 32
+
+  ensureSpace(state, frameHeight + 10)
+  const frameY = state.y - frameHeight
+  state.page.drawRectangle({
+    x: MARGIN,
+    y: frameY,
+    width: CONTENT_WIDTH,
+    height: frameHeight,
+    color: COLORS.panel,
+  })
+  state.page.drawRectangle({
+    x: MARGIN,
+    y: frameY,
+    width: CONTENT_WIDTH,
+    height: frameHeight,
+    borderColor: COLORS.border,
+    borderWidth: 0.5,
+  })
+  state.page.drawText('Operation Snapshot', {
+    x: MARGIN + 12,
+    y: state.y - 16,
+    size: 9,
+    font: state.bold,
+    color: COLORS.muted,
+  })
+  state.page.drawImage(image, {
+    x: MARGIN + (CONTENT_WIDTH - width) / 2,
+    y: frameY + 10,
+    width,
+    height,
+  })
+  state.y = frameY - 12
 }
 
 export async function createOperationBookletPdf(input: OperationBookletInput): Promise<Uint8Array> {
@@ -194,44 +362,18 @@ export async function createOperationBookletPdf(input: OperationBookletInput): P
     y: PAGE_HEIGHT - MARGIN,
     regular,
     bold,
-    columns: false,
-    column: 0,
-    columnTopY: PAGE_HEIGHT - MARGIN,
   }
 
-  drawLine(state, report.operationName, MARGIN, 18, true)
-  drawLine(state, 'Operation Booklet', MARGIN, 11)
+  drawHeader(state, report)
 
   if (report.operationDescription.trim().length > 0) {
-    state.y -= 4
-    drawWrapped(state, report.operationDescription, MARGIN, PAGE_WIDTH - MARGIN * 2, 10)
+    drawDescriptionBlock(state, report.operationDescription)
   }
 
-  if (input.snapshotPng) {
-    const image = await pdfDoc.embedPng(input.snapshotPng)
-    const maxW = PAGE_WIDTH - MARGIN * 2
-    const maxH = 260
-    const scale = Math.min(maxW / image.width, maxH / image.height)
-    const width = image.width * scale
-    const height = image.height * scale
-    ensureSpace(state, height + 18)
-    state.y -= 10
-    state.page.drawImage(image, {
-      x: MARGIN + (maxW - width) / 2,
-      y: state.y - height,
-      width,
-      height,
-    })
-    state.y -= height + 8
-  }
-
-  beginColumns(state)
+  await drawSnapshotFrame(state, input)
 
   drawSection(state, 'Overview')
   drawRows(state, descriptionRows(report))
-
-  drawSection(state, 'Target Features')
-  drawWrapped(state, report.targetFeatureNames.join(', '), MARGIN, PAGE_WIDTH - MARGIN * 2)
 
   drawSection(state, 'Tool')
   drawRows(state, report.toolRows)
@@ -249,7 +391,7 @@ export async function createOperationBookletPdf(input: OperationBookletInput): P
     }
   }
 
-  drawPageNumbers(pdfDoc, regular)
+  drawPageFooters(pdfDoc, regular, report)
 
   return pdfDoc.save()
 }

--- a/src/engine/operationBooklet/pdf.ts
+++ b/src/engine/operationBooklet/pdf.ts
@@ -1,0 +1,255 @@
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib'
+import type { PDFPage, PDFFont } from 'pdf-lib'
+import { buildOperationBookletReport } from './report'
+import type { OperationBookletInput, OperationBookletReport, OperationBookletRow } from './types'
+
+const PAGE_WIDTH = 612
+const PAGE_HEIGHT = 792
+const MARGIN = 42
+const BODY_SIZE = 9
+const SECTION_SIZE = 11
+const COLUMN_GAP = 24
+const BODY_TOP = PAGE_HEIGHT - MARGIN
+const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2
+const COLUMN_WIDTH = (CONTENT_WIDTH - COLUMN_GAP) / 2
+
+interface DrawState {
+  pdfDoc: PDFDocument
+  page: PDFPage
+  y: number
+  regular: PDFFont
+  bold: PDFFont
+  columns: boolean
+  column: 0 | 1
+  columnTopY: number
+}
+
+function pdfSafeText(text: string): string {
+  return text.replace(/[^\x20-\x7E]/g, '?')
+}
+
+function wrapText(text: string, font: PDFFont, size: number, maxWidth: number): string[] {
+  const words = pdfSafeText(text).split(/\s+/).filter(Boolean)
+  if (words.length === 0) return ['']
+
+  const lines: string[] = []
+  let current = ''
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word
+    if (font.widthOfTextAtSize(candidate, size) <= maxWidth || current.length === 0) {
+      current = candidate
+    } else {
+      lines.push(current)
+      current = word
+    }
+  }
+  if (current) lines.push(current)
+  return lines
+}
+
+function currentX(state: DrawState): number {
+  return state.columns && state.column === 1
+    ? MARGIN + COLUMN_WIDTH + COLUMN_GAP
+    : MARGIN
+}
+
+function currentWidth(state: DrawState): number {
+  return state.columns ? COLUMN_WIDTH : CONTENT_WIDTH
+}
+
+function ensureSpace(state: DrawState, required: number): void {
+  if (state.y - required >= MARGIN) return
+
+  if (state.columns && state.column === 0) {
+    state.column = 1
+    state.y = state.columnTopY
+    return
+  }
+
+  state.page = state.pdfDoc.addPage([PAGE_WIDTH, PAGE_HEIGHT])
+  state.y = BODY_TOP
+  if (state.columns) {
+    state.column = 0
+    state.columnTopY = BODY_TOP
+  }
+}
+
+function drawLine(state: DrawState, text: string, x: number, size = BODY_SIZE, bold = false): void {
+  const font = bold ? state.bold : state.regular
+  state.page.drawText(pdfSafeText(text), {
+    x,
+    y: state.y,
+    size,
+    font,
+    color: rgb(0.12, 0.14, 0.18),
+  })
+  state.y -= size + 4
+}
+
+function drawWrapped(state: DrawState, text: string, x: number, width: number, size = BODY_SIZE): void {
+  const effectiveWidth = state.columns ? currentWidth(state) : width
+  const lines = wrapText(text, state.regular, size, effectiveWidth)
+  ensureSpace(state, lines.length * (size + 4))
+  const effectiveX = state.columns ? currentX(state) : x
+  for (const line of lines) {
+    drawLine(state, line, effectiveX, size)
+  }
+}
+
+function drawSection(state: DrawState, title: string): void {
+  ensureSpace(state, 28)
+  const x = currentX(state)
+  const width = currentWidth(state)
+  state.y -= 8
+  drawLine(state, title, x, SECTION_SIZE, true)
+  state.page.drawLine({
+    start: { x, y: state.y + 6 },
+    end: { x: x + width, y: state.y + 6 },
+    thickness: 0.5,
+    color: rgb(0.68, 0.72, 0.76),
+  })
+}
+
+function drawRows(state: DrawState, rows: OperationBookletRow[]): void {
+  for (const row of rows) {
+    const width = currentWidth(state)
+    const labelW = state.columns ? 104 : 136
+    const gapW = 8
+    const valueW = width - labelW - gapW
+    const labelLines = wrapText(row.label, state.bold, BODY_SIZE, labelW)
+    const valueLines = wrapText(row.value, state.regular, BODY_SIZE, valueW)
+    const lineCount = Math.max(1, labelLines.length, valueLines.length)
+    ensureSpace(state, lineCount * (BODY_SIZE + 4) + 2)
+    const x = currentX(state)
+    const labelX = x
+    const valueX = x + labelW + gapW
+    for (let index = 0; index < labelLines.length; index += 1) {
+      state.page.drawText(labelLines[index], {
+        x: labelX,
+        y: state.y - index * (BODY_SIZE + 4),
+        size: BODY_SIZE,
+        font: state.bold,
+        color: rgb(0.28, 0.32, 0.36),
+      })
+    }
+    for (let index = 0; index < valueLines.length; index += 1) {
+      state.page.drawText(valueLines[index], {
+        x: valueX,
+        y: state.y - index * (BODY_SIZE + 4),
+        size: BODY_SIZE,
+        font: state.regular,
+        color: rgb(0.12, 0.14, 0.18),
+      })
+    }
+    state.y -= lineCount * (BODY_SIZE + 4) + 2
+  }
+}
+
+function descriptionRows(report: OperationBookletReport): OperationBookletRow[] {
+  return [
+    { label: 'Project', value: report.projectName },
+    { label: 'Generated', value: report.generatedDate },
+    { label: 'Units', value: report.units },
+    { label: 'Stock Size', value: report.stockSizeSummary },
+    { label: 'Origin Z', value: report.originZSummary },
+    { label: 'Target', value: report.targetSummary },
+  ]
+}
+
+function beginColumns(state: DrawState): void {
+  state.columns = true
+  state.column = 0
+  state.columnTopY = state.y
+}
+
+function drawPageNumbers(pdfDoc: PDFDocument, font: PDFFont): void {
+  const pages = pdfDoc.getPages()
+  for (let index = 0; index < pages.length; index += 1) {
+    const page = pages[index]
+    const label = `Page ${index + 1} of ${pages.length}`
+    const size = 8
+    const width = font.widthOfTextAtSize(label, size)
+    page.drawText(label, {
+      x: (PAGE_WIDTH - width) / 2,
+      y: 22,
+      size,
+      font,
+      color: rgb(0.42, 0.46, 0.5),
+    })
+  }
+}
+
+export async function createOperationBookletPdf(input: OperationBookletInput): Promise<Uint8Array> {
+  const report = buildOperationBookletReport(input)
+  const pdfDoc = await PDFDocument.create()
+  pdfDoc.setTitle(`${report.projectName} - ${report.operationName}`)
+  pdfDoc.setSubject('PureCutCNC operation booklet')
+  pdfDoc.setProducer('PureCutCNC')
+
+  const regular = await pdfDoc.embedFont(StandardFonts.Helvetica)
+  const bold = await pdfDoc.embedFont(StandardFonts.HelveticaBold)
+  const state: DrawState = {
+    pdfDoc,
+    page: pdfDoc.addPage([PAGE_WIDTH, PAGE_HEIGHT]),
+    y: PAGE_HEIGHT - MARGIN,
+    regular,
+    bold,
+    columns: false,
+    column: 0,
+    columnTopY: PAGE_HEIGHT - MARGIN,
+  }
+
+  drawLine(state, report.operationName, MARGIN, 18, true)
+  drawLine(state, 'Operation Booklet', MARGIN, 11)
+
+  if (report.operationDescription.trim().length > 0) {
+    state.y -= 4
+    drawWrapped(state, report.operationDescription, MARGIN, PAGE_WIDTH - MARGIN * 2, 10)
+  }
+
+  if (input.snapshotPng) {
+    const image = await pdfDoc.embedPng(input.snapshotPng)
+    const maxW = PAGE_WIDTH - MARGIN * 2
+    const maxH = 260
+    const scale = Math.min(maxW / image.width, maxH / image.height)
+    const width = image.width * scale
+    const height = image.height * scale
+    ensureSpace(state, height + 18)
+    state.y -= 10
+    state.page.drawImage(image, {
+      x: MARGIN + (maxW - width) / 2,
+      y: state.y - height,
+      width,
+      height,
+    })
+    state.y -= height + 8
+  }
+
+  beginColumns(state)
+
+  drawSection(state, 'Overview')
+  drawRows(state, descriptionRows(report))
+
+  drawSection(state, 'Target Features')
+  drawWrapped(state, report.targetFeatureNames.join(', '), MARGIN, PAGE_WIDTH - MARGIN * 2)
+
+  drawSection(state, 'Tool')
+  drawRows(state, report.toolRows)
+
+  drawSection(state, 'Operation Settings')
+  drawRows(state, report.settingRows)
+
+  drawSection(state, 'Toolpath')
+  drawRows(state, report.toolpathStats)
+
+  if (report.warnings.length > 0) {
+    drawSection(state, 'Warnings')
+    for (const warning of report.warnings) {
+      drawWrapped(state, `- ${warning}`, MARGIN, PAGE_WIDTH - MARGIN * 2)
+    }
+  }
+
+  drawPageNumbers(pdfDoc, regular)
+
+  return pdfDoc.save()
+}

--- a/src/engine/operationBooklet/report.ts
+++ b/src/engine/operationBooklet/report.ts
@@ -1,0 +1,306 @@
+import type { Operation, OperationKind, OperationPass, OperationTarget, Project } from '../../types/project'
+import { getStockBounds } from '../../types/project'
+import { formatLength } from '../../utils/units'
+import type { Units } from '../../utils/units'
+import type { NormalizedTool, ToolpathResult } from '../toolpaths/types'
+import type { OperationBookletInput, OperationBookletReport, OperationBookletRow } from './types'
+
+function operationKindLabel(kind: OperationKind): string {
+  switch (kind) {
+    case 'pocket': return 'Pocket'
+    case 'v_carve': return 'V-carve'
+    case 'v_carve_recursive': return 'V-carve Recursive'
+    case 'edge_route_inside': return 'Inside Edge Route'
+    case 'edge_route_outside': return 'Outside Edge Route'
+    case 'surface_clean': return 'Surface Clean'
+    case 'rough_surface': return 'Rough Surface'
+    case 'finish_surface': return 'Finish Surface'
+    case 'finish_surface_cleanup': return 'Finish Surface Cleanup'
+    case 'follow_line': return 'Follow Line'
+    case 'drilling': return 'Drilling'
+  }
+}
+
+function operationPassLabel(pass: OperationPass): string {
+  return pass === 'finish' ? 'Finish' : 'Rough'
+}
+
+function cutDirectionLabel(direction: NonNullable<Operation['cutDirection']>): string {
+  return direction === 'climb' ? 'Climb' : 'Conventional'
+}
+
+function machiningOrderLabel(order: NonNullable<Operation['machiningOrder']>): string {
+  return order === 'feature_first' ? 'Feature first' : 'Level first'
+}
+
+function operationSupportsCutDirection(kind: OperationKind): boolean {
+  return (
+    kind === 'pocket'
+    || kind === 'edge_route_inside'
+    || kind === 'edge_route_outside'
+    || kind === 'v_carve'
+    || kind === 'surface_clean'
+    || kind === 'rough_surface'
+    || kind === 'finish_surface'
+    || kind === 'finish_surface_cleanup'
+  )
+}
+
+function operationSupportsMachiningOrder(kind: OperationKind): boolean {
+  return kind === 'pocket' || kind === 'edge_route_inside' || kind === 'edge_route_outside'
+}
+
+function targetSummary(project: Project, target: OperationTarget): string {
+  if (target.source === 'stock') {
+    return 'Stock'
+  }
+
+  return targetFeatureNames(project, target).join(', ')
+}
+
+function targetFeatureNames(project: Project, target: OperationTarget): string[] {
+  if (target.source === 'stock') {
+    return ['Stock']
+  }
+
+  return target.featureIds.map((id) => (
+    project.features.find((feature) => feature.id === id)?.name ?? `Missing feature ${id}`
+  ))
+}
+
+function lengthWithUnits(value: number, units: Units): string {
+  return `${formatLength(value, units)} ${units === 'inch' ? 'in' : 'mm'}`
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+function generatedTimestamp(date: Date): string {
+  const timezoneOffsetMinutes = -date.getTimezoneOffset()
+  const offsetSign = timezoneOffsetMinutes >= 0 ? '+' : '-'
+  const absOffsetMinutes = Math.abs(timezoneOffsetMinutes)
+  const offsetHours = Math.floor(absOffsetMinutes / 60)
+  const offsetMinutes = absOffsetMinutes % 60
+  return [
+    `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`,
+    `${pad2(date.getHours())}:${pad2(date.getMinutes())}`,
+    `UTC${offsetSign}${pad2(offsetHours)}:${pad2(offsetMinutes)}`,
+  ].join(' ')
+}
+
+function formatNumber(value: number, maximumFractionDigits = 3): string {
+  return value.toFixed(maximumFractionDigits).replace(/(\.\d*?[1-9])0+$/u, '$1').replace(/\.0+$/u, '')
+}
+
+function feedWithUnits(value: number, units: Units): string {
+  return `${lengthWithUnits(value, units)}/min`
+}
+
+function distance3d(from: { x: number; y: number; z: number }, to: { x: number; y: number; z: number }): number {
+  return Math.hypot(to.x - from.x, to.y - from.y, to.z - from.z)
+}
+
+function durationLabel(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return 'Unavailable'
+  if (seconds < 60) return `${formatNumber(seconds, 1)} s`
+
+  const roundedSeconds = Math.round(seconds)
+  const hours = Math.floor(roundedSeconds / 3600)
+  const minutes = Math.floor((roundedSeconds % 3600) / 60)
+  const remainingSeconds = roundedSeconds % 60
+
+  if (hours > 0) {
+    return `${hours} h ${minutes} min ${remainingSeconds} s`
+  }
+  return `${minutes} min ${remainingSeconds} s`
+}
+
+function feedControlledTimeSeconds(
+  toolpath: ToolpathResult,
+  operation: Operation,
+): { seconds: number | null; rapidDistance: number } {
+  let seconds = 0
+  let rapidDistance = 0
+  let hasInvalidFeed = false
+
+  for (const move of toolpath.moves) {
+    const distance = distance3d(move.from, move.to)
+    switch (move.kind) {
+      case 'cut':
+      case 'lead_in':
+      case 'lead_out':
+        if (operation.feed > 0) {
+          seconds += (distance / operation.feed) * 60
+        } else {
+          hasInvalidFeed = true
+        }
+        break
+      case 'plunge':
+        if (operation.plungeFeed > 0) {
+          seconds += (distance / operation.plungeFeed) * 60
+        } else {
+          hasInvalidFeed = true
+        }
+        break
+      case 'rapid':
+        rapidDistance += distance
+        break
+    }
+  }
+
+  return {
+    seconds: hasInvalidFeed ? null : seconds,
+    rapidDistance,
+  }
+}
+
+function toolRows(tool: NormalizedTool | null, units: Units): OperationBookletRow[] {
+  if (!tool) {
+    return [{ label: 'Tool', value: 'No tool selected' }]
+  }
+
+  return [
+    { label: 'Name', value: tool.name },
+    { label: 'Type', value: tool.type.replace(/_/g, ' ') },
+    { label: 'Diameter', value: lengthWithUnits(tool.diameter, units) },
+    ...(tool.vBitAngle ? [{ label: 'V-bit Angle', value: `${formatNumber(tool.vBitAngle, 2)} deg` }] : []),
+    { label: 'Flutes', value: String(tool.flutes) },
+    { label: 'Material', value: tool.material },
+    { label: 'Max Cut Depth', value: lengthWithUnits(tool.maxCutDepth, units) },
+  ]
+}
+
+function originZSummary(project: Project): string {
+  return lengthWithUnits(project.origin.z, project.meta.units)
+}
+
+function stockSizeSummary(project: Project): string {
+  const bounds = getStockBounds(project.stock)
+  const units = project.meta.units
+  const width = bounds.maxX - bounds.minX
+  const height = bounds.maxY - bounds.minY
+  return `${lengthWithUnits(width, units)} x ${lengthWithUnits(height, units)} x ${lengthWithUnits(project.stock.thickness, units)}`
+}
+
+function settingRows(operation: Operation, project: Project): OperationBookletRow[] {
+  const units = project.meta.units
+  const rows: OperationBookletRow[] = [
+    { label: 'Kind', value: operationKindLabel(operation.kind) },
+    { label: 'Pass', value: operationPassLabel(operation.pass) },
+    { label: 'Target', value: targetSummary(project, operation.target) },
+    { label: 'Feed', value: feedWithUnits(operation.feed, units) },
+    { label: 'Plunge Feed', value: feedWithUnits(operation.plungeFeed, units) },
+    { label: 'RPM', value: `${Math.round(operation.rpm)} rpm` },
+  ]
+
+  if (operation.kind !== 'follow_line' && operation.kind !== 'drilling') {
+    rows.push(
+      { label: 'Stepdown', value: lengthWithUnits(operation.stepdown, units) },
+      { label: 'Stepover', value: formatLength(operation.stepover, units, { maximumFractionDigits: 4 }) },
+    )
+  }
+
+  if (operationSupportsCutDirection(operation.kind)) {
+    rows.push({ label: 'Cut Direction', value: cutDirectionLabel(operation.cutDirection ?? 'conventional') })
+  }
+
+  if (operationSupportsMachiningOrder(operation.kind)) {
+    rows.push({ label: 'Machining Order', value: machiningOrderLabel(operation.machiningOrder ?? 'level_first') })
+  }
+
+  if (operation.kind === 'pocket' || operation.kind === 'surface_clean' || operation.kind === 'finish_surface' || operation.kind === 'finish_surface_cleanup') {
+    rows.push(
+      { label: 'Pattern', value: operation.pocketPattern },
+      { label: 'Pocket Angle', value: `${formatNumber(operation.pocketAngle, 2)} deg` },
+    )
+  }
+
+  if (operation.kind === 'drilling') {
+    rows.push(
+      { label: 'Drill Type', value: operation.drillType ?? 'simple' },
+      { label: 'Peck Depth', value: lengthWithUnits(operation.peckDepth ?? 0, units) },
+      { label: 'Dwell Time', value: `${formatNumber(operation.dwellTime ?? 0, 3)} s` },
+      { label: 'Retract Height', value: lengthWithUnits(operation.retractHeight ?? 0, units) },
+    )
+  }
+
+  if (operation.kind === 'follow_line') {
+    rows.push({ label: 'Carve Depth', value: lengthWithUnits(operation.carveDepth, units) })
+  }
+
+  if (operation.kind !== 'follow_line' && operation.kind !== 'drilling') {
+    rows.push(
+      { label: 'Stock To Leave Radial', value: lengthWithUnits(operation.stockToLeaveRadial, units) },
+      { label: 'Stock To Leave Axial', value: lengthWithUnits(operation.stockToLeaveAxial, units) },
+    )
+  }
+
+  return rows
+}
+
+function statsRows(toolpath: ToolpathResult | null, operation: Operation, units: Units): OperationBookletRow[] {
+  if (!toolpath) {
+    return [{ label: 'Toolpath', value: 'Not generated' }]
+  }
+
+  const cutMoves = toolpath.moves.filter((move) => move.kind === 'cut' || move.kind === 'lead_in' || move.kind === 'lead_out').length
+  const rapidMoves = toolpath.moves.filter((move) => move.kind === 'rapid').length
+  const plungeMoves = toolpath.moves.filter((move) => move.kind === 'plunge').length
+  const timeEstimate = feedControlledTimeSeconds(toolpath, operation)
+  const rows: OperationBookletRow[] = [
+    { label: 'Moves', value: String(toolpath.moves.length) },
+    { label: 'Cut Moves', value: String(cutMoves) },
+    { label: 'Rapid Moves', value: String(rapidMoves) },
+    { label: 'Plunge Moves', value: String(plungeMoves) },
+    {
+      label: 'Estimated Feed Time',
+      value: timeEstimate.seconds === null
+        ? 'Unavailable (invalid feed)'
+        : `${durationLabel(timeEstimate.seconds)} (excludes G0 rapid time)`,
+    },
+    {
+      label: 'Rapid Travel',
+      value: `${lengthWithUnits(timeEstimate.rapidDistance, units)} (G0 speed machine-defined)`,
+    },
+  ]
+
+  if (toolpath.bounds) {
+    rows.push(
+      { label: 'Top Z', value: lengthWithUnits(toolpath.bounds.maxZ, units) },
+      { label: 'Bottom Z', value: lengthWithUnits(toolpath.bounds.minZ, units) },
+    )
+  }
+
+  return rows
+}
+
+function reportWarnings(tool: NormalizedTool | null, toolpath: ToolpathResult | null): string[] {
+  const warnings = [...(toolpath?.warnings ?? [])]
+  if (!tool) {
+    warnings.unshift('No tool is selected for this operation.')
+  }
+  if (!toolpath) {
+    warnings.unshift('Toolpath could not be generated for this operation.')
+  }
+  return warnings
+}
+
+export function buildOperationBookletReport(input: OperationBookletInput): OperationBookletReport {
+  const generatedAt = input.generatedAt ?? new Date()
+  return {
+    projectName: input.project.meta.name,
+    operationName: input.operation.name,
+    operationDescription: input.operation.description ?? '',
+    generatedDate: generatedTimestamp(generatedAt),
+    units: input.project.meta.units === 'inch' ? 'Inch' : 'Millimeter',
+    originZSummary: originZSummary(input.project),
+    stockSizeSummary: stockSizeSummary(input.project),
+    targetSummary: targetSummary(input.project, input.operation.target),
+    targetFeatureNames: targetFeatureNames(input.project, input.operation.target),
+    toolRows: toolRows(input.tool, input.project.meta.units),
+    settingRows: settingRows(input.operation, input.project),
+    warnings: reportWarnings(input.tool, input.toolpath),
+    toolpathStats: statsRows(input.toolpath, input.operation, input.project.meta.units),
+  }
+}

--- a/src/engine/operationBooklet/report.ts
+++ b/src/engine/operationBooklet/report.ts
@@ -72,6 +72,10 @@ function lengthWithUnits(value: number, units: Units): string {
   return `${formatLength(value, units)} ${units === 'inch' ? 'in' : 'mm'}`
 }
 
+function travelDistanceWithUnits(value: number, units: Units): string {
+  return `${formatLength(value, units, { maximumFractionDigits: 2 })} ${units === 'inch' ? 'in' : 'mm'}`
+}
+
 function pad2(value: number): string {
   return String(value).padStart(2, '0')
 }
@@ -119,8 +123,9 @@ function durationLabel(seconds: number): string {
 function feedControlledTimeSeconds(
   toolpath: ToolpathResult,
   operation: Operation,
-): { seconds: number | null; rapidDistance: number } {
+): { seconds: number | null; feedDistance: number; rapidDistance: number } {
   let seconds = 0
+  let feedDistance = 0
   let rapidDistance = 0
   let hasInvalidFeed = false
 
@@ -130,6 +135,7 @@ function feedControlledTimeSeconds(
       case 'cut':
       case 'lead_in':
       case 'lead_out':
+        feedDistance += distance
         if (operation.feed > 0) {
           seconds += (distance / operation.feed) * 60
         } else {
@@ -137,6 +143,7 @@ function feedControlledTimeSeconds(
         }
         break
       case 'plunge':
+        feedDistance += distance
         if (operation.plungeFeed > 0) {
           seconds += (distance / operation.plungeFeed) * 60
         } else {
@@ -151,6 +158,7 @@ function feedControlledTimeSeconds(
 
   return {
     seconds: hasInvalidFeed ? null : seconds,
+    feedDistance,
     rapidDistance,
   }
 }
@@ -260,8 +268,12 @@ function statsRows(toolpath: ToolpathResult | null, operation: Operation, units:
         : `${durationLabel(timeEstimate.seconds)} (excludes G0 rapid time)`,
     },
     {
+      label: 'Feed Travel',
+      value: `${travelDistanceWithUnits(timeEstimate.feedDistance, units)} (feed and plunge moves)`,
+    },
+    {
       label: 'Rapid Travel',
-      value: `${lengthWithUnits(timeEstimate.rapidDistance, units)} (G0 speed machine-defined)`,
+      value: `${travelDistanceWithUnits(timeEstimate.rapidDistance, units)} (G0 speed machine-defined)`,
     },
   ]
 

--- a/src/engine/operationBooklet/types.ts
+++ b/src/engine/operationBooklet/types.ts
@@ -1,0 +1,32 @@
+import type { Operation, Project } from '../../types/project'
+import type { NormalizedTool, ToolpathResult } from '../toolpaths/types'
+
+export interface OperationBookletInput {
+  project: Project
+  operation: Operation
+  tool: NormalizedTool | null
+  toolpath: ToolpathResult | null
+  snapshotPng?: Uint8Array
+  generatedAt?: Date
+}
+
+export interface OperationBookletRow {
+  label: string
+  value: string
+}
+
+export interface OperationBookletReport {
+  projectName: string
+  operationName: string
+  operationDescription: string
+  generatedDate: string
+  units: string
+  originZSummary: string
+  stockSizeSummary: string
+  targetSummary: string
+  targetFeatureNames: string[]
+  toolRows: OperationBookletRow[]
+  settingRows: OperationBookletRow[]
+  warnings: string[]
+  toolpathStats: OperationBookletRow[]
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -2129,6 +2129,7 @@ function defaultOperationForTarget(
   return {
     id: `op${index + 1}`,
     name: defaultOperationName(kind, pass, project.operations),
+    description: '',
     kind,
     pass,
     enabled: true,
@@ -2635,6 +2636,7 @@ function normalizeOperation(operation: Operation, project: Project, index: numbe
   const normalized = {
     ...defaults,
     ...operation,
+    description: operation.description ?? '',
     machiningOrder: operation.machiningOrder ?? 'level_first',
     waterlineAdaptiveRefinement: operation.waterlineAdaptiveRefinement ?? true,
     waterlineMicroStepover: operation.waterlineMicroStepover ?? 0,

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1659,6 +1659,14 @@
   grid-template-columns: minmax(92px, 104px) minmax(0, 1fr);
 }
 
+.properties-field--textarea {
+  align-items: start;
+}
+
+.properties-field--textarea > span {
+  padding-top: 8px;
+}
+
 .properties-field-label-row {
   display: inline-flex;
   align-items: center;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -393,6 +393,7 @@ export type OperationTarget =
 export interface Operation {
   id: string
   name: string
+  description?: string
   kind: OperationKind
   pass: OperationPass
   enabled: boolean


### PR DESCRIPTION
## Summary

Adds per-operation documentation and export support for setup/shop-floor review:

- Add `Operation.description` to the project model, defaults, normalization, duplication/import paths, and CAM operation UI.
- Add per-operation G-code header support in machine definitions, including `{operationDescription}` substitution and safe multiline comment handling.
- Add a per-operation PDF booklet export from the CAM panel, positioned after the rest-machining action.
- Archive the completed plan: `planning/archive/OPERATION_DESCRIPTION_BOOKLET_Plan.md`.

## Operation Booklet

The booklet includes:

- Operation overview with project, local generated date/time, units, stock size, and origin Z.
- Operation settings, selected tool details, target summary, warnings, and toolpath statistics.
- Toolpath top/bottom Z, feed-time estimate, feed travel rounded to 2 decimals, and rapid travel rounded to 2 decimals.
- A static operation snapshot image with selected geometry, printed toolpath, origin cross, tabs, and clamps.
- Page numbers and compact section-local two-column label/value formatting.

## G-code Headers

Machine definitions now support a per-operation header block, separate from the program header. Bundled machine definitions emit concise operation comments and can include the new description placeholder.

## Verification

- `npx tsx src/engine/operationBooklet/operationBooklet.test.ts`
- `npm run build`
