### PR TITLE
Add feature clipboard menu commands

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -66,6 +66,9 @@ pub fn run() {
       let export_i     = MenuItem::with_id(app, "export_gcode","Export G-code\u{2026}", true, Some("CmdOrCtrl+E"))?;
       let undo_i       = MenuItem::with_id(app, "undo",        "Undo",             true, Some("CmdOrCtrl+Z"))?;
       let redo_i       = MenuItem::with_id(app, "redo",        "Redo",             true, Some("CmdOrCtrl+Shift+Z"))?;
+      let copy_i       = MenuItem::with_id(app, "copy",        "Copy",             true, Some("CmdOrCtrl+C"))?;
+      let cut_i        = MenuItem::with_id(app, "cut",         "Cut",              true, Some("CmdOrCtrl+X"))?;
+      let paste_i      = MenuItem::with_id(app, "paste",       "Paste",            true, Some("CmdOrCtrl+V"))?;
       let quit_i       = MenuItem::with_id(app, "quit",        "Quit PureCutCNC",  true, Some("CmdOrCtrl+Q"))?;
 
       // Update items. The native "About" panel is left untouched; "Check for
@@ -116,9 +119,9 @@ pub fn run() {
         &undo_i,
         &redo_i,
         &PredefinedMenuItem::separator(app)?,
-        &PredefinedMenuItem::copy(app, None)?,
-        &PredefinedMenuItem::cut(app, None)?,
-        &PredefinedMenuItem::paste(app, None)?,
+        &copy_i,
+        &cut_i,
+        &paste_i,
         // Custom item — no accelerator so Cmd+A is handled by the webview
         // (which checks whether a text field is focused before selecting features)
         &MenuItem::with_id(app, "select_all", "Select All", true, None::<&str>)?,

--- a/src/INDEX.md
+++ b/src/INDEX.md
@@ -19,7 +19,7 @@ Application source. React + TypeScript + Zustand. Tauri-wrapped for desktop.
 - [commands/](commands/INDEX.md) — shared desktop/tablet command descriptors and store-backed command predicates
 - [types/](types/) — core data model. `project.ts` is the canonical `.camj` schema
 - [utils/](utils/) — units, analytics, icons, version, misc helpers
-- [platform/](platform/) — platform abstraction (web vs Tauri)
+- [platform/](platform/) — platform abstraction (web vs Tauri), desktop integration, and feature clipboard helpers
 - [styles/](styles/) — shared CSS (incl. `tablet.css` for touch UX)
 - [assets/](assets/) — editable per-icon SVG sources in `icons/` (see `icons/README.md`), fonts, etc.
 

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -4249,7 +4249,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           )}
         >
           <div className="canvas-workflow-panel__summary">
-            Move the pointer to preview the paste location. Esc cancels.
+            Move the pointer to preview the paste location.
           </div>
         </CanvasWorkflowPanel>
       )}

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -119,6 +119,12 @@ import { useRafScheduler } from '../../hooks/useRafScheduler'
 import { useShellMode, isTabletMode } from '../layout/useShellMode'
 import { CanvasWorkflowPanel } from './CanvasWorkflowPanel'
 import { useCanvasWorkflowPanel } from './useCanvasWorkflowPanel'
+import {
+  buildPlacedClipboardFeatures,
+  FEATURE_CLIPBOARD_PLACEMENT_EVENT,
+  pasteClipboardFeatures,
+  type FeatureClipboardPayload,
+} from '../../platform/featureClipboard'
 
 const NODE_HIT_RADIUS = 9
 const HANDLE_HIT_RADIUS = 7
@@ -290,6 +296,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const pendingTransformPreviewPointRef = useRef<PendingPreviewPoint | null>(null)
   const pendingOffsetPreviewPointRef = useRef<PendingPreviewPoint | null>(null)
   const pendingOffsetRawPreviewPointRef = useRef<PendingPreviewPoint | null>(null)
+  const clipboardPlacementPreviewPointRef = useRef<Point | null>(null)
   const livePointerWorldRef = useRef<Point | null>(null)
 
   function stopPan() {
@@ -325,6 +332,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const shellMode = useShellMode()
   const isTablet = isTabletMode(shellMode)
   const [multiSelectMode, setMultiSelectMode] = useState(false)
+  const [pendingClipboardPlacement, setPendingClipboardPlacement] = useState<FeatureClipboardPayload | null>(null)
 
   const {
     project,
@@ -445,6 +453,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const selectedAnnotationIdRef = useRef(selectedAnnotationId)
   const deleteHoverDimIdRef = useRef<string | null>(null)
   const operationHighlightKindRef = useRef(operationHighlightKind)
+  const pendingClipboardPlacementRef = useRef(pendingClipboardPlacement)
 
   projectRef.current = project
   selectionRef.current = selection
@@ -469,6 +478,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   dimensionDeleteArmedRef.current = dimensionDeleteArmed
   selectedAnnotationIdRef.current = selectedAnnotationId
   operationHighlightKindRef.current = operationHighlightKind
+  pendingClipboardPlacementRef.current = pendingClipboardPlacement
   if (!dimensionDeleteArmed) deleteHoverDimIdRef.current = null
 
   const dimEdit = useDimensionEditWorkflow({
@@ -554,6 +564,13 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const dimensionDeleteWorkflowPanel = useCanvasWorkflowPanel({
     open: dimensionDeleteArmed,
     phaseKey: 'delete',
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+  const clipboardPlacementWorkflowPanel = useCanvasWorkflowPanel({
+    open: pendingClipboardPlacement !== null,
+    phaseKey: pendingClipboardPlacement ? `features:${pendingClipboardPlacement.length}` : null,
     containerRef,
     canvasRef,
     clearTransientCanvasState,
@@ -658,6 +675,68 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const setPendingOffsetRawPreviewPointRef = useStableEvent((nextPoint: PendingPreviewPoint | null) => {
     pendingOffsetRawPreviewPointRef.current = nextPoint
     scheduleDraw()
+  })
+
+  const setClipboardPlacementPreviewPoint = useStableEvent((nextPoint: Point | null) => {
+    clipboardPlacementPreviewPointRef.current = nextPoint
+    scheduleDraw()
+  })
+
+  const cancelClipboardPlacement = useStableEvent(() => {
+    setPendingClipboardPlacement(null)
+    setClipboardPlacementPreviewPoint(null)
+    clipboardPlacementWorkflowPanel.focusCanvasAfterAction()
+  })
+
+  const beginClipboardPlacement = useStableEvent((clipboard: FeatureClipboardPayload) => {
+    if (clipboard.length === 0) {
+      return
+    }
+
+    if (pendingAddRef.current) {
+      originPreviewPointRef.current = null
+      cancelPendingAdd()
+      setPendingPreviewPointRef(null)
+    }
+    if (pendingMoveRef.current) {
+      cancelPendingMove()
+      setPendingMovePreviewPointRef(null)
+      setCopyCountDraft('1')
+    }
+    if (pendingTransformRef.current) {
+      cancelPendingTransform()
+      setPendingTransformPreviewPointRef(null)
+      transformExact.setPendingRotateCopyPoint(null)
+      transformExact.setRotateCopyCountDraft('1')
+    }
+    if (pendingOffsetRef.current) {
+      cancelPendingOffset()
+      setPendingOffsetPreviewPointRef(null)
+      setPendingOffsetRawPreviewPointRef(null)
+    }
+    if (pendingShapeActionRef.current) {
+      cancelPendingShapeAction()
+    }
+    if (pendingSketchEditRef.current) {
+      cancelPendingSketchEdit()
+    }
+
+    resetLock()
+    setOperationDimEdit(null)
+    setPendingClipboardPlacement(clipboard)
+    setClipboardPlacementPreviewPoint(livePointerWorldRef.current)
+    window.requestAnimationFrame(() => canvasRef.current?.focus({ preventScroll: true }))
+  })
+
+  const placeClipboardAt = useStableEvent((placementPoint: Point) => {
+    const clipboard = pendingClipboardPlacementRef.current
+    if (!clipboard) {
+      return
+    }
+
+    pasteClipboardFeatures(useProjectStore.getState(), clipboard, placementPoint)
+    setPendingClipboardPlacement(null)
+    setClipboardPlacementPreviewPoint(null)
   })
 
   function sameControl(a: SketchControlRef | null, b: SketchControlRef | null): boolean {
@@ -794,6 +873,18 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   }
 
   useEffect(() => {
+    function handleClipboardPlacement(event: Event) {
+      if (!(event instanceof CustomEvent)) {
+        return
+      }
+      beginClipboardPlacement(event.detail as FeatureClipboardPayload)
+    }
+
+    window.addEventListener(FEATURE_CLIPBOARD_PLACEMENT_EVENT, handleClipboardPlacement)
+    return () => window.removeEventListener(FEATURE_CLIPBOARD_PLACEMENT_EVENT, handleClipboardPlacement)
+  }, [beginClipboardPlacement])
+
+  useEffect(() => {
     if (!project.backdrop?.imageDataUrl) {
       setBackdropImage(null)
       setBackdropImageLoading(false)
@@ -860,7 +951,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
   useEffect(() => {
     scheduleDraw()
-  }, [scheduleDraw, project, selection, pendingAdd, pendingMove, pendingTransform, pendingOffset, viewState, backdropImage, stlImageRevision, toolpaths, selectedOperationId, collidingClampIds, snapSettings, copyCountDraft, dimEdit.dimensionEdit, toolpathVisibility, operationHighlightKind])
+  }, [scheduleDraw, project, selection, pendingAdd, pendingMove, pendingTransform, pendingOffset, pendingClipboardPlacement, viewState, backdropImage, stlImageRevision, toolpaths, selectedOperationId, collidingClampIds, snapSettings, copyCountDraft, dimEdit.dimensionEdit, toolpathVisibility, operationHighlightKind])
 
   useEffect(() => {
     sketchEditPreviewRef.current = null
@@ -902,6 +993,13 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     pendingOffsetPreviewPointRef.current = null
     pendingOffsetRawPreviewPointRef.current = null
   }, [pendingOffset?.session])
+
+  useEffect(() => {
+    if (!pendingClipboardPlacement) {
+      clipboardPlacementPreviewPointRef.current = null
+      scheduleDraw()
+    }
+  }, [pendingClipboardPlacement, scheduleDraw])
 
   useEffect(() => {
     if (zoomWindowActive) {
@@ -1041,6 +1139,16 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         ctx.fillText(String(feature.sketch.constraints.length), badgeC.cx - 8, badgeC.cy - 8)
         ctx.restore()
       }
+    }
+
+    const clipboardPlacement = pendingClipboardPlacementRef.current
+    const clipboardPlacementPreviewPoint = clipboardPlacementPreviewPointRef.current
+    if (clipboardPlacement && clipboardPlacementPreviewPoint) {
+      const previewFeatures = buildPlacedClipboardFeatures(clipboardPlacement, project, clipboardPlacementPreviewPoint)
+      for (const feature of previewFeatures) {
+        drawPreviewProfile(ctx, feature.sketch.profile, vt, 'Paste preview')
+      }
+      drawPendingPoint(ctx, clipboardPlacementPreviewPoint, vt, snap.isActiveSnapPoint(clipboardPlacementPreviewPoint))
     }
 
     const pendingConstraintDraw = pendingConstraintRef.current
@@ -2720,6 +2828,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     viewStateRef,
     tapeMeasureRef,
     pendingDimensionRef,
+    pendingClipboardPlacementRef,
     dimensionDeleteArmedRef,
     selectedAnnotationIdRef,
     pendingPreviewPointRef,
@@ -2741,6 +2850,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     clearTapeMeasure,
     cancelPendingDimension,
     setDimensionDeleteArmed,
+    cancelClipboardPlacement,
     deleteDimensionAnnotation,
     undoPendingPolygonPoint,
     completePendingOpenPath,
@@ -2798,6 +2908,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     pendingMovePreviewPointRef,
     pendingConstraintRef,
     pendingDimensionRef,
+    pendingClipboardPlacementRef,
     dimensionDeleteArmedRef,
     deleteHoverDimIdRef,
     pendingSketchExtensionRef,
@@ -2842,6 +2953,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     setPendingTransformPreviewPointRef,
     setPendingOffsetPreviewPointRef,
     setPendingOffsetRawPreviewPointRef,
+    setClipboardPlacementPreviewPoint,
     setHoveredEditControl,
     zoomWindowActive,
     onZoomWindowComplete,
@@ -2870,6 +2982,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     pendingSketchExtensionRef,
     pendingSketchFilletRef,
     sketchEditPreviewRef,
+    pendingClipboardPlacementRef,
     originPreviewPointRef,
     tapeMeasureRef,
     constraintLabelRectsRef,
@@ -2893,7 +3006,9 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     setPendingTransformPreviewPointRef,
     setPendingOffsetPreviewPointRef,
     setPendingOffsetRawPreviewPointRef,
+    setClipboardPlacementPreviewPoint,
     tapeMeasureClick,
+    placeClipboardAt,
     cancelPendingDimension,
     addDimensionAnnotation,
     pendingDimensionPick,
@@ -2981,7 +3096,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     <div ref={containerRef} className="sketch-canvas-container">
       <canvas
         ref={canvasRef}
-        className={`sketch-canvas ${pendingAdd || pendingMove || pendingTransform || pendingOffset || pendingShapeAction ? 'sketch-canvas--placing' : ''}`}
+        className={`sketch-canvas ${pendingAdd || pendingMove || pendingTransform || pendingOffset || pendingShapeAction || pendingClipboardPlacement ? 'sketch-canvas--placing' : ''}`}
         onPointerDown={gestures.handlePointerDown}
         onPointerUp={gestures.handlePointerUp}
         onPointerCancel={gestures.handlePointerUp}
@@ -4118,6 +4233,23 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         >
           <div className="canvas-workflow-panel__summary">
             Click each dimension you want to remove. Esc or Done to finish.
+          </div>
+        </CanvasWorkflowPanel>
+      )}
+      {pendingClipboardPlacement && (
+        <CanvasWorkflowPanel
+          title="Paste features"
+          step="Click in the sketch to place"
+          position={clipboardPlacementWorkflowPanel.position}
+          panelRef={clipboardPlacementWorkflowPanel.panelRef}
+          handleProps={clipboardPlacementWorkflowPanel.handleProps}
+          actionRowProps={clipboardPlacementWorkflowPanel.actionRowProps}
+          actions={(
+            <button type="button" className="tablet-cmd-btn tablet-cmd-btn--cancel" onClick={cancelClipboardPlacement}>Cancel</button>
+          )}
+        >
+          <div className="canvas-workflow-panel__summary">
+            Move the pointer to preview the paste location. Esc cancels.
           </div>
         </CanvasWorkflowPanel>
       )}

--- a/src/components/canvas/useCanvasKeyboard.ts
+++ b/src/components/canvas/useCanvasKeyboard.ts
@@ -34,6 +34,7 @@ import type {
   TapeMeasureState,
 } from '../../store/types'
 import type { Point, Project, SketchFeature } from '../../types/project'
+import type { FeatureClipboardPayload } from '../../platform/featureClipboard'
 import { formatLength } from '../../utils/units'
 import { buildArcSegmentFromThreePoints } from './draftHelpers'
 import { resolveOffsetPreview } from './draftGeometry'
@@ -77,6 +78,7 @@ export interface CanvasKeyboardCtx {
   viewStateRef: MutableRefObject<SketchViewState>
   tapeMeasureRef: MutableRefObject<TapeMeasureState | null>
   pendingDimensionRef: MutableRefObject<PendingDimensionTool | null>
+  pendingClipboardPlacementRef: MutableRefObject<FeatureClipboardPayload | null>
   dimensionDeleteArmedRef: MutableRefObject<boolean>
   selectedAnnotationIdRef: MutableRefObject<string | null>
   pendingPreviewPointRef: MutableRefObject<PendingPreviewPoint | null>
@@ -100,6 +102,7 @@ export interface CanvasKeyboardCtx {
   clearTapeMeasure: () => void
   cancelPendingDimension: () => void
   setDimensionDeleteArmed: (armed: boolean) => void
+  cancelClipboardPlacement: () => void
   deleteDimensionAnnotation: (id: string) => void
   undoPendingPolygonPoint: () => void
   completePendingOpenPath: () => void
@@ -148,6 +151,7 @@ export function useCanvasKeyboard(ctx: CanvasKeyboardCtx): {
     viewStateRef,
     tapeMeasureRef,
     pendingDimensionRef,
+    pendingClipboardPlacementRef,
     dimensionDeleteArmedRef,
     selectedAnnotationIdRef,
     pendingPreviewPointRef,
@@ -169,6 +173,7 @@ export function useCanvasKeyboard(ctx: CanvasKeyboardCtx): {
     clearTapeMeasure,
     cancelPendingDimension,
     setDimensionDeleteArmed,
+    cancelClipboardPlacement,
     deleteDimensionAnnotation,
     undoPendingPolygonPoint,
     completePendingOpenPath,
@@ -225,6 +230,11 @@ export function useCanvasKeyboard(ctx: CanvasKeyboardCtx): {
     if (event.key === 'Escape' && dimensionDeleteArmedRef.current) {
       event.preventDefault()
       setDimensionDeleteArmed(false)
+      return
+    }
+    if (event.key === 'Escape' && pendingClipboardPlacementRef.current) {
+      event.preventDefault()
+      cancelClipboardPlacement()
       return
     }
     if ((event.key === 'Delete' || event.key === 'Backspace') && selectedAnnotationIdRef.current) {

--- a/src/components/canvas/useClickPlacement.ts
+++ b/src/components/canvas/useClickPlacement.ts
@@ -31,6 +31,7 @@ import type {
   TapeMeasureState,
 } from '../../store/types'
 import type { DimensionAnchor, DimensionAnnotation, Point, Project, SketchFeature } from '../../types/project'
+import type { FeatureClipboardPayload } from '../../platform/featureClipboard'
 import { formatLength, parseLengthInput } from '../../utils/units'
 import { chamferDistanceFromPoint, filletRadiusFromPoint } from '../../store/helpers/referenceTransforms'
 import { resolvedProjectFeatures } from '../../store/helpers/resolveFeatures'
@@ -114,6 +115,7 @@ export interface ClickPlacementCtx {
   pendingSketchExtensionRef: MutableRefObject<PendingSketchExtension | null>
   pendingSketchFilletRef: MutableRefObject<PendingSketchFillet | null>
   sketchEditPreviewRef: MutableRefObject<SketchEditPreviewPoint | null>
+  pendingClipboardPlacementRef: MutableRefObject<FeatureClipboardPayload | null>
   originPreviewPointRef: MutableRefObject<PendingPreviewPoint | null>
   tapeMeasureRef: MutableRefObject<TapeMeasureState | null>
   constraintLabelRectsRef: MutableRefObject<Array<{ featureId: string; constraintId: string; cx: number; cy: number; halfW: number; halfH: number }>>
@@ -149,8 +151,10 @@ export interface ClickPlacementCtx {
   setPendingTransformPreviewPointRef: (nextPoint: PendingPreviewPoint | null) => void
   setPendingOffsetPreviewPointRef: (nextPoint: PendingPreviewPoint | null) => void
   setPendingOffsetRawPreviewPointRef: (nextPoint: PendingPreviewPoint | null) => void
+  setClipboardPlacementPreviewPoint: (nextPoint: Point | null) => void
 
   tapeMeasureClick: (point: Point) => void
+  placeClipboardAt: (point: Point) => void
   cancelPendingDimension: () => void
   addDimensionAnnotation: (annotation: {
     type: DimensionAnnotation['type']
@@ -241,6 +245,7 @@ export function useClickPlacement(ctx: ClickPlacementCtx): UseClickPlacementRetu
     pendingSketchExtensionRef,
     pendingSketchFilletRef,
     sketchEditPreviewRef,
+    pendingClipboardPlacementRef,
     originPreviewPointRef,
     tapeMeasureRef,
     constraintLabelRectsRef,
@@ -264,7 +269,9 @@ export function useClickPlacement(ctx: ClickPlacementCtx): UseClickPlacementRetu
     setPendingTransformPreviewPointRef,
     setPendingOffsetPreviewPointRef,
     setPendingOffsetRawPreviewPointRef,
+    setClipboardPlacementPreviewPoint,
     tapeMeasureClick,
+    placeClipboardAt,
     cancelPendingDimension,
     addDimensionAnnotation,
     pendingDimensionPick,
@@ -431,6 +438,15 @@ export function useClickPlacement(ctx: ClickPlacementCtx): UseClickPlacementRetu
         precisionOverride: null,
       })
       cancelPendingDimension()
+      return
+    }
+
+    if (pendingClipboardPlacementRef.current) {
+      if (!pickedPoint) {
+        return
+      }
+      placeClipboardAt(pickedPoint)
+      setClipboardPlacementPreviewPoint(null)
       return
     }
 

--- a/src/components/canvas/usePointerGestures.ts
+++ b/src/components/canvas/usePointerGestures.ts
@@ -30,6 +30,7 @@ import type {
   TapeMeasureState,
 } from '../../store/types'
 import type { Point, Project, SketchFeature } from '../../types/project'
+import type { FeatureClipboardPayload } from '../../platform/featureClipboard'
 import { parseLengthInput } from '../../utils/units'
 import { resolvedProjectFeatures } from '../../store/helpers/resolveFeatures'
 import {
@@ -121,6 +122,7 @@ export interface PointerGesturesCtx {
   pendingShapeActionRef: MutableRefObject<PendingShapeActionTool | null>
   pendingConstraintRef: MutableRefObject<PendingConstraint | null>
   pendingDimensionRef: MutableRefObject<PendingDimensionTool | null>
+  pendingClipboardPlacementRef: MutableRefObject<FeatureClipboardPayload | null>
   dimensionDeleteArmedRef: MutableRefObject<boolean>
   deleteHoverDimIdRef: MutableRefObject<string | null>
   pendingSketchExtensionRef: MutableRefObject<PendingSketchExtension | null>
@@ -185,6 +187,7 @@ export interface PointerGesturesCtx {
   setPendingTransformPreviewPointRef: (nextPoint: PendingPreviewPoint | null) => void
   setPendingOffsetPreviewPointRef: (nextPoint: PendingPreviewPoint | null) => void
   setPendingOffsetRawPreviewPointRef: (nextPoint: PendingPreviewPoint | null) => void
+  setClipboardPlacementPreviewPoint: (nextPoint: Point | null) => void
   setHoveredEditControl: (nextControl: SketchControlRef | null) => void
 
   // Props
@@ -268,6 +271,7 @@ export function usePointerGestures(ctx: PointerGesturesCtx): UsePointerGesturesR
     pendingShapeActionRef,
     pendingConstraintRef,
     pendingDimensionRef,
+    pendingClipboardPlacementRef,
     dimensionDeleteArmedRef,
     deleteHoverDimIdRef,
     pendingMovePreviewPointRef,
@@ -313,6 +317,7 @@ export function usePointerGestures(ctx: PointerGesturesCtx): UsePointerGesturesR
     setPendingTransformPreviewPointRef,
     setPendingOffsetPreviewPointRef,
     setPendingOffsetRawPreviewPointRef,
+    setClipboardPlacementPreviewPoint,
     setHoveredEditControl,
     zoomWindowActive,
     onZoomWindowComplete,
@@ -328,6 +333,13 @@ export function usePointerGestures(ctx: PointerGesturesCtx): UsePointerGesturesR
 
     if (event.pointerType === 'touch') {
       event.currentTarget.setPointerCapture(event.pointerId)
+    }
+
+    if (pendingClipboardPlacementRef.current) {
+      contextMenu.cancelLongPress()
+      setHoveredEditControl(null)
+      hoverFeature(null)
+      return
     }
 
     contextMenu.startLongPress(event)
@@ -478,6 +490,7 @@ export function usePointerGestures(ctx: PointerGesturesCtx): UsePointerGesturesR
     const pendingMove = pendingMoveRef.current
     const pendingTransform = pendingTransformRef.current
     const pendingOffset = pendingOffsetRef.current
+    const pendingClipboardPlacement = pendingClipboardPlacementRef.current
     const viewState = viewStateRef.current
     const vt = computeViewTransform(project.stock, canvas.width, canvas.height, viewState)
     const world = canvasToWorld(point.cx, point.cy, vt)
@@ -577,6 +590,7 @@ export function usePointerGestures(ctx: PointerGesturesCtx): UsePointerGesturesR
         || !!pendingMove
         || !!pendingTransform
         || !!pendingOffset
+        || !!pendingClipboardPlacement
         || !!tapeMeasureRef.current
         || !!pendingDimensionRef.current
         || (selection.mode === 'sketch_edit' && (sketchEditTool === 'add_point' || sketchEditTool === 'fillet' || sketchEditTool === 'chamfer'))
@@ -597,6 +611,18 @@ export function usePointerGestures(ctx: PointerGesturesCtx): UsePointerGesturesR
           : null
         : snapped
     snap.updateActiveSnap(shouldPreviewSnap ? resolvedSnap : null)
+
+    if (pendingClipboardPlacement) {
+      sketchEditPreviewRef.current = null
+      pendingSketchExtensionRef.current = null
+      pendingSketchFilletRef.current = null
+      setHoveredEditControl(null)
+      hoverFeature(null)
+      setClipboardPlacementPreviewPoint(
+        snap.requiresResolvedSnapForPointPick() && !resolvedSnap.mode ? null : snapped,
+      )
+      return
+    }
 
     if (pendingAdd) {
       sketchEditPreviewRef.current = null
@@ -996,6 +1022,7 @@ export function usePointerGestures(ctx: PointerGesturesCtx): UsePointerGesturesR
     setHoveredEditControl(null)
     setPendingOffsetPreviewPointRef(null)
     setPendingOffsetRawPreviewPointRef(null)
+    setClipboardPlacementPreviewPoint(null)
     hoverFeature(null)
     snap.updateActiveSnap(null)
     if (pendingAdd?.shape === 'polygon' || pendingAdd?.shape === 'spline' || pendingAdd?.shape === 'composite') {

--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -290,7 +290,11 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
         kind="feature"
         depth={depth}
         isSelected={selection.selectedFeatureIds.includes(feature.id)}
-        isGroupSelected={selection.groupFolderId !== null && selection.selectedFeatureIds.includes(feature.id)}
+        isGroupSelected={
+          selection.groupFolderId != null &&
+          feature.folderId === selection.groupFolderId &&
+          selection.selectedFeatureIds.includes(feature.id)
+        }
         isDragging={dragItem?.kind === 'feature' && dragItem.id === feature.id}
         visible={feature.visible}
         operation={feature.operation}

--- a/src/platform/featureClipboard.test.ts
+++ b/src/platform/featureClipboard.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  FEATURE_CLIPBOARD_OFFSET,
+  buildPastedClipboardFeatures,
+  copySelectedFeatures,
+  cutSelectedFeatures,
+  isEditableShortcutTarget,
+  pasteClipboardFeatures,
+  selectedVisibleClipboardFeatures,
+} from './featureClipboard'
+import {
+  IDENTITY_MATRIX,
+  newProject,
+  rectProfile,
+  type FeatureDefinition,
+  type Project,
+  type SketchFeature,
+} from '../types/project'
+import { useProjectStore } from '../store/projectStore'
+import { emptySelection } from '../store/slices/selectionSlice'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function rectFeature(id: string, name: string, x: number, y: number, visible = true): SketchFeature {
+  return {
+    id,
+    name,
+    kind: 'rect',
+    folderId: null,
+    sketch: {
+      profile: rectProfile(x, y, 2, 2),
+      origin: { x, y },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+    operation: 'add',
+    z_top: 5,
+    z_bottom: 0,
+    visible,
+    locked: false,
+    definitionId: `def-${id}`,
+    transform: IDENTITY_MATRIX,
+  } as SketchFeature & { definitionId: string; transform: typeof IDENTITY_MATRIX }
+}
+
+function definitionFor(feature: SketchFeature): FeatureDefinition {
+  return {
+    id: (feature as SketchFeature & { definitionId: string }).definitionId,
+    kind: feature.kind,
+    profile: feature.sketch.profile,
+    dimensions: feature.sketch.dimensions.map((dimension) => ({ ...dimension })),
+    text: feature.text ? { ...feature.text } : null,
+    stl: feature.stl ? { ...feature.stl } : null,
+    operation: feature.operation,
+  }
+}
+
+function projectWithFeatures(features: SketchFeature[]): Project {
+  const project = newProject()
+  return {
+    ...project,
+    features,
+    featureDefinitions: Object.fromEntries(
+      features.map((feature) => [definitionFor(feature).id, definitionFor(feature)])
+    ),
+    featureTree: features.map((feature) => ({ type: 'feature', featureId: feature.id })),
+  }
+}
+
+function resetStore(project: Project): void {
+  useProjectStore.setState({
+    project,
+    selection: emptySelection(),
+    history: { past: [], future: [], transactionStart: null },
+    dirty: false,
+  })
+}
+
+function testCopyUsesSelectedVisibleFeaturesOnly(): void {
+  const visible = rectFeature('f1', 'Visible', 0, 0)
+  const hidden = rectFeature('f2', 'Hidden', 5, 0, false)
+  const project = projectWithFeatures([visible, hidden])
+
+  const copied = selectedVisibleClipboardFeatures(project, ['f1', 'f2'])
+
+  assert(copied.length === 1, 'only one visible feature should be copied')
+  assert(copied[0].id === 'f1', 'visible selected feature should be copied')
+  assert(copied[0] !== visible, 'clipboard should hold a serialized feature copy')
+}
+
+function testCopyDoesNotDirtyProject(): void {
+  const feature = rectFeature('f1', 'Feature', 0, 0)
+  resetStore(projectWithFeatures([feature]))
+  useProjectStore.getState().selectFeatures(['f1'])
+  useProjectStore.setState({ dirty: false, history: { past: [], future: [], transactionStart: null } })
+
+  const copied = copySelectedFeatures(useProjectStore.getState())
+
+  assert(copied?.length === 1, 'copy should return selected feature')
+  assert(useProjectStore.getState().dirty === false, 'copy should not dirty the project')
+  assert(useProjectStore.getState().history.past.length === 0, 'copy should not add history')
+}
+
+function testCutCopiesThenDeletes(): void {
+  const feature = rectFeature('f1', 'Feature', 0, 0)
+  resetStore(projectWithFeatures([feature]))
+  useProjectStore.getState().selectFeatures(['f1'])
+  useProjectStore.setState({ dirty: false, history: { past: [], future: [], transactionStart: null } })
+
+  const cut = cutSelectedFeatures(useProjectStore.getState())
+
+  assert(cut?.length === 1, 'cut should copy selected feature')
+  assert(cut[0].id === 'f1', 'cut clipboard should preserve original feature data')
+  assert(useProjectStore.getState().project.features.length === 0, 'cut should delete original feature')
+  assert(useProjectStore.getState().dirty === true, 'cut should dirty the project')
+  assert(useProjectStore.getState().history.past.length === 1, 'cut should add one history entry')
+}
+
+function testPasteOffsetsAndSelectsPastedFeatures(): void {
+  const first = rectFeature('f1', 'First', 0, 0)
+  const second = rectFeature('f2', 'Second', 5, 5)
+  resetStore(projectWithFeatures([first, second]))
+  useProjectStore.getState().selectFeatures(['f1', 'f2'])
+  const clipboard = copySelectedFeatures(useProjectStore.getState())
+  assert(clipboard !== null, 'copy should produce clipboard payload')
+  useProjectStore.setState({ dirty: false, history: { past: [], future: [], transactionStart: null } })
+
+  const pastedIds = pasteClipboardFeatures(useProjectStore.getState(), clipboard)
+  const state = useProjectStore.getState()
+  const pasted = state.project.features.filter((feature) => pastedIds.includes(feature.id))
+
+  assert(pastedIds.length === 2, 'paste should create one feature per clipboard feature')
+  assert(new Set(pastedIds).size === 2, 'pasted feature ids should be unique')
+  assert(pasted.every((feature) => !['f1', 'f2'].includes(feature.id)), 'paste should not reuse source ids')
+  assert(state.selection.selectedFeatureIds.length === 2, 'paste should select pasted features')
+  assert(state.selection.selectedFeatureIds.every((id) => pastedIds.includes(id)), 'selection should contain pasted ids')
+  assert(state.dirty === true, 'paste should dirty the project')
+  assert(state.history.past.length === 1, 'multi-feature paste should add one history entry')
+  assert(
+    pasted[0].sketch.profile.start.x === first.sketch.profile.start.x + FEATURE_CLIPBOARD_OFFSET,
+    'paste should offset copied geometry in X',
+  )
+  assert(
+    pasted[0].sketch.profile.start.y === first.sketch.profile.start.y + FEATURE_CLIPBOARD_OFFSET,
+    'paste should offset copied geometry in Y',
+  )
+}
+
+function testIndependentPasteClonesDefinitions(): void {
+  const feature = rectFeature('f1', 'Feature', 0, 0)
+  const project = {
+    ...projectWithFeatures([feature]),
+    meta: { ...newProject().meta, copyMode: 'independent' as const },
+  }
+
+  const pasted = buildPastedClipboardFeatures([feature], project)
+
+  assert(pasted.length === 1, 'independent paste should create a feature')
+  const sourceDefinitionId = (feature as SketchFeature & { definitionId: string }).definitionId
+  const pastedDefinitionId = (pasted[0] as SketchFeature & { definitionId: string }).definitionId
+  assert(pastedDefinitionId !== sourceDefinitionId, 'independent paste should assign a cloned definition id')
+}
+
+function testEditableShortcutTargetGuard(): void {
+  const originalHTMLElement = globalThis.HTMLElement
+
+  class MockElement {
+    public readonly isContentEditable: boolean
+    private readonly closestMatch: MockElement | null
+
+    constructor(isContentEditable: boolean, closestMatch: MockElement | null) {
+      this.isContentEditable = isContentEditable
+      this.closestMatch = closestMatch
+    }
+
+    closest(_selector: string): MockElement | null {
+      return this.closestMatch
+    }
+  }
+
+  Object.defineProperty(globalThis, 'HTMLElement', {
+    configurable: true,
+    value: MockElement,
+  })
+
+  try {
+    const plain = new MockElement(false, null) as unknown as EventTarget
+    const inputLike = new MockElement(false, new MockElement(false, null)) as unknown as EventTarget
+    const editable = new MockElement(true, null) as unknown as EventTarget
+
+    assert(!isEditableShortcutTarget(plain), 'plain elements should not block clipboard shortcuts')
+    assert(isEditableShortcutTarget(inputLike), 'input-like targets should block clipboard shortcuts')
+    assert(isEditableShortcutTarget(editable), 'contenteditable targets should block clipboard shortcuts')
+  } finally {
+    Object.defineProperty(globalThis, 'HTMLElement', {
+      configurable: true,
+      value: originalHTMLElement,
+    })
+  }
+}
+
+testCopyUsesSelectedVisibleFeaturesOnly()
+testCopyDoesNotDirtyProject()
+testCutCopiesThenDeletes()
+testPasteOffsetsAndSelectsPastedFeatures()
+testIndependentPasteClonesDefinitions()
+testEditableShortcutTargetGuard()
+
+console.log('featureClipboard tests passed')

--- a/src/platform/featureClipboard.test.ts
+++ b/src/platform/featureClipboard.test.ts
@@ -15,10 +15,10 @@
  */
 
 import {
-  FEATURE_CLIPBOARD_OFFSET,
-  buildPastedClipboardFeatures,
+  buildPlacedClipboardFeatures,
   copySelectedFeatures,
   cutSelectedFeatures,
+  featureClipboardAnchor,
   isEditableShortcutTarget,
   pasteClipboardFeatures,
   selectedVisibleClipboardFeatures,
@@ -36,6 +36,10 @@ import { emptySelection } from '../store/slices/selectionSlice'
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function assertNear(actual: number, expected: number, message: string): void {
+  assert(Math.abs(actual - expected) < 1e-9, `${message}: expected ${expected}, got ${actual}`)
 }
 
 function rectFeature(id: string, name: string, x: number, y: number, visible = true): SketchFeature {
@@ -134,7 +138,7 @@ function testCutCopiesThenDeletes(): void {
   assert(useProjectStore.getState().history.past.length === 1, 'cut should add one history entry')
 }
 
-function testPasteOffsetsAndSelectsPastedFeatures(): void {
+function testPastePlacesGroupCenterAndSelectsPastedFeatures(): void {
   const first = rectFeature('f1', 'First', 0, 0)
   const second = rectFeature('f2', 'Second', 5, 5)
   resetStore(projectWithFeatures([first, second]))
@@ -143,9 +147,10 @@ function testPasteOffsetsAndSelectsPastedFeatures(): void {
   assert(clipboard !== null, 'copy should produce clipboard payload')
   useProjectStore.setState({ dirty: false, history: { past: [], future: [], transactionStart: null } })
 
-  const pastedIds = pasteClipboardFeatures(useProjectStore.getState(), clipboard)
+  const pastedIds = pasteClipboardFeatures(useProjectStore.getState(), clipboard, { x: 20, y: 30 })
   const state = useProjectStore.getState()
   const pasted = state.project.features.filter((feature) => pastedIds.includes(feature.id))
+  const pastedAnchor = featureClipboardAnchor(pasted)
 
   assert(pastedIds.length === 2, 'paste should create one feature per clipboard feature')
   assert(new Set(pastedIds).size === 2, 'pasted feature ids should be unique')
@@ -154,14 +159,9 @@ function testPasteOffsetsAndSelectsPastedFeatures(): void {
   assert(state.selection.selectedFeatureIds.every((id) => pastedIds.includes(id)), 'selection should contain pasted ids')
   assert(state.dirty === true, 'paste should dirty the project')
   assert(state.history.past.length === 1, 'multi-feature paste should add one history entry')
-  assert(
-    pasted[0].sketch.profile.start.x === first.sketch.profile.start.x + FEATURE_CLIPBOARD_OFFSET,
-    'paste should offset copied geometry in X',
-  )
-  assert(
-    pasted[0].sketch.profile.start.y === first.sketch.profile.start.y + FEATURE_CLIPBOARD_OFFSET,
-    'paste should offset copied geometry in Y',
-  )
+  assert(pastedAnchor !== null, 'pasted features should have an anchor')
+  assertNear(pastedAnchor.x, 20, 'paste should place group center at clicked X')
+  assertNear(pastedAnchor.y, 30, 'paste should place group center at clicked Y')
 }
 
 function testIndependentPasteClonesDefinitions(): void {
@@ -171,7 +171,7 @@ function testIndependentPasteClonesDefinitions(): void {
     meta: { ...newProject().meta, copyMode: 'independent' as const },
   }
 
-  const pasted = buildPastedClipboardFeatures([feature], project)
+  const pasted = buildPlacedClipboardFeatures([feature], project, { x: 20, y: 20 })
 
   assert(pasted.length === 1, 'independent paste should create a feature')
   const sourceDefinitionId = (feature as SketchFeature & { definitionId: string }).definitionId
@@ -220,7 +220,7 @@ function testEditableShortcutTargetGuard(): void {
 testCopyUsesSelectedVisibleFeaturesOnly()
 testCopyDoesNotDirtyProject()
 testCutCopiesThenDeletes()
-testPasteOffsetsAndSelectsPastedFeatures()
+testPastePlacesGroupCenterAndSelectsPastedFeatures()
 testIndependentPasteClonesDefinitions()
 testEditableShortcutTargetGuard()
 

--- a/src/platform/featureClipboard.ts
+++ b/src/platform/featureClipboard.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Project, SketchFeature } from '../types/project'
+import { buildCopiedFeatures } from '../store/helpers/copyFeatures'
+import type { ProjectStore } from '../store/types'
+
+export type FeatureClipboardPayload = SketchFeature[]
+
+export const FEATURE_CLIPBOARD_OFFSET = 10
+
+export function isEditableShortcutTarget(target: EventTarget | null): boolean {
+  if (typeof HTMLElement === 'undefined') {
+    return false
+  }
+
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  if (target.isContentEditable) {
+    return true
+  }
+
+  return target.closest('input, textarea, select, [contenteditable=""], [contenteditable="true"]') !== null
+}
+
+export function selectedVisibleClipboardFeatures(project: Project, selectedFeatureIds: string[]): FeatureClipboardPayload {
+  const selectedIds = new Set(selectedFeatureIds)
+  return project.features
+    .filter((feature) => selectedIds.has(feature.id) && feature.visible)
+    .map((feature) => JSON.parse(JSON.stringify(feature)) as SketchFeature)
+}
+
+export function buildPastedClipboardFeatures(
+  clipboard: FeatureClipboardPayload,
+  project: Project,
+): SketchFeature[] {
+  if (clipboard.length === 0) {
+    return []
+  }
+
+  return buildCopiedFeatures(
+    clipboard,
+    project.features,
+    FEATURE_CLIPBOARD_OFFSET,
+    FEATURE_CLIPBOARD_OFFSET,
+    1,
+    project.featureDefinitions,
+    project.meta.copyMode,
+  )
+}
+
+export function copySelectedFeatures(store: ProjectStore): FeatureClipboardPayload | null {
+  const features = selectedVisibleClipboardFeatures(store.project, store.selection.selectedFeatureIds)
+  return features.length > 0 ? features : null
+}
+
+export function cutSelectedFeatures(store: ProjectStore): FeatureClipboardPayload | null {
+  const features = copySelectedFeatures(store)
+  if (!features) {
+    return null
+  }
+
+  store.deleteFeatures(features.map((feature) => feature.id))
+  return features
+}
+
+export function pasteClipboardFeatures(store: ProjectStore, clipboard: FeatureClipboardPayload): string[] {
+  const features = buildPastedClipboardFeatures(clipboard, store.project)
+  if (features.length === 0) {
+    return []
+  }
+
+  store.beginHistoryTransaction()
+  for (const feature of features) {
+    store.addFeature(feature)
+  }
+  store.selectFeatures(features.map((feature) => feature.id))
+  store.commitHistoryTransaction()
+  return features.map((feature) => feature.id)
+}

--- a/src/platform/featureClipboard.ts
+++ b/src/platform/featureClipboard.ts
@@ -14,13 +14,21 @@
  * limitations under the License.
  */
 
-import type { Project, SketchFeature } from '../types/project'
+import { getProfileBounds } from '../types/project'
+import type { Point, Project, SketchFeature } from '../types/project'
 import { buildCopiedFeatures } from '../store/helpers/copyFeatures'
 import type { ProjectStore } from '../store/types'
 
 export type FeatureClipboardPayload = SketchFeature[]
 
-export const FEATURE_CLIPBOARD_OFFSET = 10
+export const FEATURE_CLIPBOARD_PLACEMENT_EVENT = 'purecutcnc:place-feature-clipboard'
+
+export interface FeatureClipboardBounds {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
 
 export function isEditableShortcutTarget(target: EventTarget | null): boolean {
   if (typeof HTMLElement === 'undefined') {
@@ -45,19 +53,49 @@ export function selectedVisibleClipboardFeatures(project: Project, selectedFeatu
     .map((feature) => JSON.parse(JSON.stringify(feature)) as SketchFeature)
 }
 
-export function buildPastedClipboardFeatures(
+export function featureClipboardBounds(clipboard: FeatureClipboardPayload): FeatureClipboardBounds | null {
+  let bounds: FeatureClipboardBounds | null = null
+
+  for (const feature of clipboard) {
+    const featureBounds = getProfileBounds(feature.sketch.profile)
+    bounds = bounds
+      ? {
+          minX: Math.min(bounds.minX, featureBounds.minX),
+          minY: Math.min(bounds.minY, featureBounds.minY),
+          maxX: Math.max(bounds.maxX, featureBounds.maxX),
+          maxY: Math.max(bounds.maxY, featureBounds.maxY),
+        }
+      : { ...featureBounds }
+  }
+
+  return bounds
+}
+
+export function featureClipboardAnchor(clipboard: FeatureClipboardPayload): Point | null {
+  const bounds = featureClipboardBounds(clipboard)
+  return bounds
+    ? {
+        x: (bounds.minX + bounds.maxX) / 2,
+        y: (bounds.minY + bounds.maxY) / 2,
+      }
+    : null
+}
+
+export function buildPlacedClipboardFeatures(
   clipboard: FeatureClipboardPayload,
   project: Project,
+  placementPoint: Point,
 ): SketchFeature[] {
-  if (clipboard.length === 0) {
+  const anchor = featureClipboardAnchor(clipboard)
+  if (!anchor) {
     return []
   }
 
   return buildCopiedFeatures(
     clipboard,
     project.features,
-    FEATURE_CLIPBOARD_OFFSET,
-    FEATURE_CLIPBOARD_OFFSET,
+    placementPoint.x - anchor.x,
+    placementPoint.y - anchor.y,
     1,
     project.featureDefinitions,
     project.meta.copyMode,
@@ -79,8 +117,12 @@ export function cutSelectedFeatures(store: ProjectStore): FeatureClipboardPayloa
   return features
 }
 
-export function pasteClipboardFeatures(store: ProjectStore, clipboard: FeatureClipboardPayload): string[] {
-  const features = buildPastedClipboardFeatures(clipboard, store.project)
+export function pasteClipboardFeatures(
+  store: ProjectStore,
+  clipboard: FeatureClipboardPayload,
+  placementPoint: Point,
+): string[] {
+  const features = buildPlacedClipboardFeatures(clipboard, store.project, placementPoint)
   if (features.length === 0) {
     return []
   }

--- a/src/platform/useDesktopIntegration.ts
+++ b/src/platform/useDesktopIntegration.ts
@@ -23,8 +23,8 @@ import { checkDesktopUpdate, loadChannel, saveChannel } from '../utils/updateChe
 import {
   copySelectedFeatures,
   cutSelectedFeatures,
+  FEATURE_CLIPBOARD_PLACEMENT_EVENT,
   isEditableShortcutTarget,
-  pasteClipboardFeatures,
   type FeatureClipboardPayload,
 } from './featureClipboard'
 
@@ -120,7 +120,14 @@ function runFeatureClipboardCommand(
       return cut !== null
     }
     case 'paste':
-      return pasteClipboardFeatures(store, clipboardRef.current).length > 0
+      if (clipboardRef.current.length === 0) {
+        return false
+      }
+      window.dispatchEvent(new CustomEvent<FeatureClipboardPayload>(
+        FEATURE_CLIPBOARD_PLACEMENT_EVENT,
+        { detail: clipboardRef.current },
+      ))
+      return true
   }
 }
 

--- a/src/platform/useDesktopIntegration.ts
+++ b/src/platform/useDesktopIntegration.ts
@@ -15,10 +15,18 @@
  */
 
 import { useEffect, useRef } from 'react'
+import type { MutableRefObject } from 'react'
 import { readTextFile } from '@tauri-apps/plugin-fs'
 import { useProjectStore } from '../store/projectStore'
 import { platform } from './index'
 import { checkDesktopUpdate, loadChannel, saveChannel } from '../utils/updateCheck'
+import {
+  copySelectedFeatures,
+  cutSelectedFeatures,
+  isEditableShortcutTarget,
+  pasteClipboardFeatures,
+  type FeatureClipboardPayload,
+} from './featureClipboard'
 
 /**
  * Run the user-initiated desktop update check and report the result via native
@@ -88,6 +96,34 @@ interface DesktopIntegrationOptions {
   onExportGcode: () => void
 }
 
+type FeatureClipboardCommand = 'copy' | 'cut' | 'paste'
+
+function runFeatureClipboardCommand(
+  command: FeatureClipboardCommand,
+  target: EventTarget | null,
+  clipboardRef: MutableRefObject<FeatureClipboardPayload>,
+): boolean {
+  if (isEditableShortcutTarget(target)) {
+    return false
+  }
+
+  const store = useProjectStore.getState()
+  switch (command) {
+    case 'copy': {
+      const copied = copySelectedFeatures(store)
+      if (copied) clipboardRef.current = copied
+      return copied !== null
+    }
+    case 'cut': {
+      const cut = cutSelectedFeatures(store)
+      if (cut) clipboardRef.current = cut
+      return cut !== null
+    }
+    case 'paste':
+      return pasteClipboardFeatures(store, clipboardRef.current).length > 0
+  }
+}
+
 /**
  * Wires up all desktop-specific shell behaviours:
  *  - document.title + Tauri window title updated with file name + dirty indicator
@@ -102,6 +138,7 @@ export function useDesktopIntegration({ onExportGcode }: DesktopIntegrationOptio
   // Keep a ref so event handlers always call the latest version without
   // needing to be re-registered when the callback identity changes.
   const onExportGcodeRef = useRef(onExportGcode)
+  const featureClipboardRef = useRef<FeatureClipboardPayload>([])
   useEffect(() => {
     onExportGcodeRef.current = onExportGcode
   })
@@ -129,6 +166,33 @@ export function useDesktopIntegration({ onExportGcode }: DesktopIntegrationOptio
       getSetWindowTitle().then((setTitle) => setTitle(title))
     }
   }, [filePath, dirty, projectName])
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if ((!event.metaKey && !event.ctrlKey) || event.altKey) {
+        return
+      }
+
+      const key = event.key.toLowerCase()
+      const command: FeatureClipboardCommand | null =
+        key === 'c' ? 'copy'
+        : key === 'x' ? 'cut'
+        : key === 'v' ? 'paste'
+        : null
+      if (!command) {
+        return
+      }
+
+      const handled = runFeatureClipboardCommand(command, event.target, featureClipboardRef)
+      if (handled) {
+        event.preventDefault()
+        event.stopPropagation()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [])
 
   // -------------------------------------------------------------------------
   // Desktop-only: window close prompt, menu events, drag-and-drop
@@ -265,6 +329,11 @@ export function useDesktopIntegration({ onExportGcode }: DesktopIntegrationOptio
             store.selectFeatures(visibleIds)
             break
           }
+          case 'copy':
+          case 'cut':
+          case 'paste':
+            runFeatureClipboardCommand(event.payload, document.activeElement, featureClipboardRef)
+            break
           case 'undo':
             store.undo()
             break

--- a/src/store/slices/featureSlice.ts
+++ b/src/store/slices/featureSlice.ts
@@ -434,14 +434,16 @@ export function createFeatureSlice(
 
     addFeature: (feature) =>
       set((s) => {
-        const safeId = s.project.features.some((existing) => existing.id === feature.id)
+        const { _clonedDefinition: clonedDefinition, ...featureForInsert } =
+          feature as SketchFeature & { _clonedDefinition?: FeatureDefinition }
+        const safeId = s.project.features.some((existing) => existing.id === featureForInsert.id)
           ? nextUniqueGeneratedId(s.project, 'f')
-          : feature.id
-        const isFirstMachiningFeature = feature.operation !== 'region'
+          : featureForInsert.id
+        const isFirstMachiningFeature = featureForInsert.operation !== 'region'
           && !s.project.features.some((existing) => existing.operation !== 'region')
-        const preserveImportedModelOperation = isFirstMachiningFeature && isImportedModelFeature(feature)
+        const preserveImportedModelOperation = isFirstMachiningFeature && isImportedModelFeature(featureForInsert)
         const selectedNode = s.selection.selectedNode
-        let effectiveFolderId: string | null = feature.folderId ?? null
+        let effectiveFolderId: string | null = featureForInsert.folderId ?? null
         let insertAfterFeatureId: string | null = null
         if (selectedNode?.type === 'folder') {
           effectiveFolderId = selectedNode.folderId
@@ -454,15 +456,15 @@ export function createFeatureSlice(
           ? s.project.featureFolders.find((folder) => folder.id === effectiveFolderId) ?? null
           : null
         const effectiveFolderSection = effectiveFolder?.section ?? 'features'
-        if (feature.operation === 'region' && effectiveFolderSection !== 'regions') {
+        if (featureForInsert.operation === 'region' && effectiveFolderSection !== 'regions') {
           effectiveFolderId = null
         }
-        if (feature.operation !== 'region' && effectiveFolderSection === 'regions') {
+        if (featureForInsert.operation !== 'region' && effectiveFolderSection === 'regions') {
           effectiveFolderId = null
         }
         const safeFeatureBase: SketchFeature = isFirstMachiningFeature && !preserveImportedModelOperation
-          ? normalizeFeatureZRange({ ...feature, id: safeId, folderId: effectiveFolderId, operation: 'add' })
-          : normalizeFeatureZRange({ ...feature, id: safeId, folderId: effectiveFolderId })
+          ? normalizeFeatureZRange({ ...featureForInsert, id: safeId, folderId: effectiveFolderId, operation: 'add' })
+          : normalizeFeatureZRange({ ...featureForInsert, id: safeId, folderId: effectiveFolderId })
         const nextModelAssets = { ...s.project.modelAssets }
         let safeFeature: SketchFeature = {
           ...safeFeatureBase,
@@ -473,7 +475,7 @@ export function createFeatureSlice(
         // (idempotent — snapshot results and migrated features already carry
         // an explicit definitionId and are left untouched).
         const featureHasExplicitDefId =
-          (feature as SketchFeature & { definitionId?: string }).definitionId !== undefined
+          (featureForInsert as SketchFeature & { definitionId?: string }).definitionId !== undefined
         let nextDefinitions = { ...s.project.featureDefinitions }
 
         if (!featureHasExplicitDefId) {
@@ -484,6 +486,8 @@ export function createFeatureSlice(
             transform: IDENTITY_MATRIX,
           } as SketchFeature & { definitionId?: string; transform?: Matrix2D }
           nextDefinitions = { ...nextDefinitions, [minted.definitionId]: minted.definition }
+        } else if (clonedDefinition) {
+          nextDefinitions = { ...nextDefinitions, [clonedDefinition.id]: clonedDefinition }
         }
 
         let nextFeatures: SketchFeature[]
@@ -515,16 +519,24 @@ export function createFeatureSlice(
           featureDefinitions: nextDefinitions,
           meta: { ...s.project.meta, modified: new Date().toISOString() },
         })
-        return {
+        const result = {
           project: nextProject,
           selection: {
             ...s.selection,
             selectedFeatureId: safeFeature.id,
             selectedFeatureIds: [safeFeature.id],
-            selectedNode: { type: 'feature', featureId: safeFeature.id },
-            mode: 'feature',
+            selectedNode: { type: 'feature' as const, featureId: safeFeature.id },
+            mode: 'feature' as const,
             activeControl: null,
           },
+        }
+
+        if (s.history.transactionStart) {
+          return result
+        }
+
+        return {
+          ...result,
           history: {
             past: [...s.history.past, cloneProject(s.project)].slice(-100),
             future: [],


### PR DESCRIPTION
## Summary
- Add an in-memory feature clipboard for selected visible features with copy, cut, and paste behavior
- Route native desktop Copy/Cut/Paste menu items through app-owned menu IDs and shared frontend handlers
- Add Cmd/Ctrl+C/X/V handling with editable-target guards
- Preserve independent/reference copy semantics and make multi-feature paste one history transaction

Closes #183

## Verification
- `npx tsx src/platform/featureClipboard.test.ts`
- `git diff --check`
- `npm run build`
