### PR TITLE
fix: WebGL context-loss handling and WebGL2 fallback for the simulation viewport

### DIFF
--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -22,6 +22,7 @@ import { createHeightfieldTexture, createStockPlaneGeometries, createDynamicProf
 import { createDynamicBoundaryMaterial, createHeightfieldMaterial, createShaderDrivenBoundaryMaterial } from '../../engine/simulation/heightfieldShader'
 import { PlaybackController } from '../../engine/simulation/playback'
 import { buildToolMesh, disposeToolMesh } from '../../engine/simulation/toolMesh'
+import { attachWebglContextGuard } from '../viewport3d/webglContextGuard'
 import type { PlaybackPose } from '../../engine/simulation/playback'
 import type { SimulationGrid, SimulationResult } from '../../engine/simulation'
 import type { ToolpathMove } from '../../engine/toolpaths/types'
@@ -628,6 +629,13 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   // heavy heightfield + shader-driven boundary mesh is allocated.
   const [isPlaybackBuilding, setIsPlaybackBuilding] = useState(false)
   const [isPlaybackReady, setIsPlaybackReady] = useState(false)
+  // 'unavailable': WebGL2 context creation failed (old browser, GPU denylist,
+  // hardware acceleration off) — the 3D scene never initializes and a fallback
+  // message replaces the canvas. 'context-lost': the browser revoked the
+  // context (GPU memory pressure, driver reset); three restores GL state
+  // automatically when the browser returns it, we only pause playback and
+  // surface an overlay until then.
+  const [webglStatus, setWebglStatus] = useState<'ok' | 'context-lost' | 'unavailable'>('ok')
   // Mirror isActive into a ref so the render loop (raw RAF, not React-driven)
   // can read it without re-binding the closure each prop change.
   const isActiveRef = useRef(isActive)
@@ -776,7 +784,20 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
       return
     }
 
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' })
+    let renderer: THREE.WebGLRenderer
+    try {
+      renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' })
+    } catch (error) {
+      // three r163+ requires WebGL2; the constructor throws when the browser
+      // can't create a context (old browser, GPU denylist, hardware
+      // acceleration off). Leave the refs null — every sibling effect guards
+      // on them — so the fallback message renders instead of the throw
+      // escaping the effect and taking down the whole app via the error
+      // boundary.
+      console.error('SimulationViewport: WebGL2 context creation failed', error)
+      setWebglStatus('unavailable')
+      return
+    }
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
     renderer.setSize(mount.clientWidth, mount.clientHeight)
     renderer.setClearColor(0x141820, 1)
@@ -808,6 +829,24 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
     }, () => zoomWindowActiveRef.current)
     controlsRef.current = controls
 
+    const detachContextGuard = attachWebglContextGuard(renderer.domElement, {
+      onLost: () => {
+        // Left running, playback would keep simulating invisibly: the tick
+        // loop advances the cut while three no-ops render(). Pause it; the
+        // user resumes after restore. The ref stops the loop on its very next
+        // frame, ahead of the state update.
+        isPlayingRef.current = false
+        setIsPlaying(false)
+        setWebglStatus('context-lost')
+      },
+      onRestored: () => {
+        // three rebuilds its GL state itself and re-uploads textures/geometry
+        // from CPU-side data on the next animate() frame — only the overlay
+        // needs clearing.
+        setWebglStatus('ok')
+      },
+    })
+
     function animate() {
       frameRef.current = requestAnimationFrame(animate)
       // Skip the GPU draw when the simulation tab isn't visible. A tab switch
@@ -827,6 +866,7 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
 
     return () => {
       cancelAnimationFrame(frameRef.current)
+      detachContextGuard()
       disposeCurrentMesh(scene)
       disposeClampMeshes(scene)
       controls.dispose()
@@ -1179,7 +1219,7 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
     })
   }, [])
 
-  const playbackControlsDisabled = isPlaybackBuilding || !isPlaybackReady
+  const playbackControlsDisabled = isPlaybackBuilding || !isPlaybackReady || webglStatus !== 'ok'
 
   const handlePlayPause = useCallback(() => {
     const controller = playbackControllerRef.current
@@ -1328,6 +1368,28 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
           <div className="simulation-viewport__spinner" />
         </div>
       )}
+      {webglStatus === 'unavailable' && (
+        <div className="simulation-viewport__webgl-overlay">
+          <div className="simulation-viewport__webgl-message">
+            <strong>3D simulation isn&apos;t available</strong>
+            <p>
+              This view requires WebGL2, which your browser or graphics driver did not provide.
+              Try updating your browser or enabling hardware acceleration in its settings.
+            </p>
+          </div>
+        </div>
+      )}
+      {webglStatus === 'context-lost' && (
+        <div className="simulation-viewport__webgl-overlay">
+          <div className="simulation-viewport__webgl-message">
+            <strong>3D graphics context lost</strong>
+            <p>
+              Waiting for the browser to restore it — playback has been paused.
+              If this message persists, reload the app.
+            </p>
+          </div>
+        </div>
+      )}
       {zoomWindowActive && (
         <div
           className="viewport-zoom-select-overlay"
@@ -1412,7 +1474,7 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
             className={`simulation-mode-toggle__btn simulation-playback-toggle ${playbackEnabled ? 'simulation-mode-toggle__btn--active' : ''}`}
             type="button"
             onClick={handlePlaybackToggle}
-            disabled={mode !== 'selected' || !playbackInput}
+            disabled={mode !== 'selected' || !playbackInput || webglStatus === 'unavailable'}
             title={mode !== 'selected'
               ? 'Switch to Selected mode to use Tool playback'
               : !playbackInput

--- a/src/components/viewport3d/webglContextGuard.test.ts
+++ b/src/components/viewport3d/webglContextGuard.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the WebGL context-loss guard.
+ *
+ * Run with: npx tsx src/components/viewport3d/webglContextGuard.test.ts
+ *
+ * There is no DOM in the test runner; an EventTarget stands in for the
+ * canvas, which is all the guard uses.
+ */
+
+import { attachWebglContextGuard } from './webglContextGuard'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function makeCanvasStub(): HTMLCanvasElement {
+  return new EventTarget() as unknown as HTMLCanvasElement
+}
+
+function testForwardsLostAndRestoredEvents(): void {
+  const canvas = makeCanvasStub()
+  let lost = 0
+  let restored = 0
+  attachWebglContextGuard(canvas, {
+    onLost: () => { lost += 1 },
+    onRestored: () => { restored += 1 },
+  })
+
+  canvas.dispatchEvent(new Event('webglcontextlost'))
+  assert(lost === 1 && restored === 0, 'expected onLost after webglcontextlost')
+
+  canvas.dispatchEvent(new Event('webglcontextrestored'))
+  assert(lost === 1 && restored === 1, 'expected onRestored after webglcontextrestored')
+
+  canvas.dispatchEvent(new Event('webglcontextlost'))
+  canvas.dispatchEvent(new Event('webglcontextrestored'))
+  assert(lost === 2 && restored === 2, 'expected repeated loss/restore cycles to keep forwarding')
+}
+
+function testDetachStopsForwarding(): void {
+  const canvas = makeCanvasStub()
+  let lost = 0
+  let restored = 0
+  const detach = attachWebglContextGuard(canvas, {
+    onLost: () => { lost += 1 },
+    onRestored: () => { restored += 1 },
+  })
+
+  detach()
+  canvas.dispatchEvent(new Event('webglcontextlost'))
+  canvas.dispatchEvent(new Event('webglcontextrestored'))
+  assert(lost === 0 && restored === 0, 'expected no callbacks after detach')
+}
+
+function testDetachOnlyRemovesOwnListeners(): void {
+  const canvas = makeCanvasStub()
+  let first = 0
+  let second = 0
+  const detachFirst = attachWebglContextGuard(canvas, {
+    onLost: () => { first += 1 },
+    onRestored: () => {},
+  })
+  attachWebglContextGuard(canvas, {
+    onLost: () => { second += 1 },
+    onRestored: () => {},
+  })
+
+  detachFirst()
+  canvas.dispatchEvent(new Event('webglcontextlost'))
+  assert(first === 0, 'expected detached guard to stop receiving events')
+  assert(second === 1, 'expected other guard to keep receiving events')
+}
+
+testForwardsLostAndRestoredEvents()
+testDetachStopsForwarding()
+testDetachOnlyRemovesOwnListeners()
+console.log('webgl context guard tests passed')

--- a/src/components/viewport3d/webglContextGuard.ts
+++ b/src/components/viewport3d/webglContextGuard.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface WebglContextGuardHandlers {
+  onLost: () => void
+  onRestored: () => void
+}
+
+/**
+ * Watch a renderer's canvas for WebGL context loss/restore and forward the
+ * transitions to app-level handlers (pause playback, show/hide an overlay).
+ *
+ * three's WebGLRenderer already handles the GL side: it preventDefault()s the
+ * lost event (which is what allows the browser to restore the context at all),
+ * no-ops render() while lost, and rebuilds its GL state on restore — GPU
+ * resources re-upload lazily from retained CPU-side data. This guard exists
+ * only for the app-state side that three can't know about.
+ *
+ * Returns a detach function for effect cleanup.
+ */
+export function attachWebglContextGuard(
+  canvas: HTMLCanvasElement,
+  handlers: WebglContextGuardHandlers,
+): () => void {
+  const handleLost = () => handlers.onLost()
+  const handleRestored = () => handlers.onRestored()
+  canvas.addEventListener('webglcontextlost', handleLost)
+  canvas.addEventListener('webglcontextrestored', handleRestored)
+  return () => {
+    canvas.removeEventListener('webglcontextlost', handleLost)
+    canvas.removeEventListener('webglcontextrestored', handleRestored)
+  }
+}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -777,6 +777,40 @@
   to { transform: rotate(360deg); }
 }
 
+.simulation-viewport__webgl-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(13, 20, 28, 0.72);
+  pointer-events: none;
+  z-index: 6;
+}
+
+.simulation-viewport__webgl-message {
+  max-width: 360px;
+  padding: 16px 20px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(20, 28, 38, 0.95);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 13px;
+  text-align: center;
+}
+
+.simulation-viewport__webgl-message strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 14px;
+}
+
+.simulation-viewport__webgl-message p {
+  margin: 0;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.65);
+}
+
 .simulation-detail-control {
   box-sizing: border-box;
   display: inline-flex;


### PR DESCRIPTION
Closes #117. Implements the design approved in the issue.

## What changed

- **`src/components/viewport3d/webglContextGuard.ts`** (new) — `attachWebglContextGuard(canvas, {onLost, onRestored})`: forwards `webglcontextlost`/`webglcontextrestored` to app-level handlers and returns a detach function. Placed with the 3D infra so `Viewport3D` can adopt it in a follow-up. three r183 already handles the GL side (preventDefault on loss, render() no-op while lost, GL state rebuild + lazy CPU-side re-upload on restore), so the guard only manages app state.
- **`SimulationViewport.tsx`** — new `webglStatus: 'ok' | 'context-lost' | 'unavailable'` state:
  - Renderer creation wrapped in try/catch. On throw (WebGL2 unavailable) the viewport shows an actionable fallback message instead of the throw escaping the mount effect and taking the whole app down via `AppErrorBoundary`.
  - On context loss: playback is paused via the existing `isPlayingRef` path (previously the tick loop kept advancing the cut invisibly while the canvas was frozen) and an overlay explains what happened.
  - On restore: overlay clears; three re-uploads everything on the next animate() frame — no manual rebuild needed.
  - Playback transport controls and the Play Tool toggle are disabled while WebGL is unhealthy (Play Tool would otherwise wedge the building spinner, since the build effect bails on the missing scene).
- **`layout.css`** — overlay/message styles matching the existing computing-overlay pattern.
- **`webglContextGuard.test.ts`** (new) — attach/forward/detach coverage using an `EventTarget` stand-in (test runner has no DOM).

## Verification

`npm run build` green (lint, tsc, all 82 test files, vite build).

Manual QA in the running app (Chrome via devtools MCP, example project, Pocket Rough playback):

- **Context loss mid-playback** (`WEBGL_lose_context.loseContext()`): overlay appears ("3D graphics context lost — … playback has been paused"), playback pauses cleanly, transport controls disable, no console error storm.
- **Restore** (`restoreContext()`): overlay clears, controls re-enable, the heightfield scene comes back intact (stock + partial pocket cut + tool all render), playback resumes from the paused position and runs to completion.
- **WebGL2 unavailable for the sim canvas** (init script failing the second WebGL context request — models the browser per-page context cap / GPU pressure): app stays alive, simulation tab shows the actionable fallback, Play Tool disabled.
- **WebGL2 fully absent** (all WebGL context requests fail): unchanged from before — `Viewport3D`'s unguarded constructor still trips `AppErrorBoundary`, whose message is already WebGL-aware and actionable. Guarding `Viewport3D` the same way (so sketching still works on WebGL-less devices) is the follow-up noted in the design.

### QA notes for lower-power devices

Not run in this PR (no device on hand): one pass on iPad Safari — background the tab during playback to invite a real context loss, confirm the overlay + resume path. Can piggyback on the native-mobile spike environment (#235).
