### PR TITLE
fix: implement feature references properly for text features (#228)

### DIFF
--- a/src/store/INDEX.md
+++ b/src/store/INDEX.md
@@ -67,6 +67,7 @@ Zustand store. The single source of truth for the current `.camj` project. **All
 - `projectStoreTransform.test.ts` — project transform actions
 - `second_cut_test.ts` — multi-pass cutting behavior
 - `snapshotOps.test.ts` — definition/instance snapshot boolean and offset operations
+- `textReference.test.ts` — issue #228: text-feature creation mints a definition, reference copies resolve (selectable), text edits propagate to definition + siblings, 16-char name truncation
 - `updateFeatureOperationPropagation.test.ts` — P1b regression: operation change on a linked instance propagates to the definition + all siblings via updateFeature
 
 ## Gotchas

--- a/src/store/helpers/naming.ts
+++ b/src/store/helpers/naming.ts
@@ -47,7 +47,7 @@ export function textFolderBaseName(text: string): string {
   if (!normalized) {
     return 'Text'
   }
-  return normalized.length > 24 ? `${normalized.slice(0, 24)}…` : normalized
+  return normalized.length > 16 ? `${normalized.slice(0, 16)}…` : normalized
 }
 
 export function createTextFeatureAt(project: Project, config: TextToolConfig, anchor: Point): SketchFeature | null {

--- a/src/store/slices/featureSlice.ts
+++ b/src/store/slices/featureSlice.ts
@@ -58,7 +58,7 @@ import {
   previewOffsetFeatures,
   type DerivedFeatureGroup,
 } from '../helpers/derivedFeatures'
-import { createDefinitionForFeature, gcOrphanedDefinitions, getInstanceIdsForDefinition } from '../helpers/featureDefinitions'
+import { createDefinitionForFeature, gcOrphanedDefinitions, getDefinitionId, getInstanceIdsForDefinition } from '../helpers/featureDefinitions'
 import { resolveFeatureInstances } from '../helpers/resolveFeatures'
 import { expandTextFeature } from '../helpers/textExpansion'
 import {
@@ -573,18 +573,45 @@ export function createFeatureSlice(
           safePatch.operation !== undefined && safePatch.operation !== existingFeature?.operation
         const shouldPropagateOp = opExplicitlyChanged && defId !== undefined
 
-        const nextDefinitions = shouldPropagateOp
-          ? {
-              ...s.project.featureDefinitions,
-              [defId!]: {
-                ...s.project.featureDefinitions[defId!],
-                operation: safeOperation as FeatureOperation,
-              },
-            } as Record<string, FeatureDefinition>
-          : s.project.featureDefinitions
+        // P1b-text: when a text feature's `text` changes, propagate it to the
+        // shared definition and every linked instance. Text geometry is
+        // rendered from the raw per-instance `feature.text`, so without this a
+        // linked copy edited in isolation would diverge from its siblings
+        // (issue #228). The frame profile is left unchanged. `getDefinitionId`
+        // also covers migrated text features that resolve via the feature-id
+        // fallback rather than an explicit `definitionId`.
+        const textDefId = existingFeature ? getDefinitionId(existingFeature) : undefined
+        const shouldPropagateText =
+          safePatch.text !== undefined &&
+          existingFeature?.kind === 'text' &&
+          textDefId !== undefined &&
+          s.project.featureDefinitions[textDefId] !== undefined
+
+        let nextDefinitions: Record<string, FeatureDefinition> = s.project.featureDefinitions
+        if (shouldPropagateOp) {
+          nextDefinitions = {
+            ...nextDefinitions,
+            [defId!]: {
+              ...nextDefinitions[defId!],
+              operation: safeOperation as FeatureOperation,
+            },
+          }
+        }
+        if (shouldPropagateText) {
+          nextDefinitions = {
+            ...nextDefinitions,
+            [textDefId!]: {
+              ...nextDefinitions[textDefId!],
+              text: safePatch.text ? { ...safePatch.text } : null,
+            },
+          }
+        }
 
         const linkedSiblingIds: Set<string> | null = shouldPropagateOp
           ? new Set(getInstanceIdsForDefinition(s.project, defId!))
+          : null
+        const textSiblingIds: Set<string> | null = shouldPropagateText
+          ? new Set(getInstanceIdsForDefinition(s.project, textDefId!))
           : null
 
         let nextProject: Project = {
@@ -592,8 +619,6 @@ export function createFeatureSlice(
           featureDefinitions: nextDefinitions,
           features: features.map((f, fi) => {
             const isEdited = f.id === id
-            const isLinkedSibling =
-              shouldPropagateOp && linkedSiblingIds !== null && linkedSiblingIds.has(f.id) && f.id !== id
 
             if (isEdited) {
               return normalizeFeatureZRange({
@@ -603,21 +628,36 @@ export function createFeatureSlice(
               })
             }
 
-            if (isLinkedSibling) {
+            const isOpSibling =
+              shouldPropagateOp && linkedSiblingIds !== null && linkedSiblingIds.has(f.id)
+            const isTextSibling =
+              shouldPropagateText && textSiblingIds !== null && textSiblingIds.has(f.id)
+
+            if (!isOpSibling && !isTextSibling) {
+              return f
+            }
+
+            let sibling = f
+            if (isOpSibling) {
               // Apply the same operation to the sibling, with its own isFirst
               // guard (first feature in the tree can't be subtract).
               const siblingIsFirst = fi === 0
               const op = safeOperation as FeatureOperation
               const siblingOp =
                 siblingIsFirst && op !== 'add' ? ('add' as const) : op
-              return normalizeFeatureZRange({
-                ...f,
+              sibling = normalizeFeatureZRange({
+                ...sibling,
                 operation: siblingOp,
-                folderId: folderIdForOperation(s.project, f.folderId, siblingOp),
+                folderId: folderIdForOperation(s.project, sibling.folderId, siblingOp),
               })
             }
-
-            return f
+            if (isTextSibling) {
+              sibling = {
+                ...sibling,
+                text: safePatch.text ? { ...safePatch.text } : null,
+              }
+            }
+            return sibling
           }),
           meta: { ...s.project.meta, modified: new Date().toISOString() },
         }

--- a/src/store/slices/pendingAddSlice.ts
+++ b/src/store/slices/pendingAddSlice.ts
@@ -19,6 +19,8 @@ import { convertLength } from '../../utils/units'
 import type { Clamp, Segment, SketchFeature, Tab } from '../../types/project'
 import { cloneProject, syncFeatureTreeProject } from '../helpers/normalize'
 import { nextPlacementSession, nextUniqueGeneratedId } from '../helpers/ids'
+import { createDefinitionForFeature } from '../helpers/featureDefinitions'
+import { IDENTITY_MATRIX } from '../../types/project'
 import { createTextFeatureAt } from '../helpers/naming'
 import { clonePoint, pointsEqual } from '../helpers/geometry'
 import {
@@ -365,15 +367,27 @@ export function createPendingAddSlice(
         return []
       }
 
-      const createdFeature = createTextFeatureAt(state.project, state.pendingAdd.config, point)
-      if (!createdFeature) {
+      const baseFeature = createTextFeatureAt(state.project, state.pendingAdd.config, point)
+      if (!baseFeature) {
         return []
       }
+
+      // Mint a FeatureDefinition so the text feature is a proper reference
+      // instance (definitionId + identity transform), like every other
+      // creation path. Without this, reference copies point at a missing
+      // definition and become un-resolvable / un-selectable (issue #228).
+      const minted = createDefinitionForFeature(state.project, baseFeature)
+      const createdFeature: SketchFeature = {
+        ...baseFeature,
+        definitionId: minted.definitionId,
+        transform: IDENTITY_MATRIX,
+      } as SketchFeature & { definitionId: string; transform: typeof IDENTITY_MATRIX }
 
       set((s) => {
         const nextProject = syncFeatureTreeProject({
           ...s.project,
           features: [...s.project.features, createdFeature],
+          featureDefinitions: { ...s.project.featureDefinitions, [minted.definitionId]: minted.definition },
           featureTree: [...s.project.featureTree, { type: 'feature', featureId: createdFeature.id }],
           meta: { ...s.project.meta, modified: new Date().toISOString() },
         })

--- a/src/store/textReference.test.ts
+++ b/src/store/textReference.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for text-feature feature-reference behavior (issue #228):
+ *   1. Creating a text feature mints a FeatureDefinition + instance link.
+ *   2. A reference copy of a text feature shares that definition and resolves
+ *      (so it is hit-testable / selectable in the canvas).
+ *   3. Editing `text` on one linked instance propagates to the definition and
+ *      every sibling instance.
+ *   4. Auto-generated text feature names are truncated to 16 chars.
+ *
+ * Run with: npx tsx src/store/textReference.test.ts
+ */
+
+import { defaultTextToolConfig } from '../text'
+import { newProject, type Project, type SketchFeature } from '../types/project'
+import { useProjectStore } from './projectStore'
+import type { ProjectStore } from './types'
+import { buildCopiedFeatures } from './helpers/copyFeatures'
+import { getDefinitionId, getInstanceIdsForDefinition } from './helpers/featureDefinitions'
+import { resolveFeatureInstance, resolvedProjectFeatures } from './helpers/resolveFeatures'
+import { textFolderBaseName } from './helpers/naming'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function resetStore(project?: Project): void {
+  useProjectStore.setState({
+    project: project ?? newProject(),
+    selection: { selectedFeatureIds: [] },
+    history: { past: [], future: [], transactionStart: null },
+  } as unknown as Partial<ProjectStore>)
+}
+
+function getProject(): Project {
+  return useProjectStore.getState().project
+}
+
+// ── 1. Creating a text feature mints a definition ──────────────────
+
+{
+  resetStore(newProject())
+  const config = defaultTextToolConfig('mm')
+  useProjectStore.getState().startAddTextPlacement(config)
+  const ids = useProjectStore.getState().placePendingTextAt({ x: 10, y: 10 })
+  assert(ids.length === 1, 'placePendingTextAt creates exactly one feature')
+
+  const project = getProject()
+  const feature = project.features.find((f) => f.id === ids[0])!
+  assert(feature.kind === 'text', 'created feature is a text feature')
+
+  const withRefs = feature as SketchFeature & { definitionId?: string }
+  assert(typeof withRefs.definitionId === 'string', 'text feature has an explicit definitionId')
+  const definition = project.featureDefinitions[withRefs.definitionId!]
+  assert(definition !== undefined, 'a FeatureDefinition was minted for the text feature')
+  assert(definition.kind === 'text', 'minted definition is kind text')
+  assert(definition.text?.text === config.text, 'definition carries the text data')
+
+  // The original resolves (sanity).
+  assert(resolveFeatureInstance(project, feature.id) !== null, 'original text feature resolves')
+}
+
+// ── 2. Reference copy shares the definition and resolves ───────────
+
+{
+  resetStore(newProject())
+  useProjectStore.getState().startAddTextPlacement(defaultTextToolConfig('mm'))
+  const [originalId] = useProjectStore.getState().placePendingTextAt({ x: 10, y: 10 })
+  const project = getProject()
+  const original = project.features.find((f) => f.id === originalId)!
+  const defId = getDefinitionId(original)
+
+  const copies = buildCopiedFeatures(
+    [original],
+    project.features,
+    200, 0, 1,
+    project.featureDefinitions,
+    'reference',
+  )
+  assert(copies.length === 1, 'one reference copy built')
+  const copy = copies[0] as SketchFeature & { definitionId?: string }
+  assert(getDefinitionId(copy) === defId, 'reference copy shares the source definition')
+
+  const copiedProject: Project = {
+    ...project,
+    features: [...project.features, copy],
+  }
+
+  // The copy must resolve through the references resolver — this is the path
+  // canvas hit-testing uses, so a null result means it cannot be selected.
+  assert(
+    resolveFeatureInstance(copiedProject, copy.id) !== null,
+    'reference copy resolves via resolveFeatureInstance (hit-testable)',
+  )
+  const resolvedIds = resolvedProjectFeatures(copiedProject).map((f) => f.id)
+  assert(resolvedIds.includes(copy.id), 'reference copy is present in resolvedProjectFeatures')
+
+  // Both rows are reported as linked instances of the one definition.
+  assert(
+    getInstanceIdsForDefinition(copiedProject, defId).length === 2,
+    'source + copy are linked instances of the shared definition',
+  )
+}
+
+// ── 3. Editing text propagates to the definition + siblings ────────
+
+{
+  resetStore(newProject())
+  useProjectStore.getState().startAddTextPlacement(defaultTextToolConfig('mm'))
+  const [originalId] = useProjectStore.getState().placePendingTextAt({ x: 10, y: 10 })
+  let project = getProject()
+  const original = project.features.find((f) => f.id === originalId)!
+  const defId = getDefinitionId(original)
+
+  // Insert a reference copy directly so both rows live in the store.
+  const copy = buildCopiedFeatures(
+    [original], project.features, 200, 0, 1, project.featureDefinitions, 'reference',
+  )[0] as SketchFeature
+  resetStore({ ...project, features: [...project.features, copy] })
+
+  // Edit the COPY's text.
+  const originalText = original.text!
+  useProjectStore.getState().updateFeature(copy.id, {
+    text: { ...originalText, text: 'CHANGED' },
+  })
+
+  project = getProject()
+  const updatedOriginal = project.features.find((f) => f.id === originalId)!
+  const updatedCopy = project.features.find((f) => f.id === copy.id)!
+  assert(updatedCopy.text?.text === 'CHANGED', 'edited copy carries the new text')
+  assert(updatedOriginal.text?.text === 'CHANGED', 'linked original updated to the new text')
+  assert(
+    project.featureDefinitions[defId].text?.text === 'CHANGED',
+    'shared definition updated to the new text',
+  )
+}
+
+// ── 4. Auto-name truncation at 16 chars ────────────────────────────
+
+{
+  assert(textFolderBaseName('SHORT') === 'SHORT', 'short text used verbatim')
+  const long = 'THIS IS A VERY LONG TEXT STRING'
+  const truncated = textFolderBaseName(long)
+  assert(truncated === `${long.slice(0, 16)}…`, 'long text truncated to 16 chars + ellipsis')
+  assert(truncated.length === 17, 'truncated name is 16 chars plus the ellipsis')
+}
+
+console.log('✓ All text reference tests passed.')


### PR DESCRIPTION
Closes #228

## Problem

Text features were the only feature type created **without** a `FeatureDefinition`. `placePendingTextAt` appended the row straight into `project.features`, skipping the `createDefinitionForFeature` minting every other creation path uses. That left them as "transitional" rows (no `definitionId`, no definition entry), breaking the feature-reference model in the two reported ways:

1. **Reference copy unselectable in the canvas.** The copy got an explicit `definitionId = source.id` (the transitional fallback) pointing at a definition that didn't exist. Hit-testing runs through `resolvedProjectFeatures` → `resolveFeatureInstance`, which returns `null` for an explicit-but-missing `definitionId`, and the row is then dropped from the resolved set. The copy still *rendered* (the canvas draws raw `project.features`), so it was visible but un-clickable; tree selection worked because it doesn't resolve geometry.
2. **Editing the copy didn't change the original.** No shared definition existed, so the "linked" chip was a false positive and text edits — which patch the per-instance `feature.text` — never propagated to siblings.

## Fix

- **`placePendingTextAt`** now mints a `FeatureDefinition` + identity `transform` for the text feature (mirroring `addFeature`), so reference copies share a real definition and resolve correctly → the copy is selectable, and the linked chip is truthful.
- **`updateFeature`** now propagates a `text` patch to the shared definition and every linked instance, parallel to the existing `operation` propagation (`getDefinitionId` also covers legacy text features that resolve via the feature-id fallback). The frame profile is left unchanged.
- **`textFolderBaseName`** truncation lowered from 24 → 16 chars for auto-generated text feature names.

## Tests

Adds `src/store/textReference.test.ts`:
- creating a text feature mints a definition + instance link;
- a reference copy shares the definition and resolves via `resolveFeatureInstance` / `resolvedProjectFeatures` (i.e. is hit-testable);
- editing `text` on one linked instance propagates to the definition and its sibling;
- 16-char name truncation.

`npm run build` is green (lint + tsc + 80 test files + vite). Existing reference/text/lifecycle suites still pass.

## Manual verification
Recommended sanity check in dev: copy a text feature, click a glyph of the copy to select it (now works), then edit the copy's text and confirm the original updates too.
