### PR TITLE
Guard against committing directly on main (Claude Code hook + AGENTS.md)

### DIFF
--- a/.claude/hooks/block-default-branch-commit.sh
+++ b/.claude/hooks/block-default-branch-commit.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) guard: refuse `git commit` while HEAD is on the default
+# branch (main/master). Forces work onto a feature branch + PR instead of
+# landing straight on main. Commits on any other branch pass through untouched.
+#
+# Wired up in .claude/settings.json. Reads the Claude Code hook payload (JSON)
+# on stdin and, to block, prints a PreToolUse deny decision as JSON on stdout.
+
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+
+# Only act on an actual `git commit` invocation (also catches it inside a
+# compound command like `git add -A && git commit`). Does not match
+# `git commit-tree`, `git log --grep=commit`, etc.
+if ! printf '%s' "$command" | grep -Eq '(^|[^[:alnum:]])git[[:space:]]+([^|;&]*[[:space:]])?commit([[:space:]]|$)'; then
+  exit 0
+fi
+
+# symbolic-ref reports the branch name even before the first commit (unborn
+# branch); fall back to rev-parse for the detached-HEAD case.
+branch=$(git symbolic-ref --short -q HEAD || git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  jq -n --arg b "$branch" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: ("Refusing to commit directly on the default branch (" + $b + "). Create a feature branch first (git checkout -b feat/your-change), commit there, and open a PR. \"commit here\"/\"no PR\" does not authorize a direct main commit.")
+    }
+  }'
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git*)",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/block-default-branch-commit.sh\"",
+            "statusMessage": "Checking branch before commit"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,13 @@ npm run sync-icons     # Regenerate public/icons.svg from src/assets/icons.camj
 
 Always run `npm run build` from the project root to verify changes compile before committing. `npm test` runs automatically as part of the build, so a failing structural test will fail the build. Do not start the dev/preview server.
 
+## Git & Branching
+
+- **Never commit directly to `main`.** All work lands through a feature branch + PR — even a one-line fix. This holds even when a request says "commit here", "commit and push", or "no PR": "no PR" means *don't open a PR yet*, not *commit onto `main`*. Branch first (`git checkout -b feat/<change>`), commit there, push the branch.
+- Only commit on `main` if a human explicitly says "commit on `main`" / "commit directly to `main`".
+- **Enforcement (Claude Code):** a `PreToolUse` hook — [`.claude/hooks/block-default-branch-commit.sh`](.claude/hooks/block-default-branch-commit.sh), wired in [`.claude/settings.json`](.claude/settings.json) — blocks any `git commit` while `HEAD` is on `main`/`master`. Commits on other branches pass through untouched.
+- **Other tools (Codex, plain `git`, humans):** that hook only binds Claude Code sessions. Codex must follow this rule by reading this file (AGENTS.md). For tool-agnostic enforcement, a native git `pre-commit` hook can be added under a committed `.githooks/` dir + `git config core.hooksPath .githooks` — not set up yet.
+
 ## DeepSeek implementation workers
 
 The project-local launcher is `scripts/run-claude-deepseek-agent.sh`. It runs one non-interactive Claude Code session against the DeepSeek Anthropic-compatible endpoint for a **user-authorized, bounded slice** — it is not a general-purpose autonomous command. The management session dispatches it directly (filling the prompt template, piping it in, reading the worker's completion block back) so the user is not a copy/paste middleman.


### PR DESCRIPTION
## Summary

Prevents accidental commits straight onto `main`, after one slipped through during the rest-region work.

- **`.claude/hooks/block-default-branch-commit.sh`** — a Claude Code `PreToolUse(Bash)` hook that denies `git commit` while `HEAD` is on `main`/`master`, with a "branch first" message. Commits on any other branch pass through. Robust to compound commands (`git add -A && git commit`) and unborn branches; does not false-positive on `git commit-tree` or `git log --grep=commit`.
- **`.claude/settings.json`** — wires the hook to `PreToolUse`/`Bash` (gated to `git*`). Committed, so it applies to anyone using Claude Code on this repo.
- **AGENTS.md → new "Git & Branching" section** — the rule in plain English (never commit to `main`; branch + PR even when a request says "commit here" / "no PR"), what enforces it, and that Codex/humans follow it via AGENTS.md.

## Scope / safety

- The hook **only binds Claude Code sessions**. It does not affect Codex, plain `git`, or CI.
- **GitHub branch protection** on `main` is the proper tool-agnostic hard stop and is safe to enable: audited all six workflows — none commit/push to this repo's `main`. Every deploy workflow commits/pushes into the separate `PureCutCNC/purecutcnc.github.io` pages repo (via `PAGES_DEPLOY_TOKEN`, inside `cd pages-repo`); `softprops/action-gh-release` only creates releases/tags (not `main` commits); `deploy-rc` reads `main` on push but writes to the pages repo; `pr-check` is read-only.

## Testing

Pipe-tested the hook script across cases:
- on `main` (incl. unborn branch, and `git add && git commit`) → **deny**
- on a feature branch, and for `git status` / `git log --grep=commit` → **allow**
- `settings.json` validates; the exact configured command denies on `main`.

Note: this PR only changes `.claude/` config and docs — no app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)