### PR TITLE
fix: render expanded property dialogs correctly in the desktop webview (#239)

### DIFF
--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -561,11 +561,20 @@
   column-gap: 24px;
 }
 
-/* Let .properties-group split across columns so its children flow.
-   Individual .properties-field / .disclosure-section rows still avoid
-   internal breaks (label + control stay together). */
+/* Let .properties-group's children flow across the columns. The group must be
+   a plain block here, for the same reason .properties-panel is (above): its
+   default display:grid makes it a single grid fragment that WebKit cannot split
+   across CSS columns, so a field straddling the break balloons and clips in the
+   desktop webview (Blink tolerates it). As a block, each .properties-field is a
+   clean block the columns break between, and break-inside:avoid (below) keeps
+   every label+control pair intact. `> * + *` restores the group's 6px gap. */
 .dialog--panel-expand .properties-group {
+  display: block;
   margin-bottom: 10px;
+}
+
+.dialog--panel-expand .properties-group > * + * {
+  margin-top: 6px;
 }
 
 .dialog--panel-expand .properties-field {


### PR DESCRIPTION
Closes #239.

## Problem
On desktop (Tauri / macOS WebKit) the expanded property dialogs mangled the two-column layout — a field ballooned and clipped at the column break, with its control orphaned at the top of the right column. The web build (Chrome/Blink) was fine, so it only showed on desktop.

## Root cause
`.dialog--panel-expand .properties-panel` uses CSS multi-column (`columns: 2`) and its sole child `.properties-group` is `display: grid`. The multicol therefore had to fragment a **grid container** across the column break — Blink does this row-by-row, WebKit cannot, so the straddling field is split/ballooned. `break-inside: avoid` on the field can't help because the mis-fragmentation is at the grid container one level up.

## Fix
Block out `.properties-group` inside the expand modal (same reasoning as the existing `.properties-panel { display: block }` right above it) so each `.properties-field` is a clean block the columns break between; restore the 6px inter-field rhythm with `> * + * { margin-top: 6px }`. One rule, scoped to the expand modal, fixes all 16 expanded property panels and keeps the two-column layout.

## Verification (headless Playwright, real `layout.css` + `dialog.css`)
Max rendered height of a single `label|control` field (normal ≈ 32px, textarea field ≈ 88px):

| Engine | Before | After |
|---|---|---|
| WebKit (desktop) | **443px** (mangled) | 88px ✅ |
| Chromium (web) | 88px | 88px ✅ (unchanged) |

`npm run build` passes. Web layout byte-identical.

> Please confirm on an actual desktop build — the fix is verified in Playwright's WebKit; the system WKWebView should behave the same, but a quick real-app check is worthwhile before merge.
