### PR TITLE
Fix AppShell rail fade effect deps

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -168,7 +168,7 @@ export function AppShell({
       rail.removeEventListener('scroll', updateFades)
       observer.disconnect()
     }
-  })
+  }, [])
 
   const showLeft = workspaceLayout === 'lcr' || workspaceLayout === 'lc'
   const showRight = workspaceLayout === 'lcr' || workspaceLayout === 'cr'


### PR DESCRIPTION
## Summary
- Add the missing empty dependency array to the AppShell left rail fade-hint effect
- Keep the existing scroll listener, ResizeObserver, update, and cleanup behavior unchanged

Closes #150

## Verification
- npm run build