### PR TITLE
Rest operation: fix wrong regions + nearest-region travel ordering

### DIFF
--- a/src/engine/toolpaths/regions.ts
+++ b/src/engine/toolpaths/regions.ts
@@ -363,6 +363,47 @@ export function clipToolpathResultToObstaclesByLevel(
   }
 }
 
+interface RegionCutGroup {
+  moves: ToolpathMove[]
+  start: ToolpathPoint
+  end: ToolpathPoint
+}
+
+/**
+ * Greedy nearest-neighbour ordering of per-region cut groups: keep the first
+ * group, then always hop to the region whose entry point is closest to where
+ * the tool currently sits. Without this, regions are machined in whatever
+ * arbitrary order their mask paths happened to be in, so the tool zig-zags back
+ * and forth across the part (very visible on rest operations, which produce many
+ * small disjoint corner regions). Mirrors orderPartsByNearestBlock.
+ */
+function orderRegionCutGroupsByNearest(groups: RegionCutGroup[]): RegionCutGroup[] {
+  if (groups.length <= 1) return groups
+
+  const ordered: RegionCutGroup[] = [groups[0]]
+  const remaining = groups.slice(1)
+  let current = groups[0].end
+
+  while (remaining.length > 0) {
+    let bestIndex = 0
+    let bestDistance = Infinity
+    for (let index = 0; index < remaining.length; index += 1) {
+      const dx = remaining[index].start.x - current.x
+      const dy = remaining[index].start.y - current.y
+      const distance = dx * dx + dy * dy
+      if (distance < bestDistance) {
+        bestIndex = index
+        bestDistance = distance
+      }
+    }
+    const [next] = remaining.splice(bestIndex, 1)
+    ordered.push(next)
+    current = next.end
+  }
+
+  return ordered
+}
+
 export function clipToolpathResultToRegionMask(
   project: Project,
   result: ToolpathResult,
@@ -376,12 +417,16 @@ export function clipToolpathResultToRegionMask(
   let clippedCutCount = 0
   const cutMoves = result.moves.filter((move) => move.kind === 'cut')
 
+  // Clip the toolpath to each region independently, keeping every region's
+  // fragments in pass order, then visit the regions nearest-first.
+  const groups: RegionCutGroup[] = []
   for (const path of mask.paths) {
     const pathMask: RegionMask = {
       paths: [path],
       containsPoint: (point) => pointInClipperPaths(point, [path]),
     }
 
+    const groupMoves: ToolpathMove[] = []
     for (const move of cutMoves) {
       const fragments = clipCutMoveToRegion(move, pathMask)
       if (fragments.length === 0) {
@@ -397,14 +442,24 @@ export function clipToolpathResultToRegionMask(
       }
 
       for (const fragment of fragments) {
-        current = pushSafeTransition(clippedMoves, current, fragment.from, safeZ)
-        clippedMoves.push({
-          ...move,
-          from: fragment.from,
-          to: fragment.to,
-        })
-        current = fragment.to
+        groupMoves.push({ ...move, from: fragment.from, to: fragment.to })
       }
+    }
+
+    if (groupMoves.length > 0) {
+      groups.push({
+        moves: groupMoves,
+        start: groupMoves[0].from,
+        end: groupMoves[groupMoves.length - 1].to,
+      })
+    }
+  }
+
+  for (const group of orderRegionCutGroupsByNearest(groups)) {
+    for (const move of group.moves) {
+      current = pushSafeTransition(clippedMoves, current, move.from, safeZ)
+      clippedMoves.push(move)
+      current = move.to
     }
   }
 

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -35,6 +35,9 @@ import { generateSurfaceCleanToolpath } from './surface'
 import { generateFollowLineToolpath } from './carving'
 import { generateDrillingToolpath } from './drilling'
 import { generatePocketRestRegionDrafts } from './restRegions'
+import { buildMaskFromClipperPaths, clipToolpathResultToRegionMask } from './regions'
+import { DEFAULT_CLIPPER_SCALE } from './geometry'
+import type { ClipperPath } from './types'
 
 function assert(condition: boolean, message: string) {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
@@ -813,6 +816,45 @@ function draftArea(draft: { profile: { start: { x: number; y: number }; segments
   return Math.abs(area / 2)
 }
 
+function testRegionMaskVisitsNearestRegionFirst() {
+  // Regression: a region-masked toolpath (e.g. a rest operation) used to machine
+  // its regions in whatever arbitrary order the mask paths happened to be in, so
+  // the tool zig-zagged across the part. It should instead hop to the nearest
+  // unvisited region each time.
+  console.log('Testing region-mask clipping visits the nearest region first...')
+  const project = newProject('region-order', 'mm')
+
+  // One left-to-right cut pass crossing three boxes laid out along X.
+  const result: ToolpathResult = {
+    operationId: 'op',
+    moves: [{ kind: 'cut', from: { x: -1, y: 1, z: -1 }, to: { x: 31, y: 1, z: -1 } }],
+    warnings: [],
+    bounds: null,
+  }
+  const box = (x0: number, x1: number): ClipperPath => [
+    { X: x0 * DEFAULT_CLIPPER_SCALE, Y: -1 * DEFAULT_CLIPPER_SCALE },
+    { X: x1 * DEFAULT_CLIPPER_SCALE, Y: -1 * DEFAULT_CLIPPER_SCALE },
+    { X: x1 * DEFAULT_CLIPPER_SCALE, Y: 3 * DEFAULT_CLIPPER_SCALE },
+    { X: x0 * DEFAULT_CLIPPER_SCALE, Y: 3 * DEFAULT_CLIPPER_SCALE },
+  ]
+  // Mask paths deliberately out of travel order: left, RIGHT, middle.
+  const mask = buildMaskFromClipperPaths([box(0, 5), box(25, 30), box(10, 15)])
+  const clipped = clipToolpathResultToRegionMask(project, result, mask)
+
+  const cutStarts = cutMoves(clipped.moves).map((move) => Math.round(move.from.x))
+  // Nearest-first from the first box (0–5) should give left→middle→right: 0,10,25.
+  // The old arbitrary order would have been 0,25,10.
+  assert(
+    cutStarts.length === 3,
+    `expected one cut fragment per region, got ${cutStarts.length} [${cutStarts.join(',')}]`,
+  )
+  assert(
+    cutStarts[0] < cutStarts[1] && cutStarts[1] < cutStarts[2],
+    `expected nearest-first region order (ascending X), got [${cutStarts.join(',')}]`,
+  )
+  console.log('region-mask nearest-region ordering: PASSED')
+}
+
 function testPocketRestRegionsUniformCorners() {
   // Regression: corner rest regions are built analytically from each pocket
   // vertex (apex + tangent points sized by the tool radius), so every equal
@@ -1488,6 +1530,7 @@ try {
   testPocketRestRegionsFindUnreachableArea()
   testPocketRestRegionsFindCornerCusps()
   testPocketRestRegionsUniformCorners()
+  testRegionMaskVisitsNearestRegionFirst()
   testEdgeInsideLevelFirstVsFeatureFirst()
   testEdgeInsideFeatureFirstNearestBlockOrder()
   testEdgeInsideRegionClipsAtBoundary()


### PR DESCRIPTION
## Summary

Fixes the **Create rest operation** producing wrong/oversized regions, and tidies the travel between regions. Two parts:

1. **Analytical corner cusps** (already on `main`, commit a86c627 — listed here for context): the old rest-region post-processing derived regions from the leftover sliver and convex-hulled them, which produced giant wedges on octagon/hexagon pockets and orientation-dependent corner sizes. Rest corners are now built **analytically** from each pocket vertex — a straight-backed triangle sized by the corner angle and effective tool radius — one per convex corner of the outer wall and islands. Equal corners come out identical regardless of orientation, each is its own region, and unreachable material away from corners (narrow channels, fully-unreachable pockets) is still covered.

2. **Nearest-region travel ordering** (this PR's diff): a region-masked toolpath used to machine regions in whatever arbitrary order the mask paths landed in after the union step, so the tool zig-zagged across the part. `clipToolpathResultToRegionMask` now groups each region's clipped fragments and visits the regions with a greedy nearest-neighbour walk (same convention as `orderPartsByNearestBlock`). Within-region pass order and Z-levels are unchanged. Benefits pocket/rest, edge-route, carving, surface and finish.

## Behaviour

- Octagon/hexagon/pentagon/triangle pockets → one uniform corner region per corner, distinct at every tool/pocket size ratio.
- Convex vs reflex handled (L-shapes get cusps only at convex corners; circles/near-circles emit none).
- Small concave-corner crumbs are suppressed; genuine narrow slots stay fully covered.
- Region-masked ops visit the nearest region next instead of zig-zagging.

## Testing

- New regression tests: uniform corner generation across orientations and pocket sizes; nearest-region visiting order.
- Full `toolpaths.test.ts` (incl. existing region-clipping/unreachable-area/corner-cusp tests), `createRestOperation.test.ts`, and `npm run build` all pass.

## Notes / follow-ups (not in this PR)

- The **outside** edge-route rest path still uses the old split/rebuild/convex-hull pipeline.
- Stock-to-leave perimeter bands (annular rest) are a known limitation — hole contours are dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)