### PR TITLE
feat: emit canned drilling cycles (G81/G82/G83/G73) from post-processor

### DIFF
--- a/src/engine/gcode/definitions/linuxcnc.json
+++ b/src/engine/gcode/definitions/linuxcnc.json
@@ -70,8 +70,10 @@
     "drillCommand": "G81",
     "drillWithDwellCommand": "G82",
     "peckDrillCommand": "G83",
+    "chipBreakDrillCommand": "G73",
     "peckStepWord": "Q",
-    "retractMode": "G98"
+    "retractMode": "G98",
+    "cancelCommand": "G80"
   },
   "coolant": {
     "floodOnCommand": "M8",

--- a/src/engine/gcode/definitions/mach3.json
+++ b/src/engine/gcode/definitions/mach3.json
@@ -70,8 +70,10 @@
     "drillCommand": "G81",
     "drillWithDwellCommand": "G82",
     "peckDrillCommand": "G83",
+    "chipBreakDrillCommand": "G73",
     "peckStepWord": "Q",
-    "retractMode": "G98"
+    "retractMode": "G98",
+    "cancelCommand": "G80"
   },
   "coolant": {
     "floodOnCommand": "M8",

--- a/src/engine/gcode/definitions/uccnc.json
+++ b/src/engine/gcode/definitions/uccnc.json
@@ -74,8 +74,10 @@
     "drillCommand": "G81",
     "drillWithDwellCommand": "G82",
     "peckDrillCommand": "G83",
+    "chipBreakDrillCommand": "G73",
     "peckStepWord": "Q",
-    "retractMode": "G98"
+    "retractMode": "G98",
+    "cancelCommand": "G80"
   },
   "coolant": {
     "floodOnCommand": "M8",

--- a/src/engine/gcode/postprocessor.test.ts
+++ b/src/engine/gcode/postprocessor.test.ts
@@ -20,9 +20,10 @@
  * Run with: npx tsx src/engine/gcode/postprocessor.test.ts
  */
 
-import { defaultTool, newProject } from '../../types/project'
-import type { Operation } from '../../types/project'
+import { circleProfile, defaultTool, newProject } from '../../types/project'
+import type { Operation, SketchFeature } from '../../types/project'
 import { normalizeToolForProject } from '../toolpaths/geometry'
+import { generateDrillingToolpath } from '../toolpaths/drilling'
 import type { ToolpathResult } from '../toolpaths/types'
 import { runPostProcessor } from './postprocessor'
 import { validateMachineDefinition } from './types'
@@ -208,4 +209,248 @@ testOperationHeaderDescription()
 testEmptyDescriptionIsSkipped()
 testMultilineDescription()
 testLegacyDefinitionFallback()
+
+// ── Canned cycle tests ────────────────────────────────────────────────
+
+function cannedCycleDefinition(): MachineDefinition {
+  return validateMachineDefinition({
+    id: 'test-canned',
+    name: 'TestCanned',
+    description: 'Test controller with canned cycles',
+    builtin: false,
+    fileExtension: 'nc',
+    coordinateSystem: { xAxis: 'X', yAxis: 'Y', zAxis: 'Z' },
+    numberFormat: {
+      decimalPlaces: { mm: 3, inch: 4 },
+      trailingZeros: false,
+      leadingZero: true,
+    },
+    units: { mmCommand: 'G21', inchCommand: 'G20' },
+    program: {
+      header: ['; {programName}'],
+      footer: [],
+      commentPrefix: ';',
+      commentSuffix: '',
+      lineNumbers: false,
+      lineNumberIncrement: 10,
+    },
+    workCoordinates: { selectCommand: null },
+    motion: {
+      rapidCommand: 'G0',
+      linearCommand: 'G1',
+      cwArcCommand: 'G2',
+      ccwArcCommand: 'G3',
+      arcFormat: 'ij',
+      modalMotion: true,
+    },
+    feedSpeed: {
+      feedCommand: 'F',
+      rpmCommand: 'S',
+      spindleOnCW: 'M3',
+      spindleOnCCW: 'M4',
+      spindleOff: 'M5',
+      inlineWithMotion: true,
+      modalFeedSpeed: true,
+    },
+    toolChange: {
+      commands: ['M0 ; Tool change: {toolName}'],
+      stopSpindleFirst: true,
+      pauseAfterChange: false,
+      pauseCommand: 'M0',
+    },
+    cannedCycles: {
+      drillCommand: 'G81',
+      drillWithDwellCommand: 'G82',
+      peckDrillCommand: 'G83',
+      chipBreakDrillCommand: 'G73',
+      peckStepWord: 'Q',
+      retractMode: 'G98',
+      cancelCommand: 'G80',
+    },
+    coolant: null,
+    stop: { programEndCommand: 'M30' },
+  })
+}
+
+function grblDefinition(): MachineDefinition {
+  return validateMachineDefinition({
+    id: 'test-grbl',
+    name: 'TestGRBL',
+    description: 'Test GRBL controller (no canned cycles)',
+    builtin: false,
+    fileExtension: 'nc',
+    coordinateSystem: { xAxis: 'X', yAxis: 'Y', zAxis: 'Z' },
+    numberFormat: {
+      decimalPlaces: { mm: 3, inch: 4 },
+      trailingZeros: false,
+      leadingZero: true,
+    },
+    units: { mmCommand: 'G21', inchCommand: 'G20' },
+    program: {
+      header: ['; {programName}'],
+      footer: [],
+      commentPrefix: ';',
+      commentSuffix: '',
+      lineNumbers: false,
+      lineNumberIncrement: 10,
+    },
+    workCoordinates: { selectCommand: null },
+    motion: {
+      rapidCommand: 'G0',
+      linearCommand: 'G1',
+      cwArcCommand: 'G2',
+      ccwArcCommand: 'G3',
+      arcFormat: 'ij',
+      modalMotion: true,
+    },
+    feedSpeed: {
+      feedCommand: 'F',
+      rpmCommand: 'S',
+      spindleOnCW: 'M3',
+      spindleOnCCW: 'M4',
+      spindleOff: 'M5',
+      inlineWithMotion: true,
+      modalFeedSpeed: true,
+    },
+    toolChange: {
+      commands: ['M0 ; Tool change: {toolName}'],
+      stopSpindleFirst: true,
+      pauseAfterChange: false,
+      pauseCommand: 'M0',
+    },
+    cannedCycles: null,
+    coolant: null,
+    stop: { programEndCommand: 'M30' },
+  })
+}
+
+function runDrillingFixture(
+  definition: MachineDefinition,
+  drillType: 'simple' | 'peck' | 'dwell' | 'chip_breaking',
+  overrides?: { peckDepth?: number; dwellTime?: number },
+): { gcode: string; warnings: string[] } {
+  const project = newProject('Canned Test', 'mm')
+  const toolRecord = { ...defaultTool('mm', 1), id: 't1', name: '3 mm Drill', type: 'drill' as const, diameter: 3, defaultPlungeFeed: 150 }
+  project.tools = [toolRecord]
+
+  const circle: SketchFeature = {
+    id: 'c1',
+    name: 'Hole',
+    kind: 'circle',
+    folderId: null,
+    sketch: {
+      profile: circleProfile(20, 20, 5),
+      origin: { x: 0, y: 0 },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+    operation: 'subtract',
+    z_top: 0,
+    z_bottom: -6,
+    visible: true,
+    locked: false,
+  }
+  project.features = [circle]
+
+  const operation: Operation = {
+    id: 'op1',
+    name: 'Drill Op',
+    kind: 'drilling',
+    pass: 'rough',
+    enabled: true,
+    showToolpath: true,
+    debugToolpath: false,
+    target: { source: 'features', featureIds: ['c1'] },
+    toolRef: 't1',
+    stepdown: 2,
+    stepover: 0.4,
+    feed: 600,
+    plungeFeed: 180,
+    rpm: 12000,
+    pocketPattern: 'offset',
+    pocketAngle: 0,
+    stockToLeaveRadial: 0,
+    stockToLeaveAxial: 0,
+    finishWalls: true,
+    finishFloor: true,
+    carveDepth: 1,
+    maxCarveDepth: 1,
+    drillType,
+    peckDepth: overrides?.peckDepth,
+    dwellTime: overrides?.dwellTime,
+  }
+
+  const toolpath = generateDrillingToolpath(project, operation)
+  if (!toolpath.drillCycles || toolpath.drillCycles.length === 0) {
+    throw new Error('Fixture error: drillCycles missing or empty')
+  }
+
+  const result = runPostProcessor({
+    project,
+    definition,
+    operations: [{
+      operation,
+      tool: normalizeToolForProject(toolRecord, project),
+      toolpath,
+    }],
+    options: {
+      emitToolChanges: true,
+      emitCoolant: false,
+      programName: project.meta.name,
+    },
+  })
+  return { gcode: result.gcode, warnings: result.warnings }
+}
+
+function testCannedSimpleG81(): void {
+  console.log('Testing canned cycle G81 (simple)...')
+  const { gcode } = runDrillingFixture(cannedCycleDefinition(), 'simple')
+  assert(gcode.includes('G81'), 'G-code should contain G81 for simple drilling')
+  assert(gcode.includes('Z'), 'G-code should contain Z depth')
+  assert(gcode.includes('R'), 'G-code should contain R retract plane')
+  assert(gcode.includes('F'), 'G-code should contain feed rate')
+  assert(gcode.includes('G80'), 'G-code should contain G80 cancel')
+}
+
+function testCannedDwellG82(): void {
+  console.log('Testing canned cycle G82 (dwell)...')
+  const { gcode } = runDrillingFixture(cannedCycleDefinition(), 'dwell', { dwellTime: 1.5 })
+  assert(gcode.includes('G82'), 'G-code should contain G82 for dwell drilling')
+  assert(gcode.includes('P'), 'G-code should contain P dwell time')
+  assert(gcode.includes('G80'), 'G-code should contain G80 cancel')
+}
+
+function testCannedPeckG83(): void {
+  console.log('Testing canned cycle G83 (peck)...')
+  const { gcode } = runDrillingFixture(cannedCycleDefinition(), 'peck', { peckDepth: 2 })
+  assert(gcode.includes('G83'), 'G-code should contain G83 for peck drilling')
+  assert(gcode.includes('Q'), 'G-code should contain Q peck step')
+  assert(gcode.includes('G80'), 'G-code should contain G80 cancel')
+}
+
+function testCannedChipBreakingG73(): void {
+  console.log('Testing canned cycle G73 (chip breaking)...')
+  const { gcode } = runDrillingFixture(cannedCycleDefinition(), 'chip_breaking', { peckDepth: 2 })
+  assert(gcode.includes('G73'), 'G-code should contain G73 for chip breaking')
+  assert(gcode.includes('Q'), 'G-code should contain Q peck step')
+  assert(gcode.includes('G80'), 'G-code should contain G80 cancel')
+}
+
+function testRegressionGrblNoCannedCycles(): void {
+  console.log('Testing regression: GRBL (cannedCycles null) still expands to G0/G1...')
+  const { gcode } = runDrillingFixture(grblDefinition(), 'simple')
+  assert(!gcode.includes('G81'), 'GRBL G-code should NOT contain G81')
+  assert(!gcode.includes('G80'), 'GRBL G-code should NOT contain G80')
+  assert(gcode.includes('G0'), 'GRBL G-code should contain G0 rapid moves')
+  assert(gcode.includes('G1'), 'GRBL G-code should contain G1 linear moves')
+  assert(gcode.includes('M30'), 'GRBL G-code should contain program end')
+}
+
+testCannedSimpleG81()
+testCannedDwellG82()
+testCannedPeckG83()
+testCannedChipBreakingG73()
+testRegressionGrblNoCannedCycles()
+
 console.log('gcode postprocessor tests passed')

--- a/src/engine/gcode/postprocessor.test.ts
+++ b/src/engine/gcode/postprocessor.test.ts
@@ -447,10 +447,80 @@ function testRegressionGrblNoCannedCycles(): void {
   assert(gcode.includes('M30'), 'GRBL G-code should contain program end')
 }
 
+function testLegacyCannedCycleDefaults(): void {
+  console.log('Testing legacy canned-cycle definition defaults (missing chipBreakDrillCommand + cancelCommand)...')
+  const legacyDef = {
+    id: 'test-legacy',
+    name: 'TestLegacy',
+    description: 'Legacy controller',
+    builtin: false,
+    fileExtension: 'nc',
+    coordinateSystem: { xAxis: 'X', yAxis: 'Y', zAxis: 'Z' },
+    numberFormat: {
+      decimalPlaces: { mm: 3, inch: 4 },
+      trailingZeros: false,
+      leadingZero: true,
+    },
+    units: { mmCommand: 'G21', inchCommand: 'G20' },
+    program: {
+      header: ['; {programName}'],
+      footer: [],
+      commentPrefix: ';',
+      commentSuffix: '',
+      lineNumbers: false,
+      lineNumberIncrement: 10,
+    },
+    workCoordinates: { selectCommand: null },
+    motion: {
+      rapidCommand: 'G0',
+      linearCommand: 'G1',
+      cwArcCommand: 'G2',
+      ccwArcCommand: 'G3',
+      arcFormat: 'ij',
+      modalMotion: true,
+    },
+    feedSpeed: {
+      feedCommand: 'F',
+      rpmCommand: 'S',
+      spindleOnCW: 'M3',
+      spindleOnCCW: 'M4',
+      spindleOff: 'M5',
+      inlineWithMotion: true,
+      modalFeedSpeed: true,
+    },
+    toolChange: {
+      commands: ['M0 ; Tool change: {toolName}'],
+      stopSpindleFirst: true,
+      pauseAfterChange: false,
+      pauseCommand: 'M0',
+    },
+    cannedCycles: {
+      drillCommand: 'G81',
+      drillWithDwellCommand: 'G82',
+      peckDrillCommand: 'G83',
+      peckStepWord: 'Q',
+      retractMode: 'G98',
+    },
+    coolant: null,
+    stop: { programEndCommand: 'M30' },
+  }
+
+  let validated: MachineDefinition
+  try {
+    validated = validateMachineDefinition(legacyDef)
+  } catch (err) {
+    throw new Error(`Legacy definition should not throw: ${String(err)}`)
+  }
+  assert(validated.cannedCycles !== null, 'cannedCycles should not be null')
+  assert(validated.cannedCycles!.chipBreakDrillCommand === null, 'chipBreakDrillCommand should default to null')
+  assert(validated.cannedCycles!.cancelCommand === 'G80', 'cancelCommand should default to G80')
+}
+
 testCannedSimpleG81()
 testCannedDwellG82()
 testCannedPeckG83()
 testCannedChipBreakingG73()
 testRegressionGrblNoCannedCycles()
+testLegacyCannedCycleDefaults()
 
 console.log('gcode postprocessor tests passed')

--- a/src/engine/gcode/postprocessor.ts
+++ b/src/engine/gcode/postprocessor.ts
@@ -251,36 +251,170 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
       }
     }
 
-    // Moves
-    toolpath.moves.forEach(move => {
-      moveCount++
-      const mPoint = projectToMachinePoint(move.to, project.origin, definition)
+    // Moves — emit canned cycles for drilling when supported, else expanded G0/G1
+    let emittedCanned = false
 
-      const feed = (move.kind === 'plunge')
-        ? (operation.plungeFeed || tool.defaultPlungeFeed)
-        : (operation.feed || tool.defaultFeed)
+    if (
+      operation.kind === 'drilling'
+      && toolpath.drillCycles
+      && toolpath.drillCycles.length > 0
+      && definition.cannedCycles
+    ) {
+      const cycles = toolpath.drillCycles
+      const cannedDef = definition.cannedCycles
 
-      if (move.kind === 'rapid') {
-        const current = state.currentPosition
-        const hasXYChange =
-          current === null
-          || current.x !== mPoint.x
-          || current.y !== mPoint.y
-        const hasZChange =
-          current === null
-          || current.z !== mPoint.z
-
-        if (hasZChange) {
-          emitMotionLine(definition.motion.rapidCommand, { z: mPoint.z })
-        }
-        if (hasXYChange) {
-          emitMotionLine(definition.motion.rapidCommand, { x: mPoint.x, y: mPoint.y })
-        }
-        return
+      // Resolve the command word for the operation's drill type
+      const drillTypeCommandMap: Record<string, string | null> = {
+        simple: cannedDef.drillCommand,
+        dwell: cannedDef.drillWithDwellCommand,
+        peck: cannedDef.peckDrillCommand,
+        chip_breaking: cannedDef.chipBreakDrillCommand,
       }
+      const cycleDrillType = cycles[0].drillType
+      const cannedCmd = drillTypeCommandMap[cycleDrillType]
 
-      emitMotionLine(definition.motion.linearCommand, mPoint, feed)
-    })
+      if (cannedCmd) {
+        emittedCanned = true
+
+        const plungeFeed = operation.plungeFeed || tool.defaultPlungeFeed
+        const feedWord = definition.feedSpeed.feedCommand
+        let feedEmitted = false
+
+        // Rapid to first hole XY at clearZ so the controller has a defined initial plane
+        const firstCycle = cycles[0]
+        const firstMachineXY = projectToMachinePoint({ x: firstCycle.x, y: firstCycle.y, z: firstCycle.clearZ }, project.origin, definition)
+        if (state.currentPosition) {
+          const cp = state.currentPosition
+          if (cp.z !== firstMachineXY.z) {
+            emitMotionLine(definition.motion.rapidCommand, { z: firstMachineXY.z })
+          }
+          if (cp.x !== firstMachineXY.x || cp.y !== firstMachineXY.y) {
+            emitMotionLine(definition.motion.rapidCommand, { x: firstMachineXY.x, y: firstMachineXY.y })
+          }
+        } else {
+          emitMotionLine(definition.motion.rapidCommand, { x: firstMachineXY.x, y: firstMachineXY.y, z: firstMachineXY.z })
+        }
+
+        // Retract mode (G98 / G99), once before the first canned line
+        if (cannedDef.retractMode) {
+          emitLine(cannedDef.retractMode)
+        }
+
+        // Emit modal canned-cycle lines
+        let lastZ: string | null = null
+        let lastR: string | null = null
+        let lastQ: string | null = null
+        let lastP: string | null = null
+
+        for (const cycle of cycles) {
+          moveCount++
+
+          const segs: string[] = []
+
+          // Command word (modal — only when first or when motion state was reset)
+          if (state.motionCommand !== cannedCmd) {
+            segs.push(cannedCmd)
+            state.motionCommand = cannedCmd
+          }
+
+          // X / Y
+          const machineXY = projectToMachinePoint({ x: cycle.x, y: cycle.y, z: 0 }, project.origin, definition)
+          segs.push(`X${formatGCodeNumber(machineXY.x, definition, outputUnits)}`)
+          segs.push(`Y${formatGCodeNumber(machineXY.y, definition, outputUnits)}`)
+
+          // Z (bottom)
+          const machineBottomZ = projectToMachinePoint({ x: cycle.x, y: cycle.y, z: cycle.bottomZ }, project.origin, definition).z
+          const zStr = formatGCodeNumber(machineBottomZ, definition, outputUnits)
+          if (zStr !== lastZ) {
+            segs.push(`Z${zStr}`)
+            lastZ = zStr
+          }
+
+          // R (retract plane)
+          const machineRetractZ = projectToMachinePoint({ x: cycle.x, y: cycle.y, z: cycle.retractZ }, project.origin, definition).z
+          const rStr = formatGCodeNumber(machineRetractZ, definition, outputUnits)
+          if (rStr !== lastR) {
+            segs.push(`R${rStr}`)
+            lastR = rStr
+          }
+
+          // Q (peck step) — only for peck / chip_breaking with positive peckDepth
+          if ((cycleDrillType === 'peck' || cycleDrillType === 'chip_breaking') && cycle.peckDepth && cycle.peckDepth > 0) {
+            const qStr = formatGCodeNumber(cycle.peckDepth, definition, outputUnits)
+            if (qStr !== lastQ) {
+              segs.push(`${cannedDef.peckStepWord}${qStr}`)
+              lastQ = qStr
+            }
+          }
+
+          // P (dwell time) — only for dwell type with positive dwellTime
+          if (cycleDrillType === 'dwell' && cycle.dwellTime && cycle.dwellTime > 0) {
+            const pStr = formatGCodeNumber(cycle.dwellTime, definition, outputUnits)
+            if (pStr !== lastP) {
+              segs.push(`P${pStr}`)
+              lastP = pStr
+            }
+          }
+
+          // F (plunge feed) — emit once, inline with motion
+          if (!feedEmitted) {
+            segs.push(`${feedWord}${formatGCodeNumber(plungeFeed, definition, outputUnits)}`)
+            state.feedRate = plungeFeed
+            feedEmitted = true
+          }
+
+          emitLine(segs.join(' '))
+        }
+
+        // Cancel canned cycle
+        emitLine(cannedDef.cancelCommand)
+
+        // Reset state: canned cancel breaks motion modality
+        state.motionCommand = null
+
+        // Track position as last hole's XY at clearZ (machine coords)
+        const lastCycle = cycles[cycles.length - 1]
+        const lastMachinePos = projectToMachinePoint({ x: lastCycle.x, y: lastCycle.y, z: lastCycle.clearZ }, project.origin, definition)
+        state.currentPosition = { x: lastMachinePos.x, y: lastMachinePos.y, z: lastMachinePos.z }
+      } else {
+        // Command not available for this drill type — fall back to expanded moves
+        warnings.push(
+          `Operation "${operation.name}": ${cycleDrillType} canned cycle not supported by machine "${definition.name}"; emitting expanded moves.`,
+        )
+      }
+    }
+
+    if (!emittedCanned) {
+      toolpath.moves.forEach(move => {
+        moveCount++
+        const mPoint = projectToMachinePoint(move.to, project.origin, definition)
+
+        const feed = (move.kind === 'plunge')
+          ? (operation.plungeFeed || tool.defaultPlungeFeed)
+          : (operation.feed || tool.defaultFeed)
+
+        if (move.kind === 'rapid') {
+          const current = state.currentPosition
+          const hasXYChange =
+            current === null
+            || current.x !== mPoint.x
+            || current.y !== mPoint.y
+          const hasZChange =
+            current === null
+            || current.z !== mPoint.z
+
+          if (hasZChange) {
+            emitMotionLine(definition.motion.rapidCommand, { z: mPoint.z })
+          }
+          if (hasXYChange) {
+            emitMotionLine(definition.motion.rapidCommand, { x: mPoint.x, y: mPoint.y })
+          }
+          return
+        }
+
+        emitMotionLine(definition.motion.linearCommand, mPoint, feed)
+      })
+    }
 
     // Spindle off after last move of operation if tool change follows or it's the last op
     const nextOp = operations[opIndex + 1]

--- a/src/engine/gcode/types.ts
+++ b/src/engine/gcode/types.ts
@@ -90,8 +90,10 @@ export const MachineDefinitionSchema = z.object({
     drillCommand: z.string().nullable(),
     drillWithDwellCommand: z.string().nullable(),
     peckDrillCommand: z.string().nullable(),
+    chipBreakDrillCommand: z.string().nullable(),
     peckStepWord: z.string(),
     retractMode: z.enum(['G98', 'G99']).nullable(),
+    cancelCommand: z.string().default('G80'),
   }).nullable(),
   coolant: z.object({
     floodOnCommand: z.string(),

--- a/src/engine/gcode/types.ts
+++ b/src/engine/gcode/types.ts
@@ -90,7 +90,7 @@ export const MachineDefinitionSchema = z.object({
     drillCommand: z.string().nullable(),
     drillWithDwellCommand: z.string().nullable(),
     peckDrillCommand: z.string().nullable(),
-    chipBreakDrillCommand: z.string().nullable(),
+    chipBreakDrillCommand: z.string().nullable().default(null),
     peckStepWord: z.string(),
     retractMode: z.enum(['G98', 'G99']).nullable(),
     cancelCommand: z.string().default('G80'),

--- a/src/engine/toolpaths/camOperationSmoke.test.ts
+++ b/src/engine/toolpaths/camOperationSmoke.test.ts
@@ -451,11 +451,11 @@ test('drilling chip_breaking: multiple plunges with small retracts', () => {
 })
 
 // ---------------------------------------------------------------------
-// NOTE: Canned cycles (G81/G82/G83/G73) are NOT currently emitted by the
-// postprocessor. The drill-type differentiation lives at the toolpath
-// generation level only. The postprocessor emits all moves as G0/G1.
-// The MachineDefinition.cannedCycles schema exists but is not wired into
-// runPostProcessor. This is a known deferred feature, not a regression.
+// NOTE: Canned cycles (G81/G82/G83/G73) are emitted by the postprocessor
+// when the active machine definition supports them AND the operation is
+// drilling. The smoke-test definition has cannedCycles:null, so these
+// tests exercise the expanded G0/G1 fallback path — that is correct and
+// expected. See postprocessor.test.ts for canned-cycle-specific tests.
 // ---------------------------------------------------------------------
 
 // =====================================================================

--- a/src/engine/toolpaths/drilling.ts
+++ b/src/engine/toolpaths/drilling.ts
@@ -15,7 +15,7 @@
  */
 
 import type { DrillType, Operation, Point, Project, SketchFeature, SketchProfile } from '../../types/project'
-import type { ToolpathBounds, ToolpathMove, ToolpathPoint, ToolpathResult } from './types'
+import type { DrillCycle, ToolpathBounds, ToolpathMove, ToolpathPoint, ToolpathResult } from './types'
 import {
   checkMaxCutDepthWarning,
   getOperationSafeZ,
@@ -306,7 +306,10 @@ export function generateDrillingToolpath(project: Project, operation: Operation)
     : Math.min(safeZ, highestTop + defaultRetractOffset)
 
   const moves: ToolpathMove[] = []
+  const drillCycles: DrillCycle[] = []
   let currentPosition: ToolpathPoint | null = null
+
+  const dwellTime = operation.dwellTime ?? 0
 
   for (const target of sortedTargets) {
     const topZ = target.span.top
@@ -328,6 +331,17 @@ export function generateDrillingToolpath(project: Project, operation: Operation)
       drillType,
       peckDepth,
     )
+
+    drillCycles.push({
+      x: target.center.x,
+      y: target.center.y,
+      clearZ: safeZ,
+      retractZ,
+      bottomZ,
+      drillType,
+      peckDepth: operation.peckDepth ?? 0,
+      dwellTime,
+    })
   }
 
   return {
@@ -335,5 +349,6 @@ export function generateDrillingToolpath(project: Project, operation: Operation)
     moves,
     warnings,
     bounds: computeBounds(moves),
+    drillCycles,
   }
 }

--- a/src/engine/toolpaths/types.ts
+++ b/src/engine/toolpaths/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Operation, Point, Tool } from '../../types/project'
+import type { Operation, Point, Tool, DrillType } from '../../types/project'
 import type { Units } from '../../utils/units'
 
 export type ToolpathMoveKind = 'rapid' | 'plunge' | 'cut' | 'lead_in' | 'lead_out'
@@ -44,6 +44,17 @@ export interface ToolpathBounds {
   maxZ: number
 }
 
+export interface DrillCycle {
+  x: number
+  y: number
+  clearZ: number
+  retractZ: number
+  bottomZ: number
+  drillType: DrillType
+  peckDepth?: number
+  dwellTime?: number
+}
+
 export interface ToolpathResult {
   operationId: string
   moves: ToolpathMove[]
@@ -56,6 +67,11 @@ export interface ToolpathResult {
   /** True when the source operation has debugToolpath enabled. The 3D viewport
    *  renders extra diagnostic markers (source-tag symbols) when this is set. */
   debugToolpath?: boolean
+  /** Structured drill cycle data for canned-cycle G-code emission.
+   *  Present only for drilling operations. When non-empty and the active
+   *  machine definition supports the cycle, the post-processor emits
+   *  G81/G82/G83/G73 blocks instead of expanded G0/G1 moves. */
+  drillCycles?: DrillCycle[]
 }
 
 export interface PocketToolpathResult extends ToolpathResult {


### PR DESCRIPTION
Closes #172

## What

Wires `MachineDefinition.cannedCycles` into `runPostProcessor` so drilling operations export canned-cycle G-code (`G81`/`G82`/`G83`/`G73` … `G80`) on machines that support them, instead of always expanding to `G0/G1`.

## How

The drilling generator already computes every cycle parameter but flattens each hole into `rapid`/`plunge` moves. Rather than reverse-engineer cycles in the post-processor, the generator now attaches structured `DrillCycle` metadata to its result **alongside the existing moves**. The post-processor reads that metadata and emits modal canned-cycle blocks when the active machine definition supports the cycle; otherwise it falls back to today's expanded-move path.

- `cannedCycles` schema gains `chipBreakDrillCommand` (G73) and `cancelCommand` (G80); added to the three canned-capable defs (uccnc/linuxcnc/mach3). grbl/grblhal/generic keep `cannedCycles: null`.
- New `DrillCycle` type + optional `drillCycles?` on `ToolpathResult`; populated in `drilling.ts` in lockstep with moves.
- Post-processor emits `<cmd> X Y Z<bottom> R<retract> [Q<peck>] [P<dwell>] F<plungeFeed>` (modal), preceded by the `G98`/`G99` retract mode and terminated with `G80`.

## Invariants preserved

- **Toolpath `moves` are unchanged** — the 3D simulation/preview consume `toolpath.moves` only and are unaffected; the canned metadata is post-processor-only.
- Machines with `cannedCycles: null` (GRBL etc.) still export expanded `G0/G1` with no canned words.
- Any drill type whose command is null (e.g. `chip_breaking` on a def without G73) falls back to expanded moves and pushes a warning.

## Tests

`postprocessor.test.ts`: G81/G82/G83/G73 emission (with Z/R/Q/P/F + closing G80) on a canned-capable def, plus a GRBL regression guard asserting no canned words. Smoke-test NOTE repointed to reflect implemented behavior.

## Verify

`npm run build` (tsc + full test suite + vite) green.

## Notes for reviewers

Implemented via the project's Claude CLI/DeepSeek worker in an isolated worktree; diff, commit, and build were reviewed and re-run independently before this PR.
