### PR TITLE
feat: 0.0.5 app changes — donate link + default update channel to stable

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -71,8 +71,13 @@ pub fn run() {
       let paste_i      = MenuItem::with_id(app, "paste",       "Paste",            true, Some("CmdOrCtrl+V"))?;
       let quit_i       = MenuItem::with_id(app, "quit",        "Quit PureCutCNC",  true, Some("CmdOrCtrl+Q"))?;
 
-      // Update items. The native "About" panel is left untouched; "Check for
-      // Updates…" is a separate, user-initiated action handled by the frontend.
+      // App menu "About" opens the in-app dialog via a "menu" event (not the OS
+      // about panel) so it can show the same rich content as the web build:
+      // description, links, license, and a support section.
+      let about_i = MenuItem::with_id(app, "about", "About PureCutCNC", true, None::<&str>)?;
+
+      // Update items. "Check for Updates…" is a separate, user-initiated action
+      // handled by the frontend.
       // The channel check state defaults to "snapshot" (the only published
       // desktop channel today); the frontend re-syncs both checkmarks on mount
       // from the persisted preference.
@@ -92,7 +97,7 @@ pub fn run() {
       // macOS app menu — must be the FIRST submenu; macOS replaces its label
       // with the running app name automatically.
       let app_menu = Submenu::with_id_and_items(app, "app", "PureCutCNC", true, &[
-        &PredefinedMenuItem::about(app, None, None)?,
+        &about_i,
         &check_updates_i,
         &channel_menu,
         &PredefinedMenuItem::separator(app)?,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,10 @@ function App() {
   }, [])
 
   const handleExportGcode = useCallback(() => setShowExportDialog(true), [])
-  useDesktopIntegration({ onExportGcode: handleExportGcode })
+  useDesktopIntegration({
+    onExportGcode: handleExportGcode,
+    onShowAbout: () => setShowAboutDialog(true),
+  })
   const { snapSettings, activeSnapMode, setActiveSnapMode, onToggleSnapEnabled, onToggleSnapMode } = useSnapSettings()
   const { zoomWindowActive, onZoomWindow, onZoomWindowComplete } = useZoomWindow()
   const [depthLegendCollapsed, setDepthLegendCollapsed] = useLocalStorageState<boolean>(

--- a/src/components/about/AboutDialog.tsx
+++ b/src/components/about/AboutDialog.tsx
@@ -27,6 +27,7 @@ const REPO_URL = 'https://github.com/PureCutCNC/purecutcnc'
 const RELEASES_URL = 'https://github.com/PureCutCNC/purecutcnc/releases'
 const SITE_URL = 'https://purecutcnc.github.io'
 const LICENSE_URL = 'https://github.com/PureCutCNC/purecutcnc/blob/main/LICENSE'
+const SPONSOR_URL = 'https://buymeacoffee.com/purecutcnc'
 
 function formatDate(iso?: string): string | null {
   if (!iso) return null
@@ -104,6 +105,9 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
           )}
 
           <div className="about-links">
+            <a className="about-link" href={SPONSOR_URL} target="_blank" rel="noopener noreferrer">
+              Buy me a coffee
+            </a>
             <a className="about-link" href={SITE_URL} target="_blank" rel="noopener noreferrer">
               Website
             </a>

--- a/src/components/about/AboutDialog.tsx
+++ b/src/components/about/AboutDialog.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useState } from 'react'
 import { useRestoreCanvasFocus } from '../../utils/useRestoreCanvasFocus'
 import { loadVersionInfo, type VersionInfo } from '../../utils/version'
+import { platform } from '../../platform'
 import './about.css'
 
 interface AboutDialogProps {
@@ -39,12 +40,23 @@ function formatDate(iso?: string): string | null {
 export function AboutDialog({ onClose }: AboutDialogProps) {
   useRestoreCanvasFocus()
   const [info, setInfo] = useState<VersionInfo | null>(null)
+  const [desktopVersion, setDesktopVersion] = useState<string | null>(null)
 
   useEffect(() => {
     let active = true
     loadVersionInfo().then((value) => {
       if (active) setInfo(value)
     })
+    // version.json is not bundled with the desktop app, so loadVersionInfo would
+    // report "dev" there — prefer Tauri's real app version instead.
+    if (platform.isDesktop) {
+      platform
+        .getAppVersion()
+        .then((v) => {
+          if (active) setDesktopVersion(v)
+        })
+        .catch(() => {})
+    }
     return () => {
       active = false
     }
@@ -58,8 +70,19 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [onClose])
 
-  const version = info?.version ?? '…'
+  const version = desktopVersion ?? info?.version ?? '…'
   const released = formatDate(info?.date)
+
+  // In the Tauri webview a plain <a target="_blank"> does not open the system
+  // browser, so on desktop route external links through the platform opener.
+  // On web the native anchor behaviour (new tab, modified-click) is left intact.
+  const handleExternalLink =
+    (url: string) => (event: React.MouseEvent<HTMLAnchorElement>) => {
+      if (platform.isDesktop) {
+        event.preventDefault()
+        void platform.openExternal(url)
+      }
+    }
 
   return (
     <div className="dialog-backdrop" onClick={onClose}>
@@ -84,7 +107,8 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
           </div>
 
           <p className="about-tagline">
-            Browser-based 2.5D CAD/CAM for CNC hobbyists — sketching and machining in one workflow.
+            2.5D CAD/CAM for CNC hobbyists — sketching and machining in one workflow, on the
+            web or your desktop.
           </p>
 
           {(released || info?.name) && (
@@ -105,20 +129,74 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
           )}
 
           <div className="about-links">
-            <a className="about-link" href={SPONSOR_URL} target="_blank" rel="noopener noreferrer">
-              Buy me a coffee
-            </a>
-            <a className="about-link" href={SITE_URL} target="_blank" rel="noopener noreferrer">
+            <a
+              className="about-link"
+              href={SITE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleExternalLink(SITE_URL)}
+            >
               Website
             </a>
-            <a className="about-link" href={REPO_URL} target="_blank" rel="noopener noreferrer">
+            <a
+              className="about-link"
+              href={REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleExternalLink(REPO_URL)}
+            >
               Source
             </a>
-            <a className="about-link" href={RELEASES_URL} target="_blank" rel="noopener noreferrer">
+            <a
+              className="about-link"
+              href={RELEASES_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleExternalLink(RELEASES_URL)}
+            >
               Releases
             </a>
-            <a className="about-link" href={LICENSE_URL} target="_blank" rel="noopener noreferrer">
+            <a
+              className="about-link"
+              href={LICENSE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleExternalLink(LICENSE_URL)}
+            >
               License (Apache-2.0)
+            </a>
+          </div>
+
+          <div className="about-support">
+            <p className="about-support-text">
+              PureCutCNC is free, and stays free — but building and maintaining it takes real
+              time and money. If it helps you, a coffee keeps it going.
+            </p>
+            <a
+              className="about-coffee-btn"
+              href={SPONSOR_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleExternalLink(SPONSOR_URL)}
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M18 8h1a4 4 0 0 1 0 8h-1" />
+                <path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z" />
+                <line x1="6" y1="1" x2="6" y2="4" />
+                <line x1="10" y1="1" x2="10" y2="4" />
+                <line x1="14" y1="1" x2="14" y2="4" />
+              </svg>
+              Buy me a coffee
             </a>
           </div>
 

--- a/src/components/about/about.css
+++ b/src/components/about/about.css
@@ -80,6 +80,43 @@
   text-decoration: underline;
 }
 
+.about-support {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px 16px;
+  border: 1px solid rgba(240, 162, 74, 0.28);
+  border-radius: 10px;
+  background: rgba(240, 162, 74, 0.07);
+}
+
+.about-support-text {
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text);
+}
+
+.about-coffee-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  align-self: flex-start;
+  padding: 8px 14px;
+  border: 1px solid #f0a24a;
+  border-radius: 8px;
+  color: #f0a24a;
+  background: transparent;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.about-coffee-btn:hover {
+  background: #f0a24a;
+  color: #1c1206;
+}
+
 .about-copyright {
   font-size: 11px;
   color: var(--text-dim);

--- a/src/platform/useDesktopIntegration.ts
+++ b/src/platform/useDesktopIntegration.ts
@@ -94,6 +94,8 @@ function getSetWindowTitle(): Promise<(title: string) => void> {
 interface DesktopIntegrationOptions {
   /** Called when the native "Export G-code" menu item is triggered. */
   onExportGcode: () => void
+  /** Called when the native "About PureCutCNC" menu item is triggered. */
+  onShowAbout: () => void
 }
 
 type FeatureClipboardCommand = 'copy' | 'cut' | 'paste'
@@ -141,13 +143,15 @@ function runFeatureClipboardCommand(
  * Safe to call in the browser — all Tauri-specific listeners are guarded by
  * `platform.isDesktop` and loaded lazily so the web bundle is not affected.
  */
-export function useDesktopIntegration({ onExportGcode }: DesktopIntegrationOptions) {
+export function useDesktopIntegration({ onExportGcode, onShowAbout }: DesktopIntegrationOptions) {
   // Keep a ref so event handlers always call the latest version without
   // needing to be re-registered when the callback identity changes.
   const onExportGcodeRef = useRef(onExportGcode)
+  const onShowAboutRef = useRef(onShowAbout)
   const featureClipboardRef = useRef<FeatureClipboardPayload>([])
   useEffect(() => {
     onExportGcodeRef.current = onExportGcode
+    onShowAboutRef.current = onShowAbout
   })
 
   // -------------------------------------------------------------------------
@@ -325,6 +329,9 @@ export function useDesktopIntegration({ onExportGcode }: DesktopIntegrationOptio
           }
           case 'export_gcode':
             onExportGcodeRef.current()
+            break
+          case 'about':
+            onShowAboutRef.current()
             break
           case 'quit':
             await handleAppExitRequest()

--- a/src/utils/updateCheck.test.ts
+++ b/src/utils/updateCheck.test.ts
@@ -199,7 +199,7 @@ function testChannelPersistence() {
   ;(globalThis as { window?: unknown }).window = fakeWindow
   try {
     // Default when nothing is stored.
-    assert(loadChannel() === 'snapshot', 'missing key -> DEFAULT_CHANNEL (snapshot)')
+    assert(loadChannel() === 'stable', 'missing key -> DEFAULT_CHANNEL (stable)')
 
     // Round-trip both valid channels.
     saveChannel('stable')
@@ -209,13 +209,13 @@ function testChannelPersistence() {
 
     // Any non-stable/snapshot stored value falls back to the default.
     map.set('purecutcnc.updateChannel', 'nightly')
-    assert(loadChannel() === 'snapshot', 'invalid stored value -> DEFAULT_CHANNEL')
+    assert(loadChannel() === 'stable', 'invalid stored value -> DEFAULT_CHANNEL')
   } finally {
     delete (globalThis as { window?: unknown }).window
   }
 
   // With no window (SSR / non-browser), load returns the default and save is a no-op.
-  assert(loadChannel() === 'snapshot', 'no window -> DEFAULT_CHANNEL')
+  assert(loadChannel() === 'stable', 'no window -> DEFAULT_CHANNEL')
   saveChannel('stable') // must not throw without a window
   console.log('testChannelPersistence PASS')
 }

--- a/src/utils/updateCheck.ts
+++ b/src/utils/updateCheck.ts
@@ -34,8 +34,8 @@ export type UpdateChannel = 'stable' | 'snapshot'
 /** Manifest platform key, matching the deploy workflows' output filenames. */
 export type UpdatePlatform = 'macos' | 'windows' | 'linux'
 
-/** Default channel — snapshot, since only snapshot desktop builds ship today. */
-export const DEFAULT_CHANNEL: UpdateChannel = 'snapshot'
+/** Default channel — stable; snapshot is opt-in for testers (via the update channel menu). */
+export const DEFAULT_CHANNEL: UpdateChannel = 'stable'
 
 const CHANNEL_STORAGE_KEY = 'purecutcnc.updateChannel'
 


### PR DESCRIPTION
Bundled app-side changes for the 0.0.5 release.

Closes #236, Closes #238.

### 1. Buy Me a Coffee support link (#236)
Adds a "Buy me a coffee" link to the About dialog, alongside Website / Source / Releases / License, pointing to https://buymeacoffee.com/purecutcnc. Reuses the existing `.about-link` anchor pattern — one URL constant + one anchor, no new mechanism.

### 2. Default update channel to stable (#238)
Flips `DEFAULT_CHANNEL` in `src/utils/updateCheck.ts` from `snapshot` to `stable`, so users with no saved channel preference check the stable channel and are offered 0.0.5. Explicit channel choices are preserved; snapshot stays opt-in for testers. The deploy workflow already publishes `downloads/stable/*` for hyphen-less versions, so this should land with the 0.0.5 release. Updates the `updateCheck` tests that pinned the old default.

Verified: `npm run build` passes (lint + tsc + tests + vite).