### PR TITLE
docs(issue-template): anchor references on file+symbol names, not line numbers

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -26,6 +26,8 @@ The strategy at a high level. Bullets are fine. Mention key data-model changes, 
 
 Keep this list honest — it's the agreement about scope.
 
+> Anchor references on **file + function/symbol names** (e.g. `updateHeightfieldTexture()` in `gpuMesh.ts`), not line numbers — line numbers go stale on the next refactor. A line number is fine as a parenthetical hint, never as the anchor.
+
 ## Tests
 
 What unit/integration tests will be added or updated. Engine work **must** have unit tests (see AGENTS.md).


### PR DESCRIPTION
Adds the reference-convention note to `.github/ISSUE_TEMPLATE/task.md`:

> Anchor references on **file + function/symbol names**, not line numbers — line numbers go stale on the next refactor. A line number is fine as a parenthetical hint, never as the anchor.

## Why this is a separate PR
This note was meant to ship in #197, but the edit was left unstaged (the Edit tooling modifies the working tree without `git add`, and that commit used `git commit` without `-a`), so only the file deletions landed. #197's description claimed the note was included — it wasn't. This PR corrects that.

Docs-only; nothing to build.