### PR TITLE
feat: reduced slot feed for fully engaged pocket cuts

### DIFF
--- a/src/app/useSimulationModel.ts
+++ b/src/app/useSimulationModel.ts
@@ -191,6 +191,7 @@ export function useSimulationModel({
     // units-per-second, so divide by 60. This becomes the "1×" playback speed so
     // users can intuitively speed up or slow down relative to the real feed rate.
     const feedPerSecond = selectedOperation.feed > 0 ? selectedOperation.feed / 60 : undefined
+    const plungeFeedPerSecond = selectedOperation.plungeFeed > 0 ? selectedOperation.plungeFeed / 60 : undefined
     // `project.meta.units` uses 'inch'; the playback UI shows the short label 'in'.
     const units: 'mm' | 'in' = project.meta.units === 'inch' ? 'in' : 'mm'
 
@@ -205,6 +206,7 @@ export function useSimulationModel({
       maxSegmentLength,
       units,
       feedPerSecond,
+      plungeFeedPerSecond,
     }
   }, [centerTab, generateToolpathForOperation, project, selectedOperation, selectedToolpath, simulationDetailCells, simulationMode])
 

--- a/src/app/useToolpathGeneration.ts
+++ b/src/app/useToolpathGeneration.ts
@@ -73,6 +73,7 @@ export function operationComputationEquals(a: Operation, b: Operation): boolean 
     && a.rpm === b.rpm
     && a.pocketPattern === b.pocketPattern
     && a.pocketAngle === b.pocketAngle
+    && a.pocketSlotFeedPercent === b.pocketSlotFeedPercent
     && a.stockToLeaveRadial === b.stockToLeaveRadial
     && a.stockToLeaveAxial === b.stockToLeaveAxial
     && a.finishWalls === b.finishWalls

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -1468,6 +1468,24 @@ export function CAMPanel({
                       onCommit={(value) => updateOperation(selectedOperation.id, { plungeFeed: value })}
                     />
                   </label>
+                  {selectedOperation.kind === 'pocket'
+                    && (selectedOperation.pass === 'rough'
+                      || (selectedOperation.pass === 'finish' && selectedOperation.finishFloor)) ? (
+                    <label
+                      className="properties-field"
+                      title="Feed percentage for fully engaged (slotting) cuts: each section's innermost loop, uncleared crossings, the parallel boundary pass, and the first fill line. 100 disables the reduction."
+                    >
+                      <span>Slot Feed (%)</span>
+                      <DraftNumberInput
+                        value={selectedOperation.pocketSlotFeedPercent ?? 100}
+                        min={1}
+                        max={100}
+                        onCommit={(value) => updateOperation(selectedOperation.id, {
+                          pocketSlotFeedPercent: Math.min(100, Math.max(1, Math.round(value))),
+                        })}
+                      />
+                    </label>
+                  ) : null}
                   <label className="properties-field">
                     <span>RPM</span>
                     <DraftNumberInput

--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -983,7 +983,14 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
           toolRadius: playbackInput.toolRadius,
           vBitAngle: playbackInput.vBitAngle,
         },
-        { maxSegmentLength: playbackInput.maxSegmentLength },
+        {
+          maxSegmentLength: playbackInput.maxSegmentLength,
+          // Anchor the tool's motion to the operation's cut feed so reduced
+          // slot-feed cuts (and slower plunges) visibly slow down, matching the
+          // feed readout instead of playing every move at one constant pace.
+          referenceFeedPerSecond: playbackInput.feedPerSecond,
+          plungeFeedPerSecond: playbackInput.plungeFeedPerSecond,
+        },
       )
       playbackControllerRef.current = controller
 

--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -27,7 +27,7 @@ import type { SimulationGrid, SimulationResult } from '../../engine/simulation'
 import type { ToolpathMove } from '../../engine/toolpaths/types'
 import type { Clamp, MachineOrigin, Operation, ToolType } from '../../types/project'
 
-const EMPTY_PLAYBACK_POSE: PlaybackPose = { x: 0, y: 0, z: 0, moveKind: null }
+const EMPTY_PLAYBACK_POSE: PlaybackPose = { x: 0, y: 0, z: 0, moveKind: null, feedScale: undefined }
 
 const DEFAULT_CAMERA_SPHERICAL = {
   theta: Math.PI / 4,
@@ -99,6 +99,9 @@ export interface SimulationPlaybackInput {
    * fall back to the generic per-unit default.
    */
   feedPerSecond?: number
+  /** Operation plunge feed in project-units-per-second, for the live feed readout
+   *  during plunge moves. Omit when unavailable. */
+  plungeFeedPerSecond?: number
 }
 
 interface SimulationViewportProps {
@@ -283,6 +286,29 @@ function formatSpeedLabel(perSecond: number, units: 'mm' | 'in'): string {
   const digits = units === 'in' ? 1 : 0
   const rounded = Number(perMinute.toFixed(digits))
   return `${rounded} ${units}/min`
+}
+
+/**
+ * The real cutting feed of the current move (project-units-per-second), used for
+ * the live feed readout. Unlike playback speed this ignores the speed multiplier
+ * — it reports the authored feed so the reduced slot feed is visible on slotting
+ * cuts. Returns null for rapids (no feed) and when the feed isn't known.
+ */
+function currentFeedPerSecond(
+  pose: PlaybackPose,
+  feedPerSecond: number | undefined,
+  plungeFeedPerSecond: number | undefined,
+): number | null {
+  switch (pose.moveKind) {
+    case 'cut':
+    case 'lead_in':
+    case 'lead_out':
+      return feedPerSecond && feedPerSecond > 0 ? feedPerSecond * (pose.feedScale ?? 1) : null
+    case 'plunge':
+      return plungeFeedPerSecond && plungeFeedPerSecond > 0 ? plungeFeedPerSecond : null
+    default:
+      return null
+  }
 }
 
 function createOrbitControls(
@@ -1107,6 +1133,7 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
     y: origin.y - pose.y,
     z: pose.z - origin.z,
     moveKind: pose.moveKind,
+    feedScale: pose.feedScale,
   }), [origin.x, origin.y, origin.z])
 
   // Throttled state update: pose + progress are written to refs every RAF frame,
@@ -1483,6 +1510,19 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
               className={`simulation-playback-bar__move-kind simulation-playback-bar__move-kind--${displayPose.moveKind ?? 'none'}`}
               title={displayPose.moveKind ?? 'Idle'}
             />
+          </div>
+          <div
+            className="simulation-playback-bar__feed"
+            title="Cutting feed of the current move. Reduced slotting pocket cuts show their scaled feed here; rapids show no feed."
+          >
+            <span className="simulation-playback-bar__xyz-label">Feed</span>
+            <span className="simulation-playback-bar__feed-value">
+              {(() => {
+                const feed = currentFeedPerSecond(displayPose, playbackInput.feedPerSecond, playbackInput.plungeFeedPerSecond)
+                if (feed !== null) return formatSpeedLabel(feed, playbackUnits)
+                return displayPose.moveKind === 'rapid' ? 'rapid' : '—'
+              })()}
+            </span>
           </div>
         </div>
       )}

--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -1515,7 +1515,6 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
               className={`simulation-playback-bar__move-kind simulation-playback-bar__move-kind--${displayPose.moveKind ?? 'none'}`}
               title={displayPose.moveKind ?? 'Idle'}
             />
-            <span className="simulation-playback-bar__xyz-label">Feed</span>
             <span className="simulation-playback-bar__feed-value">
               {(() => {
                 const feed = currentFeedPerSecond(displayPose, playbackInput.feedPerSecond, playbackInput.plungeFeedPerSecond)

--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -1506,21 +1506,20 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
             <span className="simulation-playback-bar__xyz-value">{formatCoord(displayPose.y, playbackUnits)}</span>
             <span className="simulation-playback-bar__xyz-label">Z</span>
             <span className="simulation-playback-bar__xyz-value">{formatCoord(displayPose.z, playbackUnits)}</span>
+          </div>
+          <div
+            className="simulation-playback-bar__feed"
+            title="Cutting feed of the current move. Reduced slotting pocket cuts show their scaled feed here; the dot colour marks the move kind (rapids have no feed)."
+          >
             <span
               className={`simulation-playback-bar__move-kind simulation-playback-bar__move-kind--${displayPose.moveKind ?? 'none'}`}
               title={displayPose.moveKind ?? 'Idle'}
             />
-          </div>
-          <div
-            className="simulation-playback-bar__feed"
-            title="Cutting feed of the current move. Reduced slotting pocket cuts show their scaled feed here; rapids show no feed."
-          >
             <span className="simulation-playback-bar__xyz-label">Feed</span>
             <span className="simulation-playback-bar__feed-value">
               {(() => {
                 const feed = currentFeedPerSecond(displayPose, playbackInput.feedPerSecond, playbackInput.plungeFeedPerSecond)
-                if (feed !== null) return formatSpeedLabel(feed, playbackUnits)
-                return displayPose.moveKind === 'rapid' ? 'rapid' : '—'
+                return feed !== null ? formatSpeedLabel(feed, playbackUnits) : '—'
               })()}
             </span>
           </div>

--- a/src/engine/gcode/postprocessor.test.ts
+++ b/src/engine/gcode/postprocessor.test.ts
@@ -205,10 +205,43 @@ function testLegacyDefinitionFallback(): void {
   assert(gcode.includes('; Operation: Boss Pocket'), 'legacy fallback should emit operation comment')
 }
 
+function testSlotFeedScaleEmitsReducedThenFullFeed(): void {
+  console.log('Testing feedScale cut moves emit reduced F then restore the full feed...')
+  const { operation, tool } = fixture('')
+  const project = newProject('Post Test', 'mm')
+  project.tools = [{ ...defaultTool('mm', 1), id: 't1', name: 'Test End Mill' }]
+  const toolpath: ToolpathResult = {
+    operationId: operation.id,
+    warnings: [],
+    bounds: null,
+    moves: [
+      { kind: 'rapid', from: { x: 0, y: 0, z: 5 }, to: { x: 1, y: 1, z: 5 } },
+      { kind: 'plunge', from: { x: 1, y: 1, z: 5 }, to: { x: 1, y: 1, z: 0 } },
+      { kind: 'cut', from: { x: 1, y: 1, z: 0 }, to: { x: 2, y: 1, z: 0 }, feedScale: 0.5 },
+      { kind: 'cut', from: { x: 2, y: 1, z: 0 }, to: { x: 3, y: 1, z: 0 }, feedScale: 0.5 },
+      { kind: 'cut', from: { x: 3, y: 1, z: 0 }, to: { x: 4, y: 1, z: 0 } },
+    ],
+  }
+  const gcode = runPostProcessor({
+    project,
+    definition: testDefinition(),
+    operations: [{ operation, tool, toolpath }],
+    options: { emitToolChanges: true, emitCoolant: false, programName: project.meta.name },
+  }).gcode
+
+  // operation.feed = 600, plungeFeed = 180: plunge F180, scaled cuts F300, restore F600.
+  assert(gcode.includes('F180'), 'plunge should use the unscaled plunge feed')
+  const f300Count = (gcode.match(/F300\b/g) ?? []).length
+  assert(f300Count === 1, `reduced feed should be emitted once (modal), got ${f300Count}`)
+  assert(gcode.includes('F600'), 'full feed should be re-emitted after the scaled cuts')
+  assert(gcode.indexOf('F300') < gcode.indexOf('F600'), 'reduced feed should come before the restored full feed')
+}
+
 testOperationHeaderDescription()
 testEmptyDescriptionIsSkipped()
 testMultilineDescription()
 testLegacyDefinitionFallback()
+testSlotFeedScaleEmitsReducedThenFullFeed()
 
 // ── Canned cycle tests ────────────────────────────────────────────────
 

--- a/src/engine/gcode/postprocessor.ts
+++ b/src/engine/gcode/postprocessor.ts
@@ -389,9 +389,13 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
         moveCount++
         const mPoint = projectToMachinePoint(move.to, project.origin, definition)
 
+        // feedScale marks fully engaged (slotting) pocket cuts; the modal
+        // feed logic in emitMotionLine re-emits the F word whenever the
+        // effective feed changes, so scaled and unscaled fragments alternate
+        // cleanly. Plunges always use the plunge feed unscaled.
         const feed = (move.kind === 'plunge')
           ? (operation.plungeFeed || tool.defaultPlungeFeed)
-          : (operation.feed || tool.defaultFeed)
+          : (operation.feed || tool.defaultFeed) * (move.feedScale ?? 1)
 
         if (move.kind === 'rapid') {
           const current = state.currentPosition

--- a/src/engine/operationBooklet/operationBooklet.test.ts
+++ b/src/engine/operationBooklet/operationBooklet.test.ts
@@ -158,6 +158,39 @@ async function testPdfSmoke(): Promise<void> {
   assert(header === '%PDF-', `expected PDF header, got ${header}`)
 }
 
+function testFeedTimeUsesScaledSlotFeed(): void {
+  console.log('Testing estimated feed time prices slot-feed fragments at the scaled feed...')
+  const { project, operation } = fixture()
+  const toolpath: ToolpathResult = {
+    operationId: operation.id,
+    warnings: [],
+    bounds: null,
+    moves: [
+      // 20 mm at the full 800 mm/min = 1.5 s, plus 20 mm slotting at 10%
+      // (80 mm/min) = 15 s. Pricing both at the full feed would report 3 s.
+      { kind: 'cut', from: { x: 0, y: 0, z: 0 }, to: { x: 20, y: 0, z: 0 } },
+      { kind: 'cut', from: { x: 20, y: 0, z: 0 }, to: { x: 40, y: 0, z: 0 }, feedScale: 0.1 },
+    ],
+  }
+  const report = buildOperationBookletReport({
+    project,
+    operation: { ...operation, pocketSlotFeedPercent: 10 },
+    tool: normalizeToolForProject(project.tools[0], project),
+    toolpath,
+    generatedAt: new Date('2026-06-04T12:00:00Z'),
+  })
+
+  assert(
+    report.toolpathStats.some((row) => row.label === 'Estimated Feed Time' && row.value === '16.5 s (excludes G0 rapid time)'),
+    'feed time should price feedScale fragments at the scaled feed',
+  )
+  assert(
+    report.settingRows.some((row) => row.label === 'Slot Feed' && row.value === '10 % of feed'),
+    'slot feed setting should be reported',
+  )
+}
+
 testReportContent()
+testFeedTimeUsesScaledSlotFeed()
 await testPdfSmoke()
 console.log('operation booklet tests passed')

--- a/src/engine/operationBooklet/report.ts
+++ b/src/engine/operationBooklet/report.ts
@@ -150,14 +150,19 @@ function feedControlledTimeSeconds(
     switch (move.kind) {
       case 'cut':
       case 'lead_in':
-      case 'lead_out':
+      case 'lead_out': {
         feedDistance += distance
-        if (operation.feed > 0) {
-          seconds += (distance / operation.feed) * 60
+        // Slot-feed pocket fragments carry a feedScale multiplier and run
+        // slower than the operation feed — price them at the effective feed
+        // the postprocessor emits.
+        const effectiveFeed = operation.feed * (move.feedScale ?? 1)
+        if (effectiveFeed > 0) {
+          seconds += (distance / effectiveFeed) * 60
         } else {
           hasInvalidFeed = true
         }
         break
+      }
       case 'plunge':
         feedDistance += distance
         if (operation.plungeFeed > 0) {

--- a/src/engine/operationBooklet/report.ts
+++ b/src/engine/operationBooklet/report.ts
@@ -240,6 +240,10 @@ function settingRows(operation: Operation, project: Project): OperationBookletRo
     )
   }
 
+  if (operation.kind === 'pocket' && (operation.pocketSlotFeedPercent ?? 100) < 100) {
+    rows.push({ label: 'Slot Feed', value: `${formatNumber(operation.pocketSlotFeedPercent ?? 100, 0)} % of feed` })
+  }
+
   if (operation.kind === 'drilling') {
     rows.push(
       { label: 'Drill Type', value: operation.drillType ?? 'simple' },

--- a/src/engine/simulation/playback.test.ts
+++ b/src/engine/simulation/playback.test.ts
@@ -20,7 +20,9 @@
  * Run with: npx tsx src/engine/simulation/playback.test.ts
  */
 
-import { subdivideMoves } from './playback'
+import { PlaybackController, subdivideMoves } from './playback'
+import type { PlaybackToolInfo } from './playback'
+import type { SimulationGrid } from './types'
 import type { ToolpathMove } from '../toolpaths/types'
 
 function assert(condition: boolean, message: string): void {
@@ -30,6 +32,23 @@ function assert(condition: boolean, message: string): void {
 function approx(a: number, b: number, epsilon = 1e-9): boolean {
   return Math.abs(a - b) < epsilon
 }
+
+function flatGrid(): SimulationGrid {
+  const cols = 40
+  const rows = 4
+  return {
+    cols,
+    rows,
+    cellSize: 1,
+    originX: 0,
+    originY: 0,
+    stockTopZ: 0,
+    stockBottomZ: -10,
+    topZ: new Float32Array(cols * rows).fill(0),
+  }
+}
+
+const FLAT_TOOL: PlaybackToolInfo = { toolType: 'flat_endmill', toolRadius: 1, vBitAngle: null }
 
 function testSubdividePreservesMoveMetadata(): void {
   console.log('Testing subdivideMoves preserves feedScale and source on sub-segments...')
@@ -59,9 +78,67 @@ function testSubdivideLeavesShortMovesUntouched(): void {
   console.log('subdivideMoves short-move passthrough: PASSED')
 }
 
+function testReducedFeedMoveAdvancesSlower(): void {
+  console.log('Testing feed-scaled advance covers less geometry on reduced-feed cuts...')
+  // Two equal-length cuts: the first at full feed, the second at 10% feed.
+  // The subdivision cap is disabled so each cut stays a single move.
+  const moves: ToolpathMove[] = [
+    { kind: 'cut', from: { x: 0, y: 0, z: 0 }, to: { x: 10, y: 0, z: 0 } },
+    { kind: 'cut', from: { x: 10, y: 0, z: 0 }, to: { x: 20, y: 0, z: 0 }, feedScale: 0.1 },
+  ]
+  const controller = new PlaybackController(flatGrid(), moves, FLAT_TOOL, {
+    maxSegmentLength: 0,
+    referenceFeedPerSecond: 5,
+  })
+
+  // Budget of 10 finishes the full-feed cut exactly (ratio 1 → 10 geometry).
+  controller.advance(10)
+  assert(approx(controller.getDistanceTraveled(), 10), `full-feed cut should consume budget 1:1, got ${controller.getDistanceTraveled()}`)
+  assert(controller.getMoveIndex() === 1, 'should now be on the reduced-feed cut')
+
+  // A further budget of 10 only covers 10 × 0.1 = 1 unit of the reduced cut.
+  controller.advance(10)
+  assert(approx(controller.getDistanceTraveled(), 11), `reduced cut should cover 0.1× the budget, got total ${controller.getDistanceTraveled()}`)
+  assert(!controller.isFinished(), 'reduced cut should not be finished after only 1 of 10 units')
+  console.log('reduced-feed advance is slower: PASSED')
+}
+
+function testDisabledReferenceFeedIsConstantSpeed(): void {
+  console.log('Testing advance is constant-speed geometric when no reference feed is set...')
+  const moves: ToolpathMove[] = [
+    { kind: 'cut', from: { x: 0, y: 0, z: 0 }, to: { x: 20, y: 0, z: 0 }, feedScale: 0.1 },
+  ]
+  const controller = new PlaybackController(flatGrid(), moves, FLAT_TOOL, { maxSegmentLength: 0 })
+  // No referenceFeedPerSecond → feedScale ignored for motion, budget == geometry.
+  controller.advance(5)
+  assert(approx(controller.getDistanceTraveled(), 5), `legacy advance should be 1:1 geometric, got ${controller.getDistanceTraveled()}`)
+  console.log('disabled reference feed is constant-speed: PASSED')
+}
+
+function testSeekIsGeometricDespiteFeedScaling(): void {
+  console.log('Testing seek lands on the geometric target even with reduced-feed moves...')
+  const moves: ToolpathMove[] = [
+    { kind: 'cut', from: { x: 0, y: 0, z: 0 }, to: { x: 10, y: 0, z: 0 } },
+    { kind: 'cut', from: { x: 10, y: 0, z: 0 }, to: { x: 20, y: 0, z: 0 }, feedScale: 0.1 },
+  ]
+  const controller = new PlaybackController(flatGrid(), moves, FLAT_TOOL, {
+    maxSegmentLength: 0,
+    referenceFeedPerSecond: 5,
+  })
+  assert(approx(controller.totalPathLength, 20), `path length should be 20, got ${controller.totalPathLength}`)
+  // Seeking to 75% must land at geometric distance 15, not be slowed by the
+  // reduced-feed second half.
+  controller.seekToFraction(0.75)
+  assert(approx(controller.getDistanceTraveled(), 15), `seek to 0.75 should land at geometric 15, got ${controller.getDistanceTraveled()}`)
+  console.log('seek stays geometric: PASSED')
+}
+
 try {
   testSubdividePreservesMoveMetadata()
   testSubdivideLeavesShortMovesUntouched()
+  testReducedFeedMoveAdvancesSlower()
+  testDisabledReferenceFeedIsConstantSpeed()
+  testSeekIsGeometricDespiteFeedScaling()
   console.log('\nAll playback tests PASSED.')
 } catch (e) {
   console.error(e)

--- a/src/engine/simulation/playback.test.ts
+++ b/src/engine/simulation/playback.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for playback move preparation.
+ *
+ * Run with: npx tsx src/engine/simulation/playback.test.ts
+ */
+
+import { subdivideMoves } from './playback'
+import type { ToolpathMove } from '../toolpaths/types'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function approx(a: number, b: number, epsilon = 1e-9): boolean {
+  return Math.abs(a - b) < epsilon
+}
+
+function testSubdividePreservesMoveMetadata(): void {
+  console.log('Testing subdivideMoves preserves feedScale and source on sub-segments...')
+  const moves: ToolpathMove[] = [
+    { kind: 'cut', from: { x: 0, y: 0, z: 0 }, to: { x: 10, y: 0, z: 0 }, feedScale: 0.1, source: 'slot' },
+  ]
+  const out = subdivideMoves(moves, 2)
+
+  assert(out.length === 5, `expected 5 sub-segments, got ${out.length}`)
+  assert(out.every((move) => move.feedScale === 0.1), 'every sub-segment should carry the source move feedScale')
+  assert(out.every((move) => move.source === 'slot'), 'every sub-segment should carry the source move source tag')
+  assert(out.every((move) => move.kind === 'cut'), 'every sub-segment should keep the move kind')
+  // Sub-segments tile the original move contiguously from start to end.
+  assert(approx(out[0].from.x, 0) && approx(out[out.length - 1].to.x, 10), 'sub-segments should span the original move')
+  for (let i = 1; i < out.length; i += 1) {
+    assert(approx(out[i].from.x, out[i - 1].to.x), 'sub-segments should be contiguous')
+  }
+  console.log('subdivideMoves preserves move metadata: PASSED')
+}
+
+function testSubdivideLeavesShortMovesUntouched(): void {
+  console.log('Testing subdivideMoves leaves short moves (and their metadata) untouched...')
+  const move: ToolpathMove = { kind: 'cut', from: { x: 0, y: 0, z: 0 }, to: { x: 1, y: 0, z: 0 }, feedScale: 0.5 }
+  const out = subdivideMoves([move], 2)
+  assert(out.length === 1, 'a move shorter than the max segment length should not be split')
+  assert(out[0].feedScale === 0.5, 'short move should retain feedScale')
+  console.log('subdivideMoves short-move passthrough: PASSED')
+}
+
+try {
+  testSubdividePreservesMoveMetadata()
+  testSubdivideLeavesShortMovesUntouched()
+  console.log('\nAll playback tests PASSED.')
+} catch (e) {
+  console.error(e)
+  throw e
+}

--- a/src/engine/simulation/playback.ts
+++ b/src/engine/simulation/playback.ts
@@ -40,6 +40,9 @@ export interface PlaybackPose {
   y: number
   z: number
   moveKind: ToolpathMove['kind'] | null
+  /** feedScale of the current move (undefined when the move has none, i.e. 1×).
+   *  Lets the readout show the reduced feed on slotting pocket cuts. */
+  feedScale: number | undefined
 }
 
 export function cloneSimulationGrid(source: SimulationGrid): SimulationGrid {
@@ -175,17 +178,17 @@ export class PlaybackController {
 
   getPose(): PlaybackPose {
     if (this.moves.length === 0) {
-      return { x: 0, y: 0, z: 0, moveKind: null }
+      return { x: 0, y: 0, z: 0, moveKind: null, feedScale: undefined }
     }
 
     if (this.finished) {
       const last = this.moves[this.moves.length - 1]
-      return { x: last.to.x, y: last.to.y, z: last.to.z, moveKind: last.kind }
+      return { x: last.to.x, y: last.to.y, z: last.to.z, moveKind: last.kind, feedScale: last.feedScale }
     }
 
     const move = this.moves[this.moveIndex]
     const p = interpolatePoint(move, this.moveFraction)
-    return { x: p.x, y: p.y, z: p.z, moveKind: move.kind }
+    return { x: p.x, y: p.y, z: p.z, moveKind: move.kind, feedScale: move.feedScale }
   }
 
   /**

--- a/src/engine/simulation/playback.ts
+++ b/src/engine/simulation/playback.ts
@@ -33,6 +33,21 @@ export interface PlaybackOptions {
    * Pass 0 or a negative value to disable subdivision.
    */
   maxSegmentLength?: number
+  /**
+   * Reference cut feed (project-units-per-second) that maps to the caller's "1×"
+   * pace. When set, `advance`'s distance argument is treated as a reference-feed
+   * budget: moves whose real feed is below the reference (reduced slot-feed cuts,
+   * slower plunges) consume the budget faster than they cover geometry, so the
+   * tool visibly slows on them. Omit (or pass 0) for legacy constant-speed
+   * playback where every move advances at the caller's pace.
+   */
+  referenceFeedPerSecond?: number
+  /**
+   * Plunge feed (project-units-per-second), used only when referenceFeedPerSecond
+   * is set, so plunge moves play at their real (usually slower) feed. Omit to play
+   * plunges at the reference pace.
+   */
+  plungeFeedPerSecond?: number
 }
 
 export interface PlaybackPose {
@@ -115,6 +130,8 @@ export class PlaybackController {
   private finished = false
   private lastMoveApplied = -1
   private frameDirtyRegion: DirtyRegion | null = null
+  private readonly referenceFeedPerSecond: number
+  private readonly plungeFeedPerSecond: number
 
   constructor(
     baseGrid: SimulationGrid,
@@ -128,10 +145,42 @@ export class PlaybackController {
     this.moves = subdivideMoves(moves, maxSegmentLength)
     this.tool = tool
     this.totalPathLength = this.moves.reduce((sum, move) => sum + moveLength(move), 0)
+    this.referenceFeedPerSecond = options.referenceFeedPerSecond && options.referenceFeedPerSecond > 0
+      ? options.referenceFeedPerSecond
+      : 0
+    this.plungeFeedPerSecond = options.plungeFeedPerSecond && options.plungeFeedPerSecond > 0
+      ? options.plungeFeedPerSecond
+      : 0
 
     if (this.moves.length === 0) {
       this.finished = true
     }
+  }
+
+  /**
+   * Feed of `move` relative to the reference cut feed, in (0, 1]-ish units.
+   * The tool covers `ratio × budget` geometric distance per unit of the
+   * advance budget, so a lower ratio means slower on-screen motion. Returns 1
+   * (no scaling) when no reference feed was supplied or for rapids. Cut moves
+   * fold their slot-feed reduction straight in via feedScale; plunges use the
+   * plunge/reference ratio. Clamped to a small floor to avoid div-by-zero.
+   */
+  private feedRatioForMove(move: ToolpathMove): number {
+    if (this.referenceFeedPerSecond <= 0) return 1
+    let ratio: number
+    switch (move.kind) {
+      case 'cut':
+      case 'lead_in':
+      case 'lead_out':
+        ratio = move.feedScale ?? 1
+        break
+      case 'plunge':
+        ratio = this.plungeFeedPerSecond > 0 ? this.plungeFeedPerSecond / this.referenceFeedPerSecond : 1
+        break
+      default:
+        ratio = 1
+    }
+    return ratio > 1e-3 ? ratio : 1e-3
   }
 
   reset(): void {
@@ -195,19 +244,36 @@ export class PlaybackController {
   }
 
   /**
-   * Advance the tool by `distance` along the path, applying cuts as we go.
-   * `distance` is interpreted in project units — the caller is responsible for
-   * throttling it (e.g., `min(speed * dt, maxStepPerFrame)`) before each call.
-   * Whether that distance spans one long move partially or many short moves
-   * fully is opaque to the caller; either way the cumulative cut is correct.
+   * Advance the tool along the path, applying cuts as we go.
+   *
+   * `budget` is a reference-feed distance — the geometry the tool would cover
+   * this frame at the reference cut feed (the caller passes `min(speed * dt,
+   * maxStepPerFrame)`). Each move consumes the budget scaled by its feed ratio,
+   * so a move at half the reference feed covers half the geometry per unit of
+   * budget and takes twice as long on screen. With no reference feed every
+   * ratio is 1 and this reduces to the legacy "advance by geometric distance".
+   * Whether that budget spans one long move partially or many short moves fully
+   * is opaque to the caller; either way the cumulative cut is correct.
    */
-  advance(distance: number): boolean {
-    if (this.finished || distance <= 0) {
+  advance(budget: number): boolean {
+    return this.step(budget, true)
+  }
+
+  /**
+   * Shared stepping primitive. When `feedScaled` is true the amount is a
+   * reference-feed budget scaled per move by its feed ratio (used by playback,
+   * so slow moves take longer). When false the amount is plain geometric
+   * distance with every ratio treated as 1 (used by seeking, which places the
+   * tool at a path distance instantly and must stay linear in geometry so the
+   * progress bar maps 1:1).
+   */
+  private step(amount: number, feedScaled: boolean): boolean {
+    if (this.finished || amount <= 0) {
       return false
     }
 
     this.frameDirtyRegion = null
-    let remaining = distance
+    let remaining = amount
     let gridChanged = false
 
     while (remaining > 0 && !this.finished) {
@@ -233,10 +299,14 @@ export class PlaybackController {
         continue
       }
 
+      const ratio = feedScaled ? this.feedRatioForMove(move) : 1
       const traveled = length * this.moveFraction
       const available = length - traveled
+      // Reference-feed budget needed to finish the remaining geometry of this
+      // move: slower moves (ratio < 1) cost more budget per unit of geometry.
+      const budgetToFinish = available / ratio
 
-      if (remaining >= available) {
+      if (remaining >= budgetToFinish) {
         if (isCuttingMove(move) && this.lastMoveApplied !== this.moveIndex) {
           const result = applyMoveToGrid(
             this.liveGrid,
@@ -252,11 +322,12 @@ export class PlaybackController {
           this.lastMoveApplied = this.moveIndex
         }
         this.distanceTraveled += available
-        remaining -= available
+        remaining -= budgetToFinish
         this.advanceToNextMove()
       } else {
+        const geometricProgress = remaining * ratio
         const prevFraction = this.moveFraction
-        const nextFraction = prevFraction + remaining / length
+        const nextFraction = prevFraction + geometricProgress / length
 
         if (isCuttingMove(move)) {
           const prevPoint = interpolatePoint(move, prevFraction)
@@ -280,7 +351,7 @@ export class PlaybackController {
         }
 
         this.moveFraction = nextFraction
-        this.distanceTraveled += remaining
+        this.distanceTraveled += geometricProgress
         remaining = 0
       }
     }
@@ -294,7 +365,10 @@ export class PlaybackController {
     if (clampedTarget <= 0) {
       return false
     }
-    return this.advance(clampedTarget)
+    // Seeking is instantaneous positioning by path distance — step
+    // geometrically so distanceTraveled lands exactly on the target and the
+    // progress bar stays linear regardless of per-move feed.
+    return this.step(clampedTarget, false)
   }
 
   seekToFraction(fraction: number): boolean {

--- a/src/engine/simulation/playback.ts
+++ b/src/engine/simulation/playback.ts
@@ -89,8 +89,11 @@ export function subdivideMoves(moves: ToolpathMove[], maxSegmentLength: number):
     for (let i = 0; i < subdivisions; i += 1) {
       const t0 = i / subdivisions
       const t1 = (i + 1) / subdivisions
+      // Spread the source move so per-move metadata (feedScale, source) rides
+      // along to each sub-segment — otherwise the live feed readout loses the
+      // reduced slot feed on subdivided cuts.
       out.push({
-        kind: move.kind,
+        ...move,
         from: interpolatePoint(move, t0),
         to: interpolatePoint(move, t1),
       })

--- a/src/engine/toolpaths/pocket.ts
+++ b/src/engine/toolpaths/pocket.ts
@@ -38,7 +38,7 @@ import {
 } from './geometry'
 import { isFeatureFirst, mergePocketToolpathResults, perFeatureOperations } from './multiFeature'
 import { resolvePocketRegions } from './resolver'
-import { buildRegionMask, clipToolpathResultToRegionMask, splitCutMoveAtContours, splitFeatureTargets } from './regions'
+import { buildRegionMask, clipToolpathResultToRegionMask, splitFeatureTargets } from './regions'
 
 interface PolyTreeNode {
   IsHole(): boolean
@@ -222,19 +222,28 @@ type OffsetTraversalMode = 'outer-first' | 'inner-first'
 const XY_ALIGN_EPS = 1e-6
 
 /**
- * A cut is "adjacent to cleared material" when it runs within one stepover of
- * an already-cleared child offset region. The factor adds tolerance for the
- * Clipper round-trip (inset by stepover, expand back by stepover) not being a
- * perfect identity at corners.
+ * A cut is fully engaged (slotting) when the nearest path already cut at the
+ * same level is about a tool diameter away — at that distance no neighbouring
+ * kerf absorbs any of the tool's width. The factor leaves a margin so cuts a
+ * few percent shy of a true slot still get the reduced feed. Cuts closer to a
+ * prior kerf are over-engaged at most transiently (e.g. ring corners, whose
+ * diagonal spacing exceeds the stepover) and keep the normal feed.
+ */
+const SLOT_FEED_ENGAGEMENT_FACTOR = 0.9
+
+/**
+ * Lower bound on the slot distance: a pass at exactly one stepover from its
+ * neighbour must never be misclassified as engaged, even with stepovers close
+ * to (or beyond) the engagement threshold.
  */
 const SLOT_FEED_ADJACENCY_FACTOR = 1.05
 
-export interface SlotFeedOptions {
-  /** Multiplier (0..1) applied to fully engaged cut moves. */
-  scale: number
-  /** Distance treated as "adjacent to cleared material": one stepover plus tolerance. */
-  adjacency: number
-}
+/**
+ * Lateral wiggle (as a fraction of the stepover) tolerated when deciding that
+ * a prior kerf directly behind the tool is its own trail: below half a
+ * stepover it cannot be a neighbouring pass, so it must be the path just cut.
+ */
+const SLOT_FEED_OWN_TRAIL_FACTOR = 0.45
 
 /**
  * Resolve the operation's slot-feed percentage into a cut-feed multiplier.
@@ -249,81 +258,206 @@ export function resolveSlotFeedScale(operation: Operation): number | null {
   return percent / 100
 }
 
-interface EngagementMask {
-  contours: Point[][]
-  contains(point: Point): boolean
-}
-
-function pointInContour(point: Point, contour: Point[]): boolean {
-  let inside = false
-  for (let index = 0, previous = contour.length - 1; index < contour.length; previous = index, index += 1) {
-    const a = contour[index]
-    const b = contour[previous]
-    const crosses = (a.y > point.y) !== (b.y > point.y)
-      && point.x < ((b.x - a.x) * (point.y - a.y)) / (b.y - a.y) + a.x
-    if (crosses) inside = !inside
-  }
-  return inside
+interface PriorCutSegment {
+  ax: number
+  ay: number
+  bx: number
+  by: number
 }
 
 /**
- * Build the cleared-adjacency mask from the regions already machined at this
- * level (the current node's child offset regions, expanded by the adjacency
- * distance). A point inside the mask is within one stepover of cleared
- * material, so a cut through it has normal stepover engagement; a point
- * outside is virgin material, so a cut through it is fully engaged.
+ * Spatial index over previously cut segments: segments are inserted into every
+ * grid cell their adjacency-inflated bounding box covers, so a point query
+ * only has to test its own cell's bucket.
  */
-function buildEngagementMask(clearedRegions: ResolvedPocketRegion[]): EngagementMask {
-  const contours: Point[][] = []
-  for (const region of clearedRegions) {
-    if (region.outer.length >= 3) contours.push(region.outer)
-    for (const island of region.islands) {
-      if (island.length >= 3) contours.push(island)
+class PriorCutIndex {
+  private readonly cells = new Map<string, PriorCutSegment[]>()
+  private readonly cellSize: number
+  private readonly adjacency: number
+  private readonly ownTrailLateralTolerance: number
+  private readonly maxPieceLength: number
+
+  constructor(cellSize: number, adjacency: number, ownTrailLateralTolerance: number, maxPieceLength: number) {
+    this.cellSize = cellSize
+    this.adjacency = adjacency
+    this.ownTrailLateralTolerance = ownTrailLateralTolerance
+    this.maxPieceLength = maxPieceLength
+  }
+
+  /**
+   * Segments are stored in pieces no longer than maxPieceLength. The
+   * directional query below tests each piece's closest point: with long
+   * segments the closest point can collapse onto a shared corner and be
+   * dismissed as the tool's own trail even though the rest of the kerf wraps
+   * laterally around the query point (e.g. a link hopping diagonally out of a
+   * ring corner). Short pieces provide those lateral witness points.
+   */
+  insert(segment: PriorCutSegment): void {
+    const dx = segment.bx - segment.ax
+    const dy = segment.by - segment.ay
+    const length = Math.hypot(dx, dy)
+    const pieceCount = Math.max(1, Math.ceil(length / this.maxPieceLength))
+    for (let piece = 0; piece < pieceCount; piece += 1) {
+      const t0 = piece / pieceCount
+      const t1 = (piece + 1) / pieceCount
+      this.insertPiece({
+        ax: segment.ax + dx * t0,
+        ay: segment.ay + dy * t0,
+        bx: segment.ax + dx * t1,
+        by: segment.ay + dy * t1,
+      })
     }
   }
+
+  private insertPiece(segment: PriorCutSegment): void {
+    const pad = this.adjacency
+    const colMin = Math.floor((Math.min(segment.ax, segment.bx) - pad) / this.cellSize)
+    const colMax = Math.floor((Math.max(segment.ax, segment.bx) + pad) / this.cellSize)
+    const rowMin = Math.floor((Math.min(segment.ay, segment.by) - pad) / this.cellSize)
+    const rowMax = Math.floor((Math.max(segment.ay, segment.by) + pad) / this.cellSize)
+    for (let col = colMin; col <= colMax; col += 1) {
+      for (let row = rowMin; row <= rowMax; row += 1) {
+        const key = `${col},${row}`
+        const bucket = this.cells.get(key)
+        if (bucket) {
+          bucket.push(segment)
+        } else {
+          this.cells.set(key, [segment])
+        }
+      }
+    }
+  }
+
+  /**
+   * Is the point (x, y), moving in direction (dirX, dirY) (unit vector),
+   * within the adjacency distance of a prior kerf that actually reduces the
+   * tool's engagement? A prior whose closest point lies directly BEHIND the
+   * motion (negative along-component, near-zero lateral offset) is the tool's
+   * own trail — the kerf it just cut — and says nothing about the material
+   * ahead, so it is ignored. Priors beside or ahead of the motion count.
+   */
+  isNearPrior(x: number, y: number, dirX: number, dirY: number): boolean {
+    const bucket = this.cells.get(`${Math.floor(x / this.cellSize)},${Math.floor(y / this.cellSize)}`)
+    if (!bucket) return false
+    const adjacencySq = this.adjacency * this.adjacency
+    for (const segment of bucket) {
+      const dx = segment.bx - segment.ax
+      const dy = segment.by - segment.ay
+      const lengthSq = dx * dx + dy * dy
+      const t = lengthSq > 0
+        ? Math.max(0, Math.min(1, ((x - segment.ax) * dx + (y - segment.ay) * dy) / lengthSq))
+        : 0
+      const vx = segment.ax + dx * t - x
+      const vy = segment.ay + dy * t - y
+      if (vx * vx + vy * vy > adjacencySq) continue
+      const along = vx * dirX + vy * dirY
+      const lateral = Math.abs(vx * dirY - vy * dirX)
+      if (along < 1e-9 && lateral < this.ownTrailLateralTolerance) continue
+      return true
+    }
+    return false
+  }
+}
+
+function interpolateMovePoint(move: ToolpathMove, t: number): ToolpathPoint {
+  if (t <= 0) return { ...move.from }
+  if (t >= 1) return { ...move.to }
   return {
-    contours,
-    contains: (point) => clearedRegions.some((region) =>
-      region.outer.length >= 3
-      && pointInContour(point, region.outer)
-      && !region.islands.some((island) => island.length >= 3 && pointInContour(point, island))),
+    x: move.from.x + (move.to.x - move.from.x) * t,
+    y: move.from.y + (move.to.y - move.from.y) * t,
+    z: move.from.z + (move.to.z - move.from.z) * t,
   }
 }
 
 /**
- * Re-stamp the cut moves appended since startIndex: fragments outside the
- * cleared-adjacency mask are fully engaged and get the reduced slot feed;
- * fragments inside keep the normal feed. Moves spanning both zones are split
- * at the mask boundary. With no mask (or an empty one) everything is virgin
- * material and every cut move in the range is stamped. Rapids and plunges
- * are left untouched.
+ * Stamp the reduced slot feed onto the fully engaged portions of the cut
+ * moves appended since startIndex (one Z level's worth of cutting).
+ *
+ * Engagement model: a cut is fully engaged (slotting) exactly when it runs
+ * farther than `slotDistance` (about a tool diameter) from every path already
+ * cut at this level — no neighbouring kerf is absorbing part of the tool's
+ * width. This single rule covers every case: the first pass into virgin
+ * material, each disjoint section's own inner start, ring segments crossing
+ * uncleared pinch corridors, and link cuts through virgin strips — while
+ * passes near an existing kerf (ordinary stepover rings, ring corners, the
+ * back side of a thin loop overlapping its own kerf, and links crossing
+ * already-cleared floor) keep the normal feed.
+ *
+ * Moves are classified in chunks of a quarter of the slot distance and split
+ * where the classification changes. The tool's own trail — a prior kerf lying
+ * directly behind the motion direction — is excluded from the test, so a
+ * straight slot stays fully engaged however long it runs, while a genuinely
+ * lateral neighbour (an adjacent scanline or ring, however recently cut)
+ * counts immediately. `ownTrailTolerance` is the lateral wiggle allowed for
+ * that behind-the-tool exclusion (covers gently curved trails). Rapids and
+ * plunges are left untouched and don't count as cleared paths.
  */
-function applySlotFeedScale(
+function applySlotFeedToLevel(
   moves: ToolpathMove[],
   startIndex: number,
   scale: number,
-  mask: EngagementMask | null,
+  slotDistance: number,
+  ownTrailTolerance: number,
 ): void {
   if (startIndex >= moves.length) return
 
+  const chunkLength = slotDistance / 4
+  const index = new PriorCutIndex(slotDistance, slotDistance, ownTrailTolerance, chunkLength)
   const stamped: ToolpathMove[] = []
-  for (let index = startIndex; index < moves.length; index += 1) {
-    const move = moves[index]
+
+  for (let moveIndex = startIndex; moveIndex < moves.length; moveIndex += 1) {
+    const move = moves[moveIndex]
     if (move.kind !== 'cut') {
       stamped.push(move)
       continue
     }
 
-    if (!mask || mask.contours.length === 0) {
-      stamped.push({ ...move, feedScale: scale })
+    const dx = move.to.x - move.from.x
+    const dy = move.to.y - move.from.y
+    const length = Math.hypot(dx, dy)
+    if (length <= 1e-9) {
+      stamped.push(move)
       continue
     }
+    const dirX = dx / length
+    const dirY = dy / length
 
-    for (const fragment of splitCutMoveAtContours(move, mask.contours, mask.contains)) {
-      stamped.push(fragment.inside
-        ? { ...move, from: fragment.from, to: fragment.to }
-        : { ...move, from: fragment.from, to: fragment.to, feedScale: scale })
+    const chunkCount = Math.max(1, Math.ceil(length / chunkLength))
+    let fragmentStartT = 0
+    let fragmentEngaged: boolean | null = null
+
+    const emitFragment = (t0: number, t1: number, engaged: boolean) => {
+      const from = interpolateMovePoint(move, t0)
+      const to = interpolateMovePoint(move, t1)
+      stamped.push(engaged ? { ...move, from, to, feedScale: scale } : { ...move, from, to })
     }
+
+    for (let chunk = 0; chunk < chunkCount; chunk += 1) {
+      const t0 = chunk / chunkCount
+      const t1 = (chunk + 1) / chunkCount
+      const tMid = (t0 + t1) / 2
+      const engaged = !index.isNearPrior(
+        move.from.x + dx * tMid,
+        move.from.y + dy * tMid,
+        dirX,
+        dirY,
+      )
+      if (fragmentEngaged === null) {
+        fragmentEngaged = engaged
+      } else if (engaged !== fragmentEngaged) {
+        emitFragment(fragmentStartT, t0, fragmentEngaged)
+        fragmentStartT = t0
+        fragmentEngaged = engaged
+      }
+    }
+    emitFragment(fragmentStartT, 1, fragmentEngaged ?? true)
+
+    index.insert({
+      ax: move.from.x,
+      ay: move.from.y,
+      bx: move.to.x,
+      by: move.to.y,
+    })
   }
 
   moves.length = startIndex
@@ -793,21 +927,15 @@ function orderClosedContoursGreedyPreservingRotation(contours: Point[][], start:
   return ordered
 }
 
-export interface TaggedOpenSegment {
-  points: Point[]
-  /** Index of the source region within the regions array the segments were built from. */
-  regionIndex: number
-}
-
-function orderTaggedOpenSegmentsGreedy(segments: TaggedOpenSegment[], start: Point | null): TaggedOpenSegment[] {
+export function orderOpenSegmentsGreedy(segments: Point[][], start: Point | null): Point[][] {
   if (segments.length <= 1 || start === null) {
     return segments
   }
 
   const remaining = segments
-    .filter((segment) => segment.points.length >= 2)
-    .map((segment) => ({ ...segment, points: [...segment.points] }))
-  const ordered: TaggedOpenSegment[] = []
+    .filter((segment) => segment.length >= 2)
+    .map((segment) => [...segment])
+  const ordered: Point[][] = []
   let current = start
 
   while (remaining.length > 0) {
@@ -816,7 +944,7 @@ function orderTaggedOpenSegmentsGreedy(segments: TaggedOpenSegment[], start: Poi
     let bestDistance = Number.POSITIVE_INFINITY
 
     for (let index = 0; index < remaining.length; index += 1) {
-      const segment = remaining[index].points
+      const segment = remaining[index]
       const first = segment[0]
       const last = segment[segment.length - 1]
       const forwardDistance = distanceSquared(current, first)
@@ -835,33 +963,20 @@ function orderTaggedOpenSegmentsGreedy(segments: TaggedOpenSegment[], start: Poi
     }
 
     const [nextSegment] = remaining.splice(bestIndex, 1)
-    const orderedSegment = bestReverse
-      ? { ...nextSegment, points: [...nextSegment.points].reverse() }
-      : nextSegment
+    const orderedSegment = bestReverse ? [...nextSegment].reverse() : nextSegment
     ordered.push(orderedSegment)
-    current = orderedSegment.points[orderedSegment.points.length - 1]
+    current = orderedSegment[orderedSegment.length - 1]
   }
 
   return ordered
 }
 
-export function orderOpenSegmentsGreedy(segments: Point[][], start: Point | null): Point[][] {
-  if (segments.length <= 1 || start === null) {
-    return segments
-  }
-
-  return orderTaggedOpenSegmentsGreedy(
-    segments.map((points) => ({ points, regionIndex: 0 })),
-    start,
-  ).map((segment) => segment.points)
-}
-
-export function buildPocketParallelSegmentsTagged(
+export function buildPocketParallelSegments(
   regions: ResolvedPocketRegion[],
   stepoverDistance: number,
   angleDeg: number,
-): TaggedOpenSegment[] {
-  const segments: TaggedOpenSegment[] = []
+): Point[][] {
+  const segments: Point[][] = []
   const minStepover = 1 / DEFAULT_CLIPPER_SCALE
   const step = Math.max(stepoverDistance, minStepover)
   const angleRad = (angleDeg * Math.PI) / 180
@@ -893,7 +1008,7 @@ export function buildPocketParallelSegmentsTagged(
         const left = rotatePoint({ x: startX, y }, cosForward, sinForward)
         const right = rotatePoint({ x: endX, y }, cosForward, sinForward)
         const reverse = (regionIndex + scanIndex) % 2 === 1
-        segments.push({ points: reverse ? [right, left] : [left, right], regionIndex })
+        segments.push(reverse ? [right, left] : [left, right])
       }
 
       scanIndex += 1
@@ -901,15 +1016,6 @@ export function buildPocketParallelSegmentsTagged(
   })
 
   return segments
-}
-
-export function buildPocketParallelSegments(
-  regions: ResolvedPocketRegion[],
-  stepoverDistance: number,
-  angleDeg: number,
-): Point[][] {
-  return buildPocketParallelSegmentsTagged(regions, stepoverDistance, angleDeg)
-    .map((segment) => segment.points)
 }
 
 export function cutClosedContours(
@@ -944,34 +1050,19 @@ export function cutClosedContours(
 interface OffsetRegionNode {
   region: ResolvedPocketRegion
   children: OffsetRegionNode[]
-  /** Cleared-adjacency mask for slot-feed classification; null when slot feed is off. */
-  engagementMask: EngagementMask | null
 }
 
 /**
- * Precompute the offset ring tree for a region. The tree (successive insets
- * and, when slot feed is active, the per-node engagement masks) depends only
- * on the region geometry and stepover — not on Z — so callers cutting several
- * step levels build it once and traverse it per level instead of redoing the
- * Clipper offsets at every level.
+ * Precompute the offset ring tree for a region. The successive insets depend
+ * only on the region geometry and stepover — not on Z — so callers cutting
+ * several step levels build the tree once and traverse it per level instead
+ * of redoing the Clipper offsets at every level.
  */
-function buildOffsetRegionTree(
-  region: ResolvedPocketRegion,
-  stepoverDistance: number,
-  slotFeed?: SlotFeedOptions,
-): OffsetRegionNode {
+function buildOffsetRegionTree(region: ResolvedPocketRegion, stepoverDistance: number): OffsetRegionNode {
   const childRegions = buildInsetRegions(region, stepoverDistance)
   return {
     region,
-    children: childRegions.map((child) => buildOffsetRegionTree(child, stepoverDistance, slotFeed)),
-    // In inner-first traversal the children are cut before this region's own
-    // loops, so material within one stepover of a child region is already
-    // cleared. Everything else this node's loops touch is virgin: the whole
-    // loop for leaf regions (no children), and pinch corridors of parent
-    // rings where the inset split into disjoint children.
-    engagementMask: slotFeed
-      ? buildEngagementMask(childRegions.flatMap((child) => buildInsetRegions(child, -slotFeed.adjacency)))
-      : null,
+    children: childRegions.map((child) => buildOffsetRegionTree(child, stepoverDistance)),
   }
 }
 
@@ -994,7 +1085,7 @@ function cutOffsetRegionNode(
   direction: CutDirection,
   safeLinkCheck: SafeLinkCheck | undefined,
   traversalMode: OffsetTraversalMode,
-  slotScale: number | null,
+  loops: 'all' | 'outer' = 'all',
 ): ToolpathPoint | null {
   const cutCurrentRegion = (fromPosition: ToolpathPoint | null): ToolpathPoint | null => {
     const childAnchors = traversalMode === 'outer-first'
@@ -1003,14 +1094,19 @@ function cutOffsetRegionNode(
         .filter((contour) => contour.length > 0)
         .map((contour) => contour[0])
       : []
-    const preparedContours = buildContourLoops([node.region]).map((contour) => rotateContourToBestEntry(
+    // 'outer' cuts only the region's outer boundary loop — used by the finish
+    // floor pass, where island walls are the wall pass's job, matching the
+    // outer-contours-only coverage of buildPocketFloorContours.
+    const contours = loops === 'outer'
+      ? (node.region.outer.length >= 3 ? [node.region.outer] : [])
+      : buildContourLoops([node.region])
+    const preparedContours = contours.map((contour) => rotateContourToBestEntry(
       contour,
       fromPosition ? { x: fromPosition.x, y: fromPosition.y } : null,
       childAnchors,
     ))
 
-    const startIndex = moves.length
-    const endPosition = cutClosedContours(
+    return cutClosedContours(
       moves,
       preparedContours,
       z,
@@ -1021,12 +1117,6 @@ function cutOffsetRegionNode(
       direction,
       safeLinkCheck,
     )
-
-    if (slotScale !== null && traversalMode === 'inner-first') {
-      applySlotFeedScale(moves, startIndex, slotScale, node.engagementMask)
-    }
-
-    return endPosition
   }
 
   let nextPosition = currentPosition
@@ -1050,7 +1140,7 @@ function cutOffsetRegionNode(
       direction,
       safeLinkCheck,
       traversalMode,
-      slotScale,
+      loops,
     )
   }
 
@@ -1072,11 +1162,10 @@ export function cutOffsetRegionRecursive(
   direction: CutDirection = 'conventional',
   safeLinkCheck?: SafeLinkCheck,
   traversalMode: OffsetTraversalMode = 'outer-first',
-  slotFeed?: SlotFeedOptions,
 ): ToolpathPoint | null {
   return cutOffsetRegionNode(
     moves,
-    buildOffsetRegionTree(region, stepoverDistance, slotFeed),
+    buildOffsetRegionTree(region, stepoverDistance),
     z,
     safeZ,
     maxLinkDistance,
@@ -1084,7 +1173,6 @@ export function cutOffsetRegionRecursive(
     direction,
     safeLinkCheck,
     traversalMode,
-    slotFeed ? slotFeed.scale : null,
   )
 }
 
@@ -1132,6 +1220,10 @@ function generateRoughBandMoves(
   const minStepover = 1 / DEFAULT_CLIPPER_SCALE
   const effectiveStepover = Math.max(stepoverDistance, minStepover)
   const slotScale = resolveSlotFeedScale(operation)
+  const slotDistance = Math.max(
+    toolRadius * 2 * SLOT_FEED_ENGAGEMENT_FACTOR,
+    effectiveStepover * SLOT_FEED_ADJACENCY_FACTOR,
+  )
   let currentPosition: ToolpathPoint | null = null
 
   if (operation.kind === 'pocket' && operation.pocketPattern === 'parallel') {
@@ -1145,7 +1237,7 @@ function generateRoughBandMoves(
     }
 
     const boundaryContours = applyContourDirection(buildContourLoops(roughRegions), direction)
-    const segments = buildPocketParallelSegmentsTagged(roughRegions, effectiveStepover, operation.pocketAngle)
+    const segments = buildPocketParallelSegments(roughRegions, effectiveStepover, operation.pocketAngle)
     if (segments.length === 0) {
       return {
         moves,
@@ -1155,9 +1247,7 @@ function generateRoughBandMoves(
     }
 
     for (const z of stepLevels) {
-      // The boundary pass is cut before anything is cleared at this level, so
-      // every boundary loop is a full-slot cut.
-      const boundaryStartIndex = moves.length
+      const levelStartIndex = moves.length
       for (const contour of boundaryContours) {
         const entryPoint = contourStartPoint(contour, z)
         currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
@@ -1165,29 +1255,22 @@ function generateRoughBandMoves(
         moves.push(...cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
       }
-      if (slotScale !== null) {
-        applySlotFeedScale(moves, boundaryStartIndex, slotScale, null)
-      }
 
-      const orderedSegments = orderTaggedOpenSegmentsGreedy(
+      const orderedSegments = orderOpenSegmentsGreedy(
         segments,
         currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
       )
 
-      // The first fill line cut in each region is a full-slot cut; later
-      // lines overlap the previously cleared band by the stepover.
-      const slottedRegions = new Set<number>()
-      for (const { points: segment, regionIndex } of orderedSegments) {
-        const segmentStartIndex = moves.length
+      for (const segment of orderedSegments) {
         const entryPoint = contourStartPoint(segment, z)
         currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
         const cutMoves = toOpenCutMoves(segment, z)
         moves.push(...cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
-        if (slotScale !== null && !slottedRegions.has(regionIndex)) {
-          slottedRegions.add(regionIndex)
-          applySlotFeedScale(moves, segmentStartIndex, slotScale, null)
-        }
+      }
+
+      if (slotScale !== null) {
+        applySlotFeedToLevel(moves, levelStartIndex, slotScale, slotDistance, effectiveStepover * SLOT_FEED_OWN_TRAIL_FACTOR)
       }
 
       currentPosition = retractToSafe(moves, currentPosition, safeZ)
@@ -1196,15 +1279,11 @@ function generateRoughBandMoves(
     return { moves, stepLevels, warnings }
   }
 
-  const slotFeed = slotScale !== null
-    ? { scale: slotScale, adjacency: effectiveStepover * SLOT_FEED_ADJACENCY_FACTOR }
-    : undefined
-
-  // The offset ring tree is identical at every step level — build it (and
-  // the slot-feed engagement masks) once and traverse it per level.
+  // The offset ring tree is identical at every step level — build it once
+  // and traverse it per level.
   const regionTrees = band.regions
     .flatMap((region) => buildInsetRegions(region, initialInset))
-    .map((region) => buildOffsetRegionTree(region, effectiveStepover, slotFeed))
+    .map((region) => buildOffsetRegionTree(region, effectiveStepover))
 
   for (const z of stepLevels) {
     if (regionTrees.length === 0) {
@@ -1213,6 +1292,7 @@ function generateRoughBandMoves(
       continue
     }
 
+    const levelStartIndex = moves.length
     const orderedTrees = orderNodesGreedy(
       regionTrees,
       currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
@@ -1229,8 +1309,11 @@ function generateRoughBandMoves(
         direction,
         undefined,
         'inner-first',
-        slotScale,
       )
+    }
+
+    if (slotScale !== null) {
+      applySlotFeedToLevel(moves, levelStartIndex, slotScale, slotDistance, effectiveStepover * SLOT_FEED_OWN_TRAIL_FACTOR)
     }
 
     currentPosition = retractToSafe(moves, currentPosition, safeZ)
@@ -1274,22 +1357,23 @@ function generateFinishBandMoves(
   const slotScale = resolveSlotFeedScale(operation)
   const isParallelPocket = operation.kind === 'pocket' && operation.pocketPattern === 'parallel'
   const wallContours = operation.finishWalls ? buildContourLoops(finishRegions) : []
-  // Per-region floor groups are built only when the slot feed is active; the
-  // disabled path keeps today's single global greedy ordering untouched.
-  const floorContourGroups = slotScale !== null && operation.finishFloor && !isParallelPocket
+  // Offset floors are cut through the same inner-first ring traversal as the
+  // rough pass (each disjoint floor area starts at its innermost loop and
+  // works outward). The tree roots replicate buildPocketFloorContours'
+  // geometry: a zero-inset Clipper round-trip, then one extra stepover inset
+  // so the floor pass doesn't double as a wall-finish contour.
+  const minFloorStepover = 1 / DEFAULT_CLIPPER_SCALE
+  const floorStepover = Math.max(stepoverDistance, minFloorStepover)
+  const floorTrees = operation.finishFloor && !isParallelPocket
     ? finishRegions
-      .map((region) => buildPocketFloorContours([region], 0, stepoverDistance))
-      .filter((group) => group.length > 0)
-    : null
-  const floorContours = floorContourGroups !== null
-    ? floorContourGroups.flat()
-    : operation.finishFloor && !isParallelPocket
-      ? buildPocketFloorContours(finishRegions, 0, stepoverDistance)
-      : []
-  const floorSegments = operation.finishFloor && isParallelPocket
-    ? buildPocketParallelSegmentsTagged(finishRegions, stepoverDistance, operation.pocketAngle)
+      .flatMap((region) => buildInsetRegions(region, 0))
+      .flatMap((region) => buildInsetRegions(region, floorStepover))
+      .map((region) => buildOffsetRegionTree(region, floorStepover))
     : []
-  if (wallContours.length === 0 && floorContours.length === 0 && floorSegments.length === 0) {
+  const floorSegments = operation.finishFloor && isParallelPocket
+    ? buildPocketParallelSegments(finishRegions, stepoverDistance, operation.pocketAngle)
+    : []
+  if (wallContours.length === 0 && floorTrees.length === 0 && floorSegments.length === 0) {
     return {
       moves,
       stepLevels: [],
@@ -1307,61 +1391,45 @@ function generateFinishBandMoves(
   // slot feed), so the wall pass only shaves the radial stock — and cutting
   // walls last leaves the cleanest final wall surface.
   for (const z of floorStepLevels) {
-    if (floorContourGroups !== null && slotScale !== null) {
-      // Visit floor regions nearest-first; the first floor loop cut in each
-      // region crosses the full remaining skin width (fully engaged), later
-      // loops overlap the cleared band by the stepover.
-      const remainingGroups = [...floorContourGroups]
-      while (remainingGroups.length > 0) {
-        const anchor = currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null
-        let bestIndex = 0
-        if (anchor !== null) {
-          let bestDistance = Number.POSITIVE_INFINITY
-          for (let index = 0; index < remainingGroups.length; index += 1) {
-            const distance = Math.min(
-              ...remainingGroups[index].map((contour) => contourEntryDistanceSquared(contour, anchor)),
-            )
-            if (distance < bestDistance) {
-              bestIndex = index
-              bestDistance = distance
-            }
-          }
-        }
-        const [group] = remainingGroups.splice(bestIndex, 1)
-        const orderedGroup = orderClosedContoursGreedy(group, anchor)
-        if (orderedGroup.length === 0) {
-          continue
-        }
-        const startIndex = moves.length
-        currentPosition = cutClosedContours(moves, [orderedGroup[0]], z, safeZ, maxLinkDistance, currentPosition, false, direction)
-        applySlotFeedScale(moves, startIndex, slotScale, null)
-        if (orderedGroup.length > 1) {
-          currentPosition = cutClosedContours(moves, orderedGroup.slice(1), z, safeZ, maxLinkDistance, currentPosition, false, direction)
-        }
-      }
-    } else {
-      currentPosition = cutClosedContours(moves, floorContours, z, safeZ, maxLinkDistance, currentPosition, false, direction)
+    const floorStartIndex = moves.length
+
+    const orderedTrees = orderNodesGreedy(
+      floorTrees,
+      currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
+    )
+    for (const tree of orderedTrees) {
+      currentPosition = cutOffsetRegionNode(
+        moves,
+        tree,
+        z,
+        safeZ,
+        maxLinkDistance,
+        currentPosition,
+        direction,
+        undefined,
+        'inner-first',
+        'outer',
+      )
     }
 
-    const orderedFloorSegments = orderTaggedOpenSegmentsGreedy(
+    const orderedFloorSegments = orderOpenSegmentsGreedy(
       floorSegments,
       currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
     )
-
-    // The first floor fill line cut in each region crosses the full skin
-    // width; later lines overlap the cleared band by the stepover.
-    const slottedRegions = new Set<number>()
-    for (const { points: segment, regionIndex } of orderedFloorSegments) {
-      const segmentStartIndex = moves.length
+    for (const segment of orderedFloorSegments) {
       const entryPoint = contourStartPoint(segment, z)
       currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
       const cutMoves = toOpenCutMoves(segment, z)
       moves.push(...cutMoves)
       currentPosition = cutMoves.at(-1)?.to ?? currentPosition
-      if (slotScale !== null && !slottedRegions.has(regionIndex)) {
-        slottedRegions.add(regionIndex)
-        applySlotFeedScale(moves, segmentStartIndex, slotScale, null)
-      }
+    }
+
+    if (slotScale !== null) {
+      const slotDistance = Math.max(
+        toolRadius * 2 * SLOT_FEED_ENGAGEMENT_FACTOR,
+        floorStepover * SLOT_FEED_ADJACENCY_FACTOR,
+      )
+      applySlotFeedToLevel(moves, floorStartIndex, slotScale, slotDistance, floorStepover * SLOT_FEED_OWN_TRAIL_FACTOR)
     }
 
     currentPosition = retractToSafe(moves, currentPosition, safeZ)

--- a/src/engine/toolpaths/pocket.ts
+++ b/src/engine/toolpaths/pocket.ts
@@ -1301,12 +1301,11 @@ function generateFinishBandMoves(
   const floorStepLevels = operation.finishFloor ? [effectiveBottom] : []
   let currentPosition: ToolpathPoint | null = null
 
-  for (const z of wallStepLevels) {
-    currentPosition = cutClosedContours(moves, wallContours, z, safeZ, maxLinkDistance, currentPosition, false, direction)
-
-    currentPosition = retractToSafe(moves, currentPosition, safeZ)
-  }
-
+  // Floor before walls: when roughing left axial stock, a wall pass at final
+  // depth would slot through the uncleared floor skin at full feed. Cutting
+  // the floor first removes that skin (with its first pass at the reduced
+  // slot feed), so the wall pass only shaves the radial stock — and cutting
+  // walls last leaves the cleanest final wall surface.
   for (const z of floorStepLevels) {
     if (floorContourGroups !== null && slotScale !== null) {
       // Visit floor regions nearest-first; the first floor loop cut in each
@@ -1364,6 +1363,12 @@ function generateFinishBandMoves(
         applySlotFeedScale(moves, segmentStartIndex, slotScale, null)
       }
     }
+
+    currentPosition = retractToSafe(moves, currentPosition, safeZ)
+  }
+
+  for (const z of wallStepLevels) {
+    currentPosition = cutClosedContours(moves, wallContours, z, safeZ, maxLinkDistance, currentPosition, false, direction)
 
     currentPosition = retractToSafe(moves, currentPosition, safeZ)
   }

--- a/src/engine/toolpaths/pocket.ts
+++ b/src/engine/toolpaths/pocket.ts
@@ -251,7 +251,7 @@ const SLOT_FEED_OWN_TRAIL_FACTOR = 0.45
  * out-of-range, or 100%), which callers use to skip all slot-feed work so the
  * generated move stream is byte-identical to the pre-feature output.
  */
-export function resolveSlotFeedScale(operation: Operation): number | null {
+function resolveSlotFeedScale(operation: Operation): number | null {
   if (operation.kind !== 'pocket') return null
   const percent = operation.pocketSlotFeedPercent
   if (percent === undefined || !(percent > 0) || percent >= 100) return null

--- a/src/engine/toolpaths/pocket.ts
+++ b/src/engine/toolpaths/pocket.ts
@@ -941,29 +941,69 @@ export function cutClosedContours(
   return nextPosition
 }
 
-export function cutOffsetRegionRecursive(
-  moves: ToolpathMove[],
+interface OffsetRegionNode {
+  region: ResolvedPocketRegion
+  children: OffsetRegionNode[]
+  /** Cleared-adjacency mask for slot-feed classification; null when slot feed is off. */
+  engagementMask: EngagementMask | null
+}
+
+/**
+ * Precompute the offset ring tree for a region. The tree (successive insets
+ * and, when slot feed is active, the per-node engagement masks) depends only
+ * on the region geometry and stepover — not on Z — so callers cutting several
+ * step levels build it once and traverse it per level instead of redoing the
+ * Clipper offsets at every level.
+ */
+function buildOffsetRegionTree(
   region: ResolvedPocketRegion,
+  stepoverDistance: number,
+  slotFeed?: SlotFeedOptions,
+): OffsetRegionNode {
+  const childRegions = buildInsetRegions(region, stepoverDistance)
+  return {
+    region,
+    children: childRegions.map((child) => buildOffsetRegionTree(child, stepoverDistance, slotFeed)),
+    // In inner-first traversal the children are cut before this region's own
+    // loops, so material within one stepover of a child region is already
+    // cleared. Everything else this node's loops touch is virgin: the whole
+    // loop for leaf regions (no children), and pinch corridors of parent
+    // rings where the inset split into disjoint children.
+    engagementMask: slotFeed
+      ? buildEngagementMask(childRegions.flatMap((child) => buildInsetRegions(child, -slotFeed.adjacency)))
+      : null,
+  }
+}
+
+function orderNodesGreedy(nodes: OffsetRegionNode[], start: Point | null): OffsetRegionNode[] {
+  if (nodes.length <= 1 || start === null) {
+    return nodes
+  }
+  const byRegion = new Map(nodes.map((node) => [node.region, node]))
+  return orderRegionsGreedy(nodes.map((node) => node.region), start)
+    .map((region) => byRegion.get(region) as OffsetRegionNode)
+}
+
+function cutOffsetRegionNode(
+  moves: ToolpathMove[],
+  node: OffsetRegionNode,
   z: number,
   safeZ: number,
-  stepoverDistance: number,
   maxLinkDistance: number,
   currentPosition: ToolpathPoint | null,
-  direction: CutDirection = 'conventional',
-  safeLinkCheck?: SafeLinkCheck,
-  traversalMode: OffsetTraversalMode = 'outer-first',
-  slotFeed?: SlotFeedOptions,
+  direction: CutDirection,
+  safeLinkCheck: SafeLinkCheck | undefined,
+  traversalMode: OffsetTraversalMode,
+  slotScale: number | null,
 ): ToolpathPoint | null {
-  const childRegions = buildInsetRegions(region, stepoverDistance)
-
   const cutCurrentRegion = (fromPosition: ToolpathPoint | null): ToolpathPoint | null => {
     const childAnchors = traversalMode === 'outer-first'
-      ? childRegions
-        .map((child) => child.outer)
+      ? node.children
+        .map((child) => child.region.outer)
         .filter((contour) => contour.length > 0)
         .map((contour) => contour[0])
       : []
-    const preparedContours = buildContourLoops([region]).map((contour) => rotateContourToBestEntry(
+    const preparedContours = buildContourLoops([node.region]).map((contour) => rotateContourToBestEntry(
       contour,
       fromPosition ? { x: fromPosition.x, y: fromPosition.y } : null,
       childAnchors,
@@ -982,14 +1022,8 @@ export function cutOffsetRegionRecursive(
       safeLinkCheck,
     )
 
-    if (slotFeed && traversalMode === 'inner-first') {
-      // In inner-first traversal the children were cut before this region's
-      // own loops, so material within one stepover of a child region is
-      // already cleared. Everything else this loop touches is virgin: the
-      // whole loop for leaf regions (no children), and pinch corridors of
-      // parent rings where the inset split into disjoint children.
-      const clearedAdjacent = childRegions.flatMap((child) => buildInsetRegions(child, -slotFeed.adjacency))
-      applySlotFeedScale(moves, startIndex, slotFeed.scale, buildEngagementMask(clearedAdjacent))
+    if (slotScale !== null && traversalMode === 'inner-first') {
+      applySlotFeedScale(moves, startIndex, slotScale, node.engagementMask)
     }
 
     return endPosition
@@ -1000,24 +1034,23 @@ export function cutOffsetRegionRecursive(
     nextPosition = cutCurrentRegion(nextPosition)
   }
 
-  const orderedChildren = orderRegionsGreedy(
-    childRegions,
+  const orderedChildren = orderNodesGreedy(
+    node.children,
     nextPosition ? { x: nextPosition.x, y: nextPosition.y } : null,
   )
 
-  for (const childRegion of orderedChildren) {
-    nextPosition = cutOffsetRegionRecursive(
+  for (const childNode of orderedChildren) {
+    nextPosition = cutOffsetRegionNode(
       moves,
-      childRegion,
+      childNode,
       z,
       safeZ,
-      stepoverDistance,
       maxLinkDistance,
       nextPosition,
       direction,
       safeLinkCheck,
       traversalMode,
-      slotFeed,
+      slotScale,
     )
   }
 
@@ -1026,6 +1059,33 @@ export function cutOffsetRegionRecursive(
   }
 
   return nextPosition
+}
+
+export function cutOffsetRegionRecursive(
+  moves: ToolpathMove[],
+  region: ResolvedPocketRegion,
+  z: number,
+  safeZ: number,
+  stepoverDistance: number,
+  maxLinkDistance: number,
+  currentPosition: ToolpathPoint | null,
+  direction: CutDirection = 'conventional',
+  safeLinkCheck?: SafeLinkCheck,
+  traversalMode: OffsetTraversalMode = 'outer-first',
+  slotFeed?: SlotFeedOptions,
+): ToolpathPoint | null {
+  return cutOffsetRegionNode(
+    moves,
+    buildOffsetRegionTree(region, stepoverDistance, slotFeed),
+    z,
+    safeZ,
+    maxLinkDistance,
+    currentPosition,
+    direction,
+    safeLinkCheck,
+    traversalMode,
+    slotFeed ? slotFeed.scale : null,
+  )
 }
 
 export function toOpenCutMoves(points: Point[], z: number): ToolpathMove[] {
@@ -1140,32 +1200,36 @@ function generateRoughBandMoves(
     ? { scale: slotScale, adjacency: effectiveStepover * SLOT_FEED_ADJACENCY_FACTOR }
     : undefined
 
+  // The offset ring tree is identical at every step level — build it (and
+  // the slot-feed engagement masks) once and traverse it per level.
+  const regionTrees = band.regions
+    .flatMap((region) => buildInsetRegions(region, initialInset))
+    .map((region) => buildOffsetRegionTree(region, effectiveStepover, slotFeed))
+
   for (const z of stepLevels) {
-    const currentRegions = band.regions.flatMap((region) => buildInsetRegions(region, initialInset))
-    if (currentRegions.length === 0) {
+    if (regionTrees.length === 0) {
       warnings.push(`No machinable offset contours for band ${band.topZ} -> ${band.bottomZ}`)
       currentPosition = retractToSafe(moves, currentPosition, safeZ)
       continue
     }
 
-    const orderedRegions = orderRegionsGreedy(
-      currentRegions,
+    const orderedTrees = orderNodesGreedy(
+      regionTrees,
       currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
     )
 
-    for (const region of orderedRegions) {
-      currentPosition = cutOffsetRegionRecursive(
+    for (const tree of orderedTrees) {
+      currentPosition = cutOffsetRegionNode(
         moves,
-        region,
+        tree,
         z,
         safeZ,
-        effectiveStepover,
         maxLinkDistance,
         currentPosition,
         direction,
         undefined,
         'inner-first',
-        slotFeed,
+        slotScale,
       )
     }
 

--- a/src/engine/toolpaths/pocket.ts
+++ b/src/engine/toolpaths/pocket.ts
@@ -38,7 +38,7 @@ import {
 } from './geometry'
 import { isFeatureFirst, mergePocketToolpathResults, perFeatureOperations } from './multiFeature'
 import { resolvePocketRegions } from './resolver'
-import { buildRegionMask, clipToolpathResultToRegionMask, splitFeatureTargets } from './regions'
+import { buildRegionMask, clipToolpathResultToRegionMask, splitCutMoveAtContours, splitFeatureTargets } from './regions'
 
 interface PolyTreeNode {
   IsHole(): boolean
@@ -220,6 +220,117 @@ export type SafeLinkCheck = (from: ToolpathPoint, to: ToolpathPoint) => boolean
 type OffsetTraversalMode = 'outer-first' | 'inner-first'
 
 const XY_ALIGN_EPS = 1e-6
+
+/**
+ * A cut is "adjacent to cleared material" when it runs within one stepover of
+ * an already-cleared child offset region. The factor adds tolerance for the
+ * Clipper round-trip (inset by stepover, expand back by stepover) not being a
+ * perfect identity at corners.
+ */
+const SLOT_FEED_ADJACENCY_FACTOR = 1.05
+
+export interface SlotFeedOptions {
+  /** Multiplier (0..1) applied to fully engaged cut moves. */
+  scale: number
+  /** Distance treated as "adjacent to cleared material": one stepover plus tolerance. */
+  adjacency: number
+}
+
+/**
+ * Resolve the operation's slot-feed percentage into a cut-feed multiplier.
+ * Returns null when the reduction is disabled (non-pocket kinds, undefined,
+ * out-of-range, or 100%), which callers use to skip all slot-feed work so the
+ * generated move stream is byte-identical to the pre-feature output.
+ */
+export function resolveSlotFeedScale(operation: Operation): number | null {
+  if (operation.kind !== 'pocket') return null
+  const percent = operation.pocketSlotFeedPercent
+  if (percent === undefined || !(percent > 0) || percent >= 100) return null
+  return percent / 100
+}
+
+interface EngagementMask {
+  contours: Point[][]
+  contains(point: Point): boolean
+}
+
+function pointInContour(point: Point, contour: Point[]): boolean {
+  let inside = false
+  for (let index = 0, previous = contour.length - 1; index < contour.length; previous = index, index += 1) {
+    const a = contour[index]
+    const b = contour[previous]
+    const crosses = (a.y > point.y) !== (b.y > point.y)
+      && point.x < ((b.x - a.x) * (point.y - a.y)) / (b.y - a.y) + a.x
+    if (crosses) inside = !inside
+  }
+  return inside
+}
+
+/**
+ * Build the cleared-adjacency mask from the regions already machined at this
+ * level (the current node's child offset regions, expanded by the adjacency
+ * distance). A point inside the mask is within one stepover of cleared
+ * material, so a cut through it has normal stepover engagement; a point
+ * outside is virgin material, so a cut through it is fully engaged.
+ */
+function buildEngagementMask(clearedRegions: ResolvedPocketRegion[]): EngagementMask {
+  const contours: Point[][] = []
+  for (const region of clearedRegions) {
+    if (region.outer.length >= 3) contours.push(region.outer)
+    for (const island of region.islands) {
+      if (island.length >= 3) contours.push(island)
+    }
+  }
+  return {
+    contours,
+    contains: (point) => clearedRegions.some((region) =>
+      region.outer.length >= 3
+      && pointInContour(point, region.outer)
+      && !region.islands.some((island) => island.length >= 3 && pointInContour(point, island))),
+  }
+}
+
+/**
+ * Re-stamp the cut moves appended since startIndex: fragments outside the
+ * cleared-adjacency mask are fully engaged and get the reduced slot feed;
+ * fragments inside keep the normal feed. Moves spanning both zones are split
+ * at the mask boundary. With no mask (or an empty one) everything is virgin
+ * material and every cut move in the range is stamped. Rapids and plunges
+ * are left untouched.
+ */
+function applySlotFeedScale(
+  moves: ToolpathMove[],
+  startIndex: number,
+  scale: number,
+  mask: EngagementMask | null,
+): void {
+  if (startIndex >= moves.length) return
+
+  const stamped: ToolpathMove[] = []
+  for (let index = startIndex; index < moves.length; index += 1) {
+    const move = moves[index]
+    if (move.kind !== 'cut') {
+      stamped.push(move)
+      continue
+    }
+
+    if (!mask || mask.contours.length === 0) {
+      stamped.push({ ...move, feedScale: scale })
+      continue
+    }
+
+    for (const fragment of splitCutMoveAtContours(move, mask.contours, mask.contains)) {
+      stamped.push(fragment.inside
+        ? { ...move, from: fragment.from, to: fragment.to }
+        : { ...move, from: fragment.from, to: fragment.to, feedScale: scale })
+    }
+  }
+
+  moves.length = startIndex
+  for (const move of stamped) {
+    moves.push(move)
+  }
+}
 
 export function transitionToCutEntry(
   moves: ToolpathMove[],
@@ -682,15 +793,21 @@ function orderClosedContoursGreedyPreservingRotation(contours: Point[][], start:
   return ordered
 }
 
-export function orderOpenSegmentsGreedy(segments: Point[][], start: Point | null): Point[][] {
+export interface TaggedOpenSegment {
+  points: Point[]
+  /** Index of the source region within the regions array the segments were built from. */
+  regionIndex: number
+}
+
+function orderTaggedOpenSegmentsGreedy(segments: TaggedOpenSegment[], start: Point | null): TaggedOpenSegment[] {
   if (segments.length <= 1 || start === null) {
     return segments
   }
 
   const remaining = segments
-    .filter((segment) => segment.length >= 2)
-    .map((segment) => [...segment])
-  const ordered: Point[][] = []
+    .filter((segment) => segment.points.length >= 2)
+    .map((segment) => ({ ...segment, points: [...segment.points] }))
+  const ordered: TaggedOpenSegment[] = []
   let current = start
 
   while (remaining.length > 0) {
@@ -699,7 +816,7 @@ export function orderOpenSegmentsGreedy(segments: Point[][], start: Point | null
     let bestDistance = Number.POSITIVE_INFINITY
 
     for (let index = 0; index < remaining.length; index += 1) {
-      const segment = remaining[index]
+      const segment = remaining[index].points
       const first = segment[0]
       const last = segment[segment.length - 1]
       const forwardDistance = distanceSquared(current, first)
@@ -718,20 +835,33 @@ export function orderOpenSegmentsGreedy(segments: Point[][], start: Point | null
     }
 
     const [nextSegment] = remaining.splice(bestIndex, 1)
-    const orderedSegment = bestReverse ? [...nextSegment].reverse() : nextSegment
+    const orderedSegment = bestReverse
+      ? { ...nextSegment, points: [...nextSegment.points].reverse() }
+      : nextSegment
     ordered.push(orderedSegment)
-    current = orderedSegment[orderedSegment.length - 1]
+    current = orderedSegment.points[orderedSegment.points.length - 1]
   }
 
   return ordered
 }
 
-export function buildPocketParallelSegments(
+export function orderOpenSegmentsGreedy(segments: Point[][], start: Point | null): Point[][] {
+  if (segments.length <= 1 || start === null) {
+    return segments
+  }
+
+  return orderTaggedOpenSegmentsGreedy(
+    segments.map((points) => ({ points, regionIndex: 0 })),
+    start,
+  ).map((segment) => segment.points)
+}
+
+export function buildPocketParallelSegmentsTagged(
   regions: ResolvedPocketRegion[],
   stepoverDistance: number,
   angleDeg: number,
-): Point[][] {
-  const segments: Point[][] = []
+): TaggedOpenSegment[] {
+  const segments: TaggedOpenSegment[] = []
   const minStepover = 1 / DEFAULT_CLIPPER_SCALE
   const step = Math.max(stepoverDistance, minStepover)
   const angleRad = (angleDeg * Math.PI) / 180
@@ -763,7 +893,7 @@ export function buildPocketParallelSegments(
         const left = rotatePoint({ x: startX, y }, cosForward, sinForward)
         const right = rotatePoint({ x: endX, y }, cosForward, sinForward)
         const reverse = (regionIndex + scanIndex) % 2 === 1
-        segments.push(reverse ? [right, left] : [left, right])
+        segments.push({ points: reverse ? [right, left] : [left, right], regionIndex })
       }
 
       scanIndex += 1
@@ -771,6 +901,15 @@ export function buildPocketParallelSegments(
   })
 
   return segments
+}
+
+export function buildPocketParallelSegments(
+  regions: ResolvedPocketRegion[],
+  stepoverDistance: number,
+  angleDeg: number,
+): Point[][] {
+  return buildPocketParallelSegmentsTagged(regions, stepoverDistance, angleDeg)
+    .map((segment) => segment.points)
 }
 
 export function cutClosedContours(
@@ -813,6 +952,7 @@ export function cutOffsetRegionRecursive(
   direction: CutDirection = 'conventional',
   safeLinkCheck?: SafeLinkCheck,
   traversalMode: OffsetTraversalMode = 'outer-first',
+  slotFeed?: SlotFeedOptions,
 ): ToolpathPoint | null {
   const childRegions = buildInsetRegions(region, stepoverDistance)
 
@@ -829,7 +969,8 @@ export function cutOffsetRegionRecursive(
       childAnchors,
     ))
 
-    return cutClosedContours(
+    const startIndex = moves.length
+    const endPosition = cutClosedContours(
       moves,
       preparedContours,
       z,
@@ -840,6 +981,18 @@ export function cutOffsetRegionRecursive(
       direction,
       safeLinkCheck,
     )
+
+    if (slotFeed && traversalMode === 'inner-first') {
+      // In inner-first traversal the children were cut before this region's
+      // own loops, so material within one stepover of a child region is
+      // already cleared. Everything else this loop touches is virgin: the
+      // whole loop for leaf regions (no children), and pinch corridors of
+      // parent rings where the inset split into disjoint children.
+      const clearedAdjacent = childRegions.flatMap((child) => buildInsetRegions(child, -slotFeed.adjacency))
+      applySlotFeedScale(moves, startIndex, slotFeed.scale, buildEngagementMask(clearedAdjacent))
+    }
+
+    return endPosition
   }
 
   let nextPosition = currentPosition
@@ -864,6 +1017,7 @@ export function cutOffsetRegionRecursive(
       direction,
       safeLinkCheck,
       traversalMode,
+      slotFeed,
     )
   }
 
@@ -917,6 +1071,7 @@ function generateRoughBandMoves(
   const stepLevels = generateStepLevels(band.topZ, effectiveBottom, stepdown)
   const minStepover = 1 / DEFAULT_CLIPPER_SCALE
   const effectiveStepover = Math.max(stepoverDistance, minStepover)
+  const slotScale = resolveSlotFeedScale(operation)
   let currentPosition: ToolpathPoint | null = null
 
   if (operation.kind === 'pocket' && operation.pocketPattern === 'parallel') {
@@ -930,7 +1085,7 @@ function generateRoughBandMoves(
     }
 
     const boundaryContours = applyContourDirection(buildContourLoops(roughRegions), direction)
-    const segments = buildPocketParallelSegments(roughRegions, effectiveStepover, operation.pocketAngle)
+    const segments = buildPocketParallelSegmentsTagged(roughRegions, effectiveStepover, operation.pocketAngle)
     if (segments.length === 0) {
       return {
         moves,
@@ -940,6 +1095,9 @@ function generateRoughBandMoves(
     }
 
     for (const z of stepLevels) {
+      // The boundary pass is cut before anything is cleared at this level, so
+      // every boundary loop is a full-slot cut.
+      const boundaryStartIndex = moves.length
       for (const contour of boundaryContours) {
         const entryPoint = contourStartPoint(contour, z)
         currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
@@ -947,18 +1105,29 @@ function generateRoughBandMoves(
         moves.push(...cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
       }
+      if (slotScale !== null) {
+        applySlotFeedScale(moves, boundaryStartIndex, slotScale, null)
+      }
 
-      const orderedSegments = orderOpenSegmentsGreedy(
+      const orderedSegments = orderTaggedOpenSegmentsGreedy(
         segments,
         currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
       )
 
-      for (const segment of orderedSegments) {
+      // The first fill line cut in each region is a full-slot cut; later
+      // lines overlap the previously cleared band by the stepover.
+      const slottedRegions = new Set<number>()
+      for (const { points: segment, regionIndex } of orderedSegments) {
+        const segmentStartIndex = moves.length
         const entryPoint = contourStartPoint(segment, z)
         currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
         const cutMoves = toOpenCutMoves(segment, z)
         moves.push(...cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
+        if (slotScale !== null && !slottedRegions.has(regionIndex)) {
+          slottedRegions.add(regionIndex)
+          applySlotFeedScale(moves, segmentStartIndex, slotScale, null)
+        }
       }
 
       currentPosition = retractToSafe(moves, currentPosition, safeZ)
@@ -966,6 +1135,10 @@ function generateRoughBandMoves(
 
     return { moves, stepLevels, warnings }
   }
+
+  const slotFeed = slotScale !== null
+    ? { scale: slotScale, adjacency: effectiveStepover * SLOT_FEED_ADJACENCY_FACTOR }
+    : undefined
 
   for (const z of stepLevels) {
     const currentRegions = band.regions.flatMap((region) => buildInsetRegions(region, initialInset))
@@ -992,6 +1165,7 @@ function generateRoughBandMoves(
         direction,
         undefined,
         'inner-first',
+        slotFeed,
       )
     }
 
@@ -1033,12 +1207,23 @@ function generateFinishBandMoves(
   const radialLeave = Math.max(0, operation.stockToLeaveRadial)
   const finishDelta = toolRadius + radialLeave
   const finishRegions = band.regions.flatMap((region) => buildInsetRegions(region, finishDelta))
+  const slotScale = resolveSlotFeedScale(operation)
+  const isParallelPocket = operation.kind === 'pocket' && operation.pocketPattern === 'parallel'
   const wallContours = operation.finishWalls ? buildContourLoops(finishRegions) : []
-  const floorContours = operation.finishFloor && !(operation.kind === 'pocket' && operation.pocketPattern === 'parallel')
-    ? buildPocketFloorContours(finishRegions, 0, stepoverDistance)
-    : []
-  const floorSegments = operation.finishFloor && operation.kind === 'pocket' && operation.pocketPattern === 'parallel'
-    ? buildPocketParallelSegments(finishRegions, stepoverDistance, operation.pocketAngle)
+  // Per-region floor groups are built only when the slot feed is active; the
+  // disabled path keeps today's single global greedy ordering untouched.
+  const floorContourGroups = slotScale !== null && operation.finishFloor && !isParallelPocket
+    ? finishRegions
+      .map((region) => buildPocketFloorContours([region], 0, stepoverDistance))
+      .filter((group) => group.length > 0)
+    : null
+  const floorContours = floorContourGroups !== null
+    ? floorContourGroups.flat()
+    : operation.finishFloor && !isParallelPocket
+      ? buildPocketFloorContours(finishRegions, 0, stepoverDistance)
+      : []
+  const floorSegments = operation.finishFloor && isParallelPocket
+    ? buildPocketParallelSegmentsTagged(finishRegions, stepoverDistance, operation.pocketAngle)
     : []
   if (wallContours.length === 0 && floorContours.length === 0 && floorSegments.length === 0) {
     return {
@@ -1059,19 +1244,61 @@ function generateFinishBandMoves(
   }
 
   for (const z of floorStepLevels) {
-    currentPosition = cutClosedContours(moves, floorContours, z, safeZ, maxLinkDistance, currentPosition, false, direction)
+    if (floorContourGroups !== null && slotScale !== null) {
+      // Visit floor regions nearest-first; the first floor loop cut in each
+      // region crosses the full remaining skin width (fully engaged), later
+      // loops overlap the cleared band by the stepover.
+      const remainingGroups = [...floorContourGroups]
+      while (remainingGroups.length > 0) {
+        const anchor = currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null
+        let bestIndex = 0
+        if (anchor !== null) {
+          let bestDistance = Number.POSITIVE_INFINITY
+          for (let index = 0; index < remainingGroups.length; index += 1) {
+            const distance = Math.min(
+              ...remainingGroups[index].map((contour) => contourEntryDistanceSquared(contour, anchor)),
+            )
+            if (distance < bestDistance) {
+              bestIndex = index
+              bestDistance = distance
+            }
+          }
+        }
+        const [group] = remainingGroups.splice(bestIndex, 1)
+        const orderedGroup = orderClosedContoursGreedy(group, anchor)
+        if (orderedGroup.length === 0) {
+          continue
+        }
+        const startIndex = moves.length
+        currentPosition = cutClosedContours(moves, [orderedGroup[0]], z, safeZ, maxLinkDistance, currentPosition, false, direction)
+        applySlotFeedScale(moves, startIndex, slotScale, null)
+        if (orderedGroup.length > 1) {
+          currentPosition = cutClosedContours(moves, orderedGroup.slice(1), z, safeZ, maxLinkDistance, currentPosition, false, direction)
+        }
+      }
+    } else {
+      currentPosition = cutClosedContours(moves, floorContours, z, safeZ, maxLinkDistance, currentPosition, false, direction)
+    }
 
-    const orderedFloorSegments = orderOpenSegmentsGreedy(
+    const orderedFloorSegments = orderTaggedOpenSegmentsGreedy(
       floorSegments,
       currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
     )
 
-    for (const segment of orderedFloorSegments) {
+    // The first floor fill line cut in each region crosses the full skin
+    // width; later lines overlap the cleared band by the stepover.
+    const slottedRegions = new Set<number>()
+    for (const { points: segment, regionIndex } of orderedFloorSegments) {
+      const segmentStartIndex = moves.length
       const entryPoint = contourStartPoint(segment, z)
       currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
       const cutMoves = toOpenCutMoves(segment, z)
       moves.push(...cutMoves)
       currentPosition = cutMoves.at(-1)?.to ?? currentPosition
+      if (slotScale !== null && !slottedRegions.has(regionIndex)) {
+        slottedRegions.add(regionIndex)
+        applySlotFeedScale(moves, segmentStartIndex, slotScale, null)
+      }
     }
 
     currentPosition = retractToSafe(moves, currentPosition, safeZ)

--- a/src/engine/toolpaths/regions.ts
+++ b/src/engine/toolpaths/regions.ts
@@ -239,58 +239,6 @@ function clipCutMoveToRegion(move: ToolpathMove, mask: RegionMask): LineFragment
   return fragments
 }
 
-export interface CutMoveFragment {
-  from: ToolpathPoint
-  to: ToolpathPoint
-  inside: boolean
-}
-
-/**
- * Split a straight cut move wherever it crosses the given closed contours
- * (project-unit points, implicitly closed) and classify each fragment with
- * the supplied containment test, sampled at the fragment midpoint. Z is
- * interpolated linearly along the move. Consecutive fragments with the same
- * classification are merged, so a move that never crosses a contour comes
- * back as a single fragment.
- */
-export function splitCutMoveAtContours(
-  move: ToolpathMove,
-  contours: Point[][],
-  containsPoint: (point: Point) => boolean,
-): CutMoveFragment[] {
-  const tValues = [0, 1]
-  for (const contour of contours) {
-    for (let index = 0; index < contour.length; index += 1) {
-      const t = segmentIntersectionT(move.from, move.to, contour[index], contour[(index + 1) % contour.length])
-      if (t !== null) tValues.push(t)
-    }
-  }
-
-  const sorted = [...new Set(tValues.map((value) => Number(value.toFixed(12))))]
-    .sort((left, right) => left - right)
-  const fragments: CutMoveFragment[] = []
-
-  for (let index = 0; index + 1 < sorted.length; index += 1) {
-    const startT = sorted[index]
-    const endT = sorted[index + 1]
-    if (endT - startT <= 1e-9) continue
-    const mid = interpolatePoint(move.from, move.to, (startT + endT) / 2)
-    const inside = containsPoint(mid)
-    const previous = fragments[fragments.length - 1]
-    if (previous && previous.inside === inside) {
-      previous.to = interpolatePoint(move.from, move.to, endT)
-    } else {
-      fragments.push({
-        from: interpolatePoint(move.from, move.to, startT),
-        to: interpolatePoint(move.from, move.to, endT),
-        inside,
-      })
-    }
-  }
-
-  return fragments
-}
-
 function pointsEqual(a: ToolpathPoint | null, b: ToolpathPoint): boolean {
   return !!a
     && Math.abs(a.x - b.x) < 1e-9

--- a/src/engine/toolpaths/regions.ts
+++ b/src/engine/toolpaths/regions.ts
@@ -239,6 +239,58 @@ function clipCutMoveToRegion(move: ToolpathMove, mask: RegionMask): LineFragment
   return fragments
 }
 
+export interface CutMoveFragment {
+  from: ToolpathPoint
+  to: ToolpathPoint
+  inside: boolean
+}
+
+/**
+ * Split a straight cut move wherever it crosses the given closed contours
+ * (project-unit points, implicitly closed) and classify each fragment with
+ * the supplied containment test, sampled at the fragment midpoint. Z is
+ * interpolated linearly along the move. Consecutive fragments with the same
+ * classification are merged, so a move that never crosses a contour comes
+ * back as a single fragment.
+ */
+export function splitCutMoveAtContours(
+  move: ToolpathMove,
+  contours: Point[][],
+  containsPoint: (point: Point) => boolean,
+): CutMoveFragment[] {
+  const tValues = [0, 1]
+  for (const contour of contours) {
+    for (let index = 0; index < contour.length; index += 1) {
+      const t = segmentIntersectionT(move.from, move.to, contour[index], contour[(index + 1) % contour.length])
+      if (t !== null) tValues.push(t)
+    }
+  }
+
+  const sorted = [...new Set(tValues.map((value) => Number(value.toFixed(12))))]
+    .sort((left, right) => left - right)
+  const fragments: CutMoveFragment[] = []
+
+  for (let index = 0; index + 1 < sorted.length; index += 1) {
+    const startT = sorted[index]
+    const endT = sorted[index + 1]
+    if (endT - startT <= 1e-9) continue
+    const mid = interpolatePoint(move.from, move.to, (startT + endT) / 2)
+    const inside = containsPoint(mid)
+    const previous = fragments[fragments.length - 1]
+    if (previous && previous.inside === inside) {
+      previous.to = interpolatePoint(move.from, move.to, endT)
+    } else {
+      fragments.push({
+        from: interpolatePoint(move.from, move.to, startT),
+        to: interpolatePoint(move.from, move.to, endT),
+        inside,
+      })
+    }
+  }
+
+  return fragments
+}
+
 function pointsEqual(a: ToolpathPoint | null, b: ToolpathPoint): boolean {
   return !!a
     && Math.abs(a.x - b.x) < 1e-9

--- a/src/engine/toolpaths/surface.ts
+++ b/src/engine/toolpaths/surface.ts
@@ -460,23 +460,11 @@ function generateFinishBandMoves(
   const floorStepLevels = operation.finishFloor ? [effectiveBottom] : []
   let currentPosition: ToolpathPoint | null = null
 
-  for (const z of wallStepLevels) {
-    const orderedWallContours = orderClosedContoursGreedy(
-      wallContours,
-      currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
-    )
-
-    for (const contour of orderedWallContours) {
-      const entryPoint = contourStartPoint(contour, z)
-      currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
-      const cutMoves = toClosedCutMoves(contour, z)
-      moves.push(...cutMoves)
-      currentPosition = cutMoves.at(-1)?.to ?? currentPosition
-    }
-
-    currentPosition = retractToSafe(moves, currentPosition, safeZ)
-  }
-
+  // Floor before walls: when roughing left axial stock, a wall pass at final
+  // depth would slot through the uncleared floor skin at full feed. Cutting
+  // the floor first removes that skin, so the wall pass only shaves the
+  // radial stock — and cutting walls last leaves the cleanest wall surface.
+  // Mirrors the same ordering in pocket.ts generateFinishBandMoves.
   for (const z of floorStepLevels) {
     const orderedFloorContours = orderClosedContoursGreedy(
       floorContours,
@@ -500,6 +488,23 @@ function generateFinishBandMoves(
       const entryPoint = contourStartPoint(segment, z)
       currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
       const cutMoves = toOpenCutMoves(segment, z)
+      moves.push(...cutMoves)
+      currentPosition = cutMoves.at(-1)?.to ?? currentPosition
+    }
+
+    currentPosition = retractToSafe(moves, currentPosition, safeZ)
+  }
+
+  for (const z of wallStepLevels) {
+    const orderedWallContours = orderClosedContoursGreedy(
+      wallContours,
+      currentPosition ? { x: currentPosition.x, y: currentPosition.y } : null,
+    )
+
+    for (const contour of orderedWallContours) {
+      const entryPoint = contourStartPoint(contour, z)
+      currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, maxLinkDistance)
+      const cutMoves = toClosedCutMoves(contour, z)
       moves.push(...cutMoves)
       currentPosition = cutMoves.at(-1)?.to ?? currentPosition
     }

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -1850,6 +1850,42 @@ function testPocketOffsetSlotFeedPartialDepthIsland() {
   console.log('pocket offset slot feed partial-depth island: PASSED')
 }
 
+function testSurfaceCleanFinishCutsFloorBeforeWalls() {
+  console.log('Testing surface_clean finish cuts the floor before the walls...')
+  const tool = makeFlatEndmill('t1')
+  const boss = { ...makePocketFeature('b1', 10, 10, 10, 10, 5, 0), operation: 'add' as const }
+  const project = baseProject([tool], [boss])
+  project.stock = { ...project.stock, thickness: 8 }
+  const op = makePocketOp({
+    kind: 'surface_clean',
+    pass: 'finish',
+    target: { source: 'features', featureIds: ['b1'] },
+    toolRef: 't1',
+  })
+
+  const combined = generateSurfaceCleanToolpath(project, op)
+  const floorOnly = generateSurfaceCleanToolpath(project, { ...op, finishWalls: false })
+  const wallsOnly = generateSurfaceCleanToolpath(project, { ...op, finishFloor: false })
+  const combinedCuts = cutMoves(combined.moves)
+  const floorCuts = cutMoves(floorOnly.moves)
+  const wallCuts = cutMoves(wallsOnly.moves)
+  assert(combinedCuts.length > 0 && floorCuts.length > 0 && wallCuts.length > 0, 'expected cuts in all three variants')
+
+  // Floors first: the combined pass starts exactly like the floor-only pass.
+  assert(
+    pointEquals(combinedCuts[0].from, floorCuts[0].from) && pointEquals(combinedCuts[0].to, floorCuts[0].to),
+    'combined finish should start with the floor pass',
+  )
+
+  // Walls last: the final cut lies on a wall contour (its vertices appear in
+  // the walls-only pass) and not on any floor contour.
+  const lastCutTo = combinedCuts[combinedCuts.length - 1].to
+  const matchesVertex = (cuts: ToolpathMove[]) => cuts.some((move) => pointEquals(move.to, lastCutTo))
+  assert(matchesVertex(wallCuts), 'combined finish should end on a wall contour')
+  assert(!matchesVertex(floorCuts), 'combined finish should not end on a floor contour')
+  console.log('surface_clean finish floor-before-walls: PASSED')
+}
+
 function testPocketSlotFeedDisabledParity() {
   console.log('Testing pocket slot feed disabled (undefined / 100) leaves moves untouched...')
   const tool = makeFlatEndmill('t1')
@@ -1927,6 +1963,7 @@ try {
   testPocketParallelSlotFeed()
   testPocketFinishFloorSlotFeedOffset()
   testPocketFinishFloorSlotFeedParallel()
+  testSurfaceCleanFinishCutsFloorBeforeWalls()
   testPocketSlotFeedDisabledParity()
   console.log('\nAll toolpath tests PASSED.')
 } catch (e) {

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -1751,6 +1751,53 @@ function testPocketFinishFloorSlotFeedParallel() {
   console.log('pocket finish floor slot feed parallel: PASSED')
 }
 
+function testPocketOffsetSlotFeedPartialDepthIsland() {
+  console.log('Testing pocket offset slot feed with an island whose top Z is below the pocket top (two bands)...')
+  const tool = makeFlatEndmill('t1')
+  // Pocket 4 -> 0, island only rises to z=2: the upper band has no island,
+  // the lower band is split into left/right sections by the island.
+  const pocket = makePocketFeature('p1', 0, 0, 40, 24, 4, 0)
+  const island = makeIslandFeature('i1', 12, 6, 16, 12, 2, 0)
+  const project = baseProject([tool], [pocket, island])
+  const op = makePocketOp({
+    kind: 'pocket',
+    target: { source: 'features', featureIds: ['p1'] },
+    toolRef: 't1',
+    pocketSlotFeedPercent: 50,
+  })
+
+  const result = generatePocketToolpath(project, op)
+  const cutsAt = (z: number) => cutMoves(result.moves).filter((move) => approx(move.to.z, z) && approx(move.from.z, z))
+
+  // Upper band (z=2, island absent): behaves like a plain pocket — one
+  // stamped innermost loop near the centre, nothing near the walls.
+  const upperStamped = cutsAt(2).filter((move) => move.feedScale !== undefined)
+  assert(upperStamped.length >= 3, 'upper band should stamp its innermost loop')
+  for (const move of upperStamped) {
+    for (const value of [move.from.y, move.to.y]) {
+      assert(value > 4 && value < 20, `upper band stamped y ${value} should be near the pocket centre`)
+    }
+  }
+
+  // Lower band (z=0, island present): each section's innermost start is
+  // stamped, and the outer ring is split over the pinch corridors.
+  const lowerStamped = cutsAt(0).filter((move) => move.feedScale !== undefined)
+  assert(lowerStamped.some((move) => (move.from.x + move.to.x) / 2 < 10), 'lower band left section should be stamped')
+  assert(lowerStamped.some((move) => (move.from.x + move.to.x) / 2 > 30), 'lower band right section should be stamped')
+  const lowerTopEdge = cutsAt(0).filter((move) => approx(move.from.y, 22, 1e-3) && approx(move.to.y, 22, 1e-3))
+  assert(
+    lowerTopEdge.some((move) => move.feedScale !== undefined) && lowerTopEdge.some((move) => move.feedScale === undefined),
+    'lower band outer top edge should be split into stamped corridor and unstamped section-adjacent fragments',
+  )
+
+  // Disabled parity holds across bands too.
+  const legacy = generatePocketToolpath(project, { ...op, pocketSlotFeedPercent: undefined })
+  const explicit100 = generatePocketToolpath(project, { ...op, pocketSlotFeedPercent: 100 })
+  assert(legacy.moves.every((move) => move.feedScale === undefined), 'disabled two-band pocket should have no feedScale')
+  assert(movesEqual(legacy.moves, explicit100.moves), 'percent=100 must not change the two-band move stream')
+  console.log('pocket offset slot feed partial-depth island: PASSED')
+}
+
 function testPocketSlotFeedDisabledParity() {
   console.log('Testing pocket slot feed disabled (undefined / 100) leaves moves untouched...')
   const tool = makeFlatEndmill('t1')
@@ -1824,6 +1871,7 @@ try {
   testPocketOffsetSlotFeedSimple()
   testPocketOffsetSlotFeedIslandSections()
   testPocketOffsetSlotFeedPerLevel()
+  testPocketOffsetSlotFeedPartialDepthIsland()
   testPocketParallelSlotFeed()
   testPocketFinishFloorSlotFeedOffset()
   testPocketFinishFloorSlotFeedParallel()

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -1560,16 +1560,31 @@ function testPocketOffsetSlotFeedSimple() {
   const stamped = stampedCutMoves(result.moves)
   const unstamped = unstampedCutMoves(result.moves)
 
-  assert(stamped.length >= 3, `expected a stamped innermost loop, got ${stamped.length} stamped moves`)
+  assert(stamped.length > 0, 'expected a stamped innermost loop')
   assert(unstamped.length > 0, 'expected outer loops at normal feed')
   assert(stamped.every((move) => approx(move.feedScale ?? 0, 0.5)), 'stamped moves should carry feedScale 0.5')
 
-  // 20x20 pocket, 4mm tool, 1.6 stepover: the only fully engaged loop is the
-  // innermost ring near the centre; every other ring runs one stepover from
-  // its cleared child.
+  // 20x20 pocket, 4mm tool, 1.6 stepover: the innermost ring sits at
+  // 8.4..11.6. It is the only fully engaged loop — every other ring runs one
+  // stepover from its already-cut child, so any stamped move outside the
+  // innermost box can only be a short link fragment plowing into virgin
+  // material, never a ring edge.
+  const moveLen = (move: ToolpathMove) => Math.hypot(move.to.x - move.from.x, move.to.y - move.from.y)
   for (const move of stamped) {
-    for (const value of [move.from.x, move.from.y, move.to.x, move.to.y]) {
-      assert(value > 6.5 && value < 13.5, `stamped move coordinate ${value} should be near the pocket centre`)
+    const inInnermostBox = [move.from.x, move.from.y, move.to.x, move.to.y]
+      .every((value) => value > 8 && value < 12)
+    assert(
+      inInnermostBox || moveLen(move) < 2.4,
+      `stamped move outside the innermost ring should only be a short link fragment (len=${moveLen(move).toFixed(2)})`,
+    )
+  }
+  // Ring edges of the outer loops (long moves outside the innermost box) all
+  // run at normal feed.
+  for (const move of unstamped.concat(stamped)) {
+    const outsideInnermost = [move.from.x, move.from.y, move.to.x, move.to.y]
+      .some((value) => value < 8 || value > 12)
+    if (outsideInnermost && moveLen(move) > 3) {
+      assert(move.feedScale === undefined, `long outer ring edge should be unstamped (len=${moveLen(move).toFixed(2)})`)
     }
   }
 
@@ -1597,33 +1612,38 @@ function testPocketOffsetSlotFeedIslandSections() {
   assert(stamped.length > 0, 'expected stamped moves')
 
   // The island splits the first inset into left and right sections; each
-  // section's own innermost start must run at slot feed.
+  // section's own innermost start must run at slot feed. (With self-clearing
+  // awareness only the sliver's first pass is stamped — the back pass runs
+  // one stepover from its own kerf — so expect at least one per section.)
   const stampedLeft = stamped.filter((move) => (move.from.x + move.to.x) / 2 < 10)
   const stampedRight = stamped.filter((move) => (move.from.x + move.to.x) / 2 > 30)
-  assert(stampedLeft.length >= 3, 'left section innermost loop should be stamped')
-  assert(stampedRight.length >= 3, 'right section innermost loop should be stamped')
+  assert(stampedLeft.length >= 1, 'left section innermost start should be stamped')
+  assert(stampedRight.length >= 1, 'right section innermost start should be stamped')
 
-  // The outermost ring's top edge (y=22) crosses the pinch corridors above
-  // the island where nothing is cleared: its middle fragment must be
-  // stamped, its ends (adjacent to the cleared sections) must not.
-  const topEdgeMoves = cutMoves(result.moves).filter((move) => approx(move.from.y, 22, 1e-3) && approx(move.to.y, 22, 1e-3))
-  assert(topEdgeMoves.length >= 2, `outer top edge should be split at the corridor boundary, got ${topEdgeMoves.length} moves`)
+  // The island ring's top edge (y=20) is the first pass through the virgin
+  // pinch corridor above the island — a true slot cut. Its middle fragment
+  // must be stamped and split from the ends that run within a tool width of
+  // the already-cleared left/right sections.
   const containsX = (move: ToolpathMove, x: number) =>
     Math.min(move.from.x, move.to.x) <= x && Math.max(move.from.x, move.to.x) >= x
-  assert(
-    topEdgeMoves.some((move) => move.feedScale !== undefined && containsX(move, 20)),
-    'outer top edge fragment over the corridor (x≈20) should be stamped',
-  )
-  assert(
-    topEdgeMoves.some((move) => move.feedScale === undefined && (containsX(move, 5) || containsX(move, 35))),
-    'outer top edge fragments next to the cleared sections should be unstamped',
-  )
-
-  // The island ring's top edge (y=20) also runs through virgin corridor material.
   const islandTopMoves = cutMoves(result.moves).filter((move) => approx(move.from.y, 20, 1e-3) && approx(move.to.y, 20, 1e-3))
   assert(
     islandTopMoves.some((move) => move.feedScale !== undefined && containsX(move, 20)),
     'island ring top edge over the corridor should be stamped',
+  )
+  assert(
+    islandTopMoves.some((move) => move.feedScale === undefined),
+    'island ring top edge next to the cleared sections should be unstamped',
+  )
+
+  // The outermost ring's top edge (y=22) is cut after the island ring already
+  // slotted the corridor: it runs within a kerf's reach of that pass (and of
+  // the sections at its ends), so none of it is fully engaged.
+  const topEdgeMoves = cutMoves(result.moves).filter((move) => approx(move.from.y, 22, 1e-3) && approx(move.to.y, 22, 1e-3))
+  assert(topEdgeMoves.length > 0, 'expected the outer ring top edge')
+  assert(
+    topEdgeMoves.every((move) => move.feedScale === undefined),
+    'outer top edge should run at normal feed once the island ring cleared the corridor',
   )
   console.log('pocket offset slot feed island sections: PASSED')
 }
@@ -1672,18 +1692,25 @@ function testPocketParallelSlotFeed() {
   const fills = horizontalFillMoves(result.moves, boundaryYs)
   assert(fills.length > 4, 'expected parallel fill lines')
 
-  for (const [regionName, minX, maxX] of [['left', 0, 20], ['right', 40, 60]] as const) {
-    const regionFills = fills.filter((move) => move.from.x >= minX && move.from.x <= maxX)
-    const stampedYs = new Set(regionFills.filter((move) => move.feedScale !== undefined).map((move) => move.from.y.toFixed(4)))
-    assert(stampedYs.size === 1, `${regionName} region should have exactly one stamped fill line, got ${stampedYs.size}`)
-    assert(regionFills.some((move) => move.feedScale === undefined), `${regionName} region should have unstamped fill lines`)
-  }
+  // For this geometry every fill line runs within one stepover of an earlier
+  // kerf (the first line is 0.8 from the boundary pass, later lines 1.6 from
+  // their neighbour), so no fill line is fully engaged.
+  assert(fills.every((move) => move.feedScale === undefined), 'fill lines adjacent to cleared kerf should be unstamped')
 
-  // Every boundary-ring cut is a full-slot cut and must be stamped.
-  const boundaryMoves = cutMoves(result.moves).filter((move) =>
-    boundaryYs.some((y) => approx(move.from.y, y) && approx(move.to.y, y)) && Math.abs(move.to.x - move.from.x) > 1)
-  assert(boundaryMoves.length > 0, 'expected boundary ring moves')
-  assert(boundaryMoves.every((move) => move.feedScale !== undefined), 'all boundary ring moves should be stamped')
+  // The boundary pass slots into virgin material — each region's boundary
+  // ring must carry stamped moves (the closing stretch next to the ring's own
+  // start may legitimately run at normal feed).
+  for (const [regionName, minX, maxX] of [['left', 0, 20], ['right', 40, 60]] as const) {
+    const regionBoundary = cutMoves(result.moves).filter((move) =>
+      boundaryYs.some((y) => approx(move.from.y, y) && approx(move.to.y, y))
+      && Math.abs(move.to.x - move.from.x) > 1
+      && move.from.x >= minX && move.from.x <= maxX)
+    assert(regionBoundary.length > 0, `expected ${regionName} boundary ring moves`)
+    assert(
+      regionBoundary.some((move) => move.feedScale !== undefined),
+      `${regionName} boundary ring should carry stamped slotting moves`,
+    )
+  }
   console.log('pocket parallel slot feed: PASSED')
 }
 
@@ -1702,7 +1729,15 @@ function testPocketFinishFloorSlotFeedOffset() {
 
   const result = generatePocketToolpath(project, op)
   const stamped = stampedCutMoves(result.moves)
-  assert(stamped.length >= 3, 'expected the first floor loop to be stamped')
+  assert(stamped.length >= 1, 'expected the floor entry to be stamped')
+
+  // The floor is cut inner-first like the rough pass: the very first floor
+  // cut is the innermost loop near the pocket centre.
+  const firstCut = cutMoves(result.moves)[0]
+  for (const value of [firstCut.from.x, firstCut.from.y, firstCut.to.x, firstCut.to.y]) {
+    assert(value > 13 && value < 17, `first floor cut coordinate ${value} should be at the innermost loop near the centre`)
+  }
+  assert(firstCut.feedScale !== undefined, 'the innermost floor loop should be stamped')
 
   // Wall contour runs at the tool-radius inset (x/y = 2 or 28) and must stay
   // at normal feed; floor loops start one stepover further in.
@@ -1779,25 +1814,32 @@ function testPocketOffsetSlotFeedPartialDepthIsland() {
   const result = generatePocketToolpath(project, op)
   const cutsAt = (z: number) => cutMoves(result.moves).filter((move) => approx(move.to.z, z) && approx(move.from.z, z))
 
-  // Upper band (z=2, island absent): behaves like a plain pocket — one
-  // stamped innermost loop near the centre, nothing near the walls.
+  // Upper band (z=2, island absent): behaves like a plain pocket — the
+  // stamped innermost loop sits near the centre; any stamped move elsewhere
+  // can only be a short link fragment, never a ring edge.
   const upperStamped = cutsAt(2).filter((move) => move.feedScale !== undefined)
-  assert(upperStamped.length >= 3, 'upper band should stamp its innermost loop')
+  assert(upperStamped.length >= 1, 'upper band should stamp its innermost loop')
   for (const move of upperStamped) {
-    for (const value of [move.from.y, move.to.y]) {
-      assert(value > 4 && value < 20, `upper band stamped y ${value} should be near the pocket centre`)
+    const isLong = Math.hypot(move.to.x - move.from.x, move.to.y - move.from.y) > 3
+    if (isLong) {
+      for (const value of [move.from.y, move.to.y]) {
+        assert(value > 4 && value < 20, `upper band stamped ring edge y ${value} should be near the pocket centre`)
+      }
     }
   }
 
   // Lower band (z=0, island present): each section's innermost start is
-  // stamped, and the outer ring is split over the pinch corridors.
+  // stamped, and the island ring's first pass through the virgin pinch
+  // corridor (y=20) is a stamped slot cut.
   const lowerStamped = cutsAt(0).filter((move) => move.feedScale !== undefined)
   assert(lowerStamped.some((move) => (move.from.x + move.to.x) / 2 < 10), 'lower band left section should be stamped')
   assert(lowerStamped.some((move) => (move.from.x + move.to.x) / 2 > 30), 'lower band right section should be stamped')
-  const lowerTopEdge = cutsAt(0).filter((move) => approx(move.from.y, 22, 1e-3) && approx(move.to.y, 22, 1e-3))
+  const lowerIslandTop = cutsAt(0).filter((move) => approx(move.from.y, 20, 1e-3) && approx(move.to.y, 20, 1e-3))
   assert(
-    lowerTopEdge.some((move) => move.feedScale !== undefined) && lowerTopEdge.some((move) => move.feedScale === undefined),
-    'lower band outer top edge should be split into stamped corridor and unstamped section-adjacent fragments',
+    lowerIslandTop.some((move) =>
+      move.feedScale !== undefined
+      && Math.min(move.from.x, move.to.x) <= 20 && Math.max(move.from.x, move.to.x) >= 20),
+    'lower band island ring should be stamped over the corridor',
   )
 
   // Disabled parity holds across bands too.

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -1513,6 +1513,281 @@ function testFinishSurfaceCleanupRejectsRegionOnlyTarget() {
 }
 
 // ---------------------------------------------------------------------------
+// Pocket slot feed (pocketSlotFeedPercent) tests
+// ---------------------------------------------------------------------------
+
+function makeIslandFeature(
+  id: string,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  zTop: number,
+  zBottom: number,
+): SketchFeature {
+  return { ...makePocketFeature(id, x, y, w, h, zTop, zBottom), operation: 'add' }
+}
+
+function stampedCutMoves(moves: ToolpathMove[]): ToolpathMove[] {
+  return cutMoves(moves).filter((move) => move.feedScale !== undefined)
+}
+
+function unstampedCutMoves(moves: ToolpathMove[]): ToolpathMove[] {
+  return cutMoves(moves).filter((move) => move.feedScale === undefined)
+}
+
+/** Horizontal cut moves longer than minLength (parallel fill lines at angle 0). */
+function horizontalFillMoves(moves: ToolpathMove[], boundaryYs: number[], minLength = 1): ToolpathMove[] {
+  return cutMoves(moves).filter((move) =>
+    approx(move.from.y, move.to.y)
+    && Math.abs(move.to.x - move.from.x) > minLength
+    && !boundaryYs.some((y) => approx(move.from.y, y)))
+}
+
+function testPocketOffsetSlotFeedSimple() {
+  console.log('Testing pocket offset slot feed marks only the innermost loop...')
+  const tool = makeFlatEndmill('t1')
+  const pocket = makePocketFeature('p1', 0, 0, 20, 20, 2, 0)
+  const project = baseProject([tool], [pocket])
+  const op = makePocketOp({
+    kind: 'pocket',
+    target: { source: 'features', featureIds: ['p1'] },
+    toolRef: 't1',
+    pocketSlotFeedPercent: 50,
+  })
+
+  const result = generatePocketToolpath(project, op)
+  const stamped = stampedCutMoves(result.moves)
+  const unstamped = unstampedCutMoves(result.moves)
+
+  assert(stamped.length >= 3, `expected a stamped innermost loop, got ${stamped.length} stamped moves`)
+  assert(unstamped.length > 0, 'expected outer loops at normal feed')
+  assert(stamped.every((move) => approx(move.feedScale ?? 0, 0.5)), 'stamped moves should carry feedScale 0.5')
+
+  // 20x20 pocket, 4mm tool, 1.6 stepover: the only fully engaged loop is the
+  // innermost ring near the centre; every other ring runs one stepover from
+  // its cleared child.
+  for (const move of stamped) {
+    for (const value of [move.from.x, move.from.y, move.to.x, move.to.y]) {
+      assert(value > 6.5 && value < 13.5, `stamped move coordinate ${value} should be near the pocket centre`)
+    }
+  }
+
+  const allCuts = cutMoves(result.moves)
+  assert(allCuts[0].feedScale !== undefined, 'first cut at the level (innermost loop) should be stamped')
+  assert(allCuts[allCuts.length - 1].feedScale === undefined, 'last cut (wall-adjacent loop) should be unstamped')
+  console.log('pocket offset slot feed simple: PASSED')
+}
+
+function testPocketOffsetSlotFeedIslandSections() {
+  console.log('Testing pocket offset slot feed with island-split sections and pinch corridors...')
+  const tool = makeFlatEndmill('t1')
+  const pocket = makePocketFeature('p1', 0, 0, 40, 24, 2, 0)
+  const island = makeIslandFeature('i1', 12, 6, 16, 12, 2, 0)
+  const project = baseProject([tool], [pocket, island])
+  const op = makePocketOp({
+    kind: 'pocket',
+    target: { source: 'features', featureIds: ['p1'] },
+    toolRef: 't1',
+    pocketSlotFeedPercent: 50,
+  })
+
+  const result = generatePocketToolpath(project, op)
+  const stamped = stampedCutMoves(result.moves)
+  assert(stamped.length > 0, 'expected stamped moves')
+
+  // The island splits the first inset into left and right sections; each
+  // section's own innermost start must run at slot feed.
+  const stampedLeft = stamped.filter((move) => (move.from.x + move.to.x) / 2 < 10)
+  const stampedRight = stamped.filter((move) => (move.from.x + move.to.x) / 2 > 30)
+  assert(stampedLeft.length >= 3, 'left section innermost loop should be stamped')
+  assert(stampedRight.length >= 3, 'right section innermost loop should be stamped')
+
+  // The outermost ring's top edge (y=22) crosses the pinch corridors above
+  // the island where nothing is cleared: its middle fragment must be
+  // stamped, its ends (adjacent to the cleared sections) must not.
+  const topEdgeMoves = cutMoves(result.moves).filter((move) => approx(move.from.y, 22, 1e-3) && approx(move.to.y, 22, 1e-3))
+  assert(topEdgeMoves.length >= 2, `outer top edge should be split at the corridor boundary, got ${topEdgeMoves.length} moves`)
+  const containsX = (move: ToolpathMove, x: number) =>
+    Math.min(move.from.x, move.to.x) <= x && Math.max(move.from.x, move.to.x) >= x
+  assert(
+    topEdgeMoves.some((move) => move.feedScale !== undefined && containsX(move, 20)),
+    'outer top edge fragment over the corridor (x≈20) should be stamped',
+  )
+  assert(
+    topEdgeMoves.some((move) => move.feedScale === undefined && (containsX(move, 5) || containsX(move, 35))),
+    'outer top edge fragments next to the cleared sections should be unstamped',
+  )
+
+  // The island ring's top edge (y=20) also runs through virgin corridor material.
+  const islandTopMoves = cutMoves(result.moves).filter((move) => approx(move.from.y, 20, 1e-3) && approx(move.to.y, 20, 1e-3))
+  assert(
+    islandTopMoves.some((move) => move.feedScale !== undefined && containsX(move, 20)),
+    'island ring top edge over the corridor should be stamped',
+  )
+  console.log('pocket offset slot feed island sections: PASSED')
+}
+
+function testPocketOffsetSlotFeedPerLevel() {
+  console.log('Testing pocket offset slot feed applies at every Z level...')
+  const tool = makeFlatEndmill('t1')
+  const pocket = makePocketFeature('p1', 0, 0, 20, 20, 2, 0)
+  const project = baseProject([tool], [pocket])
+  const op = makePocketOp({
+    kind: 'pocket',
+    target: { source: 'features', featureIds: ['p1'] },
+    toolRef: 't1',
+    stepdown: 1,
+    pocketSlotFeedPercent: 50,
+  })
+
+  const result = generatePocketToolpath(project, op)
+  const stamped = stampedCutMoves(result.moves)
+  assert(stamped.some((move) => approx(move.to.z, 1)), 'first level should have stamped moves')
+  assert(stamped.some((move) => approx(move.to.z, 0)), 'second level should have stamped moves')
+  console.log('pocket offset slot feed per level: PASSED')
+}
+
+function testPocketParallelSlotFeed() {
+  console.log('Testing pocket parallel slot feed marks boundary and first fill line per region...')
+  const tool = makeFlatEndmill('t1')
+  const left = makePocketFeature('p1', 0, 0, 20, 20, 2, 0)
+  const right = makePocketFeature('p2', 40, 0, 20, 20, 2, 0)
+  const project = baseProject([tool], [left, right])
+  const op = makePocketOp({
+    kind: 'pocket',
+    target: { source: 'features', featureIds: ['p1', 'p2'] },
+    toolRef: 't1',
+    pocketPattern: 'parallel',
+    pocketSlotFeedPercent: 50,
+  })
+
+  const result = generatePocketToolpath(project, op)
+  const allCuts = cutMoves(result.moves)
+  assert(allCuts[0].feedScale !== undefined, 'first boundary cut should be stamped')
+  assert(allCuts[allCuts.length - 1].feedScale === undefined, 'last fill line should be unstamped')
+
+  // Boundary rings sit at the tool-radius inset: y=2 and y=18 for both rects.
+  const boundaryYs = [2, 18]
+  const fills = horizontalFillMoves(result.moves, boundaryYs)
+  assert(fills.length > 4, 'expected parallel fill lines')
+
+  for (const [regionName, minX, maxX] of [['left', 0, 20], ['right', 40, 60]] as const) {
+    const regionFills = fills.filter((move) => move.from.x >= minX && move.from.x <= maxX)
+    const stampedYs = new Set(regionFills.filter((move) => move.feedScale !== undefined).map((move) => move.from.y.toFixed(4)))
+    assert(stampedYs.size === 1, `${regionName} region should have exactly one stamped fill line, got ${stampedYs.size}`)
+    assert(regionFills.some((move) => move.feedScale === undefined), `${regionName} region should have unstamped fill lines`)
+  }
+
+  // Every boundary-ring cut is a full-slot cut and must be stamped.
+  const boundaryMoves = cutMoves(result.moves).filter((move) =>
+    boundaryYs.some((y) => approx(move.from.y, y) && approx(move.to.y, y)) && Math.abs(move.to.x - move.from.x) > 1)
+  assert(boundaryMoves.length > 0, 'expected boundary ring moves')
+  assert(boundaryMoves.every((move) => move.feedScale !== undefined), 'all boundary ring moves should be stamped')
+  console.log('pocket parallel slot feed: PASSED')
+}
+
+function testPocketFinishFloorSlotFeedOffset() {
+  console.log('Testing pocket finish floor slot feed (offset): first floor loop only, walls untouched...')
+  const tool = makeFlatEndmill('t1')
+  const pocket = makePocketFeature('p1', 0, 0, 30, 30, 2, 0)
+  const project = baseProject([tool], [pocket])
+  const op = makePocketOp({
+    kind: 'pocket',
+    pass: 'finish',
+    target: { source: 'features', featureIds: ['p1'] },
+    toolRef: 't1',
+    pocketSlotFeedPercent: 50,
+  })
+
+  const result = generatePocketToolpath(project, op)
+  const stamped = stampedCutMoves(result.moves)
+  assert(stamped.length >= 3, 'expected the first floor loop to be stamped')
+
+  // Wall contour runs at the tool-radius inset (x/y = 2 or 28) and must stay
+  // at normal feed; floor loops start one stepover further in.
+  for (const move of stamped) {
+    for (const value of [move.from.x, move.from.y, move.to.x, move.to.y]) {
+      assert(value > 3 && value < 27, `stamped floor move coordinate ${value} should be inside the wall contour`)
+    }
+  }
+
+  // Later floor loops run at normal feed.
+  const unstampedFloor = unstampedCutMoves(result.moves).filter((move) =>
+    [move.from.x, move.from.y, move.to.x, move.to.y].every((value) => value > 3 && value < 27))
+  assert(unstampedFloor.length > 0, 'expected later floor loops at normal feed')
+
+  // Walls only + slot feed => nothing stamped.
+  const wallsOnly = generatePocketToolpath(project, { ...op, finishFloor: false })
+  assert(stampedCutMoves(wallsOnly.moves).length === 0, 'walls-only finish should have no stamped moves')
+  console.log('pocket finish floor slot feed offset: PASSED')
+}
+
+function testPocketFinishFloorSlotFeedParallel() {
+  console.log('Testing pocket finish floor slot feed (parallel): first fill line only...')
+  const tool = makeFlatEndmill('t1')
+  const pocket = makePocketFeature('p1', 0, 0, 20, 20, 2, 0)
+  const project = baseProject([tool], [pocket])
+  const op = makePocketOp({
+    kind: 'pocket',
+    pass: 'finish',
+    target: { source: 'features', featureIds: ['p1'] },
+    toolRef: 't1',
+    pocketPattern: 'parallel',
+    finishWalls: false,
+    pocketSlotFeedPercent: 50,
+  })
+
+  const result = generatePocketToolpath(project, op)
+  const allCuts = cutMoves(result.moves)
+  assert(allCuts.length > 2, 'expected floor fill lines')
+  assert(allCuts[0].feedScale !== undefined, 'first floor fill line should be stamped')
+  assert(allCuts[allCuts.length - 1].feedScale === undefined, 'last floor fill line should be unstamped')
+
+  const stampedYs = new Set(stampedCutMoves(result.moves)
+    .filter((move) => approx(move.from.y, move.to.y))
+    .map((move) => move.from.y.toFixed(4)))
+  assert(stampedYs.size === 1, `exactly one floor fill line should be stamped, got ${stampedYs.size}`)
+  console.log('pocket finish floor slot feed parallel: PASSED')
+}
+
+function testPocketSlotFeedDisabledParity() {
+  console.log('Testing pocket slot feed disabled (undefined / 100) leaves moves untouched...')
+  const tool = makeFlatEndmill('t1')
+  const pocket = makePocketFeature('p1', 0, 0, 20, 20, 2, 0)
+  const island = makeIslandFeature('i1', 6, 6, 8, 8, 2, 0)
+  const project = baseProject([tool], [pocket, island])
+
+  for (const pattern of ['offset', 'parallel'] as const) {
+    for (const pass of ['rough', 'finish'] as const) {
+      const base = makePocketOp({
+        kind: 'pocket',
+        pass,
+        target: { source: 'features', featureIds: ['p1'] },
+        toolRef: 't1',
+        pocketPattern: pattern,
+      })
+      const legacy = generatePocketToolpath(project, base)
+      const explicit100 = generatePocketToolpath(project, { ...base, pocketSlotFeedPercent: 100 })
+
+      assert(
+        legacy.moves.every((move) => move.feedScale === undefined),
+        `${pattern}/${pass}: legacy operation should have no feedScale`,
+      )
+      assert(
+        explicit100.moves.every((move) => move.feedScale === undefined),
+        `${pattern}/${pass}: percent=100 should have no feedScale`,
+      )
+      assert(
+        movesEqual(legacy.moves, explicit100.moves),
+        `${pattern}/${pass}: percent=100 must not change the move stream`,
+      )
+    }
+  }
+  console.log('pocket slot feed disabled parity: PASSED')
+}
+
+// ---------------------------------------------------------------------------
 // Driver
 // ---------------------------------------------------------------------------
 
@@ -1546,6 +1821,13 @@ try {
   testDrillingTieBreaksByOriginalOrder()
   testDrillingMinimizesSafeZTravelDistance()
   testFinishSurfaceCleanupRejectsRegionOnlyTarget()
+  testPocketOffsetSlotFeedSimple()
+  testPocketOffsetSlotFeedIslandSections()
+  testPocketOffsetSlotFeedPerLevel()
+  testPocketParallelSlotFeed()
+  testPocketFinishFloorSlotFeedOffset()
+  testPocketFinishFloorSlotFeedParallel()
+  testPocketSlotFeedDisabledParity()
   console.log('\nAll toolpath tests PASSED.')
 } catch (e) {
   console.error(e)

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -1720,6 +1720,16 @@ function testPocketFinishFloorSlotFeedOffset() {
   // Walls only + slot feed => nothing stamped.
   const wallsOnly = generatePocketToolpath(project, { ...op, finishFloor: false })
   assert(stampedCutMoves(wallsOnly.moves).length === 0, 'walls-only finish should have no stamped moves')
+
+  // Floor cuts before walls: if roughing left axial stock, a wall pass at
+  // final depth would slot through the uncleared floor skin at full feed, so
+  // the floor (whose first pass runs at slot feed) must clear it first.
+  const allCuts = cutMoves(result.moves)
+  const isWallMove = (move: ToolpathMove) =>
+    [move.from.x, move.from.y, move.to.x, move.to.y].some((value) => approx(value, 2) || approx(value, 28))
+  const firstWallIndex = allCuts.findIndex(isWallMove)
+  const lastFloorIndex = allCuts.reduce((last, move, index) => (!isWallMove(move) ? index : last), -1)
+  assert(firstWallIndex > lastFloorIndex, 'wall contour should be cut after all floor cuts')
   console.log('pocket finish floor slot feed offset: PASSED')
 }
 

--- a/src/engine/toolpaths/types.ts
+++ b/src/engine/toolpaths/types.ts
@@ -33,6 +33,11 @@ export interface ToolpathMove {
    *  Populated when operation.debugToolpath is active. Used in the 3D viewport
    *  to render shape markers that help visualise toolpath provenance. */
   source?: string
+  /** Multiplier applied to the operation's cut feed at G-code export time.
+   *  Set on fully engaged (slotting) pocket cuts when the operation's
+   *  pocketSlotFeedPercent is below 100. Absent means 1 (normal feed).
+   *  Never set on plunge moves (those use the plunge feed). */
+  feedScale?: number
 }
 
 export interface ToolpathBounds {

--- a/src/store/helpers/operationDefaults.ts
+++ b/src/store/helpers/operationDefaults.ts
@@ -285,6 +285,7 @@ export function defaultOperationForTarget(
     rpm: tool.defaultRpm,
     pocketPattern: kind === 'finish_surface' || kind === 'finish_surface_cleanup' ? 'parallel' : 'offset',
     pocketAngle: 0,
+    pocketSlotFeedPercent: 100,
     stockToLeaveRadial: 0,
     stockToLeaveAxial: 0,
     finishWalls: true,

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -986,7 +986,8 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  margin-left: 6px;
+  /* Sits at the start of the feed group; the flex gap handles spacing. */
+  flex: none;
 }
 
 .simulation-playback-bar__feed {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -942,7 +942,7 @@
 }
 
 .simulation-playback-bar__speed--slider input[type='range'] {
-  width: 130px;
+  width: 90px;
   accent-color: var(--accent);
 }
 
@@ -987,6 +987,22 @@
   height: 8px;
   border-radius: 50%;
   margin-left: 6px;
+}
+
+.simulation-playback-bar__feed {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  border-left: 1px solid var(--line-strong);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.simulation-playback-bar__feed-value {
+  color: var(--text);
+  min-width: 7em;
+  text-align: right;
 }
 
 /* Match the toolpath preview colours from Viewport3D.tsx buildToolpathOverlay().

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -476,6 +476,11 @@ export interface Operation {
   rpm: number
   pocketPattern: PocketPattern
   pocketAngle: number
+  /** Feed percentage (1-100) applied to fully engaged (slotting) pocket cuts:
+   *  each section's innermost offset loop, ring segments crossing uncleared
+   *  pinch corridors, the parallel boundary pass and first fill line, and the
+   *  first finish-floor cut. Undefined or 100 disables the reduction. */
+  pocketSlotFeedPercent?: number
   stockToLeaveRadial: number
   stockToLeaveAxial: number
   finishWalls: boolean


### PR DESCRIPTION
Implements #173, evolved through review into an engagement-based model.

## What

Adds an optional **Slot Feed (%)** setting for pocket operations: cut moves where the tool is fully engaged (slotting into virgin material) run at `feed × percent/100`; everything else runs at normal feed. Geometry is unchanged — this is feed metadata plus two ordering fixes that the feature surfaced.

## Engagement model

One rule, applied once per Z level to all pocket passes (offset rough, parallel rough, finish floor): **a cut fragment is fully engaged exactly when no kerf already cut at that level lies within ~0.9× the tool diameter of it.** Prior kerfs directly behind the motion direction (the tool's own trail) don't count, so a straight slot stays engaged however long it runs. Prior cut segments are indexed in chunk-sized pieces on a uniform grid; moves are classified in quarter-slot-distance chunks and split where the classification changes.

This yields, with no special cases: each disjoint section's own inner start reduced; the first pass through a pinch corridor reduced (and only that pass — later cuts riding its kerf are normal); links through cleared material, zigzag end links, ring corners, and the self-overlapping back side of thin loops all at normal feed; parallel boundary passes reduced and fill lines adjacent to a kerf normal.

## Ordering fixes (apply regardless of slot feed)

- **Pocket and surface finish cut the floor before the walls** — with walls first, a wall pass at final depth slots through whatever axial stock roughing left, at full feed.
- **Pocket offset finish floors cut inner-first** like the rough pass (per disjoint floor area, outer contours only). Surface-clean roughing intentionally stays outer-first: its coverage boundary hangs the tool off the material edge at light engagement, the opposite of a pocket wall.

## Plumbing

- `ToolpathMove.feedScale` multiplier; postprocessor emits `(feed || default) × feedScale` with the existing modal F-word logic.
- Optional `pocketSlotFeedPercent` field (no migration; `undefined`/100 = off, byte-identical move stream, covered by parity tests). UI: "Slot Feed (%)" for rough pockets and finish pockets with Finish Floor.
- Offset ring trees are built once per band and traversed per level (also removes pre-existing per-level Clipper recomputation).
- Simulation: playback bar shows the current move's real feed (dot + value); move subdivision preserves `feedScale`; the tool animation advances on a reference-feed budget so reduced cuts visibly slow down (seeking stays geometric).

## Testing

9 toolpath tests (simple/island/partial-depth-island/multi-level offset, parallel, offset+parallel finish floor, surface ordering, disabled parity), postprocessor modal-F test, playback tests (metadata preservation, feed-scaled advance, geometric seek), plus probe scripts verifying stamped-move sets and byte-identical disabled parity against the pre-feature stream. `npm run build` green (81 test files).

Closes #173
