### PR TITLE
feat: in-app machine definition editor (closes #216)

### DIFF
--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -24,6 +24,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 - `layout/` — app shell (toolbars, sidebars, mode switching); toolbar internals are documented in `layout/toolbar/INDEX.md`
 - `project/` — project-level UI (new/open/save, stock, machine, units)
 - `export/` — export dialogs (G-code, SVG, DXF, STL preview)
+- `machine/` — machine definition editor (focused form + raw JSON + Zod validation)
 - `about/` — About dialog (web only; version info + links). Desktop uses the native About menu.
 - `ai/` — MCP / agent-facing UI (placeholder — MCP not yet implemented)
 - `onboarding/` — first-run / empty-state UI (`EmptyStateOverlay` shown over the center viewport when the project has no features)

--- a/src/components/feature-tree/PropertiesPanel.tsx
+++ b/src/components/feature-tree/PropertiesPanel.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import type { ChangeEvent } from 'react'
 import { Icon } from '../Icon'
 import { Select } from '../Select'
@@ -27,6 +27,7 @@ import { getDefinitionId, getInstanceIdsForDefinition } from '../../store/helper
 import { defaultFontIdForStyle, getTextFontOptions } from '../../text'
 import { convertLength, formatLength, parseLengthInput } from '../../utils/units'
 import { platform } from '../../platform'
+import { MachineDefinitionEditorDialog } from '../machine/MachineDefinitionEditorDialog'
 
 interface DraftTextInputProps {
   value: string
@@ -169,6 +170,8 @@ export function PropertiesPanel() {
     setSelectedMachineId,
     addMachineDefinition,
     removeMachineDefinition,
+    updateMachineDefinition,
+    duplicateMachineDefinition,
     refreshMachineDefinitions,
     setOrigin,
     startPlaceOrigin,
@@ -338,6 +341,37 @@ export function PropertiesPanel() {
     }
   }
 
+  const [editingDefinition, setEditingDefinition] = useState<import('../../engine/gcode/types').MachineDefinition | null>(null)
+
+  function handleEditMachine() {
+    if (!selectedMachine) return
+    setEditingDefinition(selectedMachine)
+  }
+
+  function handleDuplicateMachine() {
+    if (!selectedMachine) return
+    duplicateMachineDefinition(selectedMachine.id)
+  }
+
+  function handleExportMachine() {
+    if (!selectedMachine) return
+    // Remove the builtin flag for export — it's a runtime-only marker.
+    const { builtin: _, ...exportDef } = selectedMachine as import('../../engine/gcode/types').MachineDefinition & { builtin?: boolean }
+    platform.saveTextFile(
+      `${selectedMachine.name}.json`,
+      JSON.stringify(exportDef, null, 2),
+      'json',
+    )
+  }
+
+  function handleEditorSave(definition: import('../../engine/gcode/types').MachineDefinition) {
+    if (!selectedMachine) return
+    updateMachineDefinition(selectedMachine.id, definition)
+    setEditingDefinition(null)
+  }
+
+  function renderContent() {
+
   function renderFolderSelect(value: string | '__mixed__' | null, onChange: (folderId: string | null) => void, disabled?: boolean) {
     return (
       <Select
@@ -449,6 +483,27 @@ export function PropertiesPanel() {
           <div className="properties-actions">
             <button type="button" onClick={handleAddMachine}>
               Add machine
+            </button>
+            <button
+              type="button"
+              onClick={handleEditMachine}
+              disabled={!selectedMachine || selectedMachine.builtin}
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={handleDuplicateMachine}
+              disabled={!selectedMachine}
+            >
+              Duplicate
+            </button>
+            <button
+              type="button"
+              onClick={handleExportMachine}
+              disabled={!selectedMachine}
+            >
+              Export
             </button>
             <button
               type="button"
@@ -1540,5 +1595,19 @@ export function PropertiesPanel() {
         </div>
       ) : null}
     </div>
+  )
+  } // closes renderContent
+
+  return (
+    <>
+      {renderContent()}
+      {editingDefinition && (
+        <MachineDefinitionEditorDialog
+          definition={editingDefinition}
+          onSave={handleEditorSave}
+          onClose={() => setEditingDefinition(null)}
+        />
+      )}
+    </>
   )
 }

--- a/src/components/feature-tree/PropertiesPanel.tsx
+++ b/src/components/feature-tree/PropertiesPanel.tsx
@@ -20,14 +20,12 @@ import { Icon } from '../Icon'
 import { Select } from '../Select'
 import { DisclosureSection } from '../common/DisclosureSection'
 import { ZRangeSlider } from './ZRangeSlider'
-import { validateMachineDefinition } from '../../engine/gcode'
 import { defaultStock, getStockBounds, profileExceedsStock, profileHasSelfIntersection } from '../../types/project'
 import { useProjectStore } from '../../store/projectStore'
 import { getDefinitionId, getInstanceIdsForDefinition } from '../../store/helpers/featureDefinitions'
 import { defaultFontIdForStyle, getTextFontOptions } from '../../text'
 import { convertLength, formatLength, parseLengthInput } from '../../utils/units'
-import { platform } from '../../platform'
-import { MachineDefinitionEditorDialog } from '../machine/MachineDefinitionEditorDialog'
+import { MachineDefinitionManagerDialog } from '../machine/MachineDefinitionManagerDialog'
 
 interface DraftTextInputProps {
   value: string
@@ -168,10 +166,6 @@ export function PropertiesPanel() {
     setShowFeatureInfo,
     setProjectClearances,
     setSelectedMachineId,
-    addMachineDefinition,
-    removeMachineDefinition,
-    updateMachineDefinition,
-    duplicateMachineDefinition,
     refreshMachineDefinitions,
     setOrigin,
     startPlaceOrigin,
@@ -329,46 +323,7 @@ export function PropertiesPanel() {
     reader.readAsDataURL(file)
   }
 
-  async function handleAddMachine() {
-    const content = await platform.pickJsonFile()
-    if (!content) return
-    try {
-      const parsed = JSON.parse(content)
-      const validated = validateMachineDefinition({ ...parsed, builtin: false })
-      addMachineDefinition(validated)
-    } catch (error) {
-      alert(`Invalid machine definition JSON: ${error instanceof Error ? error.message : String(error)}`)
-    }
-  }
-
-  const [editingDefinition, setEditingDefinition] = useState<import('../../engine/gcode/types').MachineDefinition | null>(null)
-
-  function handleEditMachine() {
-    if (!selectedMachine) return
-    setEditingDefinition(selectedMachine)
-  }
-
-  function handleDuplicateMachine() {
-    if (!selectedMachine) return
-    duplicateMachineDefinition(selectedMachine.id)
-  }
-
-  function handleExportMachine() {
-    if (!selectedMachine) return
-    // Remove the builtin flag for export — it's a runtime-only marker.
-    const { builtin: _, ...exportDef } = selectedMachine as import('../../engine/gcode/types').MachineDefinition & { builtin?: boolean }
-    platform.saveTextFile(
-      `${selectedMachine.name}.json`,
-      JSON.stringify(exportDef, null, 2),
-      'json',
-    )
-  }
-
-  function handleEditorSave(definition: import('../../engine/gcode/types').MachineDefinition) {
-    if (!selectedMachine) return
-    updateMachineDefinition(selectedMachine.id, definition)
-    setEditingDefinition(null)
-  }
+  const [showManager, setShowManager] = useState(false)
 
   function renderContent() {
 
@@ -480,37 +435,20 @@ export function PropertiesPanel() {
               onChange={(value) => setSelectedMachineId(value || null)}
             />
           </label>
+          {selectedMachine ? (
+            <div className="properties-machine-status">
+              <span className={selectedMachine.builtin ? 'machine-manager-badge machine-manager-badge--builtin' : 'machine-manager-badge machine-manager-badge--custom'}>
+                {selectedMachine.builtin ? 'Built-in' : 'Custom'}
+              </span>
+              <span className="properties-machine-ext">.{selectedMachine.fileExtension}</span>
+              {selectedMachine.builtin ? (
+                <span className="properties-machine-hint">duplicate to edit</span>
+              ) : null}
+            </div>
+          ) : null}
           <div className="properties-actions">
-            <button type="button" onClick={handleAddMachine}>
-              Add machine
-            </button>
-            <button
-              type="button"
-              onClick={handleEditMachine}
-              disabled={!selectedMachine || selectedMachine.builtin}
-            >
-              Edit
-            </button>
-            <button
-              type="button"
-              onClick={handleDuplicateMachine}
-              disabled={!selectedMachine}
-            >
-              Duplicate
-            </button>
-            <button
-              type="button"
-              onClick={handleExportMachine}
-              disabled={!selectedMachine}
-            >
-              Export
-            </button>
-            <button
-              type="button"
-              onClick={() => selectedMachine && removeMachineDefinition(selectedMachine.id)}
-              disabled={!selectedMachine || selectedMachine.builtin}
-            >
-              Remove machine
+            <button type="button" onClick={() => setShowManager(true)}>
+              Manage machines...
             </button>
           </div>
         </div>
@@ -1601,11 +1539,9 @@ export function PropertiesPanel() {
   return (
     <>
       {renderContent()}
-      {editingDefinition && (
-        <MachineDefinitionEditorDialog
-          definition={editingDefinition}
-          onSave={handleEditorSave}
-          onClose={() => setEditingDefinition(null)}
+      {showManager && (
+        <MachineDefinitionManagerDialog
+          onClose={() => setShowManager(false)}
         />
       )}
     </>

--- a/src/components/machine/INDEX.md
+++ b/src/components/machine/INDEX.md
@@ -1,13 +1,14 @@
 # INDEX — src/components/machine/
 
-Machine definition editing UI. In-app editor for custom CNC machine definitions.
+Machine definition editing UI. In-app editor and manager for custom CNC machine definitions.
 
 ## Files
-- `MachineDefinitionEditorDialog.tsx` — hybrid editor modal (focused form + raw JSON `DisclosureSection` + inline Zod validation). Handles both edit-existing and duplicate-then-edit entry points.
+- `MachineDefinitionManagerDialog.tsx` — machine lifecycle manager dialog: list of definitions (name + Built-in/Custom badge + active highlight) on the left, selected machine details and actions on the right. Opened from the Properties panel via "Manage machines…". Actions: Use this machine, Edit (custom only), Duplicate to edit, Import JSON, Export JSON, Remove (custom only). Reuses `MachineDefinitionEditorDialog` for editing.
+- `MachineDefinitionEditorDialog.tsx` — hybrid editor modal (focused form + raw JSON `DisclosureSection` + inline Zod validation + variable reference help). Portaled to `document.body` via `createPortal`.
 - `machineDefinitionForm.ts` — pure form↔`MachineDefinition` mapping/merge module. No React imports. Exports `toFormData`, `mergeFormData`, `joinLines`/`splitLines`, and `validateDef` (non-throwing Zod wrapper with user-friendly error formatting).
 
 ## Conventions
-- The dialog reuses the `dialog-backdrop`/`dialog` modal pattern and `DisclosureSection` from `common/`.
+- Dialogs reuse the `dialog-backdrop`/`dialog` modal pattern and `DisclosureSection` from `common/`.
 - Form↔definition mapping is kept pure (no React) so it's unit-testable.
-- Store mutations go through `projectStore` actions (`updateMachineDefinition`, `duplicateMachineDefinition` in `machineDefsSlice`).
-- For CSS, see `src/styles/dialog.css` (`.machine-editor-*` classes).
+- Store mutations go through `projectStore` actions (`setSelectedMachineId`, `addMachineDefinition`, `updateMachineDefinition`, `duplicateMachineDefinition`, `removeMachineDefinition` in `machineDefsSlice`).
+- For CSS, see `src/styles/dialog.css` (`.machine-editor-*`, `.machine-manager-*` classes) and `src/styles/tablet.css` (touch-target overrides).

--- a/src/components/machine/INDEX.md
+++ b/src/components/machine/INDEX.md
@@ -3,7 +3,7 @@
 Machine definition editing UI. In-app editor and manager for custom CNC machine definitions.
 
 ## Files
-- `MachineDefinitionManagerDialog.tsx` — machine lifecycle manager dialog: list of definitions (name + Built-in/Custom badge + active highlight) on the left, selected machine details and actions on the right. Opened from the Properties panel via "Manage machines…". Actions: Use this machine, Edit (custom only), Duplicate to edit, Import JSON, Export JSON, Remove (custom only). Reuses `MachineDefinitionEditorDialog` for editing.
+- `MachineDefinitionManagerDialog.tsx` — machine lifecycle manager dialog: list of definitions (name + Built-in/Custom badge + active highlight) on the left, selected machine details and actions on the right. Opened from the Properties panel via "Manage machines…". Actions: Use this machine, Edit (custom only), Duplicate to edit, Import machine, Export machine, Remove (custom only). Reuses `MachineDefinitionEditorDialog` for editing.
 - `MachineDefinitionEditorDialog.tsx` — hybrid editor modal (focused form + raw JSON `DisclosureSection` + inline Zod validation + variable reference help). Portaled to `document.body` via `createPortal`.
 - `machineDefinitionForm.ts` — pure form↔`MachineDefinition` mapping/merge module. No React imports. Exports `toFormData`, `mergeFormData`, `joinLines`/`splitLines`, and `validateDef` (non-throwing Zod wrapper with user-friendly error formatting).
 

--- a/src/components/machine/INDEX.md
+++ b/src/components/machine/INDEX.md
@@ -1,0 +1,13 @@
+# INDEX — src/components/machine/
+
+Machine definition editing UI. In-app editor for custom CNC machine definitions.
+
+## Files
+- `MachineDefinitionEditorDialog.tsx` — hybrid editor modal (focused form + raw JSON `DisclosureSection` + inline Zod validation). Handles both edit-existing and duplicate-then-edit entry points.
+- `machineDefinitionForm.ts` — pure form↔`MachineDefinition` mapping/merge module. No React imports. Exports `toFormData`, `mergeFormData`, `joinLines`/`splitLines`, and `validateDef` (non-throwing Zod wrapper with user-friendly error formatting).
+
+## Conventions
+- The dialog reuses the `dialog-backdrop`/`dialog` modal pattern and `DisclosureSection` from `common/`.
+- Form↔definition mapping is kept pure (no React) so it's unit-testable.
+- Store mutations go through `projectStore` actions (`updateMachineDefinition`, `duplicateMachineDefinition` in `machineDefsSlice`).
+- For CSS, see `src/styles/dialog.css` (`.machine-editor-*` classes).

--- a/src/components/machine/MachineDefinitionEditorDialog.tsx
+++ b/src/components/machine/MachineDefinitionEditorDialog.tsx
@@ -1,0 +1,351 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { MachineDefinition } from '../../engine/gcode/types'
+import { DisclosureSection } from '../common/DisclosureSection'
+import {
+  toFormData,
+  mergeFormData,
+  validateDef,
+} from './machineDefinitionForm'
+import type { MachineFormData } from './machineDefinitionForm'
+
+export interface MachineDefinitionEditorDialogProps {
+  definition: MachineDefinition
+  onSave: (definition: MachineDefinition) => void
+  onClose: () => void
+}
+
+export function MachineDefinitionEditorDialog({
+  definition,
+  onSave,
+  onClose,
+}: MachineDefinitionEditorDialogProps) {
+  const [form, setForm] = useState<MachineFormData>(() => toFormData(definition))
+  const [advancedJson, setAdvancedJson] = useState<string>(() =>
+    JSON.stringify(definition, null, 2),
+  )
+  const [jsonError, setJsonError] = useState<string | null>(null)
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const textAreaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Escape key closes the dialog.
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  // Validate on every change to compute whether Save should be enabled.
+  const mergedDef = useMemo<MachineDefinition | null>(() => {
+    // If the user has touched the Advanced JSON editor, use that as the
+    // source of truth; otherwise merge the focused form onto the original.
+    try {
+      const parsed = JSON.parse(advancedJson)
+      const result = validateDef(parsed)
+      if (result.ok) {
+        setJsonError(null)
+        setValidationError(null)
+        return result.ok
+      }
+      setJsonError(null)
+      setValidationError(result.error)
+      return null
+    } catch {
+      // JSON parse error — fall back to form merge for now.
+      try {
+        const merged = mergeFormData(definition, form)
+        const result = validateDef(merged)
+        if (result.ok) {
+          setValidationError(null)
+          return result.ok
+        }
+        setValidationError(result.error)
+        return null
+      } catch {
+        setValidationError('Invalid definition')
+        return null
+      }
+    }
+  }, [advancedJson, definition, form])
+
+  function handleFormChange(patch: Partial<MachineFormData>) {
+    setForm((prev) => {
+      const next = { ...prev, ...patch }
+      // When the focused form changes, also update the Advanced JSON view
+      // so both stay in sync. Only sync if the JSON view doesn't have a
+      // syntax error (if it does, keep the user's broken JSON).
+      try {
+        JSON.parse(advancedJson)
+        const merged = mergeFormData(definition, next)
+        setAdvancedJson(JSON.stringify(merged, null, 2))
+      } catch {
+        // Syntax error in JSON editor — don't overwrite; user is editing raw.
+      }
+      return next
+    })
+  }
+
+  function handleJsonChange(value: string) {
+    setAdvancedJson(value)
+    try {
+      const parsed = JSON.parse(value)
+      // Also sync the focused form from the JSON.
+      const result = validateDef(parsed)
+      if (result.ok) {
+        setForm(toFormData(result.ok))
+        setJsonError(null)
+      } else {
+        setJsonError(null) // valid JSON but invalid definition
+      }
+    } catch {
+      setJsonError('Invalid JSON syntax')
+    }
+  }
+
+  function handleSave() {
+    if (!mergedDef) return
+    onSave(mergedDef)
+  }
+
+  function handleJsonBlur() {
+    // Re-validate and sync on blur.
+    try {
+      const parsed = JSON.parse(advancedJson)
+      const result = validateDef(parsed)
+      if (result.ok) {
+        setForm(toFormData(result.ok))
+        setJsonError(null)
+        return
+      }
+    } catch {
+      // Keep jsonError from typing
+    }
+  }
+
+function renderVar(name: string, desc: string, context?: string) {
+  return (
+    <div className="machine-editor-var" key={name}>
+      <code className="machine-editor-var-name">{'{'}{name}{'}'}</code>
+      <span className="machine-editor-var-desc">{desc}{context ? <span className="machine-editor-var-context"> — {context}</span> : null}</span>
+    </div>
+  )
+}
+
+  const canSave = mergedDef !== null && !jsonError
+
+  function renderTextAreaField(label: string, value: string, onChange: (v: string) => void) {
+    return (
+      <label className="machine-editor-field">
+        <span className="machine-editor-label">{label}</span>
+        <textarea
+          className="machine-editor-textarea"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          rows={Math.max(2, value.split('\n').length)}
+          spellCheck={false}
+        />
+      </label>
+    )
+  }
+
+  return createPortal(
+    <div className="dialog-backdrop" onClick={onClose}>
+      <div
+        className="dialog dialog--machine-editor"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Edit machine: ${definition.name}`}
+      >
+        <div className="dialog-header">
+          <h2 className="dialog-title">
+            Edit Machine: {definition.name}
+          </h2>
+          <button className="dialog-close" onClick={onClose} aria-label="Close" type="button">
+            ✕
+          </button>
+        </div>
+
+        <div className="dialog-body">
+          <div className="dialog-section">
+            <div className="dialog-section-group">
+              <span className="dialog-section-title">General</span>
+              <label className="machine-editor-field">
+                <span className="machine-editor-label">Name</span>
+                <input
+                  className="machine-editor-input"
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => handleFormChange({ name: e.target.value })}
+                />
+              </label>
+              <label className="machine-editor-field">
+                <span className="machine-editor-label">File Extension</span>
+                <input
+                  className="machine-editor-input"
+                  type="text"
+                  value={form.fileExtension}
+                  onChange={(e) => handleFormChange({ fileExtension: e.target.value })}
+                />
+              </label>
+              <label className="machine-editor-field">
+                <span className="machine-editor-label">Units — mm command</span>
+                <input
+                  className="machine-editor-input"
+                  type="text"
+                  value={form.mmCommand}
+                  placeholder="e.g. G21"
+                  onChange={(e) => handleFormChange({ mmCommand: e.target.value })}
+                />
+              </label>
+              <label className="machine-editor-field">
+                <span className="machine-editor-label">Units — inch command</span>
+                <input
+                  className="machine-editor-input"
+                  type="text"
+                  value={form.inchCommand}
+                  placeholder="e.g. G20"
+                  onChange={(e) => handleFormChange({ inchCommand: e.target.value })}
+                />
+              </label>
+            </div>
+
+            <div className="dialog-section-group">
+              <span className="dialog-section-title">Program</span>
+              {renderTextAreaField('Header', form.header, (v) => handleFormChange({ header: v }))}
+              {renderTextAreaField('Operation Header', form.operationHeader, (v) =>
+                handleFormChange({ operationHeader: v }),
+              )}
+              {renderTextAreaField('Footer', form.footer, (v) => handleFormChange({ footer: v }))}
+            </div>
+
+            <div className="dialog-section-group">
+              <span className="dialog-section-title">Tool Change</span>
+              {renderTextAreaField('Commands', form.toolChangeCommands, (v) =>
+                handleFormChange({ toolChangeCommands: v }),
+              )}
+            </div>
+
+            <div className="dialog-section-group">
+              <span className="dialog-section-title">Coolant</span>
+              <label className="machine-editor-field">
+                <span className="machine-editor-label">Flood On</span>
+                <input
+                  className="machine-editor-input"
+                  type="text"
+                  value={form.floodOnCommand}
+                  placeholder="e.g. M8"
+                  onChange={(e) => handleFormChange({ floodOnCommand: e.target.value })}
+                />
+              </label>
+              <label className="machine-editor-field">
+                <span className="machine-editor-label">Mist On</span>
+                <input
+                  className="machine-editor-input"
+                  type="text"
+                  value={form.mistOnCommand}
+                  placeholder="e.g. M7"
+                  onChange={(e) => handleFormChange({ mistOnCommand: e.target.value })}
+                />
+              </label>
+              <label className="machine-editor-field">
+                <span className="machine-editor-label">Coolant Off</span>
+                <input
+                  className="machine-editor-input"
+                  type="text"
+                  value={form.coolantOffCommand}
+                  placeholder="e.g. M9"
+                  onChange={(e) => handleFormChange({ coolantOffCommand: e.target.value })}
+                />
+              </label>
+            </div>
+          </div>
+
+          <div className="dialog-section">
+            <DisclosureSection
+              title="Advanced (raw JSON)"
+              storageKey="machine-editor-advanced"
+            >
+              <textarea
+                ref={textAreaRef}
+                className="machine-editor-json"
+                value={advancedJson}
+                onChange={(e) => handleJsonChange(e.target.value)}
+                onBlur={handleJsonBlur}
+                rows={24}
+                spellCheck={false}
+              />
+              {jsonError ? (
+                <div className="machine-editor-error" role="alert">
+                  {jsonError}
+                </div>
+              ) : null}
+            </DisclosureSection>
+            {validationError ? (
+              <div className="machine-editor-error" role="alert">
+                {validationError}
+              </div>
+            ) : null}
+
+            <DisclosureSection
+              title="Variables reference"
+              storageKey="machine-editor-vars"
+            >
+              <div className="machine-editor-vars">
+                {renderVar('programName', 'Project name (comment-safe)', 'header, footer')}
+                {renderVar('date', 'Current date (YYYY-MM-DD)', 'header, footer')}
+                {renderVar('units', 'Project units: mm or inch', 'header, footer')}
+                {renderVar('unitsCommand', 'Units G-code command (e.g. G21)', 'header, footer')}
+                {renderVar('wcsCommand', 'Work coordinate select (e.g. G54)', 'header, footer')}
+                {renderVar('operationIndex', '1-based operation number', 'operation header')}
+                {renderVar('operationName', 'Operation name (comment-safe)', 'operation header')}
+                {renderVar('operationDescription', 'Operation description text', 'operation header')}
+                {renderVar('operationKind', 'Operation kind: contour, pocket, drill…', 'operation header')}
+                {renderVar('operationPass', 'rough or finish', 'operation header')}
+                {renderVar('operationTarget', 'Target shape summary', 'operation header')}
+                {renderVar('toolNumber', 'Tool index (1-based)', 'tool change, op header')}
+                {renderVar('toolName', 'Tool name (comment-safe)', 'tool change, op header')}
+                {renderVar('feed', 'Cutting feed rate (formatted)', 'operation header')}
+                {renderVar('plungeFeed', 'Plunge feed rate (formatted)', 'operation header')}
+                {renderVar('rpm', 'Spindle RPM (formatted)', 'tool change, op header')}
+              </div>
+            </DisclosureSection>
+          </div>
+        </div>
+
+        <div className="dialog-footer">
+          <button className="btn-secondary" type="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="btn-primary"
+            type="button"
+            onClick={handleSave}
+            disabled={!canSave}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/components/machine/MachineDefinitionEditorDialog.tsx
+++ b/src/components/machine/MachineDefinitionEditorDialog.tsx
@@ -40,8 +40,6 @@ export function MachineDefinitionEditorDialog({
   const [advancedJson, setAdvancedJson] = useState<string>(() =>
     JSON.stringify(definition, null, 2),
   )
-  const [jsonError, setJsonError] = useState<string | null>(null)
-  const [validationError, setValidationError] = useState<string | null>(null)
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
 
   // Escape key closes the dialog.
@@ -53,35 +51,28 @@ export function MachineDefinitionEditorDialog({
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [onClose])
 
-  // Validate on every change to compute whether Save should be enabled.
-  const mergedDef = useMemo<MachineDefinition | null>(() => {
-    // If the user has touched the Advanced JSON editor, use that as the
-    // source of truth; otherwise merge the focused form onto the original.
+  // Pure derivation — no setState calls inside useMemo.
+  const { mergedDef, jsonError, validationError } = useMemo(() => {
+    // Try parsing + validating the Advanced JSON editor first.
     try {
       const parsed = JSON.parse(advancedJson)
       const result = validateDef(parsed)
       if (result.ok) {
-        setJsonError(null)
-        setValidationError(null)
-        return result.ok
+        return { mergedDef: result.ok, jsonError: null, validationError: null }
       }
-      setJsonError(null)
-      setValidationError(result.error)
-      return null
+      return { mergedDef: null, jsonError: null, validationError: result.error }
     } catch {
-      // JSON parse error — fall back to form merge for now.
+      // JSON syntax error — fall back to merging the focused form.
+      const jsonErr = 'Invalid JSON syntax'
       try {
         const merged = mergeFormData(definition, form)
         const result = validateDef(merged)
         if (result.ok) {
-          setValidationError(null)
-          return result.ok
+          return { mergedDef: result.ok, jsonError: jsonErr, validationError: null }
         }
-        setValidationError(result.error)
-        return null
+        return { mergedDef: null, jsonError: jsonErr, validationError: result.error }
       } catch {
-        setValidationError('Invalid definition')
-        return null
+        return { mergedDef: null, jsonError: jsonErr, validationError: 'Invalid definition' }
       }
     }
   }, [advancedJson, definition, form])
@@ -111,12 +102,9 @@ export function MachineDefinitionEditorDialog({
       const result = validateDef(parsed)
       if (result.ok) {
         setForm(toFormData(result.ok))
-        setJsonError(null)
-      } else {
-        setJsonError(null) // valid JSON but invalid definition
       }
     } catch {
-      setJsonError('Invalid JSON syntax')
+      // JSON syntax error — jsonError is derived from advancedJson in useMemo.
     }
   }
 
@@ -126,17 +114,16 @@ export function MachineDefinitionEditorDialog({
   }
 
   function handleJsonBlur() {
-    // Re-validate and sync on blur.
+    // Re-validate and sync the focused form on blur so it stays in
+    // sync with any hand-edited JSON.
     try {
       const parsed = JSON.parse(advancedJson)
       const result = validateDef(parsed)
       if (result.ok) {
         setForm(toFormData(result.ok))
-        setJsonError(null)
-        return
       }
     } catch {
-      // Keep jsonError from typing
+      // JSON still invalid — nothing to sync.
     }
   }
 

--- a/src/components/machine/MachineDefinitionManagerDialog.tsx
+++ b/src/components/machine/MachineDefinitionManagerDialog.tsx
@@ -211,32 +211,44 @@ export function MachineDefinitionManagerDialog({
 
                 <div className="machine-manager-actions">
                   {!isActive ? (
-                    <button className="machine-manager-action btn-primary" type="button" onClick={handleUseThisMachine}>
+                    <button className="btn-primary" type="button" onClick={handleUseThisMachine}>
                       Use this machine
                     </button>
                   ) : null}
 
-                  {!previewDef.builtin ? (
-                    <button className="machine-manager-action btn-secondary" type="button" onClick={handleEdit}>
-                      Edit
+                  <div className="machine-manager-actions-row">
+                    {!previewDef.builtin ? (
+                      <button className="btn-secondary" type="button" onClick={handleEdit}>
+                        Edit
+                      </button>
+                    ) : null}
+
+                    <button className="btn-secondary" type="button" onClick={handleDuplicateToEdit}>
+                      {previewDef.builtin ? 'Duplicate to edit' : 'Duplicate'}
                     </button>
-                  ) : null}
 
-                  <button className="machine-manager-action btn-secondary" type="button" onClick={handleDuplicateToEdit}>
-                    {previewDef.builtin ? 'Duplicate to edit' : 'Duplicate'}
-                  </button>
+                    <button
+                      className="btn-secondary"
+                      type="button"
+                      onClick={handleImportJson}
+                      title="Import a machine definition JSON file"
+                    >
+                      Import machine
+                    </button>
 
-                  <button className="machine-manager-action btn-secondary" type="button" onClick={handleImportJson}>
-                    Import JSON
-                  </button>
-
-                  <button className="machine-manager-action btn-secondary" type="button" onClick={handleExportJson}>
-                    Export JSON
-                  </button>
+                    <button
+                      className="btn-secondary"
+                      type="button"
+                      onClick={handleExportJson}
+                      title="Export this machine definition as JSON"
+                    >
+                      Export machine
+                    </button>
+                  </div>
 
                   {!previewDef.builtin ? (
-                    <button className="machine-manager-action machine-manager-action--remove" type="button" onClick={handleRemove}>
-                      Remove
+                    <button className="machine-manager-action--remove" type="button" onClick={handleRemove}>
+                      Remove machine
                     </button>
                   ) : null}
                 </div>

--- a/src/components/machine/MachineDefinitionManagerDialog.tsx
+++ b/src/components/machine/MachineDefinitionManagerDialog.tsx
@@ -1,0 +1,270 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { MachineDefinition } from '../../engine/gcode/types'
+import { validateMachineDefinition } from '../../engine/gcode/types'
+import { useProjectStore } from '../../store/projectStore'
+import { platform } from '../../platform'
+import { MachineDefinitionEditorDialog } from './MachineDefinitionEditorDialog'
+
+export interface MachineDefinitionManagerDialogProps {
+  onClose: () => void
+}
+
+export function MachineDefinitionManagerDialog({
+  onClose,
+}: MachineDefinitionManagerDialogProps) {
+  const project = useProjectStore((s) => s.project)
+  const setSelectedMachineId = useProjectStore((s) => s.setSelectedMachineId)
+  const addMachineDefinition = useProjectStore((s) => s.addMachineDefinition)
+  const removeMachineDefinition = useProjectStore((s) => s.removeMachineDefinition)
+  const updateMachineDefinition = useProjectStore((s) => s.updateMachineDefinition)
+  const duplicateMachineDefinition = useProjectStore((s) => s.duplicateMachineDefinition)
+
+  const definitions = project.meta.machineDefinitions
+  const activeId = project.meta.selectedMachineId
+
+  // Track which machine is previewed in the right column (not necessarily active).
+  const [previewId, setPreviewId] = useState<string | null>(() =>
+    activeId ?? (definitions.length > 0 ? definitions[0].id : null),
+  )
+
+  // If the previewed machine was removed, fall back to the first available.
+  const safePreviewId =
+    previewId && definitions.some((d) => d.id === previewId)
+      ? previewId
+      : definitions.length > 0
+        ? definitions[0].id
+        : null
+
+  const previewDef = safePreviewId
+    ? definitions.find((d) => d.id === safePreviewId) ?? null
+    : null
+
+  const [editingDef, setEditingDef] = useState<MachineDefinition | null>(null)
+
+  // Escape key closes.
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  const handleUseThisMachine = useCallback(() => {
+    if (previewDef) {
+      setSelectedMachineId(previewDef.id)
+    }
+  }, [previewDef, setSelectedMachineId])
+
+  const handleImportJson = useCallback(async () => {
+    const content = await platform.pickJsonFile()
+    if (!content) return
+    try {
+      const parsed = JSON.parse(content)
+      const validated = validateMachineDefinition({ ...parsed, builtin: false })
+      addMachineDefinition(validated)
+      setPreviewId(validated.id)
+    } catch (error) {
+      alert(`Invalid machine definition JSON: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }, [addMachineDefinition])
+
+  const handleEdit = useCallback(() => {
+    if (previewDef) {
+      setEditingDef(previewDef)
+    }
+  }, [previewDef])
+
+  const handleDuplicateToEdit = useCallback(() => {
+    if (!previewDef) return
+    // Store the current list length so we can find the new entry.
+    const prevIds = new Set(definitions.map((d) => d.id))
+    duplicateMachineDefinition(previewDef.id)
+    // The store updates synchronously; find the new id.
+    const updated = useProjectStore.getState().project.meta.machineDefinitions
+    const newDef = updated.find((d) => !prevIds.has(d.id))
+    if (newDef) {
+      setPreviewId(newDef.id)
+      setEditingDef(newDef)
+    }
+  }, [previewDef, definitions, duplicateMachineDefinition])
+
+  const handleExportJson = useCallback(() => {
+    if (!previewDef) return
+    const { builtin: _, ...exportDef } = previewDef as MachineDefinition & { builtin?: boolean }
+    platform.saveTextFile(
+      `${previewDef.name}.json`,
+      JSON.stringify(exportDef, null, 2),
+      'json',
+    )
+  }, [previewDef])
+
+  const handleRemove = useCallback(() => {
+    if (!previewDef || previewDef.builtin) return
+    removeMachineDefinition(previewDef.id)
+    // preview will be synced by the useEffect above.
+  }, [previewDef, removeMachineDefinition])
+
+  const handleEditorSave = useCallback(
+    (definition: MachineDefinition) => {
+      updateMachineDefinition(definition.id, definition)
+      setEditingDef(null)
+    },
+    [updateMachineDefinition],
+  )
+
+  const isActive = previewDef?.id === activeId
+
+  return createPortal(
+    <div className="dialog-backdrop" onClick={onClose}>
+      <div
+        className="dialog dialog--machine-manager"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Manage machines"
+      >
+        <div className="dialog-header">
+          <h2 className="dialog-title">Manage Machines</h2>
+          <button className="dialog-close" onClick={onClose} aria-label="Close" type="button">
+            ✕
+          </button>
+        </div>
+
+        <div className="dialog-body dialog-body--machine-manager">
+          {/* Left: machine list */}
+          <div className="machine-manager-list">
+            {definitions.map((def) => (
+              <button
+                key={def.id}
+                type="button"
+                className={[
+                  'machine-manager-item',
+                  def.id === previewId ? 'machine-manager-item--selected' : '',
+                  def.id === activeId ? 'machine-manager-item--active' : '',
+                ].join(' ').trim()}
+                onClick={() => setPreviewId(def.id)}
+              >
+                <div className="machine-manager-item-name">{def.name}</div>
+                <span className={def.builtin ? 'machine-manager-badge machine-manager-badge--builtin' : 'machine-manager-badge machine-manager-badge--custom'}>
+                  {def.builtin ? 'Built-in' : 'Custom'}
+                </span>
+              </button>
+            ))}
+            {definitions.length === 0 ? (
+              <div className="machine-manager-empty">
+                No machine definitions. Import one to get started.
+              </div>
+            ) : null}
+          </div>
+
+          {/* Right: preview + actions */}
+          <div className="machine-manager-detail">
+            {previewDef ? (
+              <>
+                <div className="machine-manager-detail-header">
+                  <h3 className="machine-manager-detail-name">{previewDef.name}</h3>
+                  {isActive ? (
+                    <span className="machine-manager-badge machine-manager-badge--active">Active</span>
+                  ) : null}
+                  <span className={previewDef.builtin ? 'machine-manager-badge machine-manager-badge--builtin' : 'machine-manager-badge machine-manager-badge--custom'}>
+                    {previewDef.builtin ? 'Built-in' : 'Custom'}
+                  </span>
+                </div>
+
+                <dl className="machine-manager-meta">
+                  <dt>File extension</dt>
+                  <dd>.{previewDef.fileExtension}</dd>
+                  {previewDef.description ? (
+                    <>
+                      <dt>Description</dt>
+                      <dd>{previewDef.description}</dd>
+                    </>
+                  ) : null}
+                  {previewDef.vendor ? (
+                    <>
+                      <dt>Vendor</dt>
+                      <dd>{previewDef.vendor}</dd>
+                    </>
+                  ) : null}
+                  {previewDef.builtin ? (
+                    <dd className="machine-manager-hint">Built-in definitions are read-only. Duplicate to create an editable copy.</dd>
+                  ) : null}
+                </dl>
+
+                <div className="machine-manager-actions">
+                  {!isActive ? (
+                    <button className="machine-manager-action btn-primary" type="button" onClick={handleUseThisMachine}>
+                      Use this machine
+                    </button>
+                  ) : null}
+
+                  {!previewDef.builtin ? (
+                    <button className="machine-manager-action btn-secondary" type="button" onClick={handleEdit}>
+                      Edit
+                    </button>
+                  ) : null}
+
+                  <button className="machine-manager-action btn-secondary" type="button" onClick={handleDuplicateToEdit}>
+                    {previewDef.builtin ? 'Duplicate to edit' : 'Duplicate'}
+                  </button>
+
+                  <button className="machine-manager-action btn-secondary" type="button" onClick={handleImportJson}>
+                    Import JSON
+                  </button>
+
+                  <button className="machine-manager-action btn-secondary" type="button" onClick={handleExportJson}>
+                    Export JSON
+                  </button>
+
+                  {!previewDef.builtin ? (
+                    <button className="machine-manager-action machine-manager-action--remove" type="button" onClick={handleRemove}>
+                      Remove
+                    </button>
+                  ) : null}
+                </div>
+              </>
+            ) : (
+              <div className="machine-manager-empty">
+                Select a machine from the list or import one.
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="dialog-footer">
+          <button className="btn-primary" type="button" onClick={onClose}>
+            Done
+          </button>
+        </div>
+      </div>
+
+      {/* Nested editor dialog */}
+      {editingDef ? (
+        <MachineDefinitionEditorDialog
+          definition={editingDef}
+          onSave={handleEditorSave}
+          onClose={() => setEditingDef(null)}
+        />
+      ) : null}
+    </div>,
+    document.body,
+  )
+}

--- a/src/components/machine/MachineDefinitionManagerDialog.tsx
+++ b/src/components/machine/MachineDefinitionManagerDialog.tsx
@@ -119,15 +119,21 @@ export function MachineDefinitionManagerDialog({
   const handleRemove = useCallback(() => {
     if (!previewDef || previewDef.builtin) return
     removeMachineDefinition(previewDef.id)
-    // preview will be synced by the useEffect above.
+    // The store updates synchronously; reset previewId so the list
+    // selection row stays in sync with the detail pane.
+    const updated = useProjectStore.getState().project.meta.machineDefinitions
+    setPreviewId(updated.length > 0 ? updated[0].id : null)
   }, [previewDef, removeMachineDefinition])
 
   const handleEditorSave = useCallback(
     (definition: MachineDefinition) => {
-      updateMachineDefinition(definition.id, definition)
+      // Use the original editingDef.id for the lookup so that editing the
+      // "id" field in the raw JSON editor does not cause the update to
+      // target a non-existent key and silently no-op.
+      updateMachineDefinition(editingDef!.id, definition)
       setEditingDef(null)
     },
-    [updateMachineDefinition],
+    [updateMachineDefinition, editingDef],
   )
 
   const isActive = previewDef?.id === activeId

--- a/src/components/machine/machineDefinitionForm.test.ts
+++ b/src/components/machine/machineDefinitionForm.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MachineDefinition } from '../../engine/gcode/types'
+import {
+  joinLines,
+  splitLines,
+  toFormData,
+  mergeFormData,
+  validateDef,
+} from './machineDefinitionForm'
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function assertDeepEqual<T>(actual: T, expected: T, message: string) {
+  const a = JSON.stringify(actual)
+  const b = JSON.stringify(expected)
+  if (a !== b) {
+    throw new Error(
+      `${message}\n  expected: ${b}\n  actual:   ${a}`,
+    )
+  }
+}
+
+/** Minimal valid machine definition for testing. */
+function makeTestDef(overrides?: Partial<MachineDefinition>): MachineDefinition {
+  return {
+    id: 'test-machine',
+    name: 'Test Machine',
+    description: 'A test machine definition',
+    builtin: false,
+    fileExtension: 'nc',
+    coordinateSystem: { xAxis: 'X', yAxis: 'Y', zAxis: 'Z' },
+    numberFormat: { decimalPlaces: { mm: 3, inch: 4 }, trailingZeros: false, leadingZero: false },
+    units: { mmCommand: 'G21', inchCommand: 'G20' },
+    program: {
+      header: ['G90', 'G17'],
+      operationHeader: [],
+      footer: ['M30'],
+      commentPrefix: '(',
+      commentSuffix: ')',
+      lineNumbers: false,
+      lineNumberIncrement: 1,
+    },
+    workCoordinates: { selectCommand: 'G54' },
+    motion: {
+      rapidCommand: 'G00',
+      linearCommand: 'G01',
+      cwArcCommand: 'G02',
+      ccwArcCommand: 'G03',
+      arcFormat: 'ij',
+      modalMotion: true,
+    },
+    feedSpeed: {
+      feedCommand: 'F',
+      rpmCommand: 'S',
+      spindleOnCW: 'M03',
+      spindleOnCCW: 'M04',
+      spindleOff: 'M05',
+      inlineWithMotion: false,
+      modalFeedSpeed: true,
+    },
+    toolChange: {
+      commands: ['T[TOOL]', 'M06'],
+      stopSpindleFirst: true,
+      pauseAfterChange: false,
+      pauseCommand: 'M00',
+    },
+    cannedCycles: null,
+    coolant: {
+      floodOnCommand: 'M8',
+      mistOnCommand: 'M7',
+      coolantOffCommand: 'M9',
+    },
+    stop: { programEndCommand: 'M30' },
+    ...overrides,
+  } as MachineDefinition
+}
+
+// ── line-array helpers ──────────────────────────────────────────
+
+{
+  const lines = ['G90', 'G17', '', 'M30']
+  const joined = joinLines(lines)
+  assert(joined === 'G90\nG17\n\nM30', 'joinLines produces newline-separated text')
+  const roundTripped = splitLines(joined)
+  assertDeepEqual(roundTripped, lines, 'splitLines round-trips through joinLines')
+}
+
+{
+  const text = 'G90\r\nG17\r\nM30'
+  const lines = splitLines(text)
+  assertDeepEqual(lines, ['G90', 'G17', 'M30'], 'splitLines strips CR from CRLF')
+}
+
+{
+  assertDeepEqual(splitLines(''), [''], 'splitLines of empty string returns single empty string')
+  assertDeepEqual(joinLines([]), '', 'joinLines of empty array returns empty string')
+}
+
+{
+  // blank-line preservation
+  const text = 'G90\n\nM30'
+  const lines = splitLines(text)
+  assertDeepEqual(lines, ['G90', '', 'M30'], 'splitLines preserves blank lines')
+}
+
+// ── toFormData ──────────────────────────────────────────────────
+
+{
+  const def = makeTestDef()
+  const form = toFormData(def)
+
+  assert(form.name === 'Test Machine', 'toFormData: name')
+  assert(form.fileExtension === 'nc', 'toFormData: fileExtension')
+  assert(form.mmCommand === 'G21', 'toFormData: mmCommand')
+  assert(form.inchCommand === 'G20', 'toFormData: inchCommand')
+  assert(form.header === 'G90\nG17', 'toFormData: header joined')
+  assert(form.footer === 'M30', 'toFormData: footer joined')
+  assert(form.operationHeader === '', 'toFormData: empty operationHeader')
+  assert(form.toolChangeCommands === 'T[TOOL]\nM06', 'toFormData: toolChangeCommands joined')
+  assert(form.floodOnCommand === 'M8', 'toFormData: floodOnCommand')
+  assert(form.mistOnCommand === 'M7', 'toFormData: mistOnCommand')
+  assert(form.coolantOffCommand === 'M9', 'toFormData: coolantOffCommand')
+}
+
+{
+  // nullable fields
+  const def = makeTestDef({
+    units: { mmCommand: null, inchCommand: null },
+    coolant: null,
+  })
+  const form = toFormData(def)
+  assert(form.mmCommand === '', 'toFormData: null mmCommand becomes empty string')
+  assert(form.inchCommand === '', 'toFormData: null inchCommand becomes empty string')
+  assert(form.floodOnCommand === '', 'toFormData: null coolant -> empty strings')
+  assert(form.mistOnCommand === '', 'toFormData: null coolant -> empty mist')
+  assert(form.coolantOffCommand === '', 'toFormData: null coolant -> empty off')
+}
+
+// ── mergeFormData ───────────────────────────────────────────────
+
+{
+  const def = makeTestDef()
+  const form = toFormData(def)
+  form.name = 'Modified Machine'
+  form.header = 'G90\nG17\nG54'
+  form.floodOnCommand = 'M50'
+
+  const merged = mergeFormData(def, form)
+  assert(merged.name === 'Modified Machine', 'mergeFormData: name updated')
+  assertDeepEqual(merged.program.header, ['G90', 'G17', 'G54'], 'mergeFormData: header re-split')
+  assert(merged.coolant?.floodOnCommand === 'M50', 'mergeFormData: coolant flood updated')
+
+  // Unchanged fields preserved
+  assert(merged.fileExtension === 'nc', 'mergeFormData: unchanged field preserved')
+  assert(merged.motion.arcFormat === 'ij', 'mergeFormData: non-form field preserved')
+  assert(merged.coolant?.mistOnCommand === 'M7', 'mergeFormData: unchanged coolant field preserved')
+}
+
+{
+  // operationHeader round-trip
+  const def = makeTestDef({ program: { ...makeTestDef().program, operationHeader: ['G00 Z10', 'G01 Z-5'] } })
+  const form = toFormData(def)
+  assert(form.operationHeader === 'G00 Z10\nG01 Z-5', 'toFormData: operationHeader')
+  const merged = mergeFormData(def, form)
+  assertDeepEqual(merged.program.operationHeader, ['G00 Z10', 'G01 Z-5'], 'mergeFormData: operationHeader round-trip')
+}
+
+{
+  // toolChangeCommands round-trip
+  const def = makeTestDef({ toolChange: { ...makeTestDef().toolChange, commands: ['T1', 'M06', 'G43 H1'] } })
+  const form = toFormData(def)
+  assert(form.toolChangeCommands === 'T1\nM06\nG43 H1', 'toFormData: multi-line toolChange')
+  const merged = mergeFormData(def, form)
+  assertDeepEqual(merged.toolChange.commands, ['T1', 'M06', 'G43 H1'], 'mergeFormData: toolChange round-trip')
+}
+
+// ── validateDef ─────────────────────────────────────────────────
+
+{
+  const def = makeTestDef()
+  const result = validateDef(def)
+  assert(result.ok !== undefined, 'validateDef: valid definition returns ok')
+  assert(result.error === undefined, 'validateDef: no error on valid def')
+  assert(result.ok!.name === 'Test Machine', 'validateDef: parsed definition preserved')
+}
+
+{
+  // Missing required fields
+  const result = validateDef({ id: 'bad', name: 'Bad' })
+  assert(result.ok === undefined, 'validateDef: invalid definition returns no ok')
+  assert(result.error !== undefined, 'validateDef: error message present')
+  assert(typeof result.error === 'string', 'validateDef: error is a string')
+  assert(result.error!.length > 0, 'validateDef: error message non-empty')
+}
+
+{
+  // Bad enum value
+  const def = makeTestDef()
+  ;(def as any).motion.arcFormat = 'INVALID'
+  const result = validateDef(def)
+  assert(result.ok === undefined, 'validateDef: bad arcFormat rejected')
+  assert(
+    result.error!.toLowerCase().includes('arc'),
+    `validateDef: error message mentions arc-related issue, got: ${result.error}`,
+  )
+}
+
+{
+  // Not an object
+  const result = validateDef(null)
+  assert(result.ok === undefined, 'validateDef: null rejected')
+  assert(result.error !== undefined, 'validateDef: null produces error')
+}
+
+console.log('machineDefinitionForm.test.ts — all assertions passed')

--- a/src/components/machine/machineDefinitionForm.test.ts
+++ b/src/components/machine/machineDefinitionForm.test.ts
@@ -191,6 +191,31 @@ function makeTestDef(overrides?: Partial<MachineDefinition>): MachineDefinition 
   assertDeepEqual(merged.toolChange.commands, ['T1', 'M06', 'G43 H1'], 'mergeFormData: toolChange round-trip')
 }
 
+{
+  // Coolant: create object from form fields when source def has coolant: null.
+  const def = makeTestDef({ coolant: null })
+  const form = toFormData(def)
+  form.floodOnCommand = 'M8'
+  form.mistOnCommand = ''
+  form.coolantOffCommand = 'M9'
+  const merged = mergeFormData(def, form)
+  assert(merged.coolant !== null, 'mergeFormData: coolant created from form when source was null')
+  assert(merged.coolant!.floodOnCommand === 'M8', 'mergeFormData: coolant floodOn set')
+  assert(merged.coolant!.mistOnCommand === '', 'mergeFormData: coolant mistOn empty')
+  assert(merged.coolant!.coolantOffCommand === 'M9', 'mergeFormData: coolant off set')
+}
+
+{
+  // Coolant: stays null when all fields empty and source was null.
+  const def = makeTestDef({ coolant: null })
+  const form = toFormData(def)
+  form.floodOnCommand = ''
+  form.mistOnCommand = ''
+  form.coolantOffCommand = ''
+  const merged = mergeFormData(def, form)
+  assert(merged.coolant === null, 'mergeFormData: coolant stays null when all empty')
+}
+
 // ── validateDef ─────────────────────────────────────────────────
 
 {

--- a/src/components/machine/machineDefinitionForm.ts
+++ b/src/components/machine/machineDefinitionForm.ts
@@ -92,14 +92,15 @@ export function mergeFormData(
       ...def.toolChange,
       commands: splitLines(form.toolChangeCommands),
     },
-    coolant: def.coolant
-      ? {
-          ...def.coolant,
-          floodOnCommand: form.floodOnCommand,
-          mistOnCommand: form.mistOnCommand,
-          coolantOffCommand: form.coolantOffCommand,
-        }
-      : null,
+    coolant:
+      def.coolant || form.floodOnCommand || form.mistOnCommand || form.coolantOffCommand
+        ? {
+            ...def.coolant,
+            floodOnCommand: form.floodOnCommand,
+            mistOnCommand: form.mistOnCommand,
+            coolantOffCommand: form.coolantOffCommand,
+          }
+        : null,
   }
 }
 

--- a/src/components/machine/machineDefinitionForm.ts
+++ b/src/components/machine/machineDefinitionForm.ts
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MachineDefinition } from '../../engine/gcode/types'
+import { validateMachineDefinition } from '../../engine/gcode/types'
+
+/**
+ * Focused-form representation of a MachineDefinition. Only the fields most
+ * commonly edited by hobbyists appear here; everything else stays in the
+ * Advanced (raw JSON) editor.
+ */
+export interface MachineFormData {
+  name: string
+  fileExtension: string
+  mmCommand: string
+  inchCommand: string
+  header: string
+  footer: string
+  operationHeader: string
+  toolChangeCommands: string
+  floodOnCommand: string
+  mistOnCommand: string
+  coolantOffCommand: string
+}
+
+/** Split a string[] into a multi-line text (one entry per line). */
+export function joinLines(lines: string[]): string {
+  return lines.join('\n')
+}
+
+/** Split a multi-line text into a string[] (one line per entry). */
+export function splitLines(text: string): string[] {
+  return text
+    .split('\n')
+    .map((line) => line.replace(/\r$/, ''))
+}
+
+/** Extract focused form fields from a full MachineDefinition. */
+export function toFormData(def: MachineDefinition): MachineFormData {
+  return {
+    name: def.name,
+    fileExtension: def.fileExtension,
+    mmCommand: def.units.mmCommand ?? '',
+    inchCommand: def.units.inchCommand ?? '',
+    header: joinLines(def.program.header),
+    footer: joinLines(def.program.footer),
+    operationHeader: joinLines(def.program.operationHeader),
+    toolChangeCommands: joinLines(def.toolChange.commands),
+    floodOnCommand: def.coolant?.floodOnCommand ?? '',
+    mistOnCommand: def.coolant?.mistOnCommand ?? '',
+    coolantOffCommand: def.coolant?.coolantOffCommand ?? '',
+  }
+}
+
+/**
+ * Merge focused form edits onto a full MachineDefinition, leaving all
+ * non-form fields untouched.
+ */
+export function mergeFormData(
+  def: MachineDefinition,
+  form: MachineFormData,
+): MachineDefinition {
+  return {
+    ...def,
+    name: form.name,
+    fileExtension: form.fileExtension,
+    units: {
+      ...def.units,
+      mmCommand: form.mmCommand || null,
+      inchCommand: form.inchCommand || null,
+    },
+    program: {
+      ...def.program,
+      header: splitLines(form.header),
+      footer: splitLines(form.footer),
+      operationHeader: splitLines(form.operationHeader),
+    },
+    toolChange: {
+      ...def.toolChange,
+      commands: splitLines(form.toolChangeCommands),
+    },
+    coolant: def.coolant
+      ? {
+          ...def.coolant,
+          floodOnCommand: form.floodOnCommand,
+          mistOnCommand: form.mistOnCommand,
+          coolantOffCommand: form.coolantOffCommand,
+        }
+      : null,
+  }
+}
+
+/**
+ * Validate a MachineDefinition through Zod, returning the parsed definition
+ * or a user-friendly error message. Returns `{ok: definition}` or
+ * `{error: "..."}` — never throws.
+ */
+export function validateDef(
+  data: unknown,
+): { ok: MachineDefinition; error?: undefined } | { ok?: undefined; error: string } {
+  try {
+    const def = validateMachineDefinition(data)
+    return { ok: def }
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : String(err)
+    return { error: formatZodMessage(message) }
+  }
+}
+
+/**
+ * Try to make a Zod error message more user-friendly by unwrapping nested
+ * issue arrays and stripping internal paths.
+ */
+function formatZodMessage(message: string): string {
+  // Zod messages typically contain JSON-encoded issue arrays. Extract the
+  // first useful sentence or return the raw message.
+  const trimmed = message.trim()
+
+  // Detect JSON-encoded issues array at the start.
+  const issuesMatch = trimmed.match(/^\[[\s\S]*?\]/)
+  if (!issuesMatch) {
+    return trimmed
+  }
+
+  try {
+    const issues: Array<{ message?: string; path?: Array<string | number> }> =
+      JSON.parse(issuesMatch[0])
+    if (!Array.isArray(issues) || issues.length === 0) {
+      return trimmed
+    }
+
+    const first = issues[0]
+    const path = first.path?.join('.') ?? ''
+    const msg = first.message ?? 'Unknown validation error'
+    return path ? `${msg} (at ${path})` : msg
+  } catch {
+    return trimmed
+  }
+}

--- a/src/store/slices/machineDefsSlice.test.ts
+++ b/src/store/slices/machineDefsSlice.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MachineDefinition } from '../../engine/gcode/types'
+import { useProjectStore } from '../projectStore'
+import {
+  slugFromName,
+  allocateMachineId,
+} from './machineDefsSlice'
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+/** Minimal valid machine definition. */
+function makeDef(id: string, name?: string, builtin = false): MachineDefinition {
+  return {
+    id,
+    name: name ?? id,
+    description: `Description for ${name ?? id}`,
+    builtin,
+    fileExtension: 'nc',
+    coordinateSystem: { xAxis: 'X' as const, yAxis: 'Y' as const, zAxis: 'Z' as const },
+    numberFormat: { decimalPlaces: { mm: 3, inch: 4 }, trailingZeros: false, leadingZero: false },
+    units: { mmCommand: 'G21', inchCommand: 'G20' },
+    program: {
+      header: ['G90'],
+      operationHeader: [],
+      footer: ['M30'],
+      commentPrefix: '(',
+      commentSuffix: ')',
+      lineNumbers: false,
+      lineNumberIncrement: 1,
+    },
+    workCoordinates: { selectCommand: 'G54' },
+    motion: {
+      rapidCommand: 'G00',
+      linearCommand: 'G01',
+      cwArcCommand: 'G02',
+      ccwArcCommand: 'G03',
+      arcFormat: 'ij' as const,
+      modalMotion: true,
+    },
+    feedSpeed: {
+      feedCommand: 'F',
+      rpmCommand: 'S',
+      spindleOnCW: 'M03',
+      spindleOnCCW: 'M04',
+      spindleOff: 'M05',
+      inlineWithMotion: false,
+      modalFeedSpeed: true,
+    },
+    toolChange: {
+      commands: ['T[TOOL]', 'M06'],
+      stopSpindleFirst: true,
+      pauseAfterChange: false,
+      pauseCommand: 'M00',
+    },
+    cannedCycles: null,
+    coolant: {
+      floodOnCommand: 'M8',
+      mistOnCommand: 'M7',
+      coolantOffCommand: 'M9',
+    },
+    stop: { programEndCommand: 'M30' },
+  } as MachineDefinition
+}
+
+function makeMockProject(defs: MachineDefinition[], selectedMachineId?: string | null) {
+  return {
+    version: '1.0',
+    meta: {
+      name: 'test',
+      units: 'mm' as const,
+      created: '2026-01-01T00:00:00Z',
+      modified: '2026-01-01T00:00:00Z',
+      showFeatureInfo: false,
+      showDimensions: false,
+      copyMode: 'reference' as const,
+      maxTravelZ: 10,
+      operationClearanceZ: 5,
+      clampClearanceXY: 1,
+      clampClearanceZ: 1,
+      machineDefinitions: defs,
+      selectedMachineId: selectedMachineId ?? (defs.length > 0 ? defs[0].id : null),
+    },
+    grid: { extent: 200, majorSpacing: 20, minorSpacing: 5, snapIncrement: 0.1, visible: true },
+    stock: { x: 0, y: 0, w: 200, h: 200, thickness: 10, material: '', color: '#cccccc', visible: true, sourceFeatureId: null, sourceFeature: null },
+    origin: { name: 'Origin', x: 0, y: 0, z: 10, visible: true },
+    backdrop: null,
+    dimensions: {},
+    annotations: [],
+    modelAssets: {},
+    featureDefinitions: {},
+    features: [],
+    featureFolders: [],
+    featureTree: [],
+    global_constraints: [],
+    tools: [],
+    operations: [],
+    tabs: [],
+    clamps: [],
+    ai_history: [],
+  } as any
+}
+
+// ── slugFromName / allocateMachineId ───────────────────────────
+
+{
+  assert(slugFromName('GRBL Machine') === 'grbl-machine', 'slugFromName: spaces become hyphens')
+  assert(slugFromName('  Test--Foo  ') === 'test-foo', 'slugFromName: trim + collapse')
+  assert(slugFromName('Máquina #1') === 'm-quina-1', 'slugFromName: non-alphanumeric removed')
+  assert(slugFromName('') === '', 'slugFromName: empty')
+}
+
+{
+  const existing = new Set(['grbl', 'grbl-2', 'grbl-3'])
+  assert(allocateMachineId('grbl', existing) === 'grbl-4', 'allocateMachineId: skips occupied slugs')
+  assert(allocateMachineId('unique', existing) === 'unique', 'allocateMachineId: returns base for unique')
+  assert(allocateMachineId('', existing) === 'custom-machine', 'allocateMachineId: fallback for empty')
+}
+
+{
+  const existing = new Set<string>()
+  assert(allocateMachineId('GRBL', existing) === 'grbl', 'allocateMachineId: lowercases')
+}
+
+// ── updateMachineDefinition ─────────────────────────────────────
+
+{
+  // Set up store with two custom definitions.
+  const defA = makeDef('alpha', 'Alpha')
+  const defB = makeDef('beta', 'Beta')
+  const project = makeMockProject([defA, defB], 'alpha')
+  useProjectStore.setState({ project, history: { past: [], future: [], transactionStart: null } } as any)
+
+  // Update name in place.
+  const state = useProjectStore.getState()
+  state.updateMachineDefinition('alpha', { ...defA, name: 'Alpha Revised' })
+
+  const updated = useProjectStore.getState().project
+  const defs = updated.meta.machineDefinitions
+  assert(defs.length === 2, 'updateMachineDefinition: count unchanged')
+  assert(defs[0].id === 'alpha', 'updateMachineDefinition: first entry still alpha (order preserved)')
+  assert(defs[0].name === 'Alpha Revised', 'updateMachineDefinition: name updated')
+  assert(defs[1].id === 'beta', 'updateMachineDefinition: second entry unchanged')
+}
+
+{
+  // Rejects invalid definition (patch with bad motion.arcFormat)
+  const defA = makeDef('alpha', 'Alpha')
+  const project = makeMockProject([defA], 'alpha')
+  useProjectStore.setState({ project, history: { past: [], future: [], transactionStart: null } } as any)
+
+  const badDef = { ...defA, motion: { ...defA.motion, arcFormat: 'INVALID' } } as any
+  const state = useProjectStore.getState()
+  // Should throw from Zod validation; the state should remain unchanged.
+  let threw = false
+  try {
+    state.updateMachineDefinition('alpha', badDef)
+  } catch {
+    threw = true
+  }
+  assert(threw, 'updateMachineDefinition: throws on invalid definition')
+  // Store unchanged
+  const current = useProjectStore.getState().project.meta.machineDefinitions
+  assert(current[0].motion.arcFormat === 'ij', 'updateMachineDefinition: unchanged after failed validation')
+}
+
+{
+  // No-op on builtin definitions.
+  const defA = makeDef('builtin-alpha', 'Builtin Alpha', true)
+  const project = makeMockProject([defA], 'builtin-alpha')
+  useProjectStore.setState({ project, history: { past: [], future: [], transactionStart: null } } as any)
+
+  const state = useProjectStore.getState()
+  state.updateMachineDefinition('builtin-alpha', { ...defA, name: 'Renamed Builtin' })
+
+  const updated = useProjectStore.getState().project.meta.machineDefinitions
+  assert(updated[0].name === 'Builtin Alpha', 'updateMachineDefinition: builtin definition unchanged (no-op)')
+}
+
+{
+  // No-op on non-existent id.
+  const defA = makeDef('alpha', 'Alpha')
+  const project = makeMockProject([defA], 'alpha')
+  useProjectStore.setState({ project, history: { past: [], future: [], transactionStart: null } } as any)
+
+  const state = useProjectStore.getState()
+  state.updateMachineDefinition('nonexistent', defA)
+  // Should not have changed
+  const current = useProjectStore.getState().project.meta.machineDefinitions
+  assert(current.length === 1, 'updateMachineDefinition: no-op on non-existent id')
+}
+
+{
+  // Id change in patch is ignored (id locked).
+  const defA = makeDef('alpha', 'Alpha')
+  const project = makeMockProject([defA], 'alpha')
+  useProjectStore.setState({ project, history: { past: [], future: [], transactionStart: null } } as any)
+
+  const state = useProjectStore.getState()
+  state.updateMachineDefinition('alpha', { ...defA, id: 'hijacked' })
+
+  const updated = useProjectStore.getState().project.meta.machineDefinitions
+  assert(updated[0].id === 'alpha', 'updateMachineDefinition: id locked — patch id ignored')
+}
+
+// ── duplicateMachineDefinition ──────────────────────────────────
+
+{
+  // Duplicate a custom definition.
+  const defA = makeDef('alpha', 'Alpha')
+  const project = makeMockProject([defA], 'alpha')
+  useProjectStore.setState({ project, history: { past: [], future: [], transactionStart: null } } as any)
+
+  const state = useProjectStore.getState()
+  state.duplicateMachineDefinition('alpha')
+
+  const updated = useProjectStore.getState().project
+  const defs = updated.meta.machineDefinitions
+  assert(defs.length === 2, 'duplicateMachineDefinition: adds one definition')
+  assert(defs[1].builtin === false, 'duplicateMachineDefinition: copy is not builtin')
+  assert(defs[1].name === 'Alpha (copy)', 'duplicateMachineDefinition: name suffixed')
+  assert(defs[1].id !== 'alpha', 'duplicateMachineDefinition: copy has new id')
+  assert(updated.meta.selectedMachineId === defs[1].id, 'duplicateMachineDefinition: copy is selected')
+}
+
+{
+  // Duplicate a bundled definition (should also work).
+  const defA = makeDef('bundled', 'GRBL', true)
+  const project = makeMockProject([defA], 'bundled')
+  useProjectStore.setState({ project, history: { past: [], future: [], transactionStart: null } } as any)
+
+  const state = useProjectStore.getState()
+  state.duplicateMachineDefinition('bundled')
+
+  const updated = useProjectStore.getState().project
+  const defs = updated.meta.machineDefinitions
+  assert(defs.length === 2, 'duplicateMachineDefinition: bundled duplicated')
+  assert(defs[1].builtin === false, 'duplicateMachineDefinition: bundled copy not builtin')
+  // Bundled definitions get no suffix (they're exact clones by default; suffix for clarity)
+  assert(defs[1].name === 'GRBL (copy)', 'duplicateMachineDefinition: bundled copy has (copy)')
+  assert(updated.meta.selectedMachineId === defs[1].id, 'duplicateMachineDefinition: bundled copy selected')
+}
+
+{
+  // Duplicate twice yields distinct ids.
+  const defA = makeDef('alpha', 'Alpha')
+  const project = makeMockProject([defA], 'alpha')
+  useProjectStore.setState({ project, history: { past: [], future: [], transactionStart: null } } as any)
+
+  const state = useProjectStore.getState()
+  state.duplicateMachineDefinition('alpha')
+  state.duplicateMachineDefinition('alpha')
+
+  const updated = useProjectStore.getState().project
+  const defs = updated.meta.machineDefinitions
+  assert(defs.length === 3, 'duplicateMachineDefinition: two copies added')
+  assert(defs[1].id !== defs[2].id, 'duplicateMachineDefinition: copies have distinct ids')
+  assert(defs[1].name === 'Alpha (copy)', 'duplicateMachineDefinition: first copy name')
+  // Second copy gets unique id via allocateMachineId
+}
+
+{
+  // No-op on non-existent id.
+  const defA = makeDef('alpha', 'Alpha')
+  const project = makeMockProject([defA], 'alpha')
+  useProjectStore.setState({ project, history: { past: [], future: [], transactionStart: null } } as any)
+
+  const state = useProjectStore.getState()
+  state.duplicateMachineDefinition('nonexistent')
+
+  const defs = useProjectStore.getState().project.meta.machineDefinitions
+  assert(defs.length === 1, 'duplicateMachineDefinition: no-op on non-existent id')
+}
+
+{
+  // History is pushed on duplicate.
+  const defA = makeDef('alpha', 'Alpha')
+  const project = makeMockProject([defA], 'alpha')
+  useProjectStore.setState({ project, history: { past: [], future: [], transactionStart: null } } as any)
+
+  const state = useProjectStore.getState()
+  const pastLenBefore = state.history.past.length
+  state.duplicateMachineDefinition('alpha')
+
+  const after = useProjectStore.getState()
+  assert(after.history.past.length > pastLenBefore, 'duplicateMachineDefinition: history pushed')
+  assert(after.history.future.length === 0, 'duplicateMachineDefinition: future cleared')
+}
+
+console.log('machineDefsSlice.test.ts — all assertions passed')

--- a/src/store/slices/machineDefsSlice.ts
+++ b/src/store/slices/machineDefsSlice.ts
@@ -15,16 +15,40 @@
  */
 
 import type { StateCreator } from 'zustand'
+import type { MachineDefinition } from '../../engine/gcode/types'
 import type { ProjectStore } from '../types'
 import { copyBundledDefinitions } from '../../engine/gcode/definitions'
 import { validateMachineDefinition } from '../../engine/gcode/types'
 import { cloneProject, projectsEqual } from '../helpers/normalize'
+
+/** Turn a machine name into a URL-safe id slug (lowercase, hyphens). */
+export function slugFromName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-+/g, '-')
+}
+
+/** Allocate a unique machine-definition id from a name, deduping against existing ids. */
+export function allocateMachineId(name: string, existingIds: Set<string>): string {
+  const base = slugFromName(name) || 'custom-machine'
+  let candidate = base
+  let n = 2
+  while (existingIds.has(candidate)) {
+    candidate = `${base}-${n}`
+    n += 1
+  }
+  return candidate
+}
 
 export type MachineDefsSlice = Pick<
   ProjectStore,
   | 'setSelectedMachineId'
   | 'addMachineDefinition'
   | 'removeMachineDefinition'
+  | 'updateMachineDefinition'
+  | 'duplicateMachineDefinition'
   | 'refreshMachineDefinitions'
 >
 
@@ -108,6 +132,82 @@ export function createMachineDefsSlice(
           return {}
         }
 
+        return {
+          project: nextProject,
+          history: {
+            past: [...s.history.past, cloneProject(s.project)].slice(-100),
+            future: [],
+            transactionStart: null,
+          },
+        }
+      }),
+
+    updateMachineDefinition: (id, patch) =>
+      set((s) => {
+        const index = s.project.meta.machineDefinitions.findIndex((entry) => entry.id === id)
+        const existing = s.project.meta.machineDefinitions[index]
+        // Guard: must exist and be custom (not builtin).
+        if (!existing || existing.builtin) {
+          return {}
+        }
+        // Ignore id changes in the patch — the entry keeps its original id.
+        const validated = validateMachineDefinition({ ...patch, id: existing.id, builtin: false })
+        const machineDefinitions = [...s.project.meta.machineDefinitions]
+        // Replace in place to preserve array order.
+        machineDefinitions[index] = validated
+        const nextProject = {
+          ...s.project,
+          meta: {
+            ...s.project.meta,
+            machineDefinitions,
+            modified: new Date().toISOString(),
+          },
+        }
+        if (projectsEqual(nextProject, s.project)) {
+          return {}
+        }
+        return {
+          project: nextProject,
+          history: {
+            past: [...s.history.past, cloneProject(s.project)].slice(-100),
+            future: [],
+            transactionStart: null,
+          },
+        }
+      }),
+
+    duplicateMachineDefinition: (id) =>
+      set((s) => {
+        const source = s.project.meta.machineDefinitions.find((entry) => entry.id === id)
+        if (!source) {
+          return {}
+        }
+
+        const existingIds = new Set(s.project.meta.machineDefinitions.map((entry) => entry.id))
+        const suffix = ' (copy)'
+        const newId = allocateMachineId(`${source.name}${suffix}`, existingIds)
+
+        const clone: MachineDefinition = validateMachineDefinition({
+          ...JSON.parse(JSON.stringify(source)),
+          id: newId,
+          name: `${source.name}${suffix}`,
+          builtin: false,
+        })
+        existingIds.add(newId)
+
+        const machineDefinitions = [...s.project.meta.machineDefinitions, clone]
+        const nextProject = {
+          ...s.project,
+          meta: {
+            ...s.project.meta,
+            machineDefinitions,
+            selectedMachineId: newId,
+            modified: new Date().toISOString(),
+          },
+        }
+        if (projectsEqual(nextProject, s.project)) {
+          return {}
+        }
         return {
           project: nextProject,
           history: {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -290,6 +290,8 @@ export interface ProjectStore {
   setSelectedMachineId: (id: string | null) => void
   addMachineDefinition: (definition: MachineDefinition) => void
   removeMachineDefinition: (id: string) => void
+  updateMachineDefinition: (id: string, definition: MachineDefinition) => void
+  duplicateMachineDefinition: (id: string) => void
   refreshMachineDefinitions: () => void
   loadProject: (p: Project) => void
   saveProject: () => string

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -625,3 +625,158 @@
 [data-shell-mode="tablet-compact"] .dialog button {
   min-height: 38px;
 }
+
+/* ── Machine Definition Editor ──────────────────── */
+
+.dialog--machine-editor {
+  max-width: 820px;
+}
+
+.dialog--machine-editor .dialog-body {
+  grid-template-columns: 360px 1fr;
+}
+
+.machine-editor-field {
+  display: grid;
+  gap: 4px;
+}
+
+.machine-editor-label {
+  font-size: 12px;
+  color: var(--text-dim);
+  font-weight: 500;
+}
+
+.machine-editor-input {
+  background: #0f1820;
+  border: 1px solid var(--line-strong);
+  border-radius: 7px;
+  color: var(--text);
+  height: 34px;
+  padding: 0 10px;
+  font: inherit;
+  font-size: 13px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.machine-editor-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.machine-editor-textarea {
+  background: #0f1820;
+  border: 1px solid var(--line-strong);
+  border-radius: 7px;
+  color: var(--text);
+  padding: 8px 10px;
+  font: inherit;
+  font-size: 13px;
+  font-family: var(--font-mono);
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 42px;
+  line-height: 1.45;
+}
+
+.machine-editor-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.machine-editor-json {
+  background: #090f16;
+  border: 1px solid var(--line-strong);
+  border-radius: 7px;
+  color: var(--text);
+  padding: 10px;
+  font: inherit;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 320px;
+  line-height: 1.5;
+  tab-size: 2;
+}
+
+.machine-editor-json:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.machine-editor-error {
+  margin-top: 8px;
+  padding: 8px 12px;
+  background: rgba(255, 80, 60, 0.08);
+  border: 1px solid rgba(255, 100, 80, 0.4);
+  border-radius: 7px;
+  color: #f7726a;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+/* ── Variables reference ──────────────────── */
+
+.machine-editor-vars {
+  display: grid;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.machine-editor-var {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.machine-editor-var-name {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--accent);
+  background: rgba(255, 170, 60, 0.08);
+  padding: 1px 5px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.machine-editor-var-desc {
+  color: var(--text-dim);
+}
+
+.machine-editor-var-context {
+  color: color-mix(in oklab, var(--text-dim) 70%, transparent);
+  font-style: italic;
+}
+
+/* ── Tablet: full-width single-column ──────────────────── */
+
+@media (max-width: 720px) {
+  .dialog--machine-editor .dialog-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+[data-shell-mode="tablet"] .dialog--machine-editor,
+[data-shell-mode="tablet-compact"] .dialog--machine-editor {
+  max-width: 100%;
+  max-height: 100vh;
+  border-radius: 0;
+  border: none;
+}
+
+[data-shell-mode="tablet"] .dialog--machine-editor .dialog-body,
+[data-shell-mode="tablet-compact"] .dialog--machine-editor .dialog-body {
+  grid-template-columns: 1fr;
+}
+
+[data-shell-mode="tablet"] .machine-editor-var,
+[data-shell-mode="tablet-compact"] .machine-editor-var {
+  font-size: 14px;
+}

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -755,6 +755,193 @@
   font-style: italic;
 }
 
+/* ── Machine Definition Manager ──────────────────── */
+
+.dialog--machine-manager {
+  max-width: 720px;
+}
+
+.dialog-body--machine-manager {
+  grid-template-columns: 240px 1fr;
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+/* Left: machine list */
+.machine-manager-list {
+  border-right: 1px solid var(--line);
+  overflow-y: auto;
+  max-height: 50vh;
+}
+
+.machine-manager-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 10px 14px;
+  border: none;
+  border-bottom: 1px solid var(--line);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  gap: 8px;
+}
+
+.machine-manager-item:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.machine-manager-item--selected {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.machine-manager-item--active .machine-manager-item-name {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.machine-manager-item-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Right: detail + actions */
+.machine-manager-detail {
+  padding: 16px 20px;
+  overflow-y: auto;
+  max-height: 50vh;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.machine-manager-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.machine-manager-detail-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: #fff;
+  margin: 0;
+}
+
+/* Badges */
+.machine-manager-badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 5px;
+  line-height: 1.4;
+}
+
+.machine-manager-badge--active {
+  background: rgba(255, 170, 60, 0.18);
+  color: var(--accent);
+}
+
+.machine-manager-badge--custom {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-dim);
+}
+
+.machine-manager-badge--builtin {
+  background: rgba(100, 160, 220, 0.12);
+  color: #7eb8e0;
+}
+
+/* Meta */
+.machine-manager-meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 12px;
+  font-size: 13px;
+  margin: 0;
+}
+
+.machine-manager-meta dt {
+  color: var(--text-dim);
+  font-weight: 500;
+}
+
+.machine-manager-meta dd {
+  color: var(--text);
+  margin: 0;
+}
+
+.machine-manager-hint {
+  grid-column: 1 / -1;
+  color: var(--text-dim);
+  font-size: 12px;
+  font-style: italic;
+  margin-top: 4px;
+}
+
+/* Actions */
+.machine-manager-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.machine-manager-action {
+  width: 100%;
+  text-align: center;
+}
+
+.machine-manager-action--remove {
+  border-color: rgba(255, 100, 80, 0.35) !important;
+  color: #f7726a !important;
+  background: transparent !important;
+}
+
+.machine-manager-action--remove:hover {
+  background: rgba(255, 80, 60, 0.1) !important;
+  border-color: rgba(255, 100, 80, 0.6) !important;
+}
+
+.machine-manager-empty {
+  padding: 24px;
+  color: var(--text-dim);
+  font-size: 14px;
+  text-align: center;
+}
+
+/* ── Properties panel machine status ──────────────────── */
+
+.properties-machine-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  font-size: 12px;
+}
+
+.properties-machine-ext {
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.properties-machine-hint {
+  color: var(--text-dim);
+  font-size: 11px;
+  font-style: italic;
+}
+
 /* ── Tablet: full-width single-column ──────────────────── */
 
 @media (max-width: 720px) {
@@ -779,4 +966,42 @@
 [data-shell-mode="tablet"] .machine-editor-var,
 [data-shell-mode="tablet-compact"] .machine-editor-var {
   font-size: 14px;
+}
+
+/* Tablet: manager dialog stacks to single-column */
+[data-shell-mode="tablet"] .dialog--machine-manager,
+[data-shell-mode="tablet-compact"] .dialog--machine-manager {
+  max-width: 100%;
+  max-height: 100vh;
+  border-radius: 0;
+  border: none;
+}
+
+[data-shell-mode="tablet"] .dialog-body--machine-manager,
+[data-shell-mode="tablet-compact"] .dialog-body--machine-manager {
+  grid-template-columns: 1fr;
+  grid-template-rows: auto 1fr;
+}
+
+[data-shell-mode="tablet"] .machine-manager-list,
+[data-shell-mode="tablet-compact"] .machine-manager-list {
+  max-height: 30vh;
+  border-right: none;
+  border-bottom: 1px solid var(--line);
+}
+
+[data-shell-mode="tablet"] .machine-manager-detail,
+[data-shell-mode="tablet-compact"] .machine-manager-detail {
+  max-height: none;
+}
+
+[data-shell-mode="tablet"] .machine-manager-actions,
+[data-shell-mode="tablet-compact"] .machine-manager-actions {
+  gap: 10px;
+}
+
+[data-shell-mode="tablet"] .machine-manager-action,
+[data-shell-mode="tablet-compact"] .machine-manager-action {
+  min-height: 44px;
+  font-size: 15px;
 }

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -893,24 +893,35 @@
 .machine-manager-actions {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
   margin-top: 4px;
 }
 
-.machine-manager-action {
-  width: 100%;
-  text-align: center;
+.machine-manager-actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.machine-manager-actions-row .btn-secondary {
+  flex: 0 0 auto;
 }
 
 .machine-manager-action--remove {
-  border-color: rgba(255, 100, 80, 0.35) !important;
-  color: #f7726a !important;
-  background: transparent !important;
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  color: #f7726a;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  padding: 2px 0;
+  opacity: 0.8;
 }
 
 .machine-manager-action--remove:hover {
-  background: rgba(255, 80, 60, 0.1) !important;
-  border-color: rgba(255, 100, 80, 0.6) !important;
+  opacity: 1;
+  text-decoration: underline;
 }
 
 .machine-manager-empty {
@@ -997,11 +1008,23 @@
 
 [data-shell-mode="tablet"] .machine-manager-actions,
 [data-shell-mode="tablet-compact"] .machine-manager-actions {
+  gap: 14px;
+}
+
+[data-shell-mode="tablet"] .machine-manager-actions-row,
+[data-shell-mode="tablet-compact"] .machine-manager-actions-row {
   gap: 10px;
 }
 
-[data-shell-mode="tablet"] .machine-manager-action,
-[data-shell-mode="tablet-compact"] .machine-manager-action {
+[data-shell-mode="tablet"] .machine-manager-actions-row .btn-secondary,
+[data-shell-mode="tablet-compact"] .machine-manager-actions-row .btn-secondary {
+  min-height: 44px;
+  font-size: 15px;
+  padding: 0 18px;
+}
+
+[data-shell-mode="tablet"] .machine-manager-action--remove,
+[data-shell-mode="tablet-compact"] .machine-manager-action--remove {
   min-height: 44px;
   font-size: 15px;
 }

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -1171,6 +1171,11 @@
     overflow-y: auto;
   }
 
+  /* Machine editor needs room for its two-column layout (form + JSON/help). */
+  .dialog--machine-editor {
+    max-width: min(820px, 98vw);
+  }
+
   .dialog input,
   .dialog select,
   .dialog textarea {

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -1176,6 +1176,11 @@
     max-width: min(820px, 98vw);
   }
 
+  /* Machine manager also needs room for list + detail columns. */
+  .dialog--machine-manager {
+    max-width: min(720px, 98vw);
+  }
+
   .dialog input,
   .dialog select,
   .dialog textarea {


### PR DESCRIPTION
## Summary

Adds an in-app hybrid machine definition editor to replace the JSON-file-only workflow. Users can now edit, duplicate, and export machine definitions directly from the project properties panel.

Closes #216

## Changes

### New: Machine editor dialog
- **Focused form fields** for the most commonly-edited fields: name, file extension, units commands, header/footer/operation header, tool change commands, and coolant
- **Advanced (raw JSON)** collapsible section for everything else
- **Variables reference** help section listing all 15 template variables available in header/footer/operation header/tool change commands with descriptions and context hints
- **Live Zod validation** with inline error messages — Save disabled while invalid
- Form ↔ JSON two-way sync
- Portaled via `createPortal` to avoid tablet panel transform containing-block trap

### New: Store actions
- `updateMachineDefinition(id, patch)` — in-place replace, validated, custom-only guard, id locked
- `duplicateMachineDefinition(id)` — clone, allocate unique id, `builtin: false`, "(copy)" name suffix, auto-select
- `slugFromName` / `allocateMachineId` pure helpers

### Properties panel
- **Edit** button (disabled for bundled definitions — Duplicate first)
- **Duplicate** button (works on any definition, creates editable copy)
- **Export** button (saves JSON via `platform.saveTextFile`)

### Tests
- `machineDefinitionForm.test.ts` — line-array round-trips, form↔definition mapping, validation error formatting
- `machineDefsSlice.test.ts` — in-place replace, order preservation, builtin guard, id locking, duplicate uniqueness, history push

### CSS
- Tablet: overrides the blanket `max-width: min(560px, 92vw)` dialog cap for the two-column editor
- New `.machine-editor-*` classes for form fields, JSON editor, error display, variables reference