### PR TITLE
Fix left toolbar hover labels

### DIFF
--- a/planning/archive/LEFT_TOOLBAR_TOOLTIP_PORTAL_Plan.md
+++ b/planning/archive/LEFT_TOOLBAR_TOOLTIP_PORTAL_Plan.md
@@ -1,0 +1,37 @@
+---
+status: Done
+created: 2026-06-11
+---
+
+# Left Toolbar Tooltip Portal Plan
+
+## Goal
+
+Restore mouse-over labels for the buttons in the left creation toolbar. The labels should render outside the scroll-clipped rail so hovering any visible left-toolbar button shows the tooltip beside the rail.
+
+## Approach
+
+- Reuse the existing toolbar button label source and hover/focus behavior, but render the tooltip through `createPortal` to `document.body` when it is visible.
+- Position the floating tooltip from the button wrapper's `getBoundingClientRect()`, supporting the current `bottom` and `right` placements.
+- Keep the tooltip non-interactive and update its position while visible on scroll or resize, matching the existing portaled popover behavior.
+- Scope CSS changes to floating toolbar tooltips so regular button layout and popover menu behavior stay unchanged.
+
+## Files affected
+
+- `src/components/layout/Toolbar.tsx` — update toolbar action wrappers to portal and position tooltips outside scroll-clipped containers.
+- `src/styles/layout.css` — add floating tooltip styling and keep existing non-floating tooltip behavior intact.
+
+## Tests
+
+- Run `npm run build` after implementation.
+- Use the browser against the already-running app if available, or rely on static verification if no dev server is running, to confirm left-rail hover labels are no longer clipped.
+
+## Open questions / risks
+
+- No user decision needed. The main risk is tooltip flicker when moving across the rail; keeping hover/focus state on the button wrapper should avoid that.
+
+## Out of scope
+
+- No broader toolbar redesign.
+- No changes to tablet-only `ToolRail` behavior.
+- No changes to popover menu layout beyond preserving the existing portaled behavior.

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -16,6 +16,7 @@
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import type { ReactNode } from 'react'
 import { Icon } from '../Icon'
 import { ImportGeometryDialog } from '../project/ImportGeometryDialog'
 import { NewProjectDialog } from '../project/NewProjectDialog'
@@ -57,6 +58,97 @@ interface CreationToolbarProps {
   layout?: 'horizontal' | 'vertical'
 }
 
+function ToolbarAction({
+  label,
+  tooltipSide = 'bottom',
+  children,
+}: {
+  label: string
+  tooltipSide?: 'bottom' | 'right'
+  children: ReactNode
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const tooltipRef = useRef<HTMLSpanElement | null>(null)
+  const [tooltipVisible, setTooltipVisible] = useState(false)
+  const [tooltipCoords, setTooltipCoords] = useState<{ top: number; left: number } | null>(null)
+
+  useLayoutEffect(() => {
+    if (!tooltipVisible) {
+      setTooltipCoords(null)
+      return
+    }
+
+    function reposition() {
+      const trigger = containerRef.current
+      const tooltip = tooltipRef.current
+      if (!trigger || !tooltip) {
+        return
+      }
+
+      const triggerRect = trigger.getBoundingClientRect()
+      const tooltipRect = tooltip.getBoundingClientRect()
+      const margin = 8
+      let top: number
+      let left: number
+
+      if (tooltipSide === 'right') {
+        left = triggerRect.right + 8
+        top = triggerRect.top + triggerRect.height / 2 - tooltipRect.height / 2
+      } else {
+        top = triggerRect.bottom + 8
+        left = triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2
+      }
+
+      left = Math.max(margin, Math.min(left, window.innerWidth - tooltipRect.width - margin))
+      top = Math.max(margin, Math.min(top, window.innerHeight - tooltipRect.height - margin))
+      setTooltipCoords((prev) => (prev && prev.top === top && prev.left === left ? prev : { top, left }))
+    }
+
+    reposition()
+    window.addEventListener('scroll', reposition, true)
+    window.addEventListener('resize', reposition)
+    return () => {
+      window.removeEventListener('scroll', reposition, true)
+      window.removeEventListener('resize', reposition)
+    }
+  }, [label, tooltipSide, tooltipVisible])
+
+  return (
+    <div
+      className="toolbar-action"
+      ref={containerRef}
+      onMouseEnter={() => setTooltipVisible(true)}
+      onMouseLeave={() => setTooltipVisible(false)}
+      onFocusCapture={() => setTooltipVisible(true)}
+      onBlurCapture={(event) => {
+        const nextTarget = event.relatedTarget
+        if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) {
+          setTooltipVisible(false)
+        }
+      }}
+    >
+      {children}
+      {tooltipVisible && typeof document !== 'undefined'
+        ? createPortal(
+            <span
+              className={`toolbar-tooltip toolbar-tooltip--${tooltipSide} toolbar-tooltip--floating`}
+              ref={tooltipRef}
+              role="tooltip"
+              style={{
+                top: tooltipCoords?.top ?? -9999,
+                left: tooltipCoords?.left ?? -9999,
+                visibility: tooltipCoords ? 'visible' : 'hidden',
+              }}
+            >
+              {label}
+            </span>,
+            document.body,
+          )
+        : null}
+    </div>
+  )
+}
+
 function ToolbarActionButton({
   icon,
   label,
@@ -67,7 +159,7 @@ function ToolbarActionButton({
   onClick,
 }: ToolbarActionButtonProps) {
   return (
-    <div className="toolbar-action">
+    <ToolbarAction label={label} tooltipSide={tooltipSide}>
       <button
         className={`toolbar-icon-btn ${active ? 'toolbar-icon-btn--active' : ''} ${emphasized ? 'toolbar-icon-btn--live' : ''}`}
         onClick={(event) => {
@@ -80,10 +172,7 @@ function ToolbarActionButton({
       >
         <Icon id={icon} />
       </button>
-      <span className={`toolbar-tooltip toolbar-tooltip--${tooltipSide}`} role="tooltip">
-        {label}
-      </span>
-    </div>
+    </ToolbarAction>
   )
 }
 
@@ -666,7 +755,7 @@ function CreationActions({
   function renderCreationTargetButton(target: CreationTarget, icon: string, label: string) {
     const active = creationTarget === target
     return (
-      <div className="toolbar-action">
+      <ToolbarAction label={label} tooltipSide={tooltipSide}>
         <button
           type="button"
           className={[
@@ -682,10 +771,7 @@ function CreationActions({
         >
           <Icon id={icon} />
         </button>
-        <span className={`toolbar-tooltip toolbar-tooltip--${tooltipSide ?? 'bottom'}`} role="tooltip">
-          {label}
-        </span>
-      </div>
+      </ToolbarAction>
     )
   }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -416,6 +416,15 @@
   transform: translate(0, -50%);
 }
 
+.toolbar-tooltip--floating {
+  position: fixed;
+  bottom: auto;
+  transform: none;
+  opacity: 1;
+  visibility: visible;
+  z-index: 1000;
+}
+
 .toolbar-btn-apply {
   border-color: color-mix(in oklab, var(--accent) 50%, var(--line-strong));
 }


### PR DESCRIPTION
## Summary
- Render desktop toolbar hover labels through a shared portaled `ToolbarAction` wrapper so the scroll-clipped left rail no longer cuts them off
- Apply the same wrapper to the custom Create features / Create regions target-toggle buttons
- Archive the completed plan: `planning/archive/LEFT_TOOLBAR_TOOLTIP_PORTAL_Plan.md`

## Root cause
The recently scrollable desktop left rail uses horizontal overflow clipping, but toolbar labels were still absolutely positioned inside `.toolbar-action`. Labels that extend to the right of the narrow rail were therefore clipped.

## Verification
- `npm run build`
- Chrome on `http://localhost:1420/`: confirmed `Create features` and `Add feature rectangle` render body-level fixed tooltips outside the clipped rail
- Chrome device emulation: confirmed tablet shell uses `ToolRail` while desktop `.toolbar--creation` is absent, so this change is isolated from the tablet toolbar path
- User checked tablet emulator and reported it seems ok; real tablet check is planned separately
