### PR TITLE
Add UCCNC machine definition

### DIFF
--- a/src/engine/gcode/definitions/index.ts
+++ b/src/engine/gcode/definitions/index.ts
@@ -21,12 +21,14 @@ import grbl from './grbl.json'
 import mach3 from './mach3.json'
 import linuxcnc from './linuxcnc.json'
 import grblhal from './grblhal.json'
+import uccnc from './uccnc.json'
 
 export const BUNDLED_DEFINITIONS: MachineDefinition[] = [
   generic as unknown as MachineDefinition,
   grbl as unknown as MachineDefinition,
   grblhal as unknown as MachineDefinition,
   mach3 as unknown as MachineDefinition,
+  uccnc as unknown as MachineDefinition,
   linuxcnc as unknown as MachineDefinition,
 ]
 

--- a/src/engine/gcode/definitions/uccnc.json
+++ b/src/engine/gcode/definitions/uccnc.json
@@ -1,0 +1,88 @@
+{
+  "id": "uccnc",
+  "name": "UCCNC",
+  "description": "UCCNC \u2014 CNCdrive Windows-based CNC controller (Mach3-compatible dialect)",
+  "builtin": true,
+  "fileExtension": "txt",
+  "coordinateSystem": {
+    "xAxis": "X",
+    "yAxis": "Y",
+    "zAxis": "Z"
+  },
+  "numberFormat": {
+    "decimalPlaces": {
+      "mm": 3,
+      "inch": 4
+    },
+    "trailingZeros": true,
+    "leadingZero": true
+  },
+  "units": {
+    "mmCommand": "G21",
+    "inchCommand": "G20"
+  },
+  "program": {
+    "header": [
+      "%",
+      "O0001 ({programName})",
+      "G90 G94 G17 G40 G49 G80",
+      "{unitsCommand}",
+      "{wcsCommand}"
+    ],
+    "operationHeader": [
+      "( Operation {operationIndex}: {operationName} )",
+      "( Description: {operationDescription} )",
+      "( Tool {toolNumber}: {toolName} )"
+    ],
+    "footer": [],
+    "commentPrefix": "(",
+    "commentSuffix": ")",
+    "lineNumbers": true,
+    "lineNumberIncrement": 10
+  },
+  "workCoordinates": {
+    "selectCommand": "G54"
+  },
+  "motion": {
+    "rapidCommand": "G0",
+    "linearCommand": "G1",
+    "cwArcCommand": "G2",
+    "ccwArcCommand": "G3",
+    "arcFormat": "ij",
+    "modalMotion": true
+  },
+  "feedSpeed": {
+    "feedCommand": "F",
+    "rpmCommand": "S",
+    "spindleOnCW": "M3",
+    "spindleOnCCW": "M4",
+    "spindleOff": "M5",
+    "inlineWithMotion": true,
+    "modalFeedSpeed": true
+  },
+  "toolChange": {
+    "commands": [
+      "M5",
+      "M6 T{toolNumber}",
+      "G43 H{toolNumber}"
+    ],
+    "stopSpindleFirst": true,
+    "pauseAfterChange": false,
+    "pauseCommand": "M1"
+  },
+  "cannedCycles": {
+    "drillCommand": "G81",
+    "drillWithDwellCommand": "G82",
+    "peckDrillCommand": "G83",
+    "peckStepWord": "Q",
+    "retractMode": "G98"
+  },
+  "coolant": {
+    "floodOnCommand": "M8",
+    "mistOnCommand": "M7",
+    "coolantOffCommand": "M9"
+  },
+  "stop": {
+    "programEndCommand": "M30"
+  }
+}


### PR DESCRIPTION
## Summary
Adds **UCCNC** (CNCdrive's Windows-based controller) as a bundled machine definition so it can be selected as a post-processor target.

UCCNC uses a Mach3-compatible g-code dialect, so [`uccnc.json`](src/engine/gcode/definitions/uccnc.json) mirrors `mach3.json`:
- G54 WCS, `G90 G94 G17 G40 G49 G80` safety block header
- Canned cycles: G81 / G82 / G83 (peck word `Q`, G98 retract)
- M3/M4/M5 spindle, M7/M8/M9 coolant, M30 program end
- IJ-format arcs (G2/G3), modal motion + feed/speed
- `M6 T{n}` + `G43 H{n}` tool change with length offset
- Default file extension `.txt`

Includes the new `operationHeader` template block (`operationIndex`, `operationName`, `operationDescription`, `toolNumber`, `toolName`) introduced on main, matching the other paren-comment definitions.

Registered in `BUNDLED_DEFINITIONS` ([index.ts](src/engine/gcode/definitions/index.ts)) between Mach3 and LinuxCNC.

## Testing
- `npm test` — all 32 test files pass
- `npm run build` — succeeds (new field validates against the Zod schema)