### PR TITLE
Folder transform groups (CAD-style group container)

### DIFF
--- a/planning/FOLDER_GROUP_Plan.md
+++ b/planning/FOLDER_GROUP_Plan.md
@@ -57,6 +57,15 @@ Dispatched one at a time; each is reviewed before the next starts.
 - **Slice 3 — group transforms (shared pivot).** Fan move/resize/rotate/mirror across members with a single shared-pivot `M_group`, composed onto each member's per-instance `transform` only (never the `FeatureDefinition`). Helper in `src/store/helpers/instanceTransforms.ts`. Unit tests for relative-layout preservation + the feature-reference invariant.
 - **Slice 4 — group copy + folder-row toggle UI.** Fan instance-aware copy into a new `grouped: true` folder; add the "Group" toggle affordance to the folder row.
 
+## Phase 2 — container behaviors (post-initial-testing)
+
+A grouped folder should behave like a real CAD group container. Added after user testing of the initial feature.
+
+- **P2-1 — lock members into a grouped folder.** A feature in a grouped folder cannot be moved *out* (to another folder or root); only reordering *within* the folder is allowed. Enforce at the store level in `moveFeatureTreeFeature` and `assignFeaturesToFolder` (reject cross-folder moves out of a grouped folder), have feature-tree drag-drop (`handleDrop`) respect it, and disable the folder dropdown in `PropertiesPanel` (`renderFolderSelect`) when the selection is in a grouped folder. Dragging a feature *into* a grouped folder (already works) makes it part of the group — keep that.
+- **P2-2 — context-menu "Group" and "Add to folder".**
+  - **Group** (shown only when >1 feature is selected): create a new folder, move the selected features into it, toggle `grouped` on, and select the new group. New composite store action.
+  - **Add to folder**: a submenu (mirroring the existing Quick-Ops submenu pattern in `FeatureContextMenu.tsx`) listing existing folders + a "Create new…" entry; moves the selected feature(s) into the chosen/new folder. Disabled for features already in a grouped folder (consistent with P2-1).
+
 ## Open questions / risks
 
 - **Distinct-highlight visual** — exact treatment (single group bbox vs accent per-feature) to be decided during implementation; data marker is in scope regardless.

--- a/planning/FOLDER_GROUP_Plan.md
+++ b/planning/FOLDER_GROUP_Plan.md
@@ -1,0 +1,73 @@
+---
+status: In progress   # Draft → Approved → In progress → Done | Abandoned
+created: 2026-06-22
+---
+
+# Folder Transform Groups Plan
+
+## Goal
+
+Extend feature folders to behave like a "group" in other CAD programs: a folder can be toggled into a **grouped** state, after which all of its member features move/copy/resize/rotate/mirror **as one rigid body**. Selecting any member of a grouped folder selects the whole group (reusing the existing folder select-all), shown with a distinct group highlight so it is clearly more than an ad-hoc multi-select. Editing an individual member's sketch is intentionally **not** grouped — it stays reachable via double-click / context menu on the single feature. This is independent of the existing per-feature `locked` flag (which gates sketch editing); grouping is a separate, folder-level concept.
+
+## Approach
+
+- **Data model:** add a `grouped: boolean` flag to `FeatureFolder` (`src/types/project.ts`). Default `false`. Migration: existing folders normalize to `grouped: false`. Name in the model is `grouped`; UI label/affordance is a "Group" toggle (link-chain icon) on the folder row — deliberately **not** called "lock" to avoid colliding with the per-feature edit `locked`.
+
+- **Selection (option A):** when a feature that belongs to a grouped folder is selected (canvas click or tree click), expand the selection to all members of that folder via the existing `selectFolderFeatures(folderId)`. Record that the current selection originated as a group so it can be highlighted distinctly — add a lightweight marker to `SelectionState` (e.g. `groupFolderId: string | null`) rather than overloading `selectedFeatureIds`. Clearing/replacing selection resets the marker.
+
+- **Distinct highlight:** canvas + tree render a group selection differently from a normal multi-select (e.g. a single group bounding box / accent outline around the whole folder rather than per-feature handles). Exact visual TBD during implementation; the marker above is what makes it possible.
+
+- **Group transforms (the core):** reuse the existing `pendingTransform` flow (`move | resize | rotate | mirror`) but fan the transform across every member of the group. The critical rule is a **single shared pivot**: build one group matrix `M_group` around the group's combined bounding-box anchor and apply `newTransform = multiplyMatrix(M_group, member.transform)` to **each** member. Move is a pure translate (pivot-independent); resize/rotate/mirror MUST use the shared pivot so the group scales/rotates as a unit instead of each part transforming about its own center.
+
+- **Feature-reference correctness (hard invariant):** group transforms mutate only each member's per-instance `transform: Matrix2D`. They must **never** write to the shared `FeatureDefinition` — otherwise sibling instances of the same definition (elsewhere in the tree) would move too. Group resize is an affine transform on the instance, not a rewrite of definition-local sketch dimensions.
+
+- **Group copy:** duplicating a grouped folder fans the existing instance-aware copy (`src/store/helpers/copyFeatures.ts`) across all members, preserving relative layout, into a **new folder that is also `grouped: true`**. New members follow the established linked-copy default (new instances referencing the same definitions) — i.e. whatever single-feature copy already does; group copy does not change linked-vs-cloned semantics.
+
+- **Constraints caveat:** group *move* is a pure translate and is always safe. Group *resize/rotate/mirror* on members carrying sketch constraints (which can reference external geometry, per the per-instance constraint model) may fight the solver. Initial scope: allow move + rotate + mirror + uniform resize at the transform level; if a member's constraints reject the composed transform, fall back gracefully (skip/clamp that member) rather than corrupting the sketch. Revisit if it proves too restrictive.
+
+## Files affected
+
+- `src/types/project.ts` — add `grouped: boolean` to `FeatureFolder`; add `groupFolderId: string | null` (or similar) to `SelectionState`.
+- `src/store/helpers/normalize.ts` — default `grouped: false` on folders missing the field (migration).
+- `src/store/slices/treeVisibilitySlice.ts` — add a `toggleFolderGrouped(folderId)` action; `selectFolderFeatures` likely already sufficient for the select-all, extended to set the group marker.
+- `src/store/slices/selectionSlice.ts` — when selecting a feature in a grouped folder, expand to the folder's members and set the group marker; reset marker on clear/replace.
+- `src/store/slices/featureSlice.ts` — group-aware transform application: when the active selection is a group, compose `M_group` (shared pivot) and apply across all members instead of the single-feature path at ~`featureSlice.ts:944-952`.
+- `src/store/helpers/instanceTransforms.ts` — helper to build the shared-pivot group matrix and the combined group bounding box.
+- `src/store/helpers/copyFeatures.ts` — group copy: fan across members into a new grouped folder, preserving relative layout.
+- `src/components/feature-tree/FeatureTree.tsx` — folder-row "Group" toggle (icon) + grouped visual state.
+- `src/components/canvas/SketchCanvas.tsx` (+ related render) — distinct group-selection highlight; route canvas selection of a grouped member through the group-select path.
+- `src/store/types.ts` — type additions for the new action + selection marker.
+
+## Tests
+
+- **Store/helpers (required — engine-adjacent):**
+  - Group move translates every member's `transform` by the same delta; relative layout preserved.
+  - Group resize/rotate/mirror uses a **shared pivot**: members keep relative positions and the group bbox scales/rotates as a unit (regression guard against per-feature-pivot drift).
+  - Feature-reference invariant: a group transform on instances that share a definition does **not** mutate the `FeatureDefinition` and does **not** move sibling instances outside the folder.
+  - Group copy produces a new `grouped: true` folder with members at the correct relative offsets, following linked-copy semantics.
+  - Migration: a folder without `grouped` normalizes to `false`.
+- **Selection:** selecting a member of a grouped folder yields all members in `selectedFeatureIds` plus the group marker; ungrouped folder behaves as before.
+
+## Implementation slices
+
+Dispatched one at a time; each is reviewed before the next starts.
+
+- **Slice 1 — model + store foundation (no UI).** Add `grouped: boolean` to `FeatureFolder` and `groupFolderId: string | null` to `SelectionState` (`src/types/project.ts`); default `grouped: false` migration in `src/store/helpers/normalize.ts`; `toggleFolderGrouped(folderId)` action in `src/store/slices/treeVisibilitySlice.ts` (+ `src/store/types.ts`). Unit tests: migration defaults to `false`; toggle flips the flag. No selection/transform/canvas behavior yet.
+- **Slice 2 — group selection + distinct highlight.** Selecting a member of a grouped folder expands to all members via `selectFolderFeatures` and sets `groupFolderId`; reset on clear/replace. Canvas + tree render the group selection distinctly. Route canvas hit-selection of a grouped member through the group path.
+- **Slice 3 — group transforms (shared pivot).** Fan move/resize/rotate/mirror across members with a single shared-pivot `M_group`, composed onto each member's per-instance `transform` only (never the `FeatureDefinition`). Helper in `src/store/helpers/instanceTransforms.ts`. Unit tests for relative-layout preservation + the feature-reference invariant.
+- **Slice 4 — group copy + folder-row toggle UI.** Fan instance-aware copy into a new `grouped: true` folder; add the "Group" toggle affordance to the folder row.
+
+## Open questions / risks
+
+- **Distinct-highlight visual** — exact treatment (single group bbox vs accent per-feature) to be decided during implementation; data marker is in scope regardless.
+- **Constrained-member resize** — fallback behavior (skip/clamp vs block) needs confirmation once we see solver interaction in practice.
+- **Edit-within-group gesture** — starting with existing double-click / context-menu to edit a single member; no special "enter group" mode yet.
+- **Nested folders** — folders are currently flat (no `parentId`); groups are single-level. Not changing that here.
+
+## Out of scope
+
+- Nested/hierarchical groups.
+- Changing the per-feature `locked` (edit-lock) semantics.
+- A dedicated "enter group / isolate" editing mode beyond the existing double-click/context-menu.
+- Grouped behavior for non-feature tree entries (tabs, clamps, operations).
+- Changing linked-vs-cloned copy semantics.

--- a/planning/INDEX.md
+++ b/planning/INDEX.md
@@ -22,7 +22,6 @@ Every task: write a plan from [`TEMPLATE.md`](TEMPLATE.md) → register it under
 
 - [DEEPSEEK_CLAUDE_INTEGRATION_MANAGER_Plan.md](DEEPSEEK_CLAUDE_INTEGRATION_MANAGER_Plan.md) — project-local Claude Code/DeepSeek worker launcher and Codex-led sequential integration-manager workflow
 - [POCKET_OFFSET_INNER_FIRST_Plan.md](POCKET_OFFSET_INNER_FIRST_Plan.md) — reverse pocket rough offset traversal so offset pockets cut inner loops first and work outward while preserving selected cut direction
-- [FOLDER_GROUP_Plan.md](FOLDER_GROUP_Plan.md) — folder transform groups: toggle a folder "grouped" so its features move/copy/resize/rotate/mirror as one rigid body (shared pivot), select-all-on-member with a distinct highlight; per-instance transforms only (feature-reference safe). Sliced 1–4.
 
 ### Foundational / cross-cutting
 - [INTEGRATION_HANDOFF_TEMPLATE.md](INTEGRATION_HANDOFF_TEMPLATE.md) — detailed branch-owned handoff and slice-ledger template for sequential external implementation workers

--- a/planning/INDEX.md
+++ b/planning/INDEX.md
@@ -22,6 +22,7 @@ Every task: write a plan from [`TEMPLATE.md`](TEMPLATE.md) → register it under
 
 - [DEEPSEEK_CLAUDE_INTEGRATION_MANAGER_Plan.md](DEEPSEEK_CLAUDE_INTEGRATION_MANAGER_Plan.md) — project-local Claude Code/DeepSeek worker launcher and Codex-led sequential integration-manager workflow
 - [POCKET_OFFSET_INNER_FIRST_Plan.md](POCKET_OFFSET_INNER_FIRST_Plan.md) — reverse pocket rough offset traversal so offset pockets cut inner loops first and work outward while preserving selected cut direction
+- [FOLDER_GROUP_Plan.md](FOLDER_GROUP_Plan.md) — folder transform groups: toggle a folder "grouped" so its features move/copy/resize/rotate/mirror as one rigid body (shared pivot), select-all-on-member with a distinct highlight; per-instance transforms only (feature-reference safe). Sliced 1–4.
 
 ### Foundational / cross-cutting
 - [INTEGRATION_HANDOFF_TEMPLATE.md](INTEGRATION_HANDOFF_TEMPLATE.md) — detailed branch-owned handoff and slice-ledger template for sequential external implementation workers

--- a/planning/archive/FOLDER_GROUP_Plan.md
+++ b/planning/archive/FOLDER_GROUP_Plan.md
@@ -1,5 +1,5 @@
 ---
-status: In progress   # Draft → Approved → In progress → Done | Abandoned
+status: Done   # Draft → Approved → In progress → Done | Abandoned
 created: 2026-06-22
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,6 +115,10 @@ function App() {
     menuQuickOperations,
     quickOpsSubmenu,
     setQuickOpsSubmenu,
+    addToFolderSubmenu,
+    setAddToFolderSubmenu,
+    menuFeatureFolders,
+    menuSelectionInGroupedFolder,
     menuHasMultipleSelection,
     menuCanUseAsStock,
     menuHasLockedSelection,
@@ -124,6 +128,7 @@ function App() {
     openTabContextMenu,
     closeTreeContextMenu,
     openQuickOpsSubmenu,
+    openAddToFolderSubmenu,
   } = useTreeContextMenu({ project })
 
   const effectiveSelectedOperationId =
@@ -504,12 +509,17 @@ function App() {
         menuFeatureHasLinkedInstances={menuFeatureHasLinkedInstances}
         menuQuickOperations={menuQuickOperations}
         quickOpsSubmenu={quickOpsSubmenu}
+        menuFeatureFolders={menuFeatureFolders}
+        addToFolderSubmenu={addToFolderSubmenu}
+        menuSelectionInGroupedFolder={menuSelectionInGroupedFolder}
         tabletShell={tabletShell}
         primaryId={treeContextMenu?.primaryId ?? null}
         ids={treeContextMenu?.ids ?? []}
         actions={featureActions}
         onOpenQuickOpsSubmenu={openQuickOpsSubmenu}
         onCloseQuickOpsSubmenu={() => setQuickOpsSubmenu(null)}
+        onOpenAddToFolderSubmenu={openAddToFolderSubmenu}
+        onCloseAddToFolderSubmenu={() => setAddToFolderSubmenu(null)}
       />
     </>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,6 +119,7 @@ function App() {
     setAddToFolderSubmenu,
     menuFeatureFolders,
     menuSelectionInGroupedFolder,
+    menuSelectionIsGroup,
     menuHasMultipleSelection,
     menuCanUseAsStock,
     menuHasLockedSelection,
@@ -512,6 +513,7 @@ function App() {
         menuFeatureFolders={menuFeatureFolders}
         addToFolderSubmenu={addToFolderSubmenu}
         menuSelectionInGroupedFolder={menuSelectionInGroupedFolder}
+        menuSelectionIsGroup={menuSelectionIsGroup}
         tabletShell={tabletShell}
         primaryId={treeContextMenu?.primaryId ?? null}
         ids={treeContextMenu?.ids ?? []}

--- a/src/app/useFeatureTreeActions.test.ts
+++ b/src/app/useFeatureTreeActions.test.ts
@@ -60,6 +60,9 @@ function makeActions(
     setStockSourceFeature: noop,
     addOperation: (() => null) satisfies ProjectStore['addOperation'],
     makeUnique: noopVoid,
+    groupSelectedFeaturesIntoNewFolder: () => '',
+    assignFeaturesToFolder: noopVoid,
+    addFeatureFolder: (() => '') satisfies ProjectStore['addFeatureFolder'],
     project: undefined as unknown as ProjectStore['project'],
     ...storeOverrides,
   }

--- a/src/app/useFeatureTreeActions.ts
+++ b/src/app/useFeatureTreeActions.ts
@@ -57,6 +57,9 @@ type FeatureTreeActionStore = Pick<
   | 'setStockSourceFeature'
   | 'addOperation'
   | 'makeUnique'
+  | 'groupSelectedFeaturesIntoNewFolder'
+  | 'assignFeaturesToFolder'
+  | 'addFeatureFolder'
   | 'project'
 >
 
@@ -80,6 +83,9 @@ export interface FeatureTreeActions {
   useAsStock: (featureId: string) => void
   deleteFeatures: (featureIds: string[]) => void
   createQuickOperation: (featureId: string, quickOp: QuickOperation) => Promise<void>
+  groupFeatures: () => void
+  assignToFolder: (featureIds: string[], folderId: string) => void
+  createNewFolderAndAssign: (featureIds: string[]) => void
   editTab: (tabId: string) => void
   copyTab: (tabId: string) => void
   moveTab: (tabId: string) => void
@@ -122,6 +128,9 @@ export function createFeatureTreeActions({
     setStockSourceFeature,
     addOperation,
     makeUnique: storeMakeUnique,
+    groupSelectedFeaturesIntoNewFolder,
+    assignFeaturesToFolder,
+    addFeatureFolder,
     project,
   } = storeActions
 
@@ -199,6 +208,21 @@ export function createFeatureTreeActions({
       setRightTab('operations')
       onSelectedOperationIdChange(operationId)
     },
+    groupFeatures: () => {
+      groupSelectedFeaturesIntoNewFolder()
+      closeTreeContextMenu()
+    },
+    assignToFolder: (featureIds: string[], folderId: string) => {
+      assignFeaturesToFolder(featureIds, folderId)
+      closeTreeContextMenu()
+    },
+    createNewFolderAndAssign: (featureIds: string[]) => {
+      const folderId = addFeatureFolder('features')
+      if (folderId) {
+        assignFeaturesToFolder(featureIds, folderId)
+      }
+      closeTreeContextMenu()
+    },
     editTab: (tabId: string) => {
       enterTabEdit(tabId)
       setCenterTab('sketch')
@@ -263,6 +287,9 @@ export function useFeatureTreeActions({
     setStockSourceFeature,
     addOperation,
     makeUnique: storeMakeUnique,
+    groupSelectedFeaturesIntoNewFolder,
+    assignFeaturesToFolder,
+    addFeatureFolder,
     project,
   } = useProjectStore()
 
@@ -296,10 +323,15 @@ export function useFeatureTreeActions({
       setStockSourceFeature,
       addOperation,
       makeUnique: storeMakeUnique,
+      groupSelectedFeaturesIntoNewFolder,
+      assignFeaturesToFolder,
+      addFeatureFolder,
       project,
     },
   }), [
+    addFeatureFolder,
     addOperation,
+    assignFeaturesToFolder,
     beginConstraint,
     closeTreeContextMenu,
     deleteClamp,
@@ -308,6 +340,7 @@ export function useFeatureTreeActions({
     enterClampEdit,
     enterSketchEdit,
     enterTabEdit,
+    groupSelectedFeaturesIntoNewFolder,
     onSelectedOperationIdChange,
     project,
     selectFeature,

--- a/src/app/useTreeContextMenu.ts
+++ b/src/app/useTreeContextMenu.ts
@@ -93,6 +93,7 @@ export function useTreeContextMenu({ project }: UseTreeContextMenuArgs): {
   setAddToFolderSubmenu: Dispatch<SetStateAction<FolderSubmenuPosition | null>>
   menuFeatureFolders: MenuFolderEntry[]
   menuSelectionInGroupedFolder: boolean
+  menuSelectionIsGroup: boolean
   menuHasMultipleSelection: boolean
   menuCanUseAsStock: boolean
   menuHasLockedSelection: boolean
@@ -235,6 +236,10 @@ export function useTreeContextMenu({ project }: UseTreeContextMenuArgs): {
     [treeContextMenu, project.features, project.featureFolders],
   )
 
+  const selection = useProjectStore((s) => s.selection)
+  const menuSelectionIsGroup =
+    treeContextMenu?.entityType === 'feature' && selection.groupFolderId != null
+
   const fallbackMenuPosition = treeContextMenu && typeof window !== 'undefined'
     ? clampMenuPosition(
         treeContextMenu.x,
@@ -303,6 +308,7 @@ export function useTreeContextMenu({ project }: UseTreeContextMenuArgs): {
     setAddToFolderSubmenu,
     menuFeatureFolders,
     menuSelectionInGroupedFolder,
+    menuSelectionIsGroup,
     menuHasMultipleSelection,
     menuCanUseAsStock,
     menuHasLockedSelection,

--- a/src/app/useTreeContextMenu.ts
+++ b/src/app/useTreeContextMenu.ts
@@ -41,6 +41,17 @@ export interface QuickOpsSubmenuPosition {
   side: 'right' | 'left'
 }
 
+export interface FolderSubmenuPosition {
+  top: number
+  left: number
+  side: 'right' | 'left'
+}
+
+export interface MenuFolderEntry {
+  id: string
+  name: string
+}
+
 const CONTEXT_MENU_VIEWPORT_PADDING = 8
 const CONTEXT_MENU_INITIAL_WIDTH = 188
 const CONTEXT_MENU_INITIAL_HEIGHT = 300
@@ -78,6 +89,10 @@ export function useTreeContextMenu({ project }: UseTreeContextMenuArgs): {
   menuQuickOperations: QuickOperation[]
   quickOpsSubmenu: QuickOpsSubmenuPosition | null
   setQuickOpsSubmenu: Dispatch<SetStateAction<QuickOpsSubmenuPosition | null>>
+  addToFolderSubmenu: FolderSubmenuPosition | null
+  setAddToFolderSubmenu: Dispatch<SetStateAction<FolderSubmenuPosition | null>>
+  menuFeatureFolders: MenuFolderEntry[]
+  menuSelectionInGroupedFolder: boolean
   menuHasMultipleSelection: boolean
   menuCanUseAsStock: boolean
   menuHasLockedSelection: boolean
@@ -87,10 +102,12 @@ export function useTreeContextMenu({ project }: UseTreeContextMenuArgs): {
   openTabContextMenu: (tabId: string, x: number, y: number) => void
   closeTreeContextMenu: () => void
   openQuickOpsSubmenu: (trigger: HTMLElement) => void
+  openAddToFolderSubmenu: (trigger: HTMLElement) => void
 } {
   const [treeContextMenu, setTreeContextMenu] = useState<TreeContextMenuState | null>(null)
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null)
   const [quickOpsSubmenu, setQuickOpsSubmenu] = useState<QuickOpsSubmenuPosition | null>(null)
+  const [addToFolderSubmenu, setAddToFolderSubmenu] = useState<FolderSubmenuPosition | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
 
   const menuFeature = useMemo(
@@ -160,6 +177,16 @@ export function useTreeContextMenu({ project }: UseTreeContextMenuArgs): {
     })
   }, [])
 
+  const openAddToFolderSubmenu = useCallback((trigger: HTMLElement) => {
+    const rect = trigger.getBoundingClientRect()
+    const openLeft = rect.right + 200 > window.innerWidth
+    setAddToFolderSubmenu({
+      top: rect.top,
+      left: openLeft ? rect.left : rect.right,
+      side: openLeft ? 'left' : 'right',
+    })
+  }, [])
+
   useOutsideDismiss({
     open: treeContextMenu !== null,
     refs: menuRef,
@@ -186,6 +213,27 @@ export function useTreeContextMenu({ project }: UseTreeContextMenuArgs): {
     const defId = getDefinitionId(menuFeature)
     return getInstanceIdsForDefinition(project, defId).length > 1
   }, [treeContextMenu, menuFeature, project])
+
+  const menuFeatureFolders = useMemo<MenuFolderEntry[]>(
+    () =>
+      treeContextMenu?.entityType === 'feature'
+        ? project.featureFolders
+            .filter((folder) => (folder.section ?? 'features') === 'features')
+            .map((folder) => ({ id: folder.id, name: folder.name }))
+        : [],
+    [treeContextMenu, project.featureFolders],
+  )
+
+  const menuSelectionInGroupedFolder = useMemo(
+    () =>
+      (treeContextMenu?.entityType === 'feature' && treeContextMenu.ids.some((id) => {
+        const feature = project.features.find((f) => f.id === id)
+        if (!feature || !feature.folderId) return false
+        const folder = project.featureFolders.find((f) => f.id === feature.folderId)
+        return folder?.grouped === true
+      })) ?? false,
+    [treeContextMenu, project.features, project.featureFolders],
+  )
 
   const fallbackMenuPosition = treeContextMenu && typeof window !== 'undefined'
     ? clampMenuPosition(
@@ -251,6 +299,10 @@ export function useTreeContextMenu({ project }: UseTreeContextMenuArgs): {
     menuQuickOperations,
     quickOpsSubmenu,
     setQuickOpsSubmenu,
+    addToFolderSubmenu,
+    setAddToFolderSubmenu,
+    menuFeatureFolders,
+    menuSelectionInGroupedFolder,
     menuHasMultipleSelection,
     menuCanUseAsStock,
     menuHasLockedSelection,
@@ -260,5 +312,6 @@ export function useTreeContextMenu({ project }: UseTreeContextMenuArgs): {
     openTabContextMenu,
     closeTreeContextMenu,
     openQuickOpsSubmenu,
+    openAddToFolderSubmenu,
   }
 }

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -92,7 +92,7 @@ import {
   drawStockOutline,
   drawTabFootprint,
 } from './scenePrimitives'
-import { generateTextShapes, getFeatureGeometryBounds } from '../../text'
+import { generateTextShapes } from '../../text'
 import {
   getProfileBounds,
   polygonProfile,
@@ -954,8 +954,9 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       const selected = selection.selectedFeatureIds.includes(feature.id)
       const hovered = feature.id === selection.hoveredFeatureId
       const editing = selection.mode === 'sketch_edit' && feature.id === selection.selectedFeatureId
+      const groupSelected = selection.groupFolderId !== null && selected
 
-      drawFeature(ctx, feature, vt, project.meta.units, project.meta.showFeatureInfo, selected, hovered, editing)
+      drawFeature(ctx, feature, vt, project.meta.units, project.meta.showFeatureInfo, selected, hovered, editing, groupSelected)
 
       // A1.3: when an operation is armed in the CAM menu, ring the features it
       // could act on and veil the rest, so "what would this operate on?" is visible.
@@ -1013,39 +1014,6 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         ctx.textAlign = 'center'
         ctx.textBaseline = 'middle'
         ctx.fillText(String(feature.sketch.constraints.length), badgeC.cx - 8, badgeC.cy - 8)
-        ctx.restore()
-      }
-    }
-
-    // Group selection bounding box: when a grouped folder is selected, draw a
-    // single dashed outline around all member features.
-    if (selection.groupFolderId !== null && selection.selectedFeatureIds.length > 0) {
-      let gMinX = Infinity, gMaxX = -Infinity, gMinY = Infinity, gMaxY = -Infinity
-      for (const featureId of selection.selectedFeatureIds) {
-        const feature = project.features.find((f) => f.id === featureId)
-        if (!feature || !feature.visible) continue
-        const b = getFeatureGeometryBounds(feature)
-        if (isFinite(b.minX) && isFinite(b.maxX) && isFinite(b.minY) && isFinite(b.maxY)) {
-          gMinX = Math.min(gMinX, b.minX)
-          gMaxX = Math.max(gMaxX, b.maxX)
-          gMinY = Math.min(gMinY, b.minY)
-          gMaxY = Math.max(gMaxY, b.maxY)
-        }
-      }
-      if (isFinite(gMinX)) {
-        const PAD = 8
-        const tl = worldToCanvas({ x: gMinX, y: gMinY }, vt)
-        const br = worldToCanvas({ x: gMaxX, y: gMaxY }, vt)
-        ctx.save()
-        ctx.strokeStyle = 'rgba(220, 165, 106, 0.55)'
-        ctx.lineWidth = 1.5
-        ctx.setLineDash([8, 4])
-        ctx.strokeRect(
-          tl.cx - PAD,
-          tl.cy - PAD,
-          br.cx - tl.cx + PAD * 2,
-          br.cy - tl.cy + PAD * 2,
-        )
         ctx.restore()
       }
     }

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -92,7 +92,7 @@ import {
   drawStockOutline,
   drawTabFootprint,
 } from './scenePrimitives'
-import { generateTextShapes } from '../../text'
+import { generateTextShapes, getFeatureGeometryBounds } from '../../text'
 import {
   getProfileBounds,
   polygonProfile,
@@ -1013,6 +1013,39 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         ctx.textAlign = 'center'
         ctx.textBaseline = 'middle'
         ctx.fillText(String(feature.sketch.constraints.length), badgeC.cx - 8, badgeC.cy - 8)
+        ctx.restore()
+      }
+    }
+
+    // Group selection bounding box: when a grouped folder is selected, draw a
+    // single dashed outline around all member features.
+    if (selection.groupFolderId !== null && selection.selectedFeatureIds.length > 0) {
+      let gMinX = Infinity, gMaxX = -Infinity, gMinY = Infinity, gMaxY = -Infinity
+      for (const featureId of selection.selectedFeatureIds) {
+        const feature = project.features.find((f) => f.id === featureId)
+        if (!feature || !feature.visible) continue
+        const b = getFeatureGeometryBounds(feature)
+        if (isFinite(b.minX) && isFinite(b.maxX) && isFinite(b.minY) && isFinite(b.maxY)) {
+          gMinX = Math.min(gMinX, b.minX)
+          gMaxX = Math.max(gMaxX, b.maxX)
+          gMinY = Math.min(gMinY, b.minY)
+          gMaxY = Math.max(gMaxY, b.maxY)
+        }
+      }
+      if (isFinite(gMinX)) {
+        const PAD = 8
+        const tl = worldToCanvas({ x: gMinX, y: gMinY }, vt)
+        const br = worldToCanvas({ x: gMaxX, y: gMaxY }, vt)
+        ctx.save()
+        ctx.strokeStyle = 'rgba(220, 165, 106, 0.55)'
+        ctx.lineWidth = 1.5
+        ctx.setLineDash([8, 4])
+        ctx.strokeRect(
+          tl.cx - PAD,
+          tl.cy - PAD,
+          br.cx - tl.cx + PAD * 2,
+          br.cy - tl.cy + PAD * 2,
+        )
         ctx.restore()
       }
     }

--- a/src/components/canvas/previewPrimitives.ts
+++ b/src/components/canvas/previewPrimitives.ts
@@ -71,6 +71,7 @@ export function drawFeature(
   selected: boolean,
   hovered: boolean,
   editing: boolean,
+  groupSelected: boolean,
 ): void {
   const zTop = typeof feature.z_top === 'number' ? feature.z_top : 5
   const zBottom = typeof feature.z_bottom === 'number' ? feature.z_bottom : 0
@@ -92,6 +93,11 @@ export function drawFeature(
   if (feature.operation === 'region') {
     fill = 'rgba(153, 102, 204, 0.30)'
     stroke = '#9966cc'
+  }
+
+  if (groupSelected) {
+    fill = 'rgba(94, 196, 196, 0.30)'
+    stroke = '#5ec4c4'
   }
 
   if (hovered) {

--- a/src/components/feature-tree/FeatureContextMenu.tsx
+++ b/src/components/feature-tree/FeatureContextMenu.tsx
@@ -35,6 +35,7 @@ interface FeatureContextMenuProps {
   menuFeatureFolders: MenuFolderEntry[]
   addToFolderSubmenu: FolderSubmenuPosition | null
   menuSelectionInGroupedFolder: boolean
+  menuSelectionIsGroup: boolean
   tabletShell: boolean
   primaryId: string | null
   ids: readonly string[]
@@ -60,6 +61,7 @@ export function FeatureContextMenu({
   menuFeatureFolders,
   addToFolderSubmenu,
   menuSelectionInGroupedFolder,
+  menuSelectionIsGroup,
   tabletShell,
   primaryId,
   ids,
@@ -148,6 +150,68 @@ export function FeatureContextMenu({
               <div className="feature-context-menu__separator" />
             </>
           ) : null}
+          <button
+            className="feature-context-menu__item"
+            type="button"
+            onClick={() => actions.editSketch(menuFeature.id)}
+          >
+            Edit Sketch
+          </button>
+          <button
+            className="feature-context-menu__item"
+            type="button"
+            onClick={() => actions.constraint(menuFeature.id)}
+            disabled={menuHasMultipleSelection || menuHasLockedSelection}
+          >
+            Add Constraint
+          </button>
+          <div className="feature-context-menu__separator" />
+          <button className="feature-context-menu__item" type="button" onClick={() => actions.copyFeature(menuFeature.id)}>
+            {menuSelectionIsGroup ? 'Copy Group' : menuHasMultipleSelection ? 'Copy Selected' : 'Copy'}
+          </button>
+          <button
+            className="feature-context-menu__item"
+            type="button"
+            onClick={() => actions.moveFeature(menuFeature.id)}
+            disabled={menuHasLockedSelection}
+            title={menuHasLockedSelection ? 'Locked features cannot be moved' : undefined}
+          >
+            {menuSelectionIsGroup ? 'Move Group' : menuHasMultipleSelection ? 'Move Selected' : 'Move'}
+          </button>
+          <button
+            className="feature-context-menu__item"
+            type="button"
+            onClick={() => actions.resizeFeature(menuFeature.id)}
+            disabled={menuHasLockedSelection}
+          >
+            Resize
+          </button>
+          <button
+            className="feature-context-menu__item"
+            type="button"
+            onClick={() => actions.rotateFeature(menuFeature.id)}
+            disabled={menuHasLockedSelection}
+          >
+            Rotate
+          </button>
+          <button
+            className="feature-context-menu__item"
+            type="button"
+            onClick={() => actions.mirrorFeature(menuFeature.id)}
+            disabled={menuHasLockedSelection}
+          >
+            Mirror
+          </button>
+          <div className="feature-context-menu__separator" />
+          <button
+            className="feature-context-menu__item"
+            type="button"
+            onClick={() => actions.offsetFeatures()}
+            disabled={menuHasLockedSelection}
+          >
+            Offset
+          </button>
+          <div className="feature-context-menu__separator" />
           {!menuSelectionInGroupedFolder ? (
             <>
               <div
@@ -204,70 +268,6 @@ export function FeatureContextMenu({
           <button
             className="feature-context-menu__item"
             type="button"
-            onClick={() => actions.editSketch(menuFeature.id)}
-            disabled={menuHasMultipleSelection}
-            title={menuHasMultipleSelection ? 'Edit Sketch is only available for a single selected feature' : undefined}
-          >
-            Edit Sketch
-          </button>
-          <button
-            className="feature-context-menu__item"
-            type="button"
-            onClick={() => actions.constraint(menuFeature.id)}
-            disabled={menuHasMultipleSelection || menuHasLockedSelection}
-          >
-            Add Constraint
-          </button>
-          <div className="feature-context-menu__separator" />
-          <button className="feature-context-menu__item" type="button" onClick={() => actions.copyFeature(menuFeature.id)}>
-            {menuHasMultipleSelection ? 'Copy Selected' : 'Copy'}
-          </button>
-          <button
-            className="feature-context-menu__item"
-            type="button"
-            onClick={() => actions.moveFeature(menuFeature.id)}
-            disabled={menuHasLockedSelection}
-            title={menuHasLockedSelection ? 'Locked features cannot be moved' : undefined}
-          >
-            {menuHasMultipleSelection ? 'Move Selected' : 'Move'}
-          </button>
-          <button
-            className="feature-context-menu__item"
-            type="button"
-            onClick={() => actions.resizeFeature(menuFeature.id)}
-            disabled={menuHasLockedSelection}
-          >
-            Resize
-          </button>
-          <button
-            className="feature-context-menu__item"
-            type="button"
-            onClick={() => actions.rotateFeature(menuFeature.id)}
-            disabled={menuHasLockedSelection}
-          >
-            Rotate
-          </button>
-          <button
-            className="feature-context-menu__item"
-            type="button"
-            onClick={() => actions.mirrorFeature(menuFeature.id)}
-            disabled={menuHasLockedSelection}
-          >
-            Mirror
-          </button>
-          <div className="feature-context-menu__separator" />
-          <button
-            className="feature-context-menu__item"
-            type="button"
-            onClick={() => actions.offsetFeatures()}
-            disabled={menuHasLockedSelection}
-          >
-            Offset
-          </button>
-          <div className="feature-context-menu__separator" />
-          <button
-            className="feature-context-menu__item"
-            type="button"
             onClick={() => actions.groupFeatures()}
             disabled={!menuHasMultipleSelection}
             title={!menuHasMultipleSelection ? 'Select two or more features to group' : undefined}
@@ -308,7 +308,7 @@ export function FeatureContextMenu({
             type="button"
             onClick={() => actions.deleteFeatures([...ids])}
           >
-            {menuHasMultipleSelection ? 'Delete Selected' : 'Delete'}
+            {menuSelectionIsGroup ? 'Delete Group' : menuHasMultipleSelection ? 'Delete Selected' : 'Delete'}
           </button>
         </>
       ) : menuTab ? (

--- a/src/components/feature-tree/FeatureContextMenu.tsx
+++ b/src/components/feature-tree/FeatureContextMenu.tsx
@@ -17,7 +17,7 @@
 import type { RefObject } from 'react'
 import type { QuickOperation } from '../cam/operationValidity'
 import type { FeatureTreeActions } from '../../app/useFeatureTreeActions'
-import type { MenuPosition, QuickOpsSubmenuPosition } from '../../app/useTreeContextMenu'
+import type { MenuPosition, QuickOpsSubmenuPosition, FolderSubmenuPosition, MenuFolderEntry } from '../../app/useTreeContextMenu'
 import type { Clamp, SketchFeature, Tab } from '../../types/project'
 
 interface FeatureContextMenuProps {
@@ -32,12 +32,17 @@ interface FeatureContextMenuProps {
   menuFeatureHasLinkedInstances: boolean
   menuQuickOperations: QuickOperation[]
   quickOpsSubmenu: QuickOpsSubmenuPosition | null
+  menuFeatureFolders: MenuFolderEntry[]
+  addToFolderSubmenu: FolderSubmenuPosition | null
+  menuSelectionInGroupedFolder: boolean
   tabletShell: boolean
   primaryId: string | null
   ids: readonly string[]
   actions: FeatureTreeActions
   onOpenQuickOpsSubmenu: (trigger: HTMLElement) => void
   onCloseQuickOpsSubmenu: () => void
+  onOpenAddToFolderSubmenu: (trigger: HTMLElement) => void
+  onCloseAddToFolderSubmenu: () => void
 }
 
 export function FeatureContextMenu({
@@ -52,12 +57,17 @@ export function FeatureContextMenu({
   menuFeatureHasLinkedInstances,
   menuQuickOperations,
   quickOpsSubmenu,
+  menuFeatureFolders,
+  addToFolderSubmenu,
+  menuSelectionInGroupedFolder,
   tabletShell,
   primaryId,
   ids,
   actions,
   onOpenQuickOpsSubmenu,
   onCloseQuickOpsSubmenu,
+  onOpenAddToFolderSubmenu,
+  onCloseAddToFolderSubmenu,
 }: FeatureContextMenuProps) {
   if (!position || !primaryId || (!menuFeature && !menuTab && !menuClamp)) {
     return null
@@ -138,6 +148,59 @@ export function FeatureContextMenu({
               <div className="feature-context-menu__separator" />
             </>
           ) : null}
+          {!menuSelectionInGroupedFolder ? (
+            <>
+              <div
+                className="feature-context-menu__submenu-host"
+                onMouseEnter={tabletShell ? undefined : (event) => onOpenAddToFolderSubmenu(event.currentTarget)}
+                onMouseLeave={tabletShell ? undefined : onCloseAddToFolderSubmenu}
+              >
+                <button
+                  className="feature-context-menu__item feature-context-menu__item--submenu"
+                  type="button"
+                  aria-haspopup="menu"
+                  aria-expanded={addToFolderSubmenu !== null}
+                  onClick={(event) => {
+                    if (tabletShell && addToFolderSubmenu) {
+                      onCloseAddToFolderSubmenu()
+                    } else {
+                      onOpenAddToFolderSubmenu(event.currentTarget)
+                    }
+                  }}
+                >
+                  <span>Add to folder</span>
+                  <span className="feature-context-menu__submenu-caret" aria-hidden="true">›</span>
+                </button>
+                {addToFolderSubmenu ? (
+                  <div
+                    className={`feature-context-menu feature-context-menu__submenu feature-context-menu__submenu--${addToFolderSubmenu.side}`}
+                    style={{ top: addToFolderSubmenu.top, left: addToFolderSubmenu.left }}
+                    onContextMenu={(event) => event.preventDefault()}
+                  >
+                    {menuFeatureFolders.map((folder) => (
+                      <button
+                        key={folder.id}
+                        className="feature-context-menu__item"
+                        type="button"
+                        onClick={() => actions.assignToFolder([...ids], folder.id)}
+                      >
+                        {folder.name}
+                      </button>
+                    ))}
+                    <div className="feature-context-menu__separator" />
+                    <button
+                      className="feature-context-menu__item"
+                      type="button"
+                      onClick={() => actions.createNewFolderAndAssign([...ids])}
+                    >
+                      Create new…
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+              <div className="feature-context-menu__separator" />
+            </>
+          ) : null}
           <button
             className="feature-context-menu__item"
             type="button"
@@ -200,6 +263,16 @@ export function FeatureContextMenu({
             disabled={menuHasLockedSelection}
           >
             Offset
+          </button>
+          <div className="feature-context-menu__separator" />
+          <button
+            className="feature-context-menu__item"
+            type="button"
+            onClick={() => actions.groupFeatures()}
+            disabled={!menuHasMultipleSelection}
+            title={!menuHasMultipleSelection ? 'Select two or more features to group' : undefined}
+          >
+            Group
           </button>
           <div className="feature-context-menu__separator" />
           <button

--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -46,6 +46,7 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
     setAllRegionsVisible,
     toggleFolderVisible,
     toggleRegionFolderVisible,
+    toggleFolderGrouped,
     selectFolderFeatures,
     selectFeatures,
     setAllTabsVisible,
@@ -422,6 +423,8 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                     onMouseLeave={() => hoverFeature(null)}
                     onSelectAllFeatures={folderFeatures.length > 0 ? () => selectFolderFeatures(folder.id) : undefined}
                     onToggleVisible={folderFeatures.length > 0 ? () => toggleFolderVisible(folder.id) : undefined}
+                    grouped={folder.grouped ?? false}
+                    onToggleGrouped={() => toggleFolderGrouped(folder.id)}
                     onMoveUp={canMoveFolderUp ? () => handleMoveFolder(folder.id, -1) : undefined}
                     onMoveDown={canMoveFolderDown ? () => handleMoveFolder(folder.id, 1) : undefined}
                     draggable
@@ -491,6 +494,8 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                     onMouseLeave={() => hoverFeature(null)}
                     onSelectAllFeatures={folderFeatures.length > 0 ? () => selectFeatures(folderFeatures.map((feature) => feature.id)) : undefined}
                     onToggleVisible={folderFeatures.length > 0 ? () => toggleRegionFolderVisible(folder.id) : undefined}
+                    grouped={folder.grouped ?? false}
+                    onToggleGrouped={() => toggleFolderGrouped(folder.id)}
                     onMoveUp={canMoveFolderUp ? () => handleMoveFolder(folder.id, -1) : undefined}
                     onMoveDown={canMoveFolderDown ? () => handleMoveFolder(folder.id, 1) : undefined}
                     draggable
@@ -622,6 +627,8 @@ interface TreeRowProps {
   onMouseEnter: () => void
   onMouseLeave: () => void
   onToggleVisible?: () => void
+  grouped?: boolean
+  onToggleGrouped?: () => void
   onSelectAllFeatures?: () => void
   onToggleOperation?: (operation: FeatureOperation) => void
   onAddFolder?: () => void
@@ -654,6 +661,8 @@ function TreeRow({
   onClick,
   onMouseEnter,
   onMouseLeave,
+  grouped,
+  onToggleGrouped,
   onToggleVisible,
   onSelectAllFeatures,
   onToggleOperation,
@@ -1001,6 +1010,23 @@ function TreeRow({
             <svg viewBox="0 0 14 14" width="12" height="12" focusable="false" aria-hidden="true" style={{ display: 'block' }}>
               <rect x="1.5" y="1.5" width="11" height="11" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.5" strokeDasharray="2.5 1.5" />
             </svg>
+          </button>
+        ) : null}
+        {onToggleGrouped ? (
+          <button
+            type="button"
+            className={[
+              'tree-action-btn',
+              grouped ? 'tree-action-btn--grouped' : '',
+            ].join(' ')}
+            onClick={(event) => {
+              event.stopPropagation()
+              onToggleGrouped()
+            }}
+            title={grouped ? 'Ungroup features' : 'Group features'}
+            aria-label={grouped ? 'Ungroup features' : 'Group features'}
+          >
+            <Icon id="link" />
           </button>
         ) : null}
         {onEditEntry && kind !== 'feature' ? (

--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -265,6 +265,7 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
         kind="feature"
         depth={depth}
         isSelected={selection.selectedFeatureIds.includes(feature.id)}
+        isGroupSelected={selection.groupFolderId !== null && selection.selectedFeatureIds.includes(feature.id)}
         isDragging={dragItem?.kind === 'feature' && dragItem.id === feature.id}
         visible={feature.visible}
         operation={feature.operation}
@@ -627,6 +628,7 @@ interface TreeRowProps {
   onMouseEnter: () => void
   onMouseLeave: () => void
   onToggleVisible?: () => void
+  isGroupSelected?: boolean
   grouped?: boolean
   onToggleGrouped?: () => void
   onSelectAllFeatures?: () => void
@@ -661,6 +663,7 @@ function TreeRow({
   onClick,
   onMouseEnter,
   onMouseLeave,
+  isGroupSelected,
   grouped,
   onToggleGrouped,
   onToggleVisible,
@@ -700,6 +703,7 @@ function TreeRow({
         depth > 0 ? 'tree-row--nested' : '',
         depth > 1 ? 'tree-row--deep' : '',
         isSelected ? 'tree-row--selected' : '',
+        isGroupSelected ? 'tree-row--group-selected' : '',
         isDragging ? 'tree-row--dragging' : '',
         kind === 'feature' && operation === 'region' ? 'tree-row--region' : '',
       ].join(' ')}

--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -1030,7 +1030,7 @@ function TreeRow({
             title={grouped ? 'Ungroup features' : 'Group features'}
             aria-label={grouped ? 'Ungroup features' : 'Group features'}
           >
-            <Icon id="link" />
+            <Icon id="composite" />
           </button>
         ) : null}
         {onEditEntry && kind !== 'feature' ? (

--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -460,6 +460,21 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                     onDragEnd={() => setDragItem(null)}
                     onDragOver={(event) => handleDragOver(event, { kind: 'folder', id: folder.id })}
                     onDrop={handleDrop}
+                    onContextMenu={(event) => {
+                      event.preventDefault()
+                      if (folder.grouped && folderFeatures.length > 0) {
+                        if (selection.groupFolderId !== folder.id) {
+                          selectFolderFeatures(folder.id)
+                        }
+                        onFeatureContextMenu?.(folderFeatures[0].id, event.clientX, event.clientY)
+                      }
+                    }}
+                    onMoreMenu={tabletShell && onFeatureContextMenu && folder.grouped && folderFeatures.length > 0 ? (x, y) => {
+                      if (selection.groupFolderId !== folder.id) {
+                        selectFolderFeatures(folder.id)
+                      }
+                      onFeatureContextMenu(folderFeatures[0].id, x, y)
+                    } : undefined}
                   />
                   {!folder.collapsed ? (
                     <div className="tree-children">
@@ -533,6 +548,21 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                     onDragEnd={() => setDragItem(null)}
                     onDragOver={(event) => handleDragOver(event, { kind: 'folder', id: folder.id })}
                     onDrop={handleDrop}
+                    onContextMenu={(event) => {
+                      event.preventDefault()
+                      if (folder.grouped && folderFeatures.length > 0) {
+                        if (selection.groupFolderId !== folder.id) {
+                          selectFolderFeatures(folder.id)
+                        }
+                        onFeatureContextMenu?.(folderFeatures[0].id, event.clientX, event.clientY)
+                      }
+                    }}
+                    onMoreMenu={tabletShell && onFeatureContextMenu && folder.grouped && folderFeatures.length > 0 ? (x, y) => {
+                      if (selection.groupFolderId !== folder.id) {
+                        selectFolderFeatures(folder.id)
+                      }
+                      onFeatureContextMenu(folderFeatures[0].id, x, y)
+                    } : undefined}
                   />
                   {!folder.collapsed ? (
                     <div className="tree-children">

--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -104,6 +104,31 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
 
     const target = dragOverTarget.current
 
+    // P2-1: skip move when dragging a feature out of its grouped folder (store would reject it).
+    // Reordering within the same grouped folder stays allowed.
+    if (dragItem.kind === 'feature') {
+      const sourceFeature = project.features.find((f) => f.id === dragItem.id)
+      const sourceFolder = sourceFeature?.folderId
+        ? project.featureFolders.find((f) => f.id === sourceFeature.folderId)
+        : null
+      if (sourceFeature && sourceFolder?.grouped) {
+        let targetFolder: string | null = null
+        if (target.kind === 'features') {
+          targetFolder = null
+        } else if (target.kind === 'folder') {
+          targetFolder = target.id ?? null
+        } else if (target.kind === 'feature' && target.id) {
+          const targetFeature = project.features.find((f) => f.id === target.id)
+          targetFolder = targetFeature?.folderId ?? null
+        }
+        if (targetFolder !== sourceFeature.folderId) {
+          setDragItem(null)
+          dragOverTarget.current = null
+          return
+        }
+      }
+    }
+
     if (dragItem.kind === 'feature') {
       if (target.kind === 'features') {
         moveFeatureTreeFeature(dragItem.id, null)

--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -296,7 +296,7 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
         operation={feature.operation}
         isFirstFeature={index === 0}
         linkedCount={linkedCount}
-        onClick={(event) => selectFeature(feature.id, event.metaKey || event.ctrlKey || event.shiftKey)}
+        onClick={(event) => selectFeature(feature.id, event.metaKey || event.ctrlKey || event.shiftKey, false)}
         onMouseEnter={() => hoverFeature(feature.id)}
         onMouseLeave={() => hoverFeature(null)}
         onToggleVisible={() => updateFeature(feature.id, { visible: !feature.visible })}
@@ -308,13 +308,13 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
         onContextMenu={(event) => {
           event.preventDefault()
           if (!selection.selectedFeatureIds.includes(feature.id)) {
-            selectFeature(feature.id)
+            selectFeature(feature.id, false, false)
           }
           onFeatureContextMenu?.(feature.id, event.clientX, event.clientY)
         }}
         onMoreMenu={tabletShell && onFeatureContextMenu ? (x, y) => {
           if (!selection.selectedFeatureIds.includes(feature.id)) {
-            selectFeature(feature.id)
+            selectFeature(feature.id, false, false)
           }
           onFeatureContextMenu(feature.id, x, y)
         } : undefined}
@@ -444,7 +444,9 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                     isDragging={dragItem?.kind === 'folder' && dragItem.id === folder.id}
 
                     visible={folderVisible}
-                    onClick={() => { selectFeatureFolder(folder.id); updateFeatureFolder(folder.id, { collapsed: !folder.collapsed }) }}
+                    onClick={() => { folder.grouped ? selectFolderFeatures(folder.id) : selectFeatureFolder(folder.id) }}
+                    collapsed={folder.collapsed}
+                    onToggleCollapsed={() => updateFeatureFolder(folder.id, { collapsed: !folder.collapsed })}
                     onMouseEnter={() => hoverFeature(null)}
                     onMouseLeave={() => hoverFeature(null)}
                     onSelectAllFeatures={folderFeatures.length > 0 ? () => selectFolderFeatures(folder.id) : undefined}
@@ -515,7 +517,9 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
                     isDragging={dragItem?.kind === 'folder' && dragItem.id === folder.id}
 
                     visible={folderVisible}
-                    onClick={() => { selectFeatureFolder(folder.id); updateFeatureFolder(folder.id, { collapsed: !folder.collapsed }) }}
+                    onClick={() => { folder.grouped ? selectFolderFeatures(folder.id) : selectFeatureFolder(folder.id) }}
+                    collapsed={folder.collapsed}
+                    onToggleCollapsed={() => updateFeatureFolder(folder.id, { collapsed: !folder.collapsed })}
                     onMouseEnter={() => hoverFeature(null)}
                     onMouseLeave={() => hoverFeature(null)}
                     onSelectAllFeatures={folderFeatures.length > 0 ? () => selectFeatures(folderFeatures.map((feature) => feature.id)) : undefined}
@@ -668,6 +672,8 @@ interface TreeRowProps {
   onMoreMenu?: (x: number, y: number) => void
   onMoveUp?: () => void
   onMoveDown?: () => void
+  collapsed?: boolean
+  onToggleCollapsed?: () => void
   draggable?: boolean
   onDragStart?: () => void
   onDragEnd?: () => void
@@ -704,6 +710,8 @@ function TreeRow({
   onMoreMenu,
   onMoveUp,
   onMoveDown,
+  collapsed,
+  onToggleCollapsed,
   draggable,
   onDragStart,
   onDragEnd,
@@ -748,9 +756,22 @@ function TreeRow({
       onContextMenu={onContextMenu}
       style={{ paddingLeft: `${depth * 8}px` }}
     >
-      <span className={`tree-branch tree-branch--${kind}`} aria-hidden="true">
+      <span className={`tree-branch tree-branch--${kind}`}>
         {kind === 'folder' ? (
-          <Icon id="folder" className="tree-icon--folder" />
+          <>
+            {onToggleCollapsed ? (
+              <button
+                type="button"
+                className="tree-folder-chevron"
+                onClick={(e) => { e.stopPropagation(); onToggleCollapsed() }}
+                aria-label={collapsed ? 'Expand folder' : 'Collapse folder'}
+                tabIndex={0}
+              >
+                <Icon id="chevron-down" className={`tree-chevron-icon${collapsed ? ' tree-chevron-icon--collapsed' : ''}`} size={14} />
+              </button>
+            ) : null}
+            <Icon id="folder" className="tree-icon--folder" />
+          </>
         ) : (
           kind === 'project'
             ? 'proj'

--- a/src/components/feature-tree/PropertiesPanel.tsx
+++ b/src/components/feature-tree/PropertiesPanel.tsx
@@ -228,6 +228,14 @@ export function PropertiesPanel() {
     allSelectedFeatures.every((feature) => feature.folderId === allSelectedFeatures[0]?.folderId)
       ? allSelectedFeatures[0]?.folderId ?? null
       : '__mixed__'
+  // P2-1: all selected features are in a grouped folder — disable the folder dropdown.
+  const allSelectedInGroupedFolder =
+    allSelectedFeatures.length > 0 &&
+    allSelectedFeatures.every((f) => {
+      if (!f.folderId) return false
+      const folder = project.featureFolders.find((ff) => ff.id === f.folderId)
+      return folder?.grouped === true
+    })
   const commonSelectedOperation =
     allSelectedFeatures.length > 0 &&
     allSelectedFeatures.every((feature) => feature.operation === allSelectedFeatures[0]?.operation)
@@ -329,7 +337,7 @@ export function PropertiesPanel() {
     }
   }
 
-  function renderFolderSelect(value: string | '__mixed__' | null, onChange: (folderId: string | null) => void) {
+  function renderFolderSelect(value: string | '__mixed__' | null, onChange: (folderId: string | null) => void, disabled?: boolean) {
     return (
       <Select
         value={value ?? ''}
@@ -339,6 +347,7 @@ export function PropertiesPanel() {
           ...project.featureFolders.map((folder) => ({ value: folder.id, label: folder.name })),
         ]}
         onChange={(next) => onChange(next === '' || next === '__mixed__' ? null : next)}
+        disabled={disabled}
       />
     )
   }
@@ -1095,9 +1104,9 @@ export function PropertiesPanel() {
             </label>
             <label className="properties-field">
               <span>Folder</span>
-              {renderFolderSelect(commonSelectedFolderId, (folderId) =>
-                assignFeaturesToFolder(selectedFeatureIds, folderId),
-              )}
+              {renderFolderSelect(commonSelectedFolderId, (folderId) => {
+                assignFeaturesToFolder(selectedFeatureIds, folderId)
+              }, allSelectedInGroupedFolder)}
             </label>
             <label className="properties-field">
               <span>Operation</span>
@@ -1409,9 +1418,9 @@ export function PropertiesPanel() {
           )}
           <label className="properties-field">
             <span>Folder</span>
-            {renderFolderSelect(selectedFeature.folderId, (folderId) =>
-              assignFeaturesToFolder([selectedFeature.id], folderId),
-            )}
+            {renderFolderSelect(selectedFeature.folderId, (folderId) => {
+              assignFeaturesToFolder([selectedFeature.id], folderId)
+            }, project.featureFolders.find((f) => f.id === selectedFeature.folderId)?.grouped === true)}
           </label>
           <label className="properties-check">
             <input

--- a/src/components/feature-tree/PropertiesPanel.tsx
+++ b/src/components/feature-tree/PropertiesPanel.tsx
@@ -162,6 +162,7 @@ export function PropertiesPanel() {
     deleteTab,
     deleteClamp,
     deleteFeatureFolder,
+    toggleFolderGrouped,
     setProjectName,
     setShowFeatureInfo,
     setProjectClearances,
@@ -1093,6 +1094,31 @@ export function PropertiesPanel() {
     if (selectedFeatureIds.length > 1) {
       return (
         <div className="properties-panel">
+          {selection.groupFolderId ? (() => {
+            const groupFolder = project.featureFolders.find(f => f.id === selection.groupFolderId)
+            if (!groupFolder) return null
+            return (
+              <div className="properties-group">
+                <span className="properties-section-title">Group</span>
+                <label className="properties-field">
+                  <span>Name</span>
+                  <DraftTextInput
+                    key={`group-name-${groupFolder.id}-${groupFolder.name}`}
+                    value={groupFolder.name}
+                    onCommit={(next) => updateFeatureFolder(groupFolder.id, { name: next })}
+                  />
+                </label>
+                <div className="properties-actions">
+                  <button className="feat-btn" type="button" onClick={() => toggleFolderGrouped(groupFolder.id)}>
+                    Ungroup
+                  </button>
+                  <button className="feat-btn feat-btn--delete" type="button" onClick={() => deleteFeatureFolder(groupFolder.id)}>
+                    Delete Group
+                  </button>
+                </div>
+              </div>
+            )
+          })() : null}
           <div className="properties-group">
             <label className="properties-field">
               <span>Selection</span>

--- a/src/store/folderGroup.test.ts
+++ b/src/store/folderGroup.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { newProject, type FeatureFolder, type Project } from '../types/project'
-import { syncFeatureTreeProject } from './helpers/normalize'
+import { projectsEqual, syncFeatureTreeProject } from './helpers/normalize'
 import { useProjectStore } from './projectStore'
 
 // ── Assertion helpers ──────────────────────────────────────────────
@@ -297,6 +297,172 @@ test('after a group selection, a subsequent ungrouped single-feature select rese
     `expected 1 selected feature after ungrouped select, got ${selNormal.selectedFeatureIds.length}`,
   )
   assert(selNormal.selectedFeatureIds[0] === nf1, 'expected nf1 to be selected')
+})
+
+// ============================================================================
+// 4. P2-1 — lock members into a grouped folder
+// ============================================================================
+
+console.log('\nP2-1 — lock members into a grouped folder')
+
+function setupGroupedFolder(): { folderId: string; f1: string; f2: string } {
+  resetStore()
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().addRectFeature('F2', 200, 0, 100, 100, 5)
+  const f2 = useProjectStore.getState().selection.selectedFeatureId!
+  return { folderId, f1, f2 }
+}
+
+test('moveFeatureTreeFeature cannot move feature out of grouped folder to root', () => {
+  const { f1 } = setupGroupedFolder()
+  const before = useProjectStore.getState().project
+
+  useProjectStore.getState().moveFeatureTreeFeature(f1, null) // move to root
+
+  const after = useProjectStore.getState().project
+  const feature = after.features.find((f) => f.id === f1)
+  assert(feature !== undefined, 'feature should still exist')
+  assert(
+    feature.folderId !== null,
+    `expected feature to still be in its folder (folderId !== null), got folderId=${feature.folderId}`,
+  )
+  assert(
+    projectsEqual(before, after),
+    'project state should be unchanged when move is rejected',
+  )
+})
+
+test('moveFeatureTreeFeature cannot move feature from one grouped folder to another folder', () => {
+  const { f1 } = setupGroupedFolder()
+  // Create a second folder
+  useProjectStore.getState().selectProject()
+  const otherFolderId = useProjectStore.getState().addFeatureFolder('features')
+  const before = useProjectStore.getState().project
+
+  useProjectStore.getState().moveFeatureTreeFeature(f1, otherFolderId)
+
+  const after = useProjectStore.getState().project
+  const feature = after.features.find((f) => f.id === f1)
+  assert(feature !== undefined, 'feature should still exist')
+  assert(
+    feature.folderId !== otherFolderId,
+    `expected feature to NOT be in otherFolderId, got folderId=${feature.folderId}`,
+  )
+  assert(
+    projectsEqual(before, after),
+    'project state should be unchanged when move is rejected',
+  )
+})
+
+test('moveFeatureTreeFeature can reorder within the same grouped folder', () => {
+  const { folderId, f1, f2 } = setupGroupedFolder()
+  const state = useProjectStore.getState()
+  // f2 is the second feature; reorder f1 before f2
+  state.moveFeatureTreeFeature(f1, folderId, f2)
+
+  const features = useProjectStore.getState().project.features
+  const f1Index = features.findIndex((f) => f.id === f1)
+  const f2Index = features.findIndex((f) => f.id === f2)
+
+  assert(f1Index !== -1, 'f1 should exist')
+  assert(f2Index !== -1, 'f2 should exist')
+  assert(f1Index < f2Index, `f1 should be before f2 after reorder, got f1=${f1Index}, f2=${f2Index}`)
+})
+
+test('feature in non-grouped folder can still be moved freely (regression)', () => {
+  resetStore()
+  // Create a non-grouped folder (feature goes into it, then we move it out)
+  useProjectStore.getState().addFeatureFolder('features')
+  // grouped stays false (default)
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Move to root
+  useProjectStore.getState().moveFeatureTreeFeature(f1, null)
+  const after = useProjectStore.getState().project.features.find((f) => f.id === f1)
+  assert(after !== undefined, 'feature should still exist')
+  assert(after.folderId === null, `expected feature at root, got folderId=${after.folderId}`)
+})
+
+test('moving a feature into a grouped folder succeeds', () => {
+  const { folderId } = setupGroupedFolder()
+  // Create a feature in root
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().addRectFeature('RootF', 0, 200, 100, 100, 5)
+  const rootF = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Move rootF into the grouped folder
+  useProjectStore.getState().moveFeatureTreeFeature(rootF, folderId)
+  const after = useProjectStore.getState().project.features.find((f) => f.id === rootF)
+  assert(after !== undefined, 'feature should still exist')
+  assert(after.folderId === folderId, `expected feature in grouped folder, got folderId=${after.folderId}`)
+})
+
+test('assignFeaturesToFolder does not relocate a feature in a grouped folder to a different folder', () => {
+  const { folderId, f1 } = setupGroupedFolder()
+  // Create another folder
+  useProjectStore.getState().selectProject()
+  const otherFolderId = useProjectStore.getState().addFeatureFolder('features')
+
+  // Try to assign f1 (in grouped folder) to otherFolderId
+  useProjectStore.getState().assignFeaturesToFolder([f1], otherFolderId)
+  const after = useProjectStore.getState().project.features.find((f) => f.id === f1)
+  assert(after !== undefined, 'feature should still exist')
+  assert(
+    after.folderId === folderId,
+    `expected feature to still be in original grouped folder, got folderId=${after.folderId}`,
+  )
+})
+
+test('assignFeaturesToFolder still works for non-grouped features (regression)', () => {
+  resetStore()
+  useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+
+  useProjectStore.getState().selectProject()
+  const otherFolderId = useProjectStore.getState().addFeatureFolder('features')
+
+  // Move f1 (non-grouped) to otherFolderId
+  useProjectStore.getState().assignFeaturesToFolder([f1], otherFolderId)
+  const after = useProjectStore.getState().project.features.find((f) => f.id === f1)
+  assert(after !== undefined, 'feature should still exist')
+  assert(after.folderId === otherFolderId, `expected feature in otherFolderId, got folderId=${after.folderId}`)
+})
+
+test('assignFeaturesToFolder moves non-grouped features while skipping grouped ones in mixed batch', () => {
+  const { folderId: groupedFolderId, f1: groupedF1 } = setupGroupedFolder()
+
+  // Create a non-grouped folder with a feature
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().addRectFeature('NF1', 0, 200, 100, 100, 5)
+  const normalF = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Create target folder
+  useProjectStore.getState().selectProject()
+  const targetFolderId = useProjectStore.getState().addFeatureFolder('features')
+
+  // Try to move both the grouped feature and the normal feature to targetFolderId
+  useProjectStore.getState().assignFeaturesToFolder([groupedF1, normalF], targetFolderId)
+
+  const after = useProjectStore.getState().project
+  const groupedAfter = after.features.find((f) => f.id === groupedF1)
+  const normalAfter = after.features.find((f) => f.id === normalF)
+
+  assert(groupedAfter !== undefined, 'grouped feature should still exist')
+  assert(
+    groupedAfter.folderId === groupedFolderId,
+    `grouped feature should stay in original folder, got folderId=${groupedAfter.folderId}`,
+  )
+  assert(normalAfter !== undefined, 'normal feature should still exist')
+  assert(
+    normalAfter.folderId === targetFolderId,
+    `normal feature should move to target folder, got folderId=${normalAfter.folderId}`,
+  )
 })
 
 // ============================================================================

--- a/src/store/folderGroup.test.ts
+++ b/src/store/folderGroup.test.ts
@@ -755,6 +755,65 @@ test('creating a new folder and assigning features via addFeatureFolder + assign
 })
 
 // ============================================================================
+// 6. selectFeature expandGroup parameter
+// ============================================================================
+
+console.log('\nselectFeature expandGroup parameter')
+
+test('selectFeature with expandGroup=false on a grouped-folder member selects only that feature', () => {
+  resetStore()
+
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().addRectFeature('F2', 200, 0, 100, 100, 5)
+
+  // Deselect so we can test single-feature select
+  useProjectStore.getState().selectProject()
+
+  // Select f1 with expandGroup=false — should select only f1, no groupFolderId
+  useProjectStore.getState().selectFeature(f1, false, false)
+  const sel = useProjectStore.getState().selection
+
+  assert(
+    sel.selectedFeatureIds.length === 1,
+    `expected 1 selected feature, got ${sel.selectedFeatureIds.length}`,
+  )
+  assert(sel.selectedFeatureIds[0] === f1, `expected f1 selected, got ${sel.selectedFeatureIds[0]}`)
+  assert(sel.groupFolderId === null, `expected groupFolderId === null, got ${sel.groupFolderId}`)
+})
+
+test('selectFeature with default expandGroup on a grouped-folder member still expands to whole group (canvas regression guard)', () => {
+  resetStore()
+
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().addRectFeature('F2', 200, 0, 100, 100, 5)
+  const f2 = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Deselect so we can test single-feature select
+  useProjectStore.getState().selectProject()
+
+  // Select f1 with default expandGroup=true (omitted) — must still expand to entire group
+  useProjectStore.getState().selectFeature(f1, false)
+  const sel = useProjectStore.getState().selection
+
+  assert(
+    sel.selectedFeatureIds.length === 2,
+    `expected 2 selected features, got ${sel.selectedFeatureIds.length}`,
+  )
+  assert(sel.selectedFeatureIds.includes(f1), 'f1 should be selected')
+  assert(sel.selectedFeatureIds.includes(f2), 'f2 should be selected')
+  assert(
+    sel.groupFolderId === folderId,
+    `expected groupFolderId === ${folderId}, got ${sel.groupFolderId}`,
+  )
+})
+
+// ============================================================================
 // Summary
 // ============================================================================
 

--- a/src/store/folderGroup.test.ts
+++ b/src/store/folderGroup.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Folder Transform Groups — Slice 1 unit tests.
+ *
+ * Run with: npx tsx src/store/folderGroup.test.ts
+ */
+
+import { newProject, type FeatureFolder, type Project } from '../types/project'
+import { syncFeatureTreeProject } from './helpers/normalize'
+import { useProjectStore } from './projectStore'
+
+// ── Assertion helpers ──────────────────────────────────────────────
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+// ── Store helpers ──────────────────────────────────────────────────
+
+function resetStore(project?: Project): void {
+  useProjectStore.setState({
+    project: project ?? newProject(),
+    selection: {
+      selectedFeatureIds: [],
+      selectedFeatureId: null,
+      selectedNode: null,
+      mode: 'feature' as const,
+      sketchEditTool: null,
+      activeControl: null,
+      hoveredFeatureId: null,
+    },
+    history: { past: [], future: [], transactionStart: null },
+    sketchEditSession: null,
+    pendingConstraint: null,
+    pendingTransform: null,
+    pendingOffset: null,
+  } as any)
+}
+
+// ── Test runner ────────────────────────────────────────────────────
+
+let passed = 0
+let failed = 0
+
+function test(name: string, fn: () => void): void {
+  try {
+    fn()
+    passed += 1
+    console.log(`   ✓ ${name}`)
+  } catch (err: unknown) {
+    failed += 1
+    const msg = err instanceof Error ? err.message : String(err)
+    console.log(`   ✗ ${name}: ${msg}`)
+  }
+}
+
+// ============================================================================
+// 1. Migration — folder missing `grouped` normalizes to false
+// ============================================================================
+
+console.log('\nMigration — folder missing grouped normalizes to false')
+
+test('folder without grouped field gets grouped === false', () => {
+  const project = newProject()
+  const rawFolder = { id: 'fd-test', name: 'Test', collapsed: false } as FeatureFolder
+  // Cast through unknown to simulate loaded JSON missing the grouped field
+  const loaded = {
+    ...project,
+    featureFolders: [rawFolder],
+    featureTree: [{ type: 'folder' as const, folderId: 'fd-test' }],
+  }
+  const normalized = syncFeatureTreeProject(loaded)
+  const folder = normalized.featureFolders.find((f) => f.id === 'fd-test')
+  assert(folder !== undefined, 'folder should exist after sync')
+  assert(folder.grouped === false, `expected grouped === false, got ${folder.grouped}`)
+})
+
+test('folder with grouped: true preserves the value', () => {
+  const project = newProject()
+  const folder: FeatureFolder = { id: 'fd-test', name: 'Test', collapsed: false, grouped: true }
+  const loaded = {
+    ...project,
+    featureFolders: [folder],
+    featureTree: [{ type: 'folder' as const, folderId: 'fd-test' }],
+  }
+  const normalized = syncFeatureTreeProject(loaded)
+  const result = normalized.featureFolders.find((f) => f.id === 'fd-test')
+  assert(result !== undefined, 'folder should exist after sync')
+  assert(result.grouped === true, `expected grouped === true, got ${result.grouped}`)
+})
+
+// ============================================================================
+// 2. toggleFolderGrouped — flips the flag on the target folder only
+// ============================================================================
+
+console.log('\ntoggleFolderGrouped — flips grouped on target folder only')
+
+test('toggleFolderGrouped sets grouped: true on a default folder', () => {
+  resetStore()
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  const stateAfterAdd = useProjectStore.getState()
+  const before = stateAfterAdd.project.featureFolders.find((f) => f.id === folderId)
+  assert(before !== undefined, 'folder should exist')
+  assert(before.grouped === false, `expected initial grouped === false, got ${before.grouped}`)
+
+  stateAfterAdd.toggleFolderGrouped(folderId)
+  const after = useProjectStore.getState().project.featureFolders.find((f) => f.id === folderId)
+  assert(after !== undefined, 'folder should still exist')
+  assert(after.grouped === true, `expected grouped === true after toggle, got ${after.grouped}`)
+})
+
+test('toggleFolderGrouped flips back to false on second call', () => {
+  resetStore()
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+  assert(
+    useProjectStore.getState().project.featureFolders.find((f) => f.id === folderId)?.grouped === true,
+    'first toggle should set grouped to true',
+  )
+
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+  assert(
+    useProjectStore.getState().project.featureFolders.find((f) => f.id === folderId)?.grouped === false,
+    'second toggle should set grouped back to false',
+  )
+})
+
+test('toggleFolderGrouped does not affect other folders', () => {
+  resetStore()
+  const folderA = useProjectStore.getState().addFeatureFolder('features')
+  const folderB = useProjectStore.getState().addFeatureFolder('features')
+
+  useProjectStore.getState().toggleFolderGrouped(folderA)
+
+  const state = useProjectStore.getState()
+  const a = state.project.featureFolders.find((f) => f.id === folderA)
+  const b = state.project.featureFolders.find((f) => f.id === folderB)
+
+  assert(a?.grouped === true, `folder A should be grouped === true, got ${a?.grouped}`)
+  assert(b?.grouped === false, `folder B should be grouped === false, got ${b?.grouped}`)
+})
+
+test('toggleFolderGrouped on unknown folder is a no-op', () => {
+  resetStore()
+  const before = useProjectStore.getState().project.featureFolders.length
+  useProjectStore.getState().toggleFolderGrouped('nonexistent')
+  const after = useProjectStore.getState().project.featureFolders.length
+  assert(before === after, 'folder count should not change')
+})
+
+// ============================================================================
+// Summary
+// ============================================================================
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  process.exitCode = 1
+}

--- a/src/store/folderGroup.test.ts
+++ b/src/store/folderGroup.test.ts
@@ -466,6 +466,184 @@ test('assignFeaturesToFolder moves non-grouped features while skipping grouped o
 })
 
 // ============================================================================
+// 5. P2-2 — groupSelectedFeaturesIntoNewFolder
+// ============================================================================
+
+console.log('\nP2-2 — groupSelectedFeaturesIntoNewFolder')
+
+test('groupSelectedFeaturesIntoNewFolder creates a new grouped folder with selected features', () => {
+  resetStore()
+  // Create features at root
+  useProjectStore.getState().addRectFeature('A', 0, 0, 100, 100, 5)
+  const fA = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().addRectFeature('B', 200, 0, 100, 100, 5)
+  const fB = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Select both features
+  useProjectStore.getState().selectFeatures([fA, fB])
+
+  const state = useProjectStore.getState()
+  const historyLengthBefore = state.history.past.length
+  const folderId = state.groupSelectedFeaturesIntoNewFolder()
+
+  assert(folderId !== '', 'should return a non-empty folder id')
+  const after = useProjectStore.getState()
+
+  // Folder created
+  const folder = after.project.featureFolders.find((f) => f.id === folderId)
+  assert(folder !== undefined, 'folder should exist')
+  assert(folder.grouped === true, `expected grouped === true, got ${folder.grouped}`)
+  assert(folder.section === 'features', `expected section features, got ${folder.section}`)
+
+  // Features in folder
+  const fA2 = after.project.features.find((f) => f.id === fA)
+  const fB2 = after.project.features.find((f) => f.id === fB)
+  assert(fA2?.folderId === folderId, `fA should be in folder, got folderId=${fA2?.folderId}`)
+  assert(fB2?.folderId === folderId, `fB should be in folder, got folderId=${fB2?.folderId}`)
+
+  // Selection
+  assert(
+    after.selection.selectedFeatureIds.length === 2,
+    `expected 2 selected features, got ${after.selection.selectedFeatureIds.length}`,
+  )
+  assert(after.selection.selectedFeatureIds.includes(fA), 'fA should be selected')
+  assert(after.selection.selectedFeatureIds.includes(fB), 'fB should be selected')
+  assert(
+    after.selection.groupFolderId === folderId,
+    `expected groupFolderId === ${folderId}, got ${after.selection.groupFolderId}`,
+  )
+  assert(
+    after.selection.selectedNode?.type === 'folder' && after.selection.selectedNode.folderId === folderId,
+    `expected selectedNode to be folder ${folderId}, got ${JSON.stringify(after.selection.selectedNode)}`,
+  )
+
+  // Single history entry
+  assert(
+    after.history.past.length === historyLengthBefore + 1,
+    `expected ${historyLengthBefore + 1} history entries, got ${after.history.past.length}`,
+  )
+})
+
+test('groupSelectedFeaturesIntoNewFolder returns empty string when < 2 features selected', () => {
+  resetStore()
+  useProjectStore.getState().addRectFeature('A', 0, 0, 100, 100, 5)
+
+  const state = useProjectStore.getState()
+  const historyBefore = state.history.past.length
+  const result = state.groupSelectedFeaturesIntoNewFolder()
+
+  assert(result === '', `expected empty string, got "${result}"`)
+  assert(
+    useProjectStore.getState().history.past.length === historyBefore,
+    'history should not change',
+  )
+})
+
+test('groupSelectedFeaturesIntoNewFolder produces a unique folder name', () => {
+  resetStore()
+  useProjectStore.getState().addFeatureFolder('features') // Folder 1
+  useProjectStore.getState().addRectFeature('A', 0, 0, 100, 100, 5)
+  const fA = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().addRectFeature('B', 200, 0, 100, 100, 5)
+  const fB = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Select both features
+  useProjectStore.getState().selectFeatures([fA, fB])
+
+  const folderId = useProjectStore.getState().groupSelectedFeaturesIntoNewFolder()
+  const folder = useProjectStore.getState().project.featureFolders.find((f) => f.id === folderId)
+  assert(folder !== undefined, 'folder should exist')
+  assert(folder.name.startsWith('Group '), `expected name to start with "Group ", got "${folder.name}"`)
+})
+
+// ============================================================================
+// 6. P2-2 — Add to folder path
+// ============================================================================
+
+console.log('\nP2-2 — Add to folder path')
+
+test('assignFeaturesToFolder moves non-grouped features to an existing folder', () => {
+  resetStore()
+  useProjectStore.getState().addFeatureFolder('features')
+  const folderId = useProjectStore.getState().selection.selectedNode?.type === 'folder'
+    ? (useProjectStore.getState().selection.selectedNode as { folderId: string }).folderId
+    : ''
+  assert(folderId !== '', 'should have selected the new folder')
+
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().addRectFeature('F2', 200, 0, 100, 100, 5)
+  const f2 = useProjectStore.getState().selection.selectedFeatureId!
+
+  useProjectStore.getState().assignFeaturesToFolder([f1, f2], folderId)
+
+  const f1After = useProjectStore.getState().project.features.find((f) => f.id === f1)
+  const f2After = useProjectStore.getState().project.features.find((f) => f.id === f2)
+  assert(f1After?.folderId === folderId, `f1 should be in folder, got ${f1After?.folderId}`)
+  assert(f2After?.folderId === folderId, `f2 should be in folder, got ${f2After?.folderId}`)
+})
+
+test('assignFeaturesToFolder into a grouped folder succeeds (joins the group)', () => {
+  resetStore()
+  // Create a grouped folder
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+  useProjectStore.getState().addRectFeature('GF1', 0, 0, 100, 100, 5)
+
+  // Create a root feature
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().addRectFeature('RF1', 200, 0, 100, 100, 5)
+  const rf1 = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Move root feature into the grouped folder
+  useProjectStore.getState().assignFeaturesToFolder([rf1], folderId)
+
+  const rf1After = useProjectStore.getState().project.features.find((f) => f.id === rf1)
+  assert(rf1After?.folderId === folderId, `rf1 should be in grouped folder, got folderId=${rf1After?.folderId}`)
+})
+
+test('assignFeaturesToFolder refuses to move features out of a grouped folder (P2-1 regression)', () => {
+  // Setup from existing P2-1 test
+  resetStore()
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+  useProjectStore.getState().addRectFeature('GF1', 0, 0, 100, 100, 5)
+  const gf1 = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Create another folder
+  useProjectStore.getState().selectProject()
+  const otherFolderId = useProjectStore.getState().addFeatureFolder('features')
+
+  // Try to move gf1 (in grouped folder) to otherFolderId
+  useProjectStore.getState().assignFeaturesToFolder([gf1], otherFolderId)
+
+  const gf1After = useProjectStore.getState().project.features.find((f) => f.id === gf1)
+  assert(gf1After !== undefined, 'feature should still exist')
+  assert(
+    gf1After.folderId === folderId,
+    `feature should still be in original grouped folder, got folderId=${gf1After.folderId}`,
+  )
+})
+
+test('creating a new folder and assigning features via addFeatureFolder + assignFeaturesToFolder works', () => {
+  resetStore()
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().addRectFeature('F2', 200, 0, 100, 100, 5)
+  const f2 = useProjectStore.getState().selection.selectedFeatureId!
+
+  const newFolderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().assignFeaturesToFolder([f1, f2], newFolderId)
+
+  const f1After = useProjectStore.getState().project.features.find((f) => f.id === f1)
+  const f2After = useProjectStore.getState().project.features.find((f) => f.id === f2)
+  assert(f1After?.folderId === newFolderId, `f1 should be in new folder, got folderId=${f1After?.folderId}`)
+  assert(f2After?.folderId === newFolderId, `f2 should be in new folder, got folderId=${f2After?.folderId}`)
+})
+
+// ============================================================================
 // Summary
 // ============================================================================
 

--- a/src/store/folderGroup.test.ts
+++ b/src/store/folderGroup.test.ts
@@ -165,6 +165,141 @@ test('toggleFolderGrouped on unknown folder is a no-op', () => {
 })
 
 // ============================================================================
+// 3. Slice 2a — group selection (store only)
+// ============================================================================
+
+console.log('\nSlice 2a — group selection')
+
+test('selectFeature on a grouped folder member expands to all members and sets groupFolderId', () => {
+  resetStore()
+
+  // Create a folder (this selects the folder so new features auto-assign)
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  // Toggle to grouped
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+
+  // Add features — they auto-assign to the selected folder
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().addRectFeature('F2', 200, 0, 100, 100, 5)
+  const f2 = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Deselect by clicking project, so we can test single-feature select
+  useProjectStore.getState().selectProject()
+
+  // Select f1 non-additively
+  useProjectStore.getState().selectFeature(f1, false)
+  const sel = useProjectStore.getState().selection
+
+  assert(
+    sel.selectedFeatureIds.length === 2,
+    `expected 2 selected features, got ${sel.selectedFeatureIds.length}`,
+  )
+  assert(sel.selectedFeatureIds.includes(f1), 'f1 should be selected')
+  assert(sel.selectedFeatureIds.includes(f2), 'f2 should be selected')
+  assert(sel.groupFolderId === folderId, `expected groupFolderId === ${folderId}, got ${sel.groupFolderId}`)
+})
+
+test('selectFeature on a non-grouped folder member selects only that feature and leaves groupFolderId null', () => {
+  resetStore()
+
+  // Create a folder (not grouped)
+  useProjectStore.getState().addFeatureFolder('features')
+  // Keep grouped === false (default)
+
+  // Add features
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().addRectFeature('F2', 200, 0, 100, 100, 5)
+
+  // Deselect
+  useProjectStore.getState().selectProject()
+
+  // Select f1 non-additively
+  useProjectStore.getState().selectFeature(f1, false)
+  const sel = useProjectStore.getState().selection
+
+  assert(
+    sel.selectedFeatureIds.length === 1,
+    `expected 1 selected feature, got ${sel.selectedFeatureIds.length}`,
+  )
+  assert(sel.selectedFeatureIds[0] === f1, `expected f1 selected, got ${sel.selectedFeatureIds[0]}`)
+  assert(sel.groupFolderId === null, `expected groupFolderId === null, got ${sel.groupFolderId}`)
+})
+
+test('selectFolderFeatures on a grouped folder sets groupFolderId, on a non-grouped folder it is null', () => {
+  resetStore()
+
+  // Create a grouped folder
+  const groupedFolderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().toggleFolderGrouped(groupedFolderId)
+  useProjectStore.getState().addRectFeature('GF1', 0, 0, 100, 100, 5)
+  useProjectStore.getState().addRectFeature('GF2', 200, 0, 100, 100, 5)
+
+  // Create a non-grouped folder (select project first so next folder doesn't inherit selection context)
+  useProjectStore.getState().selectProject()
+  const normalFolderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().addRectFeature('NF1', 0, 200, 100, 100, 5)
+
+  // Test grouped folder
+  useProjectStore.getState().selectFolderFeatures(groupedFolderId)
+  const selGrouped = useProjectStore.getState().selection
+  assert(
+    selGrouped.groupFolderId === groupedFolderId,
+    `expected groupFolderId === ${groupedFolderId}, got ${selGrouped.groupFolderId}`,
+  )
+
+  // Test non-grouped folder
+  useProjectStore.getState().selectFolderFeatures(normalFolderId)
+  const selNormal = useProjectStore.getState().selection
+  assert(
+    selNormal.groupFolderId === null,
+    `expected groupFolderId === null for non-grouped folder, got ${selNormal.groupFolderId}`,
+  )
+})
+
+test('after a group selection, a subsequent ungrouped single-feature select resets groupFolderId to null', () => {
+  resetStore()
+
+  // Create a grouped folder with features
+  const groupedFolderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().toggleFolderGrouped(groupedFolderId)
+  useProjectStore.getState().addRectFeature('GF1', 0, 0, 100, 100, 5)
+
+  // Create a non-grouped folder with a feature
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().addRectFeature('NF1', 0, 200, 100, 100, 5)
+  const nf1 = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Deselect
+  useProjectStore.getState().selectProject()
+
+  // First, select a feature in the grouped folder to establish groupFolderId
+  const state = useProjectStore.getState()
+  const gf1 = state.project.features.find((f) => f.folderId === groupedFolderId)!.id
+  useProjectStore.getState().selectFeature(gf1, false)
+  const selGrouped = useProjectStore.getState().selection
+  assert(
+    selGrouped.groupFolderId === groupedFolderId,
+    `expected groupFolderId === ${groupedFolderId} after group select, got ${selGrouped.groupFolderId}`,
+  )
+
+  // Now select a feature in the non-grouped folder
+  useProjectStore.getState().selectFeature(nf1, false)
+  const selNormal = useProjectStore.getState().selection
+  assert(
+    selNormal.groupFolderId === null,
+    `expected groupFolderId === null after ungrouped select, got ${selNormal.groupFolderId}`,
+  )
+  assert(
+    selNormal.selectedFeatureIds.length === 1,
+    `expected 1 selected feature after ungrouped select, got ${selNormal.selectedFeatureIds.length}`,
+  )
+  assert(selNormal.selectedFeatureIds[0] === nf1, 'expected nf1 to be selected')
+})
+
+// ============================================================================
 // Summary
 // ============================================================================
 

--- a/src/store/folderGroup.test.ts
+++ b/src/store/folderGroup.test.ts
@@ -165,6 +165,117 @@ test('toggleFolderGrouped on unknown folder is a no-op', () => {
 })
 
 // ============================================================================
+// 2b. toggleFolderGrouped — groupFolderId reconciliation
+// ============================================================================
+
+console.log('\ntoggleFolderGrouped — groupFolderId reconciliation')
+
+test('toggling a grouped folder OFF while it is the active group selection clears groupFolderId to null', () => {
+  resetStore()
+
+  // Create a grouped folder with features
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().addRectFeature('F2', 200, 0, 100, 100, 5)
+  const f2 = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Deselect, then select one feature to trigger group expansion
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+
+  // Verify groupFolderId is set
+  const selBefore = useProjectStore.getState().selection
+  assert(
+    selBefore.groupFolderId === folderId,
+    `expected groupFolderId === ${folderId}, got ${selBefore.groupFolderId}`,
+  )
+
+  // Toggle grouping OFF
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+
+  const selAfter = useProjectStore.getState().selection
+  assert(
+    selAfter.groupFolderId === null,
+    `expected groupFolderId === null after turning grouping off, got ${selAfter.groupFolderId}`,
+  )
+  // grouped flag is flipped
+  const folder = useProjectStore.getState().project.featureFolders.find((f) => f.id === folderId)
+  assert(folder?.grouped === false, `expected folder grouped === false, got ${folder?.grouped}`)
+  // selection is otherwise unchanged
+  assert(selAfter.selectedFeatureIds.includes(f1), 'f1 should still be selected')
+  assert(selAfter.selectedFeatureIds.includes(f2), 'f2 should still be selected')
+})
+
+test('toggling a folder ON while its members are the current selection sets groupFolderId to that folder', () => {
+  resetStore()
+
+  // Create a non-grouped folder with features
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  // grouped stays false (default)
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().addRectFeature('F2', 200, 0, 100, 100, 5)
+  const f2 = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Select both features in the folder
+  useProjectStore.getState().selectFeatures([f1, f2])
+  const selBefore = useProjectStore.getState().selection
+  assert(
+    selBefore.groupFolderId === (undefined as unknown) || selBefore.groupFolderId === null,
+    `expected groupFolderId to be undefined/null before toggle, got ${selBefore.groupFolderId}`,
+  )
+
+  // Toggle grouping ON
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+
+  const selAfter = useProjectStore.getState().selection
+  assert(
+    selAfter.groupFolderId === folderId,
+    `expected groupFolderId === ${folderId} after turning grouping on, got ${selAfter.groupFolderId}`,
+  )
+  // grouped flag is flipped
+  const folder = useProjectStore.getState().project.featureFolders.find((f) => f.id === folderId)
+  assert(folder?.grouped === true, `expected folder grouped === true, got ${folder?.grouped}`)
+  // selection is otherwise unchanged
+  assert(selAfter.selectedFeatureIds.includes(f1), 'f1 should still be selected')
+  assert(selAfter.selectedFeatureIds.includes(f2), 'f2 should still be selected')
+})
+
+test('toggling a folder whose members are NOT the current selection does not change groupFolderId', () => {
+  resetStore()
+
+  // Create a folder with features
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  useProjectStore.getState().addRectFeature('F2', 200, 0, 100, 100, 5)
+
+  // Create a second folder with a feature (not selected)
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().addRectFeature('F3', 0, 200, 100, 100, 5)
+  const f3 = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Select only the feature in the other folder
+  useProjectStore.getState().selectFeature(f3, false)
+  const selBefore = useProjectStore.getState().selection
+  const initialGroupFolderId = selBefore.groupFolderId
+
+  // Toggle grouping ON for the folder whose members are NOT selected
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+
+  const selAfter = useProjectStore.getState().selection
+  assert(
+    selAfter.groupFolderId === (initialGroupFolderId ?? null),
+    `expected groupFolderId to remain ${initialGroupFolderId}, got ${selAfter.groupFolderId}`,
+  )
+  // grouped flag is still flipped
+  const folder = useProjectStore.getState().project.featureFolders.find((f) => f.id === folderId)
+  assert(folder?.grouped === true, `expected folder grouped === true, got ${folder?.grouped}`)
+})
+
+// ============================================================================
 // 3. Slice 2a — group selection (store only)
 // ============================================================================
 

--- a/src/store/folderGroupTransforms.test.ts
+++ b/src/store/folderGroupTransforms.test.ts
@@ -565,6 +565,294 @@ test('completePendingMove with copy on grouped members creates copies for all me
 })
 
 // ============================================================================
+// 4b. Group copy creates a new grouped folder (Slice 4 fix)
+// ============================================================================
+
+console.log('\n4b. Group copy creates a new grouped folder')
+
+test('group copy creates a new grouped folder containing all copies', () => {
+  const { folderId: sourceFolderId, featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1, f2] = featureIds
+
+  const foldersBefore = useProjectStore.getState().project.featureFolders.length
+  const featuresBefore = useProjectStore.getState().project.features.length
+  assert(foldersBefore === 1, `expected 1 folder before copy, got ${foldersBefore}`)
+  assert(featuresBefore === 2, `expected 2 features before copy, got ${featuresBefore}`)
+
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+
+  // Start copy and complete it
+  useProjectStore.getState().startCopyFeature(f1)
+  useProjectStore.getState().setPendingMoveFrom({ x: 0, y: 0 })
+  useProjectStore.getState().completePendingMove({ x: 50, y: 30 })
+
+  const state = useProjectStore.getState()
+  const project = state.project
+
+  // One new folder should be created
+  assert(
+    project.featureFolders.length === 2,
+    `expected 2 folders (1 original + 1 new), got ${project.featureFolders.length}`,
+  )
+
+  // The new folder should be grouped
+  const newFolder = project.featureFolders.find((f) => f.id !== sourceFolderId)
+  assert(newFolder !== undefined, 'new folder should exist')
+  assert(newFolder.grouped === true, 'new folder should be grouped')
+  assert(newFolder.collapsed === false, 'new folder should not be collapsed')
+  assert(
+    newFolder.name.includes('Copy'),
+    `new folder name should include "Copy", got "${newFolder.name}"`,
+  )
+
+  // Source folder should still exist and be grouped
+  const sourceFolder = project.featureFolders.find((f) => f.id === sourceFolderId)
+  assert(sourceFolder !== undefined, 'source folder should still exist')
+  assert(sourceFolder.grouped === true, 'source folder should still be grouped')
+
+  // All features should exist (2 original + 2 copies = 4)
+  assert(project.features.length === 4,
+    `expected 4 features, got ${project.features.length}`)
+
+  // Original features should still belong to the source folder
+  const origF1 = project.features.find((f) => f.id === f1)
+  const origF2 = project.features.find((f) => f.id === f2)
+  assert(origF1 !== undefined, 'original f1 should exist')
+  assert(origF2 !== undefined, 'original f2 should exist')
+  assert(origF1.folderId === sourceFolderId,
+    `original f1 should belong to source folder, got ${origF1.folderId}`)
+  assert(origF2.folderId === sourceFolderId,
+    `original f2 should belong to source folder, got ${origF2.folderId}`)
+
+  // Copy features should belong to the NEW folder (not the source folder)
+  const copyFeatures = project.features.filter((f) => f.id !== f1 && f.id !== f2)
+  assert(copyFeatures.length === 2,
+    `expected 2 copy features, got ${copyFeatures.length}`)
+  for (const cf of copyFeatures) {
+    assert(cf.folderId === newFolder.id,
+      `copy feature ${cf.id} should belong to new folder ${newFolder.id}, got ${cf.folderId}`)
+  }
+
+  // Selection should point to the copies with groupFolderId set to the new folder
+  const sel = state.selection
+  assert(sel.selectedFeatureIds.length === 2,
+    `expected 2 selected features, got ${sel.selectedFeatureIds.length}`)
+  assert(
+    sel.selectedFeatureIds.every((id) => id !== f1 && id !== f2),
+    'selected IDs should be the copy IDs',
+  )
+  assert(sel.groupFolderId === newFolder.id,
+    `groupFolderId should be ${newFolder.id}, got ${sel.groupFolderId}`)
+})
+
+test('group copy featureTree has one new folder entry and no root feature entries for copies', () => {
+  const { folderId: sourceFolderId, featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1] = featureIds
+
+  const treeEntryCountBefore = useProjectStore.getState().project.featureTree.length
+  assert(treeEntryCountBefore === 1,
+    `expected 1 featureTree entry before copy, got ${treeEntryCountBefore}`)
+
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+
+  useProjectStore.getState().startCopyFeature(f1)
+  useProjectStore.getState().setPendingMoveFrom({ x: 0, y: 0 })
+  useProjectStore.getState().completePendingMove({ x: 50, y: 30 })
+
+  const project = useProjectStore.getState().project
+  const newFolder = project.featureFolders.find((f) => f.id !== sourceFolderId)
+  assert(newFolder !== undefined, 'new folder should exist')
+
+  // featureTree should have the original folder entry + one new folder entry
+  assert(
+    project.featureTree.length === 2,
+    `expected 2 featureTree entries (1 original folder + 1 new folder), got ${project.featureTree.length}`,
+  )
+
+  // The new entry should be a folder entry pointing to the new folder
+  const folderEntries = project.featureTree.filter((e) => e.type === 'folder')
+  assert(folderEntries.length === 2,
+    `expected 2 folder entries, got ${folderEntries.length}`)
+  assert(
+    folderEntries.some((e) => e.folderId === sourceFolderId),
+    'source folder entry should still exist',
+  )
+  assert(
+    folderEntries.some((e) => e.folderId === newFolder.id),
+    'new folder entry should exist',
+  )
+
+  // No root feature entries for the copies (their membership comes from folderId)
+  const copyFeatureIds = project.features
+    .filter((f) => f.folderId === newFolder.id)
+    .map((f) => f.id)
+  assert(copyFeatureIds.length === 2,
+    `expected 2 features in new folder, got ${copyFeatureIds.length}`)
+
+  const rootFeatureEntries = project.featureTree.filter((e) => e.type === 'feature')
+  for (const entry of rootFeatureEntries) {
+    if (entry.type === 'feature') {
+      assert(
+        !copyFeatureIds.includes(entry.featureId),
+        `copy feature ${entry.featureId} should NOT have a root featureTree entry`,
+      )
+    }
+  }
+
+  // No feature id appears both in a folder and at root (sync consistency)
+  const folderMemberIds = new Set(
+    project.features.filter((f) => f.folderId !== null).map((f) => f.id),
+  )
+  for (const entry of rootFeatureEntries) {
+    if (entry.type === 'feature') {
+      assert(
+        !folderMemberIds.has(entry.featureId),
+        `feature ${entry.featureId} is both a folder member and a root entry`,
+      )
+    }
+  }
+})
+
+test('group copy selection has groupFolderId set to the new folder', () => {
+  const { folderId: sourceFolderId, featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1] = featureIds
+
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+
+  useProjectStore.getState().startCopyFeature(f1)
+  useProjectStore.getState().setPendingMoveFrom({ x: 0, y: 0 })
+  useProjectStore.getState().completePendingMove({ x: 50, y: 30 })
+
+  const state = useProjectStore.getState()
+  const sel = state.selection
+  const newFolder = state.project.featureFolders.find((f) => f.id !== sourceFolderId)
+  assert(newFolder !== undefined, 'new folder should exist')
+
+  assert(sel.groupFolderId === newFolder.id,
+    `groupFolderId should be ${newFolder.id}, got ${sel.groupFolderId}`)
+  assert(sel.selectedFeatureIds.length === 1,
+    'should have 1 selected feature (the copy)')
+  assert(sel.selectedFeatureIds[0] !== f1,
+    'selected feature should be the copy, not the original')
+  assert(sel.selectedNode?.type === 'folder',
+    `selectedNode should be folder, got ${sel.selectedNode?.type}`)
+})
+
+// ============================================================================
+// 4c. Non-group copy regression guard
+// ============================================================================
+
+console.log('\n4c. Non-group copy regression guard')
+
+test('non-group copy (feature not in any folder) still creates root featureTree entries', () => {
+  resetStore()
+
+  // Add a feature NOT in any folder
+  useProjectStore.getState().addRectFeature('Solo', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+  const featuresBefore = useProjectStore.getState().project.features.length
+
+  // Copy it
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+  useProjectStore.getState().startCopyFeature(f1)
+  useProjectStore.getState().setPendingMoveFrom({ x: 0, y: 0 })
+  useProjectStore.getState().completePendingMove({ x: 50, y: 30 })
+
+  const project = useProjectStore.getState().project
+  assert(project.features.length === featuresBefore + 1,
+    `expected ${featuresBefore + 1} features after solo copy, got ${project.features.length}`)
+
+  // The original feature should still have no folderId
+  const orig = project.features.find((f) => f.id === f1)
+  assert(orig !== undefined, 'original feature should still exist')
+  assert(orig.folderId === null, 'original feature should have no folderId')
+
+  // The copy should also have no folderId (non-group copy preserves folderId)
+  const copy = project.features.find((f) => f.id !== f1)
+  assert(copy !== undefined, 'copy feature should exist')
+  assert(copy.folderId === null,
+    `copy feature should have null folderId (non-group), got ${copy.folderId}`)
+
+  // featureTree should have a root entry for the copy
+  const rootFeatureIds = project.featureTree
+    .filter((e) => e.type === 'feature')
+    .map((e) => e.type === 'feature' ? e.featureId : '')
+    .filter(Boolean)
+  assert(rootFeatureIds.includes(copy.id),
+    'copy feature should have a root featureTree entry')
+
+  // Selection should NOT have groupFolderId set (not a group copy)
+  const sel = useProjectStore.getState().selection
+  assert(
+    sel.groupFolderId === undefined || sel.groupFolderId === null,
+    `groupFolderId should be null/undefined for non-group copy, got ${sel.groupFolderId}`,
+  )
+  assert(sel.selectedFeatureIds.length === 1,
+    'should have 1 selected feature')
+})
+
+test('copy feature in non-grouped folder preserves existing behavior (root entry + same folderId)', () => {
+  resetStore()
+
+  // Create a non-grouped folder
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  // grouped defaults to false — do NOT toggle it
+
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+
+  // f1 should be in the non-grouped folder
+  const f1Feature = useProjectStore.getState().project.features.find((f) => f.id === f1)
+  assert(f1Feature?.folderId === folderId,
+    `f1 should be in the non-grouped folder, got folderId=${f1Feature?.folderId}`)
+
+  // Copy it
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+  useProjectStore.getState().startCopyFeature(f1)
+  useProjectStore.getState().setPendingMoveFrom({ x: 0, y: 0 })
+  useProjectStore.getState().completePendingMove({ x: 50, y: 30 })
+
+  const project = useProjectStore.getState().project
+  const folders = project.featureFolders
+  assert(folders.length === 1,
+    `expected 1 folder (no new folder for non-group copy), got ${folders.length}`)
+
+  // Copy should have the same folderId as original (not a new folder)
+  const copyFeature = project.features.find((f) => f.id !== f1)
+  assert(copyFeature !== undefined, 'copy feature should exist')
+  assert(copyFeature.folderId === folderId,
+    `copy should belong to same folder, got folderId=${copyFeature.folderId}`)
+
+  // featureTree should have a root entry for the copy (existing behavior)
+  const rootEntries = project.featureTree.filter((e) => e.type === 'feature')
+  const rootCopyEntry = rootEntries.find(
+    (e) => e.type === 'feature' && e.featureId === copyFeature.id,
+  )
+  assert(rootCopyEntry !== undefined,
+    'copy feature should have a root featureTree entry (existing non-group behavior)')
+
+  // Selection should NOT have groupFolderId
+  const sel = useProjectStore.getState().selection
+  assert(
+    sel.groupFolderId === undefined || sel.groupFolderId === null,
+    `groupFolderId should be null/undefined for non-group copy, got ${sel.groupFolderId}`,
+  )
+})
+
+// ============================================================================
 // 5. Edge cases
 // ============================================================================
 

--- a/src/store/folderGroupTransforms.test.ts
+++ b/src/store/folderGroupTransforms.test.ts
@@ -1,0 +1,638 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Folder Transform Groups — Slice 3 (verification) unit tests.
+ *
+ * Verifies that group transforms (move/copy/resize/rotate/mirror) already
+ * work through the existing transform machinery when slice 2a selection
+ * expansion fans out the entity IDs. No new transform code is added;
+ * these tests confirm the behavior.
+ *
+ * Run with: npx tsx src/store/folderGroupTransforms.test.ts
+ */
+
+import { newProject, type Matrix2D, type SketchFeature } from '../types/project'
+import { useProjectStore } from './projectStore'
+import { multiplyMatrix, rotateDelta } from './helpers/instanceTransforms'
+import { isIdentityMatrix } from './helpers/resolveFeatures'
+
+// ── Assertion helpers ──────────────────────────────────────────────
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function approx(left: number, right: number, epsilon = 1e-6): boolean {
+  return Math.abs(left - right) <= epsilon
+}
+
+function assertApprox(left: number, right: number, message: string, epsilon = 1e-5): void {
+  assert(approx(left, right, epsilon), `${message}: expected ~${right}, got ${left}`)
+}
+
+// ── Store helpers ──────────────────────────────────────────────────
+
+function resetStore(): void {
+  useProjectStore.setState({
+    project: newProject(),
+    selection: {
+      selectedFeatureIds: [],
+      selectedFeatureId: null,
+      selectedNode: null,
+      mode: 'feature' as const,
+      sketchEditTool: null,
+      activeControl: null,
+      hoveredFeatureId: null,
+    },
+    history: { past: [], future: [], transactionStart: null },
+    sketchEditSession: null,
+    pendingConstraint: null,
+    pendingMove: null,
+    pendingTransform: null,
+    pendingOffset: null,
+    pendingShapeAction: null,
+    pendingAdd: null,
+    creationTarget: 'feature',
+  } as any)
+}
+
+/**
+ * Build a grouped folder with N rect features and return their ids + folder id.
+ * Each rect is placed at the given position. After this, the store state
+ * has the newly created feature selected (single-feature selection from addFeature).
+ */
+function setupGroupedFolderWithRects(
+  rects: Array<{ name: string; x: number; y: number; w: number; h: number; depth: number }>,
+): { folderId: string; featureIds: string[] } {
+  resetStore()
+
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+
+  const featureIds: string[] = []
+  for (const r of rects) {
+    useProjectStore.getState().addRectFeature(r.name, r.x, r.y, r.w, r.h, r.depth)
+    const sel = useProjectStore.getState().selection
+    assert(sel.selectedFeatureId !== null, 'expected a selected feature after addRectFeature')
+    featureIds.push(sel.selectedFeatureId)
+  }
+
+  return { folderId, featureIds }
+}
+
+/**
+ * Get the transform matrix from a feature in the store, defaulting to identity.
+ */
+function getFeatureTransform(featureId: string): Matrix2D {
+  const state = useProjectStore.getState()
+  const feature = state.project.features.find((f) => f.id === featureId)
+  assert(feature !== undefined, `feature ${featureId} not found in project`)
+  const transform = (feature as SketchFeature & { transform?: Matrix2D }).transform
+  return transform ?? { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 }
+}
+
+/**
+ * Get the definition ID for a feature, if any.
+ */
+function getFeatureDefinitionId(featureId: string): string | undefined {
+  const state = useProjectStore.getState()
+  const feature = state.project.features.find((f) => f.id === featureId)
+  assert(feature !== undefined, `feature ${featureId} not found in project`)
+  return (feature as SketchFeature & { definitionId?: string }).definitionId
+}
+
+// ── Test runner ────────────────────────────────────────────────────
+
+let passed = 0
+let failed = 0
+
+function test(name: string, fn: () => void): void {
+  try {
+    fn()
+    passed += 1
+    console.log(`   ✓ ${name}`)
+  } catch (err: unknown) {
+    failed += 1
+    const msg = err instanceof Error ? err.message : String(err)
+    console.log(`   ✗ ${name}: ${msg}`)
+  }
+}
+
+// ============================================================================
+// 1. start* actions fan entityIds to all group members
+// ============================================================================
+
+console.log('\n1. start* actions fan entityIds to all group members')
+
+test('startResizeFeature on grouped member sets entityIds to all members', () => {
+  const { featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  assert(featureIds.length === 2, `expected 2 features, got ${featureIds.length}`)
+  const [f1, f2] = featureIds
+
+  // Deselect, then select f1 non-additively to trigger group expansion
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+  const selPre = useProjectStore.getState().selection
+  assert(selPre.selectedFeatureIds.length === 2, 'selection should include both group members')
+  assert(selPre.groupFolderId !== null, 'groupFolderId should be set')
+
+  // Start resize on one member
+  useProjectStore.getState().startResizeFeature(f1)
+  const pending = useProjectStore.getState().pendingTransform
+  assert(pending !== null, 'pendingTransform should be set')
+  assert(pending.mode === 'resize', 'pending transform mode should be resize')
+  assert(pending.entityIds.length === 2, `expected 2 entityIds, got ${pending.entityIds.length}`)
+  assert(pending.entityIds.includes(f1), 'entityIds should include f1')
+  assert(pending.entityIds.includes(f2), 'entityIds should include f2')
+})
+
+test('startRotateFeature on grouped member sets entityIds to all members', () => {
+  const { featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1, f2] = featureIds
+
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+
+  useProjectStore.getState().startRotateFeature(f1)
+  const pending = useProjectStore.getState().pendingTransform
+  assert(pending !== null, 'pendingTransform should be set')
+  assert(pending.mode === 'rotate', 'pending transform mode should be rotate')
+  assert(pending.entityIds.length === 2, `expected 2 entityIds, got ${pending.entityIds.length}`)
+  assert(pending.entityIds.includes(f1) && pending.entityIds.includes(f2), 'entityIds should include both members')
+})
+
+test('startMirrorFeature on grouped member sets entityIds to all members', () => {
+  const { featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1, f2] = featureIds
+
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+
+  useProjectStore.getState().startMirrorFeature(f1)
+  const pending = useProjectStore.getState().pendingTransform
+  assert(pending !== null, 'pendingTransform should be set')
+  assert(pending.mode === 'mirror', 'pending transform mode should be mirror')
+  assert(pending.entityIds.length === 2, `expected 2 entityIds, got ${pending.entityIds.length}`)
+  assert(pending.entityIds.includes(f1) && pending.entityIds.includes(f2), 'entityIds should include both members')
+})
+
+test('startMoveFeature on grouped member sets entityIds to all members', () => {
+  const { featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1, f2] = featureIds
+
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+
+  useProjectStore.getState().startMoveFeature(f1)
+  const pending = useProjectStore.getState().pendingMove
+  assert(pending !== null, 'pendingMove should be set')
+  assert(pending.mode === 'move', 'pending move mode should be move')
+  assert(pending.entityIds.length === 2, `expected 2 entityIds, got ${pending.entityIds.length}`)
+  assert(pending.entityIds.includes(f1) && pending.entityIds.includes(f2), 'entityIds should include both members')
+})
+
+test('startCopyFeature on grouped member sets entityIds to all members', () => {
+  const { featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1, f2] = featureIds
+
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+
+  useProjectStore.getState().startCopyFeature(f1)
+  const pending = useProjectStore.getState().pendingMove
+  assert(pending !== null, 'pendingMove should be set for copy')
+  assert(pending.mode === 'copy', 'pending move mode should be copy')
+  assert(pending.entityIds.length === 2, `expected 2 entityIds, got ${pending.entityIds.length}`)
+  assert(pending.entityIds.includes(f1) && pending.entityIds.includes(f2), 'entityIds should include both members')
+})
+
+// ============================================================================
+// 2. Rigid-body transform: shared pivot preserves relative layout
+// ============================================================================
+
+console.log('\n2. Rigid-body transform preserves relative layout')
+
+test('group rotate transforms all members about the same shared pivot', () => {
+  const { featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1, f2] = featureIds
+
+  // Record pre-transform state
+  const oldTransform1 = getFeatureTransform(f1)
+  const oldTransform2 = getFeatureTransform(f2)
+  const oldDefIds = new Set([getFeatureDefinitionId(f1), getFeatureDefinitionId(f2)])
+
+  // Select group and start rotate
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+  useProjectStore.getState().startRotateFeature(f1)
+
+  // Set up a 90° CCW rotation around pivot (100, 0)
+  // referenceStart=100,0  referenceEnd=110,0  previewPoint=100,10
+  // startVector=(10,0), endVector=(0,10), angle=atan2(10*10 - 0*0, 0) = atan2(100, 0) = π/2
+  const pivot = { x: 100, y: 0 }
+  useProjectStore.getState().setPendingTransformReferenceStart(pivot)
+  useProjectStore.getState().setPendingTransformReferenceEnd({ x: 110, y: 0 })
+  useProjectStore.getState().completePendingTransform({ x: 100, y: 10 })
+
+  // Verify pending transform cleared
+  assert(useProjectStore.getState().pendingTransform === null, 'pendingTransform should be cleared')
+
+  // Verify both features still exist
+  const newTransform1 = getFeatureTransform(f1)
+  const newTransform2 = getFeatureTransform(f2)
+  assert(!isIdentityMatrix(newTransform1), 'f1 transform should not be identity after rotate')
+  assert(!isIdentityMatrix(newTransform2), 'f2 transform should not be identity after rotate')
+
+  // Expected rotation delta: rotateDelta(pivot, π/2)
+  const expectedDelta = rotateDelta(pivot, Math.PI / 2)
+
+  // Verify each feature's new transform = expectedDelta * oldTransform (rigid-body invariant)
+  const expectedT1 = multiplyMatrix(expectedDelta, oldTransform1)
+  const expectedT2 = multiplyMatrix(expectedDelta, oldTransform2)
+
+  for (const key of ['a', 'b', 'c', 'd', 'e', 'f'] as const) {
+    assertApprox(newTransform1[key], expectedT1[key], `f1 transform.${key} mismatch`)
+    assertApprox(newTransform2[key], expectedT2[key], `f2 transform.${key} mismatch`)
+  }
+
+  // Verify feature definitions are unchanged (no new definitions, old ones still present)
+  const state = useProjectStore.getState()
+  for (const defId of oldDefIds) {
+    assert(defId !== undefined && state.project.featureDefinitions[defId] !== undefined,
+      `definition ${defId} should still exist`)
+  }
+})
+
+test('group resize transforms all members about the same shared pivot', () => {
+  const { featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1, f2] = featureIds
+
+  // Select group and start resize
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+  useProjectStore.getState().startResizeFeature(f1)
+
+  // Use a pivot between the two features (at x=100, y=0) so both features
+  // are offset from the pivot. referenceStart=(100,0), referenceEnd=(200,0),
+  // previewPoint=(300,0) → 2x scale along X pivoted at (100,0).
+  useProjectStore.getState().setPendingTransformReferenceStart({ x: 100, y: 0 })
+  useProjectStore.getState().setPendingTransformReferenceEnd({ x: 200, y: 0 })
+  useProjectStore.getState().completePendingTransform({ x: 300, y: 0 })
+
+  assert(useProjectStore.getState().pendingTransform === null, 'pendingTransform should be cleared')
+
+  // Both features should have non-identity transforms after resize
+  const newTransform1 = getFeatureTransform(f1)
+  const newTransform2 = getFeatureTransform(f2)
+  assert(!isIdentityMatrix(newTransform1), 'f1 transform should not be identity after resize')
+  assert(!isIdentityMatrix(newTransform2), 'f2 transform should not be identity after resize')
+
+  // Verify both features still exist in the project
+  const state = useProjectStore.getState()
+  assert(state.project.features.some((f) => f.id === f1), 'f1 should still exist')
+  assert(state.project.features.some((f) => f.id === f2), 'f2 should still exist')
+
+  // Shared-pivot proof: both features receive the same scale transform composed
+  // onto their current transform. Since both start from IDENTITY, they should
+  // have identical resulting transforms — proving they share the same pivot.
+  const bothScaled = newTransform1.a > 1 && newTransform2.a > 1
+  assert(bothScaled, 'both features should have X-scale > 1')
+
+  // All 6 matrix components must match (both features get the same composed delta)
+  for (const key of ['a', 'b', 'c', 'd', 'e', 'f'] as const) {
+    assertApprox(newTransform1[key], newTransform2[key],
+      `shared-pivot invariant: transform.${key} should match for both members`)
+  }
+})
+
+test('group move translates all members by the same delta', () => {
+  const { featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1, f2] = featureIds
+
+  const oldTransform1 = getFeatureTransform(f1)
+  const oldTransform2 = getFeatureTransform(f2)
+
+  // Select group and start move
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+  useProjectStore.getState().startMoveFeature(f1)
+
+  // Move by (50, 30)
+  useProjectStore.getState().setPendingMoveFrom({ x: 0, y: 0 })
+  useProjectStore.getState().completePendingMove({ x: 50, y: 30 })
+
+  assert(useProjectStore.getState().pendingMove === null, 'pendingMove should be cleared')
+
+  const newTransform1 = getFeatureTransform(f1)
+  const newTransform2 = getFeatureTransform(f2)
+
+  // Both should have their translation components incremented by (50, 30)
+  assertApprox(newTransform1.e, oldTransform1.e + 50, 'f1 transform.e')
+  assertApprox(newTransform1.f, oldTransform1.f + 30, 'f1 transform.f')
+  assertApprox(newTransform2.e, oldTransform2.e + 50, 'f2 transform.e')
+  assertApprox(newTransform2.f, oldTransform2.f + 30, 'f2 transform.f')
+
+  // Linear parts (a,b,c,d) should be unchanged (move is pure translation)
+  assertApprox(newTransform1.a, oldTransform1.a, 'f1 transform.a')
+  assertApprox(newTransform1.b, oldTransform1.b, 'f1 transform.b')
+  assertApprox(newTransform1.c, oldTransform1.c, 'f1 transform.c')
+  assertApprox(newTransform1.d, oldTransform1.d, 'f1 transform.d')
+
+  assertApprox(newTransform2.a, oldTransform2.a, 'f2 transform.a')
+  assertApprox(newTransform2.b, oldTransform2.b, 'f2 transform.b')
+  assertApprox(newTransform2.c, oldTransform2.c, 'f2 transform.c')
+  assertApprox(newTransform2.d, oldTransform2.d, 'f2 transform.d')
+})
+
+// ============================================================================
+// 3. Feature-reference invariant
+// ============================================================================
+
+console.log('\n3. Feature-reference invariant')
+
+test('group transform does not mutate FeatureDefinition entries', () => {
+  const { featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1] = featureIds
+
+  // Snapshot definitions before transform
+  const stateBefore = useProjectStore.getState()
+  const defIdsBefore = new Set(Object.keys(stateBefore.project.featureDefinitions))
+  const defSnapshots = new Map(
+    Object.entries(stateBefore.project.featureDefinitions).map(([id, def]) => [id, JSON.stringify(def)]),
+  )
+
+  // Select group and perform a rotate
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+  useProjectStore.getState().startRotateFeature(f1)
+
+  useProjectStore.getState().setPendingTransformReferenceStart({ x: 100, y: 0 })
+  useProjectStore.getState().setPendingTransformReferenceEnd({ x: 110, y: 0 })
+  useProjectStore.getState().completePendingTransform({ x: 100, y: 10 })
+
+  const stateAfter = useProjectStore.getState()
+  const defIdsAfter = new Set(Object.keys(stateAfter.project.featureDefinitions))
+
+  // No definitions should have been added or removed
+  assert(defIdsBefore.size === defIdsAfter.size,
+    `definition count changed: ${defIdsBefore.size} → ${defIdsAfter.size}`)
+
+  // Each definition should be byte-identical
+  for (const defId of defIdsBefore) {
+    assert(defIdsAfter.has(defId), `definition ${defId} missing after transform`)
+    const before = defSnapshots.get(defId)
+    const after = JSON.stringify(stateAfter.project.featureDefinitions[defId])
+    assert(before === after, `definition ${defId} was mutated by group transform`)
+  }
+})
+
+test('out-of-group instance sharing a definition is NOT affected by group transform', () => {
+  // Create a grouped folder with one feature
+  const { featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1] = featureIds
+
+  const defId = getFeatureDefinitionId(f1)
+  assert(defId !== undefined, 'f1 should have a definitionId')
+
+  // Create a second feature OUTSIDE the folder that shares f1's definition
+  // We do this by selecting project root (not the folder) and adding a feature
+  // with the same definition ID manually via addFeature with definitionId set
+  useProjectStore.getState().selectProject()
+
+  // Get the f1 feature and its definition
+  const state = useProjectStore.getState()
+  const f1Feature = state.project.features.find((f) => f.id === f1)
+  assert(f1Feature !== undefined, 'f1 should exist')
+
+  // Create a new feature outside the folder that shares the same definition
+  // We construct it manually and call addFeature with explicit definitionId
+  const nextId = 'f-outgroup'
+  const outgroupFeature: SketchFeature & { definitionId?: string; transform?: Matrix2D } = {
+    ...f1Feature,
+    id: nextId,
+    name: 'F-outgroup',
+    folderId: null, // NOT in the folder
+    definitionId: defId,
+    transform: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+  }
+  useProjectStore.getState().addFeature(outgroupFeature as SketchFeature)
+
+  // Verify outgroup feature exists with same definition
+  const stateMid = useProjectStore.getState()
+  const outgroupF = stateMid.project.features.find((f) => f.id === nextId)
+  assert(outgroupF !== undefined, 'outgroup feature should exist')
+  assert(getFeatureDefinitionId(nextId) === defId,
+    `outgroup feature should share definition ${defId}, got ${getFeatureDefinitionId(nextId)}`)
+
+  // Snapshot outgroup feature state before group transform
+  const outgroupTransformBefore = getFeatureTransform(nextId)
+
+  // Now perform a group transform on the grouped folder member
+  useProjectStore.getState().selectFeature(f1, false)
+  useProjectStore.getState().startRotateFeature(f1)
+
+  useProjectStore.getState().setPendingTransformReferenceStart({ x: 100, y: 0 })
+  useProjectStore.getState().setPendingTransformReferenceEnd({ x: 110, y: 0 })
+  useProjectStore.getState().completePendingTransform({ x: 100, y: 10 })
+
+  // Group member f1 should have changed
+  const f1After = getFeatureTransform(f1)
+  assert(!isIdentityMatrix(f1After), 'f1 transform should be non-identity after rotate')
+
+  // Out-of-group feature should be completely unaffected
+  const stateAfter = useProjectStore.getState()
+  const outgroupAfter = stateAfter.project.features.find((f) => f.id === nextId)
+  assert(outgroupAfter !== undefined, 'outgroup feature should still exist')
+  const outgroupTransformAfter = getFeatureTransform(nextId)
+  assert(
+    JSON.stringify(outgroupTransformBefore) === JSON.stringify(outgroupTransformAfter),
+    'outgroup feature transform should be unchanged',
+  )
+  // Also verify the sketch profile is unchanged
+  assert(
+    JSON.stringify(outgroupAfter.sketch.profile) === JSON.stringify(outgroupF.sketch.profile),
+    'outgroup feature sketch profile should be unchanged',
+  )
+})
+
+// ============================================================================
+// 4. Group copy includes all members
+// ============================================================================
+
+console.log('\n4. Group copy includes all members')
+
+test('startCopyFeature on grouped member includes all members in entityIds', () => {
+  const { featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1, f2] = featureIds
+
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+
+  // Start copy
+  useProjectStore.getState().startCopyFeature(f1)
+  const pending = useProjectStore.getState().pendingMove
+  assert(pending !== null, 'pendingMove should be set for copy')
+  assert(pending.mode === 'copy', 'mode should be copy')
+  assert(pending.entityIds.includes(f1), 'entityIds should include f1')
+  assert(pending.entityIds.includes(f2), 'entityIds should include f2')
+  assert(pending.entityIds.length === 2, `expected 2 entityIds, got ${pending.entityIds.length}`)
+})
+
+test('completePendingMove with copy on grouped members creates copies for all members', () => {
+  const { featureIds } = setupGroupedFolderWithRects([
+    { name: 'F1', x: 0, y: 0, w: 100, h: 100, depth: 5 },
+    { name: 'F2', x: 200, y: 0, w: 100, h: 100, depth: 5 },
+  ])
+  const [f1, f2] = featureIds
+
+  const featureCountBefore = useProjectStore.getState().project.features.length
+  assert(featureCountBefore === 2, `expected 2 features, got ${featureCountBefore}`)
+
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+
+  // Start copy and complete it
+  useProjectStore.getState().startCopyFeature(f1)
+  useProjectStore.getState().setPendingMoveFrom({ x: 0, y: 0 })
+  useProjectStore.getState().completePendingMove({ x: 50, y: 30 })
+
+  // Should now have original 2 + 2 copies = 4 features
+  const featureCountAfter = useProjectStore.getState().project.features.length
+  assert(featureCountAfter === 4,
+    `expected 4 features after group copy (2 original + 2 copies), got ${featureCountAfter}`)
+
+  // Original features should still exist
+  const state = useProjectStore.getState()
+  assert(state.project.features.some((f) => f.id === f1), 'f1 should still exist')
+  assert(state.project.features.some((f) => f.id === f2), 'f2 should still exist')
+
+  // The selection should point to the newly created copies
+  const sel = state.selection
+  assert(sel.selectedFeatureIds.length === 2,
+    `expected 2 selected features (the copies), got ${sel.selectedFeatureIds.length}`)
+  assert(!sel.selectedFeatureIds.includes(f1), 'original f1 should not be selected')
+  assert(!sel.selectedFeatureIds.includes(f2), 'original f2 should not be selected')
+  assert(
+    sel.selectedFeatureIds.every((id) => id !== f1 && id !== f2),
+    'selected IDs should be the new copy IDs',
+  )
+})
+
+// ============================================================================
+// 5. Edge cases
+// ============================================================================
+
+console.log('\n5. Edge cases')
+
+test('startResizeFeature on non-grouped folder selects only the clicked feature', () => {
+  resetStore()
+
+  // Create a non-grouped folder
+  useProjectStore.getState().addFeatureFolder('features')
+  // Keep grouped as false (default)
+
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().addRectFeature('F2', 200, 0, 100, 100, 5)
+
+  // Deselect, then select f1
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+
+  // Verify non-grouped selection
+  const sel = useProjectStore.getState().selection
+  assert(sel.selectedFeatureIds.length === 1, 'non-grouped select should have 1 feature')
+  assert(sel.groupFolderId === null || sel.groupFolderId === undefined,
+    `groupFolderId should be null/undefined for non-grouped, got ${sel.groupFolderId}`)
+
+  // Start resize
+  useProjectStore.getState().startResizeFeature(f1)
+  const pending = useProjectStore.getState().pendingTransform
+  assert(pending !== null, 'pendingTransform should be set')
+  assert(pending.entityIds.length === 1,
+    `non-grouped pending transform should have 1 entityId, got ${pending.entityIds.length}`)
+  assert(pending.entityIds[0] === f1, 'entityIds should contain only f1')
+})
+
+test('locked feature in grouped folder does not block transform of other members', () => {
+  resetStore()
+
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().toggleFolderGrouped(folderId)
+
+  useProjectStore.getState().addRectFeature('F1', 0, 0, 100, 100, 5)
+  const f1 = useProjectStore.getState().selection.selectedFeatureId!
+  useProjectStore.getState().addRectFeature('F2', 200, 0, 100, 100, 5)
+  const f2 = useProjectStore.getState().selection.selectedFeatureId!
+
+  // Lock f2
+  useProjectStore.getState().updateFeature(f2, { locked: true })
+
+  // Select group (f1)
+  useProjectStore.getState().selectProject()
+  useProjectStore.getState().selectFeature(f1, false)
+  const sel = useProjectStore.getState().selection
+  assert(sel.selectedFeatureIds.includes(f2), 'locked f2 should still be in group selection')
+
+  // Start resize — should be blocked because one member is locked
+  useProjectStore.getState().startResizeFeature(f1)
+  const pending = useProjectStore.getState().pendingTransform
+  // The pendingActionsSlice checks: features.some((feature) => feature.locked) → returns {}
+  assert(pending === null,
+    'pendingTransform should be null when a group member is locked')
+})
+
+// ============================================================================
+// Summary
+// ============================================================================
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  process.exitCode = 1
+}

--- a/src/store/helpers/normalize.ts
+++ b/src/store/helpers/normalize.ts
@@ -322,7 +322,10 @@ export function normalizeMachineDefinitions(project: Project): {
 }
 
 export function syncFeatureTreeProject(project: Project): Project {
-  const featureFolders = project.featureFolders ?? []
+  const featureFolders = (project.featureFolders ?? []).map((folder) => ({
+    ...folder,
+    grouped: folder.grouped ?? false,
+  }))
   const folderIdSet = new Set(featureFolders.map((folder) => folder.id))
   const features = project.features.map((feature) => (
     feature.folderId && !folderIdSet.has(feature.folderId)

--- a/src/store/slices/featureSlice.ts
+++ b/src/store/slices/featureSlice.ts
@@ -212,14 +212,27 @@ export function createFeatureSlice(
         if (ids.length === 0) {
           return {}
         }
+        // P2-1: skip features that are in a grouped folder and would be moved to a different folder.
+        // Reorder within the same folder (folderId === feature.folderId) stays allowed. Root features
+        // (folderId === null) are never in a grouped folder so they always pass.
+        const movableIds = ids.filter((id) => {
+          const feature = s.project.features.find((f) => f.id === id)
+          if (!feature) return false
+          if (feature.folderId === null || feature.folderId === folderId) return true
+          const currentFolder = s.project.featureFolders.find((f) => f.id === feature.folderId)
+          return !currentFolder?.grouped
+        })
+        if (movableIds.length === 0) {
+          return {}
+        }
         const nextProject = syncFeatureTreeProject({
           ...s.project,
           features: s.project.features.map((feature) => (
-            ids.includes(feature.id) ? { ...feature, folderId } : feature
+            movableIds.includes(feature.id) ? { ...feature, folderId } : feature
           )),
           featureTree: [
-            ...s.project.featureTree.filter((entry) => !(entry.type === 'feature' && ids.includes(entry.featureId))),
-            ...(folderId === null ? ids.map((featureId) => ({ type: 'feature', featureId } as FeatureTreeEntry)) : []),
+            ...s.project.featureTree.filter((entry) => !(entry.type === 'feature' && movableIds.includes(entry.featureId))),
+            ...(folderId === null ? movableIds.map((featureId) => ({ type: 'feature', featureId } as FeatureTreeEntry)) : []),
           ],
           meta: { ...s.project.meta, modified: new Date().toISOString() },
         })
@@ -240,6 +253,15 @@ export function createFeatureSlice(
           return {}
         }
         if (folderId !== null && !s.project.featureFolders.some((folder) => folder.id === folderId)) {
+          return {}
+        }
+
+        // P2-1: features in a grouped folder cannot be moved to a different folder or root.
+        // Reordering within the same grouped folder (folderId === sourceFeature.folderId) stays allowed.
+        const currentFolder = sourceFeature.folderId
+          ? s.project.featureFolders.find((f) => f.id === sourceFeature.folderId)
+          : null
+        if (currentFolder?.grouped && folderId !== sourceFeature.folderId) {
           return {}
         }
 

--- a/src/store/slices/featureSlice.ts
+++ b/src/store/slices/featureSlice.ts
@@ -87,6 +87,7 @@ export type FeatureSlice = Pick<
   | 'moveFeatureTreeFeature'
   | 'reorderFeatureTreeEntries'
   | 'setAllFeaturesVisible'
+  | 'groupSelectedFeaturesIntoNewFolder'
   | 'addRectFeature'
   | 'addCircleFeature'
   | 'addEllipseFeature'
@@ -344,6 +345,61 @@ export function createFeatureSlice(
           },
         }
       }),
+
+    groupSelectedFeaturesIntoNewFolder: () => {
+      const state = get()
+      const selectedIds = state.selection.selectedFeatureIds
+      if (selectedIds.length < 2) {
+        return ''
+      }
+      const nextId = nextUniqueGeneratedId(state.project, 'fd')
+      const existingSectionFolders = state.project.featureFolders.filter(
+        (folder) => (folder.section ?? 'features') === 'features',
+      )
+      const folder: FeatureFolder = {
+        id: nextId,
+        name: `Group ${existingSectionFolders.length + 1}`,
+        collapsed: false,
+        section: 'features',
+        grouped: true,
+      }
+
+      set((s) => {
+        const idSet = new Set(selectedIds)
+        const nextProject = syncFeatureTreeProject({
+          ...s.project,
+          featureFolders: [...s.project.featureFolders, folder],
+          features: s.project.features.map((feature) => (
+            idSet.has(feature.id) ? { ...feature, folderId: nextId } : feature
+          )),
+          featureTree: [
+            ...s.project.featureTree.filter((entry) => !(entry.type === 'feature' && idSet.has(entry.featureId))),
+            { type: 'folder' as const, folderId: nextId },
+          ],
+          meta: { ...s.project.meta, modified: new Date().toISOString() },
+        })
+        return {
+          project: nextProject,
+          pendingShapeAction: null,
+          selection: {
+            ...s.selection,
+            selectedFeatureId: selectedIds[selectedIds.length - 1],
+            selectedFeatureIds: [...selectedIds],
+            selectedNode: { type: 'folder', folderId: nextId },
+            mode: 'feature',
+            activeControl: null,
+            groupFolderId: nextId,
+          },
+          history: {
+            past: [...s.history.past, cloneProject(s.project)].slice(-100),
+            future: [],
+            transactionStart: null,
+          },
+        }
+      })
+
+      return nextId
+    },
 
     setAllFeaturesVisible: (visible) =>
       set((s) => {

--- a/src/store/slices/pendingCompletionSlice.ts
+++ b/src/store/slices/pendingCompletionSlice.ts
@@ -16,7 +16,7 @@
 
 import type { StateCreator } from 'zustand'
 import { IDENTITY_MATRIX } from '../../types/project'
-import type { Clamp, FeatureDefinition, Matrix2D, Point, Project, SketchFeature, Tab } from '../../types/project'
+import type { Clamp, FeatureDefinition, FeatureFolder, Matrix2D, Point, Project, SketchFeature, Tab } from '../../types/project'
 import {
   cloneProject,
   projectsEqual,
@@ -29,6 +29,7 @@ import {
 } from '../helpers/derivedFeatures'
 import type { DerivedFeatureGroup } from '../helpers/derivedFeatures'
 import { gcOrphanedDefinitions } from '../helpers/featureDefinitions'
+import { nextUniqueGeneratedId } from '../helpers/ids'
 import type { ProjectStore } from '../types'
 import { transformProfile, translateClamp, translateTab } from '../helpers/transform'
 import { moveDelta, multiplyMatrix } from '../helpers/instanceTransforms'
@@ -40,6 +41,7 @@ import {
   rotateFeatureFromReference,
 } from '../helpers/referenceTransforms'
 import { buildCopiedClamps, buildCopiedFeatures, buildCopiedTabs, buildMirroredCopies, buildRotatedCopies, extractClonedDefinitions } from '../helpers/copyFeatures'
+import { uniqueFolderName } from '../helpers/naming'
 
 export interface PendingCompletionSliceDependencies {
   clearStaleConstraints: (features: SketchFeature[], movedIds: Set<string>) => SketchFeature[]
@@ -157,9 +159,47 @@ export function createPendingCompletionSlice(
               })
             : []
 
+          // Detect group copy: all source features share the same folderId
+          // and that folder has grouped === true. If so, create a new
+          // grouped folder for the copies instead of appending root entries.
+          let finalCreatedFeatures: SketchFeature[] = cleanedCreatedFeatures
+          let groupCopyFolder: FeatureFolder | null = null
+
+          if (mode === 'copy' && cleanedCreatedFeatures.length > 0) {
+            const firstFolderId = sourceFeatures[0].folderId
+            if (
+              firstFolderId != null &&
+              sourceFeatures.every((f) => f.folderId === firstFolderId)
+            ) {
+              const sourceFolder = s.project.featureFolders.find(
+                (f) => f.id === firstFolderId,
+              )
+              if (sourceFolder?.grouped === true) {
+                const newFolderId = nextUniqueGeneratedId(s.project, 'fd')
+                const newFolderName = uniqueFolderName(
+                  `${sourceFolder.name} Copy`,
+                  s.project.featureFolders,
+                )
+                groupCopyFolder = {
+                  id: newFolderId,
+                  name: newFolderName,
+                  collapsed: false,
+                  section: sourceFolder.section,
+                  grouped: true,
+                }
+                finalCreatedFeatures = cleanedCreatedFeatures.map((f) => ({
+                  ...f,
+                  folderId: newFolderId,
+                }))
+              }
+            }
+          }
+
+          const isGroupCopy = groupCopyFolder !== null
+
           const translatedFeatures =
             mode === 'copy'
-              ? [...s.project.features, ...cleanedCreatedFeatures]
+              ? [...s.project.features, ...finalCreatedFeatures]
               : s.project.features.map((feature) => {
                   if (!entityIds.includes(feature.id) || feature.locked) {
                     return feature
@@ -188,7 +228,7 @@ export function createPendingCompletionSlice(
                 })
           const resolvedFeatures =
             mode === 'copy'
-              ? deps.clearStaleConstraints(translatedFeatures, new Set(cleanedCreatedFeatures.map((f) => f.id)))
+              ? deps.clearStaleConstraints(translatedFeatures, new Set(finalCreatedFeatures.map((f) => f.id)))
               : deps.validateAllConstraints(deps.propagateConstraintsOnTranslate(
                   translatedFeatures,
                   new Map(entityIds.filter((id) => !s.project.features.find((f) => f.id === id)?.locked).map((id) => [id, { dx, dy }])),
@@ -201,13 +241,22 @@ export function createPendingCompletionSlice(
             ...s.project,
             features: resolvedFeatures,
             featureDefinitions: nextFeatureDefinitions,
+            featureFolders:
+              isGroupCopy
+                ? [...s.project.featureFolders, groupCopyFolder!]
+                : s.project.featureFolders,
             featureTree:
-              mode === 'copy'
+              isGroupCopy
                 ? [
                     ...s.project.featureTree,
-                    ...cleanedCreatedFeatures.map((feature) => ({ type: 'feature' as const, featureId: feature.id })),
+                    { type: 'folder' as const, folderId: groupCopyFolder!.id },
                   ]
-                : s.project.featureTree,
+                : mode === 'copy'
+                  ? [
+                      ...s.project.featureTree,
+                      ...finalCreatedFeatures.map((feature) => ({ type: 'feature' as const, featureId: feature.id })),
+                    ]
+                  : s.project.featureTree,
             meta: { ...s.project.meta, modified: new Date().toISOString() },
           }
 
@@ -222,11 +271,14 @@ export function createPendingCompletionSlice(
               mode === 'copy'
                 ? {
                     ...s.selection,
-                    selectedFeatureId: cleanedCreatedFeatures.at(-1)?.id ?? s.selection.selectedFeatureId,
-                    selectedFeatureIds: cleanedCreatedFeatures.map((feature) => feature.id),
-                    selectedNode: cleanedCreatedFeatures.at(-1)
-                      ? { type: 'feature', featureId: cleanedCreatedFeatures.at(-1)!.id }
-                      : s.selection.selectedNode,
+                    selectedFeatureId: finalCreatedFeatures.at(-1)?.id ?? s.selection.selectedFeatureId,
+                    selectedFeatureIds: finalCreatedFeatures.map((f) => f.id),
+                    selectedNode: isGroupCopy
+                      ? { type: 'folder', folderId: groupCopyFolder!.id }
+                      : finalCreatedFeatures.at(-1)
+                        ? { type: 'feature', featureId: finalCreatedFeatures.at(-1)!.id }
+                        : s.selection.selectedNode,
+                    groupFolderId: isGroupCopy ? groupCopyFolder!.id : undefined,
                   }
                 : s.selection,
             history: {

--- a/src/store/slices/selectionSlice.ts
+++ b/src/store/slices/selectionSlice.ts
@@ -62,6 +62,7 @@ export function emptySelection(): SelectionState {
     hoveredFeatureId: null,
     sketchEditTool: null,
     activeControl: null,
+    groupFolderId: null,
   }
 }
 
@@ -86,6 +87,7 @@ export function sanitizeSelection(project: Project, selection: SelectionState): 
         hoveredFeatureId: null,
         sketchEditTool: null,
         activeControl: null,
+        groupFolderId: null,
       }
     }
   }
@@ -199,6 +201,7 @@ export function createSelectionSlice(
               selectedNode: nextPrimaryId ? { type: 'feature', featureId: nextPrimaryId } : null,
               mode: 'feature',
               activeControl: null,
+              groupFolderId: null,
             },
           }
         }
@@ -236,6 +239,7 @@ export function createSelectionSlice(
                   selectedNode: null,
                   mode: 'feature',
                   activeControl: null,
+                  groupFolderId: null,
                 },
               }
             }
@@ -249,6 +253,7 @@ export function createSelectionSlice(
                 selectedNode: null,
                 mode: 'feature',
                 activeControl: null,
+                groupFolderId: null,
               },
             }
           }
@@ -269,6 +274,7 @@ export function createSelectionSlice(
                 selectedNode: { type: 'feature', featureId: id },
                 mode: 'feature',
                 activeControl: null,
+                groupFolderId: null,
               },
             }
           }
@@ -302,6 +308,7 @@ export function createSelectionSlice(
               selectedNode: nextPrimaryId ? { type: 'feature', featureId: nextPrimaryId } : null,
               mode: 'feature',
               activeControl: null,
+              groupFolderId: null,
             },
           }
         }
@@ -327,17 +334,37 @@ export function createSelectionSlice(
                       selectedFeatureId: nextPrimaryId,
                       selectedFeatureIds: nextIds,
                       selectedNode: nextPrimaryId ? { type: 'feature', featureId: nextPrimaryId } : null,
+                      groupFolderId: null,
                     }
                   })()
-                : {
-                    selectedFeatureId: id,
-                    selectedFeatureIds: [id],
-                    selectedNode: { type: 'feature', featureId: id },
-                  }
+                : (() => {
+                    const feature = featureById(s.project, id)
+                    const folderId = feature?.folderId
+                    const folder = folderId ? s.project.featureFolders.find((f) => f.id === folderId) : undefined
+                    if (folder && (folder.grouped ?? false)) {
+                      const ids = s.project.features
+                        .filter((f) => f.folderId === folderId)
+                        .map((f) => f.id)
+                      const primaryId = ids.at(-1) ?? null
+                      return {
+                        selectedFeatureId: primaryId,
+                        selectedFeatureIds: ids,
+                        selectedNode: primaryId ? { type: 'feature', featureId: primaryId } : null,
+                        groupFolderId: folderId,
+                      }
+                    }
+                    return {
+                      selectedFeatureId: id,
+                      selectedFeatureIds: [id],
+                      selectedNode: { type: 'feature', featureId: id },
+                      groupFolderId: null,
+                    }
+                  })()
               : {
                   selectedFeatureId: null,
                   selectedFeatureIds: [],
                   selectedNode: null,
+                  groupFolderId: null,
                 }),
             mode: 'feature',
             activeControl: null,
@@ -378,6 +405,7 @@ export function createSelectionSlice(
             selectedNode: nextPrimaryId ? { type: 'feature', featureId: nextPrimaryId } : null,
             mode: 'feature',
             activeControl: null,
+            groupFolderId: null,
           },
         }
       }),
@@ -393,6 +421,7 @@ export function createSelectionSlice(
           selectedNode: { type: 'project' },
           mode: 'feature',
           activeControl: null,
+          groupFolderId: null,
         },
         sketchEditSession: null,
       })),
@@ -407,6 +436,7 @@ export function createSelectionSlice(
           selectedFeatureIds: [],
           selectedNode: { type: 'grid' },
           mode: 'feature',
+          groupFolderId: null,
         },
         sketchEditSession: null,
       })),
@@ -421,6 +451,7 @@ export function createSelectionSlice(
           selectedFeatureIds: [],
           selectedNode: { type: 'stock' },
           mode: 'feature',
+          groupFolderId: null,
         },
         sketchEditSession: null,
       })),
@@ -436,6 +467,7 @@ export function createSelectionSlice(
           selectedNode: { type: 'origin' },
           mode: 'feature',
           activeControl: null,
+          groupFolderId: null,
         },
         sketchEditSession: null,
       })),
@@ -451,6 +483,7 @@ export function createSelectionSlice(
           selectedNode: { type: 'backdrop' },
           mode: 'feature',
           activeControl: null,
+          groupFolderId: null,
         },
         sketchEditSession: null,
       })),
@@ -465,6 +498,7 @@ export function createSelectionSlice(
           selectedNode: { type: 'features_root' },
           mode: 'feature',
           activeControl: null,
+          groupFolderId: null,
         },
         sketchEditSession: null,
       })),
@@ -479,6 +513,7 @@ export function createSelectionSlice(
           selectedNode: { type: 'tabs_root' },
           mode: 'feature',
           activeControl: null,
+          groupFolderId: null,
         },
         sketchEditSession: null,
       })),
@@ -493,6 +528,7 @@ export function createSelectionSlice(
           selectedNode: { type: 'regions_root' },
           mode: 'feature',
           activeControl: null,
+          groupFolderId: null,
         },
         sketchEditSession: null,
       })),
@@ -507,6 +543,7 @@ export function createSelectionSlice(
           selectedNode: { type: 'clamps_root' },
           mode: 'feature',
           activeControl: null,
+          groupFolderId: null,
         },
         sketchEditSession: null,
       })),
@@ -521,6 +558,7 @@ export function createSelectionSlice(
           selectedNode: { type: 'folder', folderId: id },
           mode: 'feature',
           activeControl: null,
+          groupFolderId: null,
         },
         sketchEditSession: null,
       })),
@@ -535,6 +573,7 @@ export function createSelectionSlice(
           selectedNode: { type: 'tab', tabId: id },
           mode: 'feature',
           activeControl: null,
+          groupFolderId: null,
         },
         sketchEditSession: null,
       })),
@@ -549,6 +588,7 @@ export function createSelectionSlice(
           selectedNode: { type: 'clamp', clampId: id },
           mode: 'feature',
           activeControl: null,
+          groupFolderId: null,
         },
         sketchEditSession: null,
       })),
@@ -587,6 +627,7 @@ export function createSelectionSlice(
             mode: 'sketch_edit',
             sketchEditTool: null,
             activeControl: null,
+            groupFolderId: null,
           },
           sketchEditSession: {
             entityType: 'feature',
@@ -609,6 +650,7 @@ export function createSelectionSlice(
           mode: 'sketch_edit',
           sketchEditTool: null,
           activeControl: null,
+          groupFolderId: null,
         },
         sketchEditSession: {
           entityType: 'clamp',
@@ -630,6 +672,7 @@ export function createSelectionSlice(
           mode: 'sketch_edit',
           sketchEditTool: null,
           activeControl: null,
+          groupFolderId: null,
         },
         sketchEditSession: {
           entityType: 'tab',
@@ -661,7 +704,7 @@ export function createSelectionSlice(
               featureTree: nextFeatureTree,
               meta: { ...s.project.meta, modified: new Date().toISOString() },
             },
-            selection: { ...s.selection, mode: 'feature', sketchEditTool: null, activeControl: null },
+            selection: { ...s.selection, mode: 'feature', sketchEditTool: null, activeControl: null, groupFolderId: null },
             sketchEditSession: null,
             pendingConstraint: null,
             history: {
@@ -689,7 +732,7 @@ export function createSelectionSlice(
 
           return {
             project,
-            selection: { ...s.selection, mode: 'feature', sketchEditTool: null, activeControl: null },
+            selection: { ...s.selection, mode: 'feature', sketchEditTool: null, activeControl: null, groupFolderId: null },
             sketchEditSession: null,
             pendingConstraint: null,
           }
@@ -697,7 +740,7 @@ export function createSelectionSlice(
 
         // Normal case: not a stock source feature
         return {
-          selection: { ...s.selection, mode: 'feature', sketchEditTool: null, activeControl: null },
+          selection: { ...s.selection, mode: 'feature', sketchEditTool: null, activeControl: null, groupFolderId: null },
           sketchEditSession: null,
           pendingConstraint: null,
         }
@@ -707,7 +750,7 @@ export function createSelectionSlice(
       set((s) => {
         if (!s.sketchEditSession) {
           return {
-            selection: { ...s.selection, mode: 'feature', sketchEditTool: null, activeControl: null },
+            selection: { ...s.selection, mode: 'feature', sketchEditTool: null, activeControl: null, groupFolderId: null },
             sketchEditSession: null,
             pendingConstraint: null,
           }
@@ -721,6 +764,7 @@ export function createSelectionSlice(
             mode: 'feature',
             sketchEditTool: null,
             activeControl: null,
+            groupFolderId: null,
           },
           sketchEditSession: null,
           pendingConstraint: null,

--- a/src/store/slices/selectionSlice.ts
+++ b/src/store/slices/selectionSlice.ts
@@ -159,7 +159,7 @@ export function createSelectionSlice(
     selection: emptySelection(),
     sketchEditSession: null,
 
-    selectFeature: (id, additive = false) =>
+    selectFeature: (id, additive = false, expandGroup = true) =>
       set((s) => {
         const joinMode = s.pendingShapeAction?.kind === 'join'
         const cutMode = s.pendingShapeAction?.kind === 'cut'
@@ -341,7 +341,7 @@ export function createSelectionSlice(
                     const feature = featureById(s.project, id)
                     const folderId = feature?.folderId
                     const folder = folderId ? s.project.featureFolders.find((f) => f.id === folderId) : undefined
-                    if (folder && (folder.grouped ?? false)) {
+                    if (expandGroup && folder && (folder.grouped ?? false)) {
                       const ids = s.project.features
                         .filter((f) => f.folderId === folderId)
                         .map((f) => f.id)

--- a/src/store/slices/treeVisibilitySlice.ts
+++ b/src/store/slices/treeVisibilitySlice.ts
@@ -24,6 +24,7 @@ export type TreeVisibilitySlice = Pick<
   | 'toggleFolderVisible'
   | 'toggleRegionFolderVisible'
   | 'selectFolderFeatures'
+  | 'toggleFolderGrouped'
 >
 
 export function createTreeVisibilitySlice(
@@ -124,6 +125,30 @@ export function createTreeVisibilitySlice(
           activeControl: null,
         },
         sketchEditSession: null,
+      }
+    }),
+
+  toggleFolderGrouped: (folderId) =>
+    set((s) => {
+      const folder = s.project.featureFolders.find((f) => f.id === folderId)
+      if (!folder) {
+        return {}
+      }
+      const nextGrouped = !(folder.grouped ?? false)
+      const nextProject = {
+        ...s.project,
+        featureFolders: s.project.featureFolders.map((f) =>
+          f.id === folderId ? { ...f, grouped: nextGrouped } : f
+        ),
+        meta: { ...s.project.meta, modified: new Date().toISOString() },
+      }
+      return {
+        project: nextProject,
+        history: {
+          past: [...s.history.past, cloneProject(s.project)].slice(-100),
+          future: [],
+          transactionStart: null,
+        },
       }
     }),
 

--- a/src/store/slices/treeVisibilitySlice.ts
+++ b/src/store/slices/treeVisibilitySlice.ts
@@ -113,6 +113,8 @@ export function createTreeVisibilitySlice(
         return {}
       }
       const primaryId = ids.at(-1) ?? null
+      const folder = s.project.featureFolders.find((f) => f.id === folderId)
+      const isGrouped = folder?.grouped ?? false
       return {
         pendingOffset: null,
         pendingShapeAction: null,
@@ -123,6 +125,7 @@ export function createTreeVisibilitySlice(
           selectedNode: primaryId ? { type: 'feature', featureId: primaryId } : null,
           mode: 'feature',
           activeControl: null,
+          groupFolderId: isGrouped ? folderId : null,
         },
         sketchEditSession: null,
       }

--- a/src/store/slices/treeVisibilitySlice.ts
+++ b/src/store/slices/treeVisibilitySlice.ts
@@ -145,7 +145,27 @@ export function createTreeVisibilitySlice(
         ),
         meta: { ...s.project.meta, modified: new Date().toISOString() },
       }
-      return {
+      // Reconcile selection.groupFolderId with the new grouped state.
+      let nextGroupFolderId = s.selection.groupFolderId
+      if (!nextGrouped && s.selection.groupFolderId === folderId) {
+        // Folder is being turned OFF while it was the active group selection.
+        nextGroupFolderId = null
+      } else if (nextGrouped) {
+        // Folder is being turned ON; if every currently selected feature belongs
+        // to this folder, set the group highlight.
+        const selectedIds = s.selection.selectedFeatureIds
+        if (selectedIds.length > 0) {
+          const allInFolder = selectedIds.every((id) => {
+            const feat = s.project.features.find((f) => f.id === id)
+            return feat !== undefined && feat.folderId === folderId
+          })
+          if (allInFolder) {
+            nextGroupFolderId = folderId
+          }
+        }
+      }
+      const selectionChanged = nextGroupFolderId !== s.selection.groupFolderId
+      const base = {
         project: nextProject,
         history: {
           past: [...s.history.past, cloneProject(s.project)].slice(-100),
@@ -153,6 +173,9 @@ export function createTreeVisibilitySlice(
           transactionStart: null,
         },
       }
+      return selectionChanged
+        ? { ...base, selection: { ...s.selection, groupFolderId: nextGroupFolderId } }
+        : base
     }),
 
   }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -326,6 +326,7 @@ export interface ProjectStore {
   toggleRegionFolderVisible: (folderId: string) => void
   selectFolderFeatures: (folderId: string) => void
   toggleFolderGrouped: (folderId: string) => void
+  groupSelectedFeaturesIntoNewFolder: () => string
   addFeature: (feature: SketchFeature) => void
   importShapes: (input: { fileName: string; sourceType: ImportSourceType; shapes: ImportedShape[] }) => string[]
   importCamjFolders: (input: { fileName: string; sourceProject: Project; selectedFolderIds: string[]; importStock?: boolean }) => string[]

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -51,6 +51,8 @@ export interface SelectionState {
   hoveredFeatureId: string | null
   sketchEditTool: SketchEditTool | null
   activeControl: SketchControlRef | null
+  /** When set, the current selection originated as a grouped-folder select-all. */
+  groupFolderId?: string | null
 }
 
 export interface SketchControlRef {
@@ -323,6 +325,7 @@ export interface ProjectStore {
   toggleFolderVisible: (folderId: string) => void
   toggleRegionFolderVisible: (folderId: string) => void
   selectFolderFeatures: (folderId: string) => void
+  toggleFolderGrouped: (folderId: string) => void
   addFeature: (feature: SketchFeature) => void
   importShapes: (input: { fileName: string; sourceType: ImportSourceType; shapes: ImportedShape[] }) => string[]
   importCamjFolders: (input: { fileName: string; sourceProject: Project; selectedFolderIds: string[]; importStock?: boolean }) => string[]

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -379,7 +379,7 @@ export interface ProjectStore {
   duplicateOperation: (id: string) => string | null
   reorderOperations: (ids: string[]) => void
 
-  selectFeature: (id: string | null, additive?: boolean) => void
+  selectFeature: (id: string | null, additive?: boolean, expandGroup?: boolean) => void
   selectFeatures: (ids: string[]) => void
   selectProject: () => void
   selectGrid: () => void

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1624,8 +1624,10 @@
 }
 
 .tree-action-btn--grouped {
-  color: #7eb3de;
-  border-color: rgba(78, 141, 193, 0.55);
+  color: #fff;
+  border-color: rgba(220, 165, 106, 0.65);
+  background: rgba(220, 165, 106, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(220, 165, 106, 0.25);
 }
 
 .tree-action-btn--muted {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1618,6 +1618,11 @@
   border-color: rgba(78, 141, 193, 0.45);
 }
 
+.tree-action-btn--grouped {
+  color: #7eb3de;
+  border-color: rgba(78, 141, 193, 0.55);
+}
+
 .tree-action-btn--muted {
   opacity: 0.58;
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1545,6 +1545,36 @@
   color: rgba(214, 226, 236, 0.78);
 }
 
+/* ── Folder chevron collapse toggle ───────────────────────── */
+
+.tree-folder-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.tree-folder-chevron:hover {
+  color: var(--text);
+}
+.tree-folder-chevron .icon-sprite {
+  width: 14px;
+  height: 14px;
+}
+
+.tree-chevron-icon {
+  transition: transform 0.15s ease;
+}
+.tree-chevron-icon--collapsed {
+  transform: rotate(-90deg);
+}
+
 /* Holds the label plus any inline badges (region/linked) in a single grid
    column so badges never push the row actions onto a second line. */
 .tree-label-wrap {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1441,6 +1441,11 @@
   color: #fff;
 }
 
+.tree-row--group-selected {
+  background: rgba(220, 165, 106, 0.18);
+  box-shadow: inset 3px 0 0 rgba(234, 170, 97, 0.55);
+}
+
 .tree-row--dragging {
   opacity: 0.35;
 }

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -361,6 +361,7 @@ export interface FeatureFolder {
   name: string
   collapsed: boolean
   section?: 'features' | 'regions'
+  grouped?: boolean
 }
 
 export type FeatureTreeEntry =


### PR DESCRIPTION
## What

Turns feature folders into proper **CAD-style group containers**: a folder can be toggled "grouped", after which its features select, move/resize/rotate/mirror, and copy **as one rigid body**, with the folder acting as a real container (locked membership, context-menu management, group properties).

## Highlights

**Core grouping**
- `grouped` flag on `FeatureFolder` (+ migration); "Group" toggle on folder rows (chain-link→`composite` icon, clear active state).
- Selecting a grouped member (canvas, or folder title in the tree) selects the whole group; distinct teal outline on member features (rotates/moves with them).
- Move/resize/rotate/mirror fan across members about a **shared pivot**, composed onto each member's per-instance `transform` only — never the shared `FeatureDefinition` (feature-reference safe; covered by tests, incl. an out-of-group sibling-instance guard).
- **Group copy** creates a new `grouped` folder containing the copies (no duplicated tree entries).

**Container behaviors**
- Members are **locked into** a grouped folder (no drag-out / no folder-dropdown reassignment); reorder-within and drag-in still work.
- Context menu: **Group** (when >1 selected) and **Add to folder** (submenu: existing folders + Create new…).
- Bulk menu labels read **"…Group"** when a group is selected.

**Selection model & UX**
- Tree **feature row → drill into the individual** (its own properties); **folder title → select the group**; collapse moved to a chevron.
- **Edit Sketch** available from the context menu on the right-clicked member (no double-click; tablet-friendly).
- Right-click on a folder/group no longer shows the browser menu (opens the app's group menu instead).
- A **Group** section (rename / Ungroup / Delete) in the properties panel when a group is selected.

## Out of scope (follow-up)

Linked/component groups — group copies that *reference* the same sketches (group-level analogue of feature references). Needs its own "group definition" abstraction; tracked separately.

## Verification

`npm run build` (tsc + full test suite + vite) green throughout; each slice was reviewed against its real diff + an independent build. Feature was user-tested across several rounds.

Note: built slice-by-slice via delegated workers — recommend **Squash and merge** for a clean history.