### PR TITLE
UX: Select all button in Add-operation hint row + Apache header policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ src/types/project.ts    Core data model definitions
 
 ## Coding Standards
 
+- Every `src/**/*.ts` / `*.tsx` file (including tests and `.d.ts`) starts with the Apache 2.0 license header — copy the exact comment block from any existing source file
 - Strict TypeScript — no `any`
 - React + vanilla CSS (no UI component libraries)
 - New engine features or bug fixes must include unit tests

--- a/planning/archive/LICENSE_HEADER_POLICY_Plan.md
+++ b/planning/archive/LICENSE_HEADER_POLICY_Plan.md
@@ -1,0 +1,45 @@
+---
+status: Done
+created: 2026-06-10
+---
+
+# License Header Policy Plan
+
+> Approval: requested directly by the user in-session ("lets add the
+> instructions and also add missing headers as part of this change"), riding on
+> the same branch as `OPERATION_HINT_SELECT_ALL_Plan.md`.
+
+## Goal
+
+Make the Apache 2.0 file header an explicit, documented rule and bring the
+codebase into compliance. Today 141 of 183 `src/**/*.ts(x)` files carry the
+header as an undocumented convention; 42 do not, and no instruction file
+mentions it.
+
+## Approach
+
+- Add a line to AGENTS.md "Coding Standards": every `src/**/*.ts(x)` file
+  starts with the Apache 2.0 license header.
+- Prepend the exact existing 15-line header block (uniform across all 141
+  files: "Copyright 2026 Franja (Frank) Povazanj") to the 42 files missing it,
+  including test files and `.d.ts` files. No other content changes.
+
+## Files affected
+
+- `AGENTS.md` — one new Coding Standards bullet.
+- 42 files under `src/` — header block prepended (mechanical; list derivable
+  via `grep -rL "Licensed under the Apache License" src --include="*.ts" --include="*.tsx"`).
+
+## Tests
+
+None — comment-only change. `npm run build` (tsc + tests + vite) verifies
+nothing breaks.
+
+## Open questions / risks
+
+- None. Header text is byte-identical to the existing convention.
+
+## Out of scope
+
+- Headers for non-TypeScript files (CSS, scripts/, configs).
+- A lint rule or CI check enforcing the header (could be a follow-up).

--- a/planning/archive/OPERATION_HINT_SELECT_ALL_Plan.md
+++ b/planning/archive/OPERATION_HINT_SELECT_ALL_Plan.md
@@ -1,0 +1,69 @@
+---
+status: Done
+created: 2026-06-10
+---
+
+# Operation Hint "Select all" Plan
+
+> **Process note:** this plan was written retroactively — implementation happened
+> before the plan, violating the Plan → Approve → Implement loop. It is recorded
+> here so scope and intent are still traceable. The user verified the result in
+> the app on 2026-06-10, including tablet (no hover there — tapping the
+> operation row arms the hint and "Select all").
+
+## Goal
+
+In the "Add operation" menu, when an operation row shows its validity hint
+("This operation only accepts subtract features plus optional closed regions"),
+let the user fix the selection in one click: a right-aligned **Select all**
+button inside the hint line selects every feature the operation can act on.
+The button appears only on the hovered row (or tap-armed row on touch),
+matching the existing A1.3 hover-highlight behaviour.
+
+## Approach
+
+- New helper `selectAllCompatibleFeatureIds(project, kind)` in
+  `operationValidity.ts`. It reuses `compatibleFeatureIdsForOperation` (the
+  same list driving the A1.3 canvas highlight) but returns `[]` when selecting
+  all of them together would itself be invalid — e.g. 3D Surface finish accepts
+  exactly one model, so with two compatible models there is no unambiguous
+  "all" and the button is not offered.
+- `CAMPanel` computes `selectAllFeatureIds` per operation button (only while a
+  hint is showing) and passes the store's existing `selectFeatures` action down
+  as `onSelectFeatures`.
+- `OperationAddMenu` tracks `hoveredOperationKind` (set alongside the existing
+  highlight calls on mouse enter/leave and tap-expand) and renders the button
+  in the hint row for that kind only, styled with the existing
+  `cam-subtab--compact` button language.
+- Clicking the button replaces the selection; the hint recomputes to `null`,
+  the hint row disappears, and the row's Add/pass buttons enable.
+
+## Files affected
+
+- `src/components/cam/operationValidity.ts` — new exported helper
+  `selectAllCompatibleFeatureIds`.
+- `src/components/cam/operationValidity.test.ts` — unit tests for the helper.
+- `src/components/cam/CAMPanel.tsx` — `operationButtons` entries gain
+  `selectAllFeatureIds` (the 11 copy-pasted objects were collapsed into a local
+  builder to add the field once); passes `selectFeatures` to the menu.
+- `src/components/cam/OperationAddMenu.tsx` — hovered-row state; "Select all"
+  button in the hint line.
+- `src/styles/layout.css` — `.cam-operation-hint` becomes a flex row;
+  `.cam-operation-hint__text` / `.cam-operation-hint__select-all` styles.
+
+## Tests
+
+- Unit tests for `selectAllCompatibleFeatureIds`: returns compatible ids when
+  the combined selection is valid; returns `[]` when nothing is compatible;
+  returns `[]` when individually-compatible features are jointly invalid
+  (two models for `finish_surface`).
+
+## Open questions / risks
+
+- None blocking. UX detail: on touch the button appears after tap-expanding a
+  row, mirroring the A1.5 tap-arm behaviour for the canvas highlight.
+
+## Out of scope
+
+- Partial selection (e.g. "select first model" for exactly-one-model kinds).
+- Any change to quick-operation context menus or the canvas highlight itself.

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -39,7 +39,7 @@ import { createOperationBookletPdf } from '../../engine/operationBooklet'
 import { renderOperationSnapshotPng } from '../canvas/operationSnapshot'
 import { platform } from '../../platform'
 import { featureHasClosedGeometry } from '../../text'
-import { getOperationAddHint, operationKindLabel, operationRequiresClosedProfiles, operationTargetsRegion } from './operationValidity'
+import { getOperationAddHint, operationKindLabel, operationRequiresClosedProfiles, operationTargetsRegion, selectAllCompatibleFeatureIds } from './operationValidity'
 import { convertToolUnits, formatLength, parseLengthInput } from '../../utils/units'
 import { Icon } from '../Icon'
 import { isTabletMode, useShellMode } from '../layout/useShellMode'
@@ -704,64 +704,33 @@ export function CAMPanel({
     void ensureBundledLibraryLoaded()
   }, [ensureBundledLibraryLoaded, libraryError, libraryLoading, libraryTools.length, mode])
 
-  const operationButtons = useMemo<Array<{ kind: OperationKind; label: string; hint?: string }>>(
-    () => ([
-      {
-        kind: 'pocket',
-        label: operationAddButtonLabel('pocket'),
-        hint: getOperationAddHint(project, selection, 'pocket') ?? undefined,
-      },
-      {
-        kind: 'v_carve',
-        label: operationAddButtonLabel('v_carve'),
-        hint: getOperationAddHint(project, selection, 'v_carve') ?? undefined,
-      },
-      {
-        kind: 'v_carve_recursive',
-        label: operationAddButtonLabel('v_carve_recursive'),
-        hint: getOperationAddHint(project, selection, 'v_carve_recursive') ?? undefined,
-      },
-      {
-        kind: 'edge_route_inside',
-        label: operationAddButtonLabel('edge_route_inside'),
-        hint: getOperationAddHint(project, selection, 'edge_route_inside') ?? undefined,
-      },
-      {
-        kind: 'edge_route_outside',
-        label: operationAddButtonLabel('edge_route_outside'),
-        hint: getOperationAddHint(project, selection, 'edge_route_outside') ?? undefined,
-      },
-      {
-        kind: 'surface_clean',
-        label: operationAddButtonLabel('surface_clean'),
-        hint: getOperationAddHint(project, selection, 'surface_clean') ?? undefined,
-      },
-      {
-        kind: 'follow_line',
-        label: operationAddButtonLabel('follow_line'),
-        hint: getOperationAddHint(project, selection, 'follow_line') ?? undefined,
-      },
-      {
-        kind: 'drilling',
-        label: operationAddButtonLabel('drilling'),
-        hint: getOperationAddHint(project, selection, 'drilling') ?? undefined,
-      },
-      {
-        kind: 'rough_surface',
-        label: operationAddButtonLabel('rough_surface'),
-        hint: getOperationAddHint(project, selection, 'rough_surface') ?? undefined,
-      },
-      {
-        kind: 'finish_surface_cleanup',
-        label: operationAddButtonLabel('finish_surface_cleanup'),
-        hint: getOperationAddHint(project, selection, 'finish_surface_cleanup') ?? undefined,
-      },
-      {
-        kind: 'finish_surface',
-        label: operationAddButtonLabel('finish_surface'),
-        hint: getOperationAddHint(project, selection, 'finish_surface') ?? undefined,
-      },
-    ]),
+  const operationButtons = useMemo<Array<{ kind: OperationKind; label: string; hint?: string; selectAllFeatureIds: string[] }>>(
+    () => {
+      const button = (kind: OperationKind) => {
+        const hint = getOperationAddHint(project, selection, kind)
+        return {
+          kind,
+          label: operationAddButtonLabel(kind),
+          hint: hint ?? undefined,
+          // "Select all" is only offered while the hint is showing, so skip
+          // the compatibility scan when the current selection is already valid.
+          selectAllFeatureIds: hint ? selectAllCompatibleFeatureIds(project, kind) : [],
+        }
+      }
+      return [
+        button('pocket'),
+        button('v_carve'),
+        button('v_carve_recursive'),
+        button('edge_route_inside'),
+        button('edge_route_outside'),
+        button('surface_clean'),
+        button('follow_line'),
+        button('drilling'),
+        button('rough_surface'),
+        button('finish_surface_cleanup'),
+        button('finish_surface'),
+      ]
+    },
     [project, selection]
   )
 
@@ -1157,6 +1126,7 @@ export function CAMPanel({
                         onChooseOperation={handleChooseOperationForAdd}
                         onAddOperation={handleAddOperation}
                         onHighlightOperation={onOperationHighlightChange}
+                        onSelectFeatures={selectFeatures}
                       />
                     ) : null}
                   </div>

--- a/src/components/cam/OperationAddMenu.tsx
+++ b/src/components/cam/OperationAddMenu.tsx
@@ -23,6 +23,8 @@ interface OperationButton {
   kind: OperationKind
   label: string
   hint?: string
+  /** Features "Select all" would select; empty when the affordance is unavailable. */
+  selectAllFeatureIds?: string[]
 }
 
 interface OperationAddMenuProps {
@@ -34,6 +36,8 @@ interface OperationAddMenuProps {
   onAddOperation: (kind: OperationKind, mode: 'rough' | 'finish' | 'pair') => void
   /** A1.3: arm a kind (on hover or tap-expand) so the canvas highlights its compatible features. */
   onHighlightOperation?: (kind: OperationKind | null) => void
+  /** Replace the current selection (drives the hint row's "Select all" button). */
+  onSelectFeatures?: (featureIds: string[]) => void
 }
 
 export function OperationAddMenu({
@@ -44,12 +48,16 @@ export function OperationAddMenu({
   onChooseOperation,
   onAddOperation,
   onHighlightOperation,
+  onSelectFeatures,
 }: OperationAddMenuProps) {
   // expandedOperationKind: which description card is open (one at a time).
   // selectedNewOperationKind (prop): which operation the user last attempted to add via the
   // + button for non-pass operations — separate from expansion state so the user can browse
   // descriptions without clearing the attempted-operation highlight.
   const [expandedOperationKind, setExpandedOperationKind] = useState<OperationKind | null>(null)
+  // Which row the pointer is on (or was tap-armed on, for touch) — gates the
+  // hint row's "Select all" button to the hovered operation only.
+  const [hoveredOperationKind, setHoveredOperationKind] = useState<OperationKind | null>(null)
   const [imageErrors, setImageErrors] = useState<Set<OperationKind>>(new Set())
   const expandedRef = useRef<HTMLDivElement>(null)
 
@@ -79,8 +87,14 @@ export function OperationAddMenu({
               <div
                 key={button.kind}
                 className={`cam-operation-item ${isExpanded ? 'cam-operation-item--expanded' : ''}`}
-                onMouseEnter={() => onHighlightOperation?.(button.kind)}
-                onMouseLeave={() => onHighlightOperation?.(null)}
+                onMouseEnter={() => {
+                  setHoveredOperationKind(button.kind)
+                  onHighlightOperation?.(button.kind)
+                }}
+                onMouseLeave={() => {
+                  setHoveredOperationKind(null)
+                  onHighlightOperation?.(null)
+                }}
               >
                 {/* Operation row */}
                 <div className="cam-operation-row">
@@ -94,6 +108,7 @@ export function OperationAddMenu({
                       // armed on collapse — it matches hover (the pointer is
                       // still on the row) and clears when the menu closes.
                       setExpandedOperationKind(isExpanded ? null : button.kind)
+                      setHoveredOperationKind(button.kind)
                       onHighlightOperation?.(button.kind)
                     }}
                   >
@@ -148,7 +163,19 @@ export function OperationAddMenu({
                     unavailable, promoted from the button tooltip. */}
                 {button.hint ? (
                   <div className="cam-operation-hint" role="note">
-                    {button.hint}
+                    <span className="cam-operation-hint__text">{button.hint}</span>
+                    {hoveredOperationKind === button.kind
+                      && onSelectFeatures
+                      && (button.selectAllFeatureIds?.length ?? 0) > 0 ? (
+                      <button
+                        className="cam-subtab cam-subtab--compact cam-operation-hint__select-all"
+                        type="button"
+                        title={`Select all features compatible with ${button.label}`}
+                        onClick={() => onSelectFeatures(button.selectAllFeatureIds ?? [])}
+                      >
+                        Select all
+                      </button>
+                    ) : null}
                   </div>
                 ) : null}
 

--- a/src/components/cam/operationValidity.test.ts
+++ b/src/components/cam/operationValidity.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for the shared operation-validity helpers.
  *
  * Two concerns are covered:
@@ -15,6 +31,7 @@ import {
   getOperationAddHint,
   operationTargetsRegion,
   quickOperationLabel,
+  selectAllCompatibleFeatureIds,
   validQuickOperationsForFeature,
 } from './operationValidity'
 import type { SelectionState } from '../../store/types'
@@ -254,6 +271,56 @@ function testCompatibleFeatureIdsMatchAddHint(): void {
   }
 }
 
+// ── selectAllCompatibleFeatureIds ("Select all" in the add menu) ──
+
+function testSelectAllReturnsCompatibleIdsWhenJointlyValid(): void {
+  const project = projectWith([
+    makeFeature('sub1', 'subtract'),
+    makeFeature('sub2', 'subtract'),
+    makeFeature('add', 'add'),
+  ])
+
+  // Pocket accepts multiple subtract features together, so "Select all" offers
+  // exactly the compatible set.
+  assert(
+    JSON.stringify(selectAllCompatibleFeatureIds(project, 'pocket')) === JSON.stringify(['sub1', 'sub2']),
+    'pocket select-all should return both subtract features',
+  )
+}
+
+function testSelectAllReturnsEmptyWhenNothingCompatible(): void {
+  const project = projectWith([makeFeature('add', 'add')])
+  assert(
+    selectAllCompatibleFeatureIds(project, 'pocket').length === 0,
+    'pocket select-all should be empty with no subtract features',
+  )
+}
+
+function testSelectAllReturnsEmptyWhenJointSelectionInvalid(): void {
+  // Two models are each individually valid for finish_surface, but the kind
+  // accepts exactly one model — there is no unambiguous "all", so the
+  // affordance must not be offered.
+  const project = projectWith([
+    makeFeature('model1', 'model', 'stl'),
+    makeFeature('model2', 'model', 'stl'),
+  ])
+
+  assert(
+    JSON.stringify(compatibleFeatureIdsForOperation(project, 'finish_surface'))
+      === JSON.stringify(['model1', 'model2']),
+    'both models should be individually compatible with finish surface',
+  )
+  assert(
+    selectAllCompatibleFeatureIds(project, 'finish_surface').length === 0,
+    'finish-surface select-all should be empty when two models exist',
+  )
+  assert(
+    JSON.stringify(selectAllCompatibleFeatureIds(projectWith([makeFeature('model1', 'model', 'stl')]), 'finish_surface'))
+      === JSON.stringify(['model1']),
+    'finish-surface select-all should offer a single model',
+  )
+}
+
 // ── operationTargetsRegion (A1.4 region-as-parameter note) ────────
 
 function testOperationTargetsRegion(): void {
@@ -285,6 +352,9 @@ testQuickOperationCarriesDefaultPassAndLabel()
 testGetOperationAddHintGoldenValues()
 testCompatibleFeatureIdsReuseValidityRules()
 testCompatibleFeatureIdsMatchAddHint()
+testSelectAllReturnsCompatibleIdsWhenJointlyValid()
+testSelectAllReturnsEmptyWhenNothingCompatible()
+testSelectAllReturnsEmptyWhenJointSelectionInvalid()
 testOperationTargetsRegion()
 
 console.log('operationValidity tests passed')

--- a/src/components/cam/operationValidity.ts
+++ b/src/components/cam/operationValidity.ts
@@ -352,6 +352,32 @@ export function compatibleFeatureIdsForOperation(project: Project, kind: Operati
 }
 
 /**
+ * Returns the feature ids the "Select all" affordance in the "Add operation"
+ * menu should select for an operation kind, or an empty list when the
+ * affordance should not be offered. The ids are the individually compatible
+ * features (`compatibleFeatureIdsForOperation`), but only when selecting them
+ * all together is itself a valid selection for the kind — e.g. 3D Surface
+ * finish accepts exactly one model, so with two compatible models there is no
+ * unambiguous "all" to select.
+ */
+export function selectAllCompatibleFeatureIds(project: Project, kind: OperationKind): string[] {
+  const featureIds = compatibleFeatureIdsForOperation(project, kind)
+  if (featureIds.length === 0) {
+    return []
+  }
+  const selection: SelectionState = {
+    mode: 'feature',
+    selectedFeatureId: featureIds[0],
+    selectedFeatureIds: featureIds,
+    selectedNode: null,
+    hoveredFeatureId: null,
+    sketchEditTool: null,
+    activeControl: null,
+  }
+  return getOperationAddHint(project, selection, kind) === null ? featureIds : []
+}
+
+/**
  * True when an operation's target list includes at least one `region` feature.
  * Used by the CAM panel (A1.4) to show a plain-language note clarifying that a
  * region limits where the operation may cut rather than being machined itself.

--- a/src/components/canvas/CanvasWorkflowPanel.tsx
+++ b/src/components/canvas/CanvasWorkflowPanel.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { HTMLAttributes, ReactNode, RefObject } from 'react'
 import type { CanvasWorkflowPanelPosition } from './useCanvasWorkflowPanel'
 

--- a/src/components/canvas/operationSnapshot.ts
+++ b/src/components/canvas/operationSnapshot.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { getFeatureGeometryProfiles } from '../../text'
 import { getProfileBounds, rectProfile } from '../../types/project'
 import type { Operation, Project, SketchProfile } from '../../types/project'

--- a/src/components/canvas/useCanvasWorkflowPanel.ts
+++ b/src/components/canvas/useCanvasWorkflowPanel.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useEffect, useRef, useState } from 'react'
 import type { PointerEvent as ReactPointerEvent, RefObject } from 'react'
 

--- a/src/components/layout/SnapPopover.tsx
+++ b/src/components/layout/SnapPopover.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useEffect, useRef, useState } from 'react'
 import { Icon } from '../Icon'
 import type { SnapMode, SnapSettings } from '../../sketch/snapping'

--- a/src/components/layout/ToolRail.tsx
+++ b/src/components/layout/ToolRail.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { Icon } from '../Icon'

--- a/src/components/layout/TopCommandBar.tsx
+++ b/src/components/layout/TopCommandBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useEffect, useState } from 'react'
 import { Icon } from '../Icon'
 import { useProjectStore } from '../../store/projectStore'

--- a/src/components/layout/useShellMode.ts
+++ b/src/components/layout/useShellMode.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useEffect, useState } from 'react'
 
 export type ShellMode = 'desktop-wide' | 'desktop-compact' | 'tablet' | 'tablet-compact'

--- a/src/components/project/exampleManifest.test.ts
+++ b/src/components/project/exampleManifest.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Structural test for the bundled example projects.
  *
  * Asserts that every entry in `public/examples/manifest.json` resolves to a

--- a/src/components/viewport3d/toolpathOverlay.test.ts
+++ b/src/components/viewport3d/toolpathOverlay.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for 3D viewport toolpath overlay helpers.
  *
  * Run with: npx tsx src/components/viewport3d/toolpathOverlay.test.ts

--- a/src/engine/gcode/postprocessor.test.ts
+++ b/src/engine/gcode/postprocessor.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for machine-definition G-code postprocessing.
  *
  * Run with: npx tsx src/engine/gcode/postprocessor.test.ts

--- a/src/engine/importedMesh.test.ts
+++ b/src/engine/importedMesh.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for shared imported mesh parsing.
  *
  * Run with: npx tsx src/engine/importedMesh.test.ts

--- a/src/engine/modelExport/stl.test.ts
+++ b/src/engine/modelExport/stl.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for the STL writer used by the model export pipeline.
  *
  * Run with: npx tsx src/engine/modelExport/stl.test.ts

--- a/src/engine/operationBooklet/index.ts
+++ b/src/engine/operationBooklet/index.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export * from './pdf'
 export * from './report'
 export * from './types'

--- a/src/engine/operationBooklet/operationBooklet.test.ts
+++ b/src/engine/operationBooklet/operationBooklet.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for operation booklet report and PDF generation.
  *
  * Run with: npx tsx src/engine/operationBooklet/operationBooklet.test.ts

--- a/src/engine/operationBooklet/pdf.ts
+++ b/src/engine/operationBooklet/pdf.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { PDFDocument, StandardFonts, rgb } from 'pdf-lib'
 import type { PDFPage, PDFFont } from 'pdf-lib'
 import { buildOperationBookletReport } from './report'

--- a/src/engine/operationBooklet/report.ts
+++ b/src/engine/operationBooklet/report.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { Operation, OperationKind, OperationPass, OperationTarget, Project } from '../../types/project'
 import { getStockBounds } from '../../types/project'
 import { formatLength } from '../../utils/units'

--- a/src/engine/operationBooklet/types.ts
+++ b/src/engine/operationBooklet/types.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { Operation, Project } from '../../types/project'
 import type { NormalizedTool, ToolpathResult } from '../toolpaths/types'
 

--- a/src/engine/operations/toolSelection.test.ts
+++ b/src/engine/operations/toolSelection.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for automatic tool selection when an operation is added.
  *
  * Run with: npx tsx src/engine/operations/toolSelection.test.ts

--- a/src/engine/simulation/gpuMesh.test.ts
+++ b/src/engine/simulation/gpuMesh.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for GPU simulation mesh construction.
  *
  * Run with: npx tsx src/engine/simulation/gpuMesh.test.ts

--- a/src/engine/toolpaths/finishSurface.test.ts
+++ b/src/engine/toolpaths/finishSurface.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Integration tests for finish surface toolpath generation.
  *
  * Run with: npx tsx src/engine/toolpaths/finishSurface.test.ts

--- a/src/engine/toolpaths/finishSurfaceCleanup.test.ts
+++ b/src/engine/toolpaths/finishSurfaceCleanup.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Integration tests for 3D surface cleanup toolpath generation.
  *
  * Run with: npx tsx src/engine/toolpaths/finishSurfaceCleanup.test.ts

--- a/src/engine/toolpaths/meshSlicing.test.ts
+++ b/src/engine/toolpaths/meshSlicing.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for shared STL mesh slicing.
  *
  * Run with: npx tsx src/engine/toolpaths/meshSlicing.test.ts

--- a/src/engine/toolpaths/roughSurface.test.ts
+++ b/src/engine/toolpaths/roughSurface.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Integration tests for rough surface toolpath generation.
  *
  * Run with: npx tsx src/engine/toolpaths/roughSurface.test.ts

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Unit tests for toolpath generation — machiningOrder (level_first vs
  * feature_first), perFeatureOperations, mergeToolpathResults, and a
  * per-kind regression check that single-feature operations produce

--- a/src/engine/toolpaths/vcarveRecursive.test.ts
+++ b/src/engine/toolpaths/vcarveRecursive.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Unit tests for vcarveRecursive geometry helpers and integration.
  * Run with: npx tsx src/engine/toolpaths/vcarveRecursive.test.ts
  */

--- a/src/import/camj.test.ts
+++ b/src/import/camj.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for .camj folder-import inspection and merge.
  *
  * Run with: npx tsx src/import/camj.test.ts

--- a/src/import/obj.test.ts
+++ b/src/import/obj.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for OBJ import profile and bounds extraction.
  *
  * Run with: npx tsx src/import/obj.test.ts

--- a/src/import/stl.test.ts
+++ b/src/import/stl.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for STL import profile and bounds extraction.
  *
  * Run with: npx tsx src/import/stl.test.ts

--- a/src/sketch/constraintSolver.test.ts
+++ b/src/sketch/constraintSolver.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 
 import { propagateConstraintsOnTranslate, propagateConstraintsOnRotate, rederiveConstraintGeometry, calculateGeometricCenter, nearestVertexIndex, nearestSegmentIndex, projectPointOntoSegmentT } from './constraintSolver'
 import type { SketchFeature, Point, SketchProfile } from '../types/project'

--- a/src/sketch/useAxisLock.test.ts
+++ b/src/sketch/useAxisLock.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Unit tests for axis lock utilities.
  * Run with: npx tsx src/sketch/useAxisLock.test.ts
  */

--- a/src/sketch/useCanvasGestures.ts
+++ b/src/sketch/useCanvasGestures.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useCallback, useEffect, useRef } from 'react'
 import type { SketchViewState } from '../components/canvas/viewTransform'
 

--- a/src/store/addOperationTool.test.ts
+++ b/src/store/addOperationTool.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests that addOperation auto-selects/imports a proper tool.
  *
  * Run with: npx tsx src/store/addOperationTool.test.ts

--- a/src/store/createRestOperation.test.ts
+++ b/src/store/createRestOperation.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for rest operation creation behavior.
  *
  * Run with: npx tsx src/store/createRestOperation.test.ts

--- a/src/store/helpers/offsetSimplify.test.ts
+++ b/src/store/helpers/offsetSimplify.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for simplifyOffsetContour — the post-Clipper-offset arc/circle fitting
  * pass. Each test runs Clipper offset on a synthesized source profile, hands
  * the result through simplifyOffsetContour, and asserts:

--- a/src/store/openProfileJoin.test.ts
+++ b/src/store/openProfileJoin.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Unit tests for open-profile joining.
  *
  * Run with: npx tsx src/store/openProfileJoin.test.ts

--- a/src/store/polygonSplit.test.ts
+++ b/src/store/polygonSplit.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Test the polygon-split-by-polyline algorithm.
  *
  * Run with: npx tsx src/store/polygonSplit.test.ts

--- a/src/store/projectStoreTransform.test.ts
+++ b/src/store/projectStoreTransform.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for feature transform helpers.
  *
  * Run with: npx tsx src/store/projectStoreTransform.test.ts

--- a/src/store/second_cut_test.ts
+++ b/src/store/second_cut_test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Reproduce: half circles of Circle 4 cut by Cutter Circle
  * Verify clipperContourToProfilePreserving produces correct results.
  */

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -3556,6 +3556,9 @@
 
 /* A1.3: inline "why is this disabled" note under an operation row. */
 .cam-operation-hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin: 0 10px 6px;
   padding: 4px 8px;
   border-radius: 6px;
@@ -3564,6 +3567,16 @@
   color: #e0c08a;
   font-size: 10.5px;
   line-height: 1.3;
+}
+
+.cam-operation-hint__text {
+  flex: 1;
+}
+
+/* Right-aligned quick action: select every feature the hovered operation accepts. */
+.cam-operation-hint__select-all {
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .cam-operation-label-btn {

--- a/src/types/file-system-access.d.ts
+++ b/src/types/file-system-access.d.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /** Minimal type declarations for the File System Access API (Chromium). */
 
 interface FileSystemWritableFileStream extends WritableStream {

--- a/src/utils/updateCheck.test.ts
+++ b/src/utils/updateCheck.test.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Tests for the user-initiated desktop update check.
  *
  * Run with: npx tsx src/utils/updateCheck.test.ts

--- a/src/utils/useRestoreCanvasFocus.ts
+++ b/src/utils/useRestoreCanvasFocus.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useEffect } from 'react'
 
 export function useRestoreCanvasFocus() {


### PR DESCRIPTION
## What

### 1. "Select all" in the Add-operation menu
When an operation row shows its validity hint ("This operation only accepts subtract features plus optional closed regions"), a right-aligned **Select all** button now appears inside the hint line for the hovered row. Clicking it selects every feature the operation can act on, clearing the hint and enabling the row's Rough/Finish/Both (or Add) buttons.

- Shown only on the hovered row; on tablet (no hover) tapping the operation row arms it, mirroring the existing A1.3/A1.5 tap-to-highlight behaviour — verified on tablet.
- Reuses `compatibleFeatureIdsForOperation` (the same source of truth as the canvas highlight). Not offered when selecting all compatible features would itself be invalid, e.g. two STL models for 3D Surface finish (exactly-one-model rule).
- Touch targets: the button uses `cam-subtab--compact`, which the existing `pointer: coarse` rule bumps to 44px.
- Unit tests for the new `selectAllCompatibleFeatureIds` helper in `operationValidity.test.ts`.

Plan: [planning/archive/OPERATION_HINT_SELECT_ALL_Plan.md](planning/archive/OPERATION_HINT_SELECT_ALL_Plan.md)

### 2. Apache 2.0 header rule + backfill
AGENTS.md Coding Standards now requires the Apache 2.0 license header in every `src/**/*.ts(x)` file (including tests and `.d.ts`). The 42 files missing it got the byte-identical header block; the other 141 already had it. Comment-only change.

Plan: [planning/archive/LICENSE_HEADER_POLICY_Plan.md](planning/archive/LICENSE_HEADER_POLICY_Plan.md)

## Verification

- `npm run build` (icon gen + tsc + full test suite + vite) green, including after merging latest `main` (PR #144).
- `npx eslint` clean on all four feature files (repo-wide lint issues are pre-existing).
- Manually tested by the project owner on desktop and tablet.