### PR TITLE
chore: archive completed plans + tidy planning index

### DIFF
--- a/planning/INDEX.md
+++ b/planning/INDEX.md
@@ -20,8 +20,6 @@ Every task: write a plan from [`TEMPLATE.md`](TEMPLATE.md) → register it under
 
 ## In progress
 
-- [DEEPSEEK_CLAUDE_INTEGRATION_MANAGER_Plan.md](DEEPSEEK_CLAUDE_INTEGRATION_MANAGER_Plan.md) — project-local Claude Code/DeepSeek worker launcher and Codex-led sequential integration-manager workflow
-- [POCKET_OFFSET_INNER_FIRST_Plan.md](POCKET_OFFSET_INNER_FIRST_Plan.md) — reverse pocket rough offset traversal so offset pockets cut inner loops first and work outward while preserving selected cut direction
 
 ### Foundational / cross-cutting
 - [INTEGRATION_HANDOFF_TEMPLATE.md](INTEGRATION_HANDOFF_TEMPLATE.md) — detailed branch-owned handoff and slice-ledger template for sequential external implementation workers

--- a/planning/archive/DEEPSEEK_CLAUDE_INTEGRATION_MANAGER_Plan.md
+++ b/planning/archive/DEEPSEEK_CLAUDE_INTEGRATION_MANAGER_Plan.md
@@ -1,5 +1,5 @@
 ---
-status: In progress
+status: Done
 created: 2026-06-22
 ---
 

--- a/planning/archive/POCKET_OFFSET_INNER_FIRST_Plan.md
+++ b/planning/archive/POCKET_OFFSET_INNER_FIRST_Plan.md
@@ -1,5 +1,5 @@
 ---
-status: In progress
+status: Done
 created: 2026-06-16
 ---
 


### PR DESCRIPTION
Planning-doc hygiene only — no code changes.

Two plans were left under **In progress** in `planning/INDEX.md` after their work shipped:
- **POCKET_OFFSET_INNER_FIRST** — shipped via #153 ("Cut pocket offsets inner first").
- **DEEPSEEK_CLAUDE_INTEGRATION_MANAGER** — the worker-launcher / integration-manager tooling, now in active use.

This PR sets both to `status: Done`, moves them to `planning/archive/`, and removes their stale "In progress" index entries — completing the documented plan workflow for already-merged work.

`npm run build` clean (docs-only; no source touched).