### PR TITLE
Export design as SVG (reuse the designPrint renderer)

### DIFF
--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -23,7 +23,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 - `feature-tree/` — sketch feature tree UI (reordering, visibility, grouping) plus the extracted feature/tab/clamp context menu
 - `layout/` — app shell (toolbars, sidebars, mode switching); toolbar internals are documented in `layout/toolbar/INDEX.md`
 - `project/` — project-level UI (new/open/save, stock, machine, units)
-- `export/` — export dialogs (G-code, SVG, DXF, STL preview) and the Print Design dialog (`PrintDesignDialog`, backed by `src/engine/designPrint/`)
+- `export/` — export dialogs: G-code (`ExportDialog`), the Export Model dialog (`ModelExportDialog`, STL mesh + 2D design SVG via `src/engine/modelExport/`), and the Print Design dialog (`PrintDesignDialog`, backed by `src/engine/designPrint/`)
 - `machine/` — machine definition editor (focused form + raw JSON + Zod validation)
 - `about/` — About dialog (web only; version info + links). Desktop uses the native About menu.
 - `ai/` — MCP / agent-facing UI (placeholder — MCP not yet implemented)

--- a/src/components/export/ModelExportDialog.tsx
+++ b/src/components/export/ModelExportDialog.tsx
@@ -29,7 +29,16 @@ import {
   type CurveQuality,
   type ExportTriangleMesh,
   type STLExportOptions,
+  type SvgExportOptions,
 } from '../../engine/modelExport'
+import {
+  defaultDesignSvgExportOptions,
+  resolvePrintBounds,
+  type DesignSvgExportArea,
+  type DesignSvgExportContent,
+} from '../../engine/designPrint'
+import { formatLength } from '../../utils/units'
+import type { Project } from '../../types/project'
 
 interface ModelExportDialogProps {
   onClose: () => void
@@ -46,6 +55,9 @@ export function ModelExportDialog({ onClose }: ModelExportDialogProps) {
 
   const [formatId, setFormatId] = useState<string>(MODEL_EXPORT_FORMATS[0]?.id ?? 'stl')
   const [stlOptions, setStlOptions] = useState<STLExportOptions>(STL_DEFAULT_OPTIONS)
+  const [svgOptions, setSvgOptions] = useState<SvgExportOptions>(() =>
+    defaultDesignSvgExportOptions(project),
+  )
   const [curveQuality, setCurveQuality] = useState<CurveQuality>('normal')
   const [fileName, setFileName] = useState<string>(() => sanitizeFileName(project.meta.name))
   const [assembled, setAssembled] = useState<AssembledMesh | null>(null)
@@ -54,10 +66,13 @@ export function ModelExportDialog({ onClose }: ModelExportDialogProps) {
   const [exporting, setExporting] = useState(false)
 
   const format = useMemo(() => getModelExportFormat(formatId) ?? MODEL_EXPORT_FORMATS[0], [formatId])
+  const is2d = format?.kind === '2d'
 
   // Re-assemble whenever the user toggles "include imported meshes" — the
   // assembled mesh is the only piece of state that depends on that option.
+  // 2D formats render from the project directly, so no mesh is assembled.
   useEffect(() => {
+    if (is2d) return
     let cancelled = false
     setAssembling(true)
     setErrorMessage(null)
@@ -80,43 +95,66 @@ export function ModelExportDialog({ onClose }: ModelExportDialogProps) {
     return () => {
       cancelled = true
     }
-  }, [project, stlOptions.includeImportedMeshes, curveQuality])
+  }, [project, stlOptions.includeImportedMeshes, curveQuality, is2d])
 
   const triangleCount = assembled ? countTriangles(assembled.mesh) : 0
   const estimatedSize = assembled && format?.id === 'stl'
     ? estimateStlFileSize(assembled.mesh, stlOptions.format)
     : null
 
+  // Physical output size of the SVG export (world units are project units).
+  const svgTabs = svgOptions.content.tabs
+  const svgClamps = svgOptions.content.clamps
+  const svgBounds = useMemo(
+    () =>
+      is2d
+        ? resolvePrintBounds(project, svgOptions.area, null, {
+            backdrop: false,
+            tabs: svgTabs,
+            clamps: svgClamps,
+          })
+        : null,
+    [is2d, project, svgOptions.area, svgTabs, svgClamps],
+  )
+
   const warnings = useMemo(() => {
+    if (is2d) return []
     const list = [...(assembled?.warnings ?? [])]
     if (assembled && triangleCount === 0) {
       list.push('No solid geometry to export — add visible features first.')
     }
     return list
-  }, [assembled, triangleCount])
+  }, [is2d, assembled, triangleCount])
 
   async function handleExport() {
-    if (!assembled || !format || triangleCount === 0) return
+    if (!format) return
+    if (!is2d && (!assembled || triangleCount === 0)) return
     setExporting(true)
     try {
       const output = await format.export(
-        { project, mesh: assembled.mesh },
-        format.id === 'stl' ? stlOptions : format.defaultOptions,
+        { project, mesh: assembled?.mesh },
+        format.id === 'stl' ? stlOptions : format.id === 'svg' ? svgOptions : format.defaultOptions,
       )
       const suggestedName = sanitizeFileName(fileName || project.meta.name)
+      // The remembered path is written to without a dialog, so reuse it only
+      // for the same file type — never overwrite a .stl target with SVG text.
+      const rememberedPath =
+        lastModelExportPath?.toLowerCase().endsWith(`.${format.extension}`)
+          ? lastModelExportPath
+          : null
       const savedPath = output.encoding === 'binary'
         ? await platform.saveBinaryFile(
             suggestedName,
             output.data as Uint8Array,
             format.extension,
             format.mimeType,
-            lastModelExportPath,
+            rememberedPath,
           )
         : await platform.saveTextFile(
             suggestedName,
             output.data as string,
             format.extension,
-            lastModelExportPath,
+            rememberedPath,
           )
       if (savedPath) {
         markModelExported(savedPath)
@@ -168,27 +206,46 @@ export function ModelExportDialog({ onClose }: ModelExportDialogProps) {
               </div>
             </div>
 
-            <div className="dialog-section-group">
-              <label className="dialog-section-title">Curve quality</label>
-              <Select<CurveQuality>
-                value={curveQuality}
-                options={CURVE_QUALITY_OPTIONS}
-                onChange={setCurveQuality}
-              />
-              <div style={{ fontSize: '11px', color: 'var(--text-dim)' }}>
-                Controls how finely arcs and bezier curves are tessellated. Finer = more triangles, smoother curves.
+            {!is2d && (
+              <div className="dialog-section-group">
+                <label className="dialog-section-title">Curve quality</label>
+                <Select<CurveQuality>
+                  value={curveQuality}
+                  options={CURVE_QUALITY_OPTIONS}
+                  onChange={setCurveQuality}
+                />
+                <div style={{ fontSize: '11px', color: 'var(--text-dim)' }}>
+                  Controls how finely arcs and bezier curves are tessellated. Finer = more triangles, smoother curves.
+                </div>
               </div>
-            </div>
+            )}
 
             {format?.id === 'stl' && (
               <StlOptionsPanel options={stlOptions} onChange={setStlOptions} />
             )}
 
+            {format?.id === 'svg' && (
+              <SvgOptionsPanel project={project} options={svgOptions} onChange={setSvgOptions} />
+            )}
+
             <div className="dialog-section-group">
               <label className="dialog-section-title">Summary</label>
               <div style={{ fontSize: '13px', color: 'var(--text)', display: 'grid', gap: '4px' }}>
-                <div>{assembling ? 'Assembling mesh…' : `${triangleCount.toLocaleString()} triangles`}</div>
-                {estimatedSize !== null && (
+                {is2d && svgBounds ? (
+                  <>
+                    <div>
+                      Exported size: {formatLength(svgBounds.maxX - svgBounds.minX, project.meta.units)} ×{' '}
+                      {formatLength(svgBounds.maxY - svgBounds.minY, project.meta.units)}{' '}
+                      {project.meta.units === 'inch' ? 'in' : 'mm'} at 1:1
+                    </div>
+                    <div style={{ fontSize: '11px', color: 'var(--text-dim)' }}>
+                      Editable vector paths; hidden features are left out and dimensions follow the sketch setting.
+                    </div>
+                  </>
+                ) : (
+                  <div>{assembling ? 'Assembling mesh…' : `${triangleCount.toLocaleString()} triangles`}</div>
+                )}
+                {estimatedSize !== null && !is2d && (
                   <div style={{ fontSize: '11px', color: 'var(--text-dim)' }}>
                     Estimated file size: {formatBytes(estimatedSize)}
                   </div>
@@ -223,7 +280,7 @@ export function ModelExportDialog({ onClose }: ModelExportDialogProps) {
           <button
             className="btn-primary"
             onClick={handleExport}
-            disabled={!assembled || triangleCount === 0 || assembling || exporting}
+            disabled={exporting || (!is2d && (!assembled || triangleCount === 0 || assembling))}
             type="button"
           >
             {exporting ? 'Exporting…' : `Export .${format?.extension ?? ''}`}
@@ -276,6 +333,98 @@ function StlOptionsPanel({
               onChange={(event) => onChange({ ...options, includeImportedMeshes: event.target.checked })}
             />
             Include imported meshes
+          </label>
+        </div>
+      </div>
+    </>
+  )
+}
+
+function SvgOptionsPanel({
+  project,
+  options,
+  onChange,
+}: {
+  project: Project
+  options: SvgExportOptions
+  onChange: (next: SvgExportOptions) => void
+}) {
+  const areaOptions: { value: DesignSvgExportArea; label: string }[] = [
+    { value: 'visible', label: 'Visible design extents' },
+    { value: 'stock', label: 'Stock extents' },
+  ]
+
+  function updateContent(partial: Partial<DesignSvgExportContent>) {
+    onChange({ ...options, content: { ...options.content, ...partial } })
+  }
+
+  return (
+    <>
+      <div className="dialog-section-group">
+        <label className="dialog-section-title">Export area</label>
+        <Select<DesignSvgExportArea>
+          value={options.area}
+          options={areaOptions}
+          onChange={(area) => onChange({ ...options, area })}
+        />
+      </div>
+
+      <div className="dialog-section-group">
+        <label className="dialog-section-title">Content</label>
+        <div className="export-option-group">
+          <label className="export-option" title={project.tabs.length === 0 ? 'No tabs in this project' : undefined}>
+            <input
+              type="checkbox"
+              checked={options.content.tabs}
+              disabled={project.tabs.length === 0}
+              onChange={(event) => updateContent({ tabs: event.target.checked })}
+            />
+            Tabs
+          </label>
+          <label className="export-option" title={project.clamps.length === 0 ? 'No clamps in this project' : undefined}>
+            <input
+              type="checkbox"
+              checked={options.content.clamps}
+              disabled={project.clamps.length === 0}
+              onChange={(event) => updateContent({ clamps: event.target.checked })}
+            />
+            Clamps
+          </label>
+          <label className="export-option">
+            <input
+              type="checkbox"
+              checked={options.content.featureLabels}
+              onChange={(event) => updateContent({ featureLabels: event.target.checked })}
+            />
+            Feature labels
+          </label>
+          <label className="export-option">
+            <input
+              type="checkbox"
+              checked={options.content.grid}
+              onChange={(event) => updateContent({ grid: event.target.checked })}
+            />
+            Grid
+          </label>
+        </div>
+        <div className="export-option-group">
+          <label className="export-option">
+            <input
+              type="radio"
+              name="svg-color"
+              checked={options.colorMode === 'color'}
+              onChange={() => onChange({ ...options, colorMode: 'color' })}
+            />
+            Color
+          </label>
+          <label className="export-option">
+            <input
+              type="radio"
+              name="svg-color"
+              checked={options.colorMode === 'monochrome'}
+              onChange={() => onChange({ ...options, colorMode: 'monochrome' })}
+            />
+            Monochrome
           </label>
         </div>
       </div>

--- a/src/engine/INDEX.md
+++ b/src/engine/INDEX.md
@@ -19,12 +19,13 @@ Pure-logic CAM core. No React, no DOM. Everything here is testable in isolation.
   - `definitions/` — bundled machine definitions (Marlin, GRBL flavors, etc.)
   - `types.ts` — `MachineDefinition` and validation
   - `utils.ts` — formatting helpers
-- `modelExport/` — 3D model export (STL today; pluggable format registry)
+- `modelExport/` — model/design export (pluggable format registry: 3D mesh formats and 2D vector formats)
   - `index.ts` — public API and `MODEL_EXPORT_FORMATS` registry
-  - `types.ts` — format/option interfaces
+  - `types.ts` — format/option interfaces (`kind: '2d' | '3d'` gates mesh assembly)
   - `assemble.ts` — manifold union → standard Z-up right-handed export mesh
   - `stl.ts` — binary + ASCII STL writers and the `stlExportFormat` entry
-- [designPrint/](designPrint/INDEX.md) — print-specific vector renderer for the 2D design view: page/scale layout math + SVG/HTML generation (issue #254)
+  - `svg.ts` — `svgExportFormat`: 2D design SVG at true 1:1, backed by `designPrint/` (issue #257)
+- [designPrint/](designPrint/INDEX.md) — vector renderer for the 2D design view: page/scale layout math + SVG/HTML generation for printing (issue #254) and the geometry-only SVG export (issue #257)
 - [operationBooklet/](operationBooklet/INDEX.md) — per-operation report model and PDF booklet generation
 - [simulation/](simulation/INDEX.md) — heightfield-based material removal sim (grid, replay/stepping, GPU heightfield mesh + shaders)
 

--- a/src/engine/designPrint/INDEX.md
+++ b/src/engine/designPrint/INDEX.md
@@ -1,24 +1,26 @@
 # INDEX — src/engine/designPrint/
 
-Print-specific vector renderer for the 2D design/sketch view (issue #254).
-DOM-free: layout math and SVG/HTML generation are plain string/number logic so
-the whole pipeline is unit-testable without a browser. All physical quantities
-are millimetres internally; user inputs (margins, offsets, custom paper) are
-project units converted by the layout.
+Vector renderer for the 2D design/sketch view: printing (issue #254) and
+geometry-only SVG export (issue #257). DOM-free: layout math and SVG/HTML
+generation are plain string/number logic so the whole pipeline is
+unit-testable without a browser. All physical quantities are millimetres
+internally; user inputs (margins, offsets, custom paper) are project units
+converted by the layout.
 
 ## Files
 
-- `types.ts` — print options (paper preset, orientation, margins, print area, scale mode, content toggles, color mode), the resolved `DesignPrintLayout`, and per-project defaults.
+- `types.ts` — print options (paper preset, orientation, margins, print area, scale mode, content toggles, color mode), the resolved `DesignPrintLayout`, SVG-export options (`DesignSvgExportOptions`), and per-project defaults.
 - `layout.ts` — pure page math: paper presets, printable/drawable area, print-bounds resolution (visible extents / stock extents / current view), fit/actual/custom scale, custom-scale parsing, centering + registration offsets, clipping detection.
-- `svg.ts` — converts project geometry (stock, features with text resolved, imported-model silhouettes, tabs/clamps, origin, dimensions, grid, backdrop, toolpath overlays, footer/title block) into a self-contained SVG string in physical mm.
+- `svg.ts` — converts project geometry (stock, features with text resolved, imported-model silhouettes, tabs/clamps, origin, dimensions, grid, backdrop, toolpath overlays, footer/title block) into a self-contained SVG string in physical mm. `buildDesignPrintSvg` renders the full print page; `buildDesignSvgExport` renders the shared world content as a standalone editable SVG at true 1:1 (tight viewBox, per-feature groups, outlines only, no page scaffolding).
 - `html.ts` — wraps the SVG in a printable HTML document (`@page` sizing, white background, no app CSS).
 - `index.ts` — public exports.
 
 ## Tests
 
-- `designPrint.test.ts` — printable-area math, scale conversion (mm/inch actual size, fit aspect, custom ratio parsing), clipping detection, and SVG/HTML smoke tests over a small deterministic project. Run with `npx tsx src/engine/designPrint/designPrint.test.ts`.
+- `designPrint.test.ts` — printable-area math, scale conversion (mm/inch actual size, fit aspect, custom ratio parsing), clipping detection, SVG/HTML smoke tests, and geometry-only SVG export (viewBox/physical size, feature groups, content toggles) over a small deterministic project. Run with `npx tsx src/engine/designPrint/designPrint.test.ts`.
 
 ## Consumers
 
 - `src/components/export/PrintDesignDialog.tsx` — the print dialog (preview + options UI).
 - `src/platform/printDocument.ts` — prints the generated HTML via a hidden iframe.
+- `src/engine/modelExport/svg.ts` — the SVG entry in the Export Model format registry (backed by `buildDesignSvgExport`).

--- a/src/engine/designPrint/designPrint.test.ts
+++ b/src/engine/designPrint/designPrint.test.ts
@@ -638,6 +638,39 @@ function buildTestExportSvg(
   )
 }
 
+{
+  // Annotation text (origin labels, feature labels, dimension values) is
+  // emitted as lightweight single-stroke skeleton geometry, never <text>, so
+  // the geometry export re-imports as a few line segments instead of dense
+  // filled glyph outlines (issue #257 round-trip bloat).
+  const { svg } = buildTestExportSvg('mm') // origin visible → X/Y labels present
+  assert(!svg.includes('<text'), 'geometry export emits no <text> elements')
+  assert(svg.includes('class="pc-text"'), 'origin axis labels render as skeleton strokes')
+
+  const dimension: DimensionAnnotation = {
+    id: 'dim-skel',
+    type: 'aligned',
+    a: { kind: 'free', point: { x: 10, y: 10 } },
+    b: { kind: 'free', point: { x: 40, y: 10 } },
+    offset: -6,
+    visible: true,
+    locked: false,
+    textOverride: null,
+    precisionOverride: null,
+  }
+  const annotated = buildTestExportSvg('mm', (project) => {
+    project.annotations.push(dimension)
+    project.meta.showDimensions = true
+  }, { content: { featureLabels: true } })
+  assert(!annotated.svg.includes('<text'), 'labels and dimensions never emit <text> in the export')
+  // Skeleton strokes are open polylines, so the value is geometry, not a node.
+  assert(!annotated.svg.includes('>30<'), 'dimension value is skeleton geometry, not a text node')
+
+  // The print SVG keeps crisp native <text>; only the geometry export skeletonizes.
+  const print = buildTestSvg()
+  assert(print.svg.includes('<text'), 'print SVG still uses native <text>')
+}
+
 // ── Path data ────────────────────────────────────────────────
 
 {

--- a/src/engine/designPrint/designPrint.test.ts
+++ b/src/engine/designPrint/designPrint.test.ts
@@ -29,10 +29,15 @@ import {
   parseCustomScale,
   resolvePrintBounds,
 } from './layout'
-import { buildDesignPrintSvg, profileToPathD } from './svg'
+import { buildDesignPrintSvg, buildDesignSvgExport, profileToPathD } from './svg'
 import { buildDesignPrintHtml } from './html'
-import { defaultDesignPrintOptions } from './types'
-import type { DesignPrintContent, DesignPrintOptions } from './types'
+import { defaultDesignPrintOptions, defaultDesignSvgExportOptions } from './types'
+import type {
+  DesignPrintContent,
+  DesignPrintOptions,
+  DesignSvgExportContent,
+  DesignSvgExportOptions,
+} from './types'
 
 function assert(condition: boolean, message: string) {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
@@ -461,6 +466,176 @@ function buildTestSvg(mutate?: (project: Project) => void, optionOverrides: Test
   })
   assert(svg.includes('A &lt;b&gt; &amp; &quot;quote&quot;'), 'project name is XML-escaped in footer')
   assert(!svg.includes('A <b>'), 'raw markup never lands in the svg')
+}
+
+// ── Geometry-only SVG export (issue #257) ────────────────────
+
+// Mirrors buildDesignPrintSvg's fmt() so expected attribute strings match.
+function fmtNum(value: number): string {
+  const rounded = Math.round(value * 10000) / 10000
+  return String(rounded === 0 ? 0 : rounded)
+}
+
+type ExportOptionOverrides = Omit<Partial<DesignSvgExportOptions>, 'content'> & {
+  content?: Partial<DesignSvgExportContent>
+}
+
+function buildTestExportSvg(
+  units: 'mm' | 'inch' = 'mm',
+  mutate?: (project: Project) => void,
+  overrides: ExportOptionOverrides = {},
+) {
+  const project = newProject('SvgExportTest', units)
+  project.features.push(makeFeature('visible-rect'))
+  project.features.push(makeFeature('hidden-circle', {
+    kind: 'circle',
+    visible: false,
+    sketch: {
+      profile: circleProfile(70, 40, 10),
+      origin: { x: 0, y: 0 },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+  }))
+  mutate?.(project)
+  const base = defaultDesignSvgExportOptions(project)
+  const options: DesignSvgExportOptions = {
+    ...base,
+    ...overrides,
+    content: { ...base.content, ...(overrides.content ?? {}) },
+  }
+  const bounds = resolvePrintBounds(project, options.area, null, {
+    backdrop: false,
+    tabs: options.content.tabs,
+    clamps: options.content.clamps,
+  })
+  return { project, options, bounds, svg: buildDesignSvgExport(project, options) }
+}
+
+{
+  // Tight viewBox around the exported bounds, physical mm size at true 1:1.
+  const { svg, bounds } = buildTestExportSvg('mm')
+  const w = bounds.maxX - bounds.minX
+  const h = bounds.maxY - bounds.minY
+  assert(
+    svg.includes(`viewBox="${fmtNum(bounds.minX)} ${fmtNum(bounds.minY)} ${fmtNum(w)} ${fmtNum(h)}"`),
+    'export viewBox equals the exported bounds',
+  )
+  assert(svg.includes(`width="${fmtNum(w)}mm"`), 'mm project: 1 unit = 1 mm')
+  assert(svg.includes(`height="${fmtNum(h)}mm"`), 'mm project: physical height matches bounds')
+}
+
+{
+  // Inch projects export at 1 unit = 25.4 mm.
+  const { svg, bounds } = buildTestExportSvg('inch')
+  const w = bounds.maxX - bounds.minX
+  assert(svg.includes(`width="${fmtNum(w * 25.4)}mm"`), 'inch project: 1 unit = 25.4 mm')
+}
+
+{
+  // No page scaffolding: footer, white background, and clipping are print-only.
+  const { svg } = buildTestExportSvg('mm')
+  assert(!svg.includes('pc-footer'), 'export has no footer/title block')
+  assert(!svg.includes('fill="#ffffff"'), 'export has no background rect')
+  assert(!svg.includes('clipPath'), 'export has no clip path')
+  assert(!svg.includes('pc-print-clip'), 'export references no print clip')
+}
+
+{
+  // Per-feature groups keep layers selectable in vector editors; hidden
+  // features stay out; outlines only, even in color mode.
+  const { svg } = buildTestExportSvg('mm')
+  assert(
+    svg.includes('<g id="feature-visible-rect" data-name="visible-rect">'),
+    'visible feature gets an identified group',
+  )
+  assert(!svg.includes('hidden-circle'), 'hidden feature is omitted entirely')
+  assert(!svg.includes('rgba('), 'export never uses tinted fills')
+  assert(svg.includes('stroke="#1f6fb2"'), 'color mode keeps the color palette strokes')
+
+  const mono = buildTestExportSvg('mm', undefined, { colorMode: 'monochrome' })
+  assert(!mono.svg.includes('#1f6fb2'), 'monochrome mode drops color strokes')
+}
+
+{
+  // Construction geometry: dashed, unfilled; hidden construction omitted.
+  const { svg } = buildTestExportSvg('mm', (project) => {
+    project.features.push(makeFeature('construction-line', {
+      operation: 'construction',
+      sketch: {
+        profile: { start: { x: 0, y: 40 }, segments: [{ type: 'line', to: { x: 100, y: 40 } }], closed: false },
+        origin: { x: 0, y: 0 },
+        orientationAngle: 0,
+        dimensions: [],
+        constraints: [],
+      },
+    }))
+    project.features.push(makeFeature('construction-hidden', { operation: 'construction', visible: false }))
+  })
+  assert(count(svg, 'data-op="construction"') === 1, 'hidden construction geometry is omitted')
+  const constructionLine = svg.split('\n').find((line) => line.includes('data-op="construction"'))
+  assert(constructionLine !== undefined, 'construction geometry exports')
+  assert(constructionLine!.includes('stroke-dasharray'), 'exported construction geometry is dashed')
+  assert(constructionLine!.includes('fill="none"'), 'exported construction geometry is unfilled')
+}
+
+{
+  // Dimensions follow project.meta.showDimensions, same as printing.
+  const dimension: DimensionAnnotation = {
+    id: 'dim1',
+    type: 'aligned',
+    a: { kind: 'free', point: { x: 10, y: 10 } },
+    b: { kind: 'free', point: { x: 40, y: 10 } },
+    offset: -6,
+    visible: true,
+    locked: false,
+    textOverride: null,
+    precisionOverride: null,
+  }
+  const withDims = buildTestExportSvg('mm', (project) => {
+    project.annotations.push(dimension)
+    project.meta.showDimensions = true
+  })
+  assert(withDims.svg.includes('class="pc-dimension"'), 'dimensions export when enabled')
+  const withoutDims = buildTestExportSvg('mm', (project) => {
+    project.annotations.push(dimension)
+    project.meta.showDimensions = false
+  })
+  assert(!withoutDims.svg.includes('class="pc-dimension"'), 'dimensions omitted when showDimensions is off')
+}
+
+{
+  // Content toggles and area modes; bounds follow the enabled layers.
+  const addFixtures = (project: Project) => {
+    project.tabs.push({ id: 't1', name: 'Tab 1', x: -30, y: 5, w: 8, h: 4, z_top: 3, z_bottom: 0, visible: true })
+    project.clamps.push({ id: 'c1', name: 'Clamp 1', type: 'step_clamp', x: 120, y: 5, w: 10, h: 10, height: 20, visible: true })
+  }
+
+  const defaults = buildTestExportSvg('mm', addFixtures)
+  assert(defaults.options.content.tabs, 'visible tabs default the toggle on')
+  assert(defaults.svg.includes('class="pc-tab"'), 'tabs export when toggled on')
+  assert(defaults.svg.includes('class="pc-clamp"'), 'clamps export when toggled on')
+  assert(!defaults.svg.includes('class="pc-grid"'), 'grid is off by default')
+  assert(!defaults.svg.includes('class="pc-feature-labels"'), 'labels are off by default')
+  assertClose(defaults.bounds.minX, -30, 'enabled tabs widen the exported bounds')
+
+  const bare = buildTestExportSvg('mm', addFixtures, {
+    content: { tabs: false, clamps: false, grid: true, featureLabels: true },
+  })
+  assert(!bare.svg.includes('class="pc-tab"'), 'disabled tabs stay out of the export')
+  assert(!bare.svg.includes('class="pc-clamp"'), 'disabled clamps stay out of the export')
+  assert(bare.svg.includes('class="pc-grid"'), 'grid exports when toggled on')
+  assert(bare.svg.includes('class="pc-feature-labels"'), 'labels export when toggled on')
+  assertClose(bare.bounds.minX, 0, 'disabled fixtures are excluded from the exported bounds')
+
+  const stock = buildTestExportSvg('mm', (project) => {
+    project.origin.visible = false
+  }, { area: 'stock' })
+  assert(
+    stock.svg.includes(`viewBox="0 0 ${fmtNum(stock.bounds.maxX)} ${fmtNum(stock.bounds.maxY)}"`),
+    'stock area exports the stock extents',
+  )
 }
 
 // ── Path data ────────────────────────────────────────────────

--- a/src/engine/designPrint/index.ts
+++ b/src/engine/designPrint/index.ts
@@ -25,15 +25,22 @@ export {
   resolvePrintBounds,
   unitToMm,
 } from './layout'
-export { buildDesignPrintSvg, profileToPathD } from './svg'
+export { buildDesignPrintSvg, buildDesignSvgExport, profileToPathD } from './svg'
 export type { DesignPrintSvgExtras } from './svg'
 export { buildDesignPrintHtml } from './html'
 export type { DesignPrintHtmlArgs } from './html'
-export { defaultDesignPrintOptions, defaultPrintMargin } from './types'
+export {
+  defaultDesignPrintOptions,
+  defaultDesignSvgExportOptions,
+  defaultPrintMargin,
+} from './types'
 export type {
   DesignPrintContent,
   DesignPrintLayout,
   DesignPrintOptions,
+  DesignSvgExportArea,
+  DesignSvgExportContent,
+  DesignSvgExportOptions,
   PaperOrientation,
   PaperPreset,
   PaperPresetId,

--- a/src/engine/designPrint/svg.ts
+++ b/src/engine/designPrint/svg.ts
@@ -32,8 +32,8 @@ import {
   isDimensionDangling,
   measureValue,
 } from '../../sketch/dimensions'
-import { getFeatureGeometryBounds, getFeatureGeometryProfiles } from '../../text'
-import { getStockBounds, rectProfile } from '../../types/project'
+import { generateTextShapes, getFeatureGeometryBounds, getFeatureGeometryProfiles } from '../../text'
+import { getProfileBounds, getStockBounds, rectProfile } from '../../types/project'
 import type { Point, Project, SketchFeature, SketchProfile } from '../../types/project'
 import { formatAngle, formatLength } from '../../utils/units'
 import type { Units } from '../../utils/units'
@@ -245,6 +245,13 @@ interface WorldContext {
   /** Tinted fills inside closed profiles; off for monochrome and SVG export. */
   fills: boolean
   units: Units
+  /**
+   * How label/dimension/origin text is rendered. 'native' emits `<text>`
+   * (crisp on paper). 'skeleton' emits single-stroke `<path>` geometry so the
+   * geometry SVG export stays lightweight and re-imports cleanly instead of
+   * ballooning into filled glyph outlines.
+   */
+  textMode: 'native' | 'skeleton'
 }
 
 /** A length given in paper millimetres expressed in world units. */
@@ -256,20 +263,79 @@ function dash(ctx: WorldContext, ...pattern: number[]): string {
   return pattern.map((v) => fmt(mm(ctx, v))).join(' ')
 }
 
+interface TextElOptions {
+  sizeMm: number
+  fill: string
+  anchor?: 'start' | 'middle' | 'end'
+  rotateDeg?: number
+  halo?: boolean
+  weight?: number
+}
+
+// Skeleton lettering visual tuning. The single-stroke font's `size` is roughly
+// its full glyph height, so scale it down to approximate a `<text>` cap height
+// and give the strokes a weight that stays legible at label sizes.
+const SKELETON_TEXT_CAP_RATIO = 0.72
+const SKELETON_TEXT_STROKE_RATIO = 0.09
+const SKELETON_TEXT_MIN_STROKE_MM = 0.22
+
+/**
+ * Render text as single-stroke skeleton `<path>` geometry positioned to match
+ * the equivalent `<text>` element (horizontal anchor + vertical centering,
+ * optional rotation about the anchor point). Used by the geometry SVG export so
+ * labels stay a handful of line segments instead of dense filled outlines.
+ */
+function skeletonTextEl(ctx: WorldContext, x: number, y: number, content: string, options: TextElOptions): string {
+  const sizeWorld = mm(ctx, options.sizeMm * SKELETON_TEXT_CAP_RATIO)
+  const shapes = generateTextShapes(
+    { text: content, style: 'skeleton', fontId: 'simple_stroke', size: sizeWorld, operation: 'subtract' },
+    { x: 0, y: 0 },
+  )
+  if (shapes.length === 0) return ''
+
+  let minX = Infinity
+  let maxX = -Infinity
+  let minY = Infinity
+  let maxY = -Infinity
+  for (const shape of shapes) {
+    const bounds = getProfileBounds(shape.profile)
+    minX = Math.min(minX, bounds.minX)
+    maxX = Math.max(maxX, bounds.maxX)
+    minY = Math.min(minY, bounds.minY)
+    maxY = Math.max(maxY, bounds.maxY)
+  }
+
+  const anchor = options.anchor ?? 'middle'
+  let tx = x - minX
+  if (anchor === 'middle') tx -= (maxX - minX) / 2
+  else if (anchor === 'end') tx -= maxX - minX
+  const ty = y - (minY + (maxY - minY) / 2)
+
+  const strokeWidth = fmt(mm(ctx, Math.max(SKELETON_TEXT_MIN_STROKE_MM, options.sizeMm * SKELETON_TEXT_STROKE_RATIO)))
+  const rotate =
+    options.rotateDeg !== undefined && Math.abs(options.rotateDeg) > 0.01
+      ? `rotate(${fmt(options.rotateDeg)} ${fmt(x)} ${fmt(y)}) `
+      : ''
+  const body = shapes
+    .map(
+      (shape) =>
+        `<path d="${profileToPathD(shape.profile)}" fill="none" stroke="${options.fill}"` +
+        ` stroke-width="${strokeWidth}" stroke-linecap="round" stroke-linejoin="round"/>`,
+    )
+    .join('')
+  return `<g class="pc-text" transform="${rotate}translate(${fmt(tx)} ${fmt(ty)})">${body}</g>`
+}
+
 function textEl(
   ctx: WorldContext,
   x: number,
   y: number,
   content: string,
-  options: {
-    sizeMm: number
-    fill: string
-    anchor?: 'start' | 'middle' | 'end'
-    rotateDeg?: number
-    halo?: boolean
-    weight?: number
-  },
+  options: TextElOptions,
 ): string {
+  if (ctx.textMode === 'skeleton') {
+    return skeletonTextEl(ctx, x, y, content, options)
+  }
   const anchor = options.anchor ?? 'middle'
   const transform =
     options.rotateDeg !== undefined && Math.abs(options.rotateDeg) > 0.01
@@ -772,6 +838,7 @@ export function buildDesignPrintSvg(
     palette,
     fills: options.colorMode !== 'monochrome',
     units,
+    textMode: 'native',
   }
 
   const tx = layout.originXMm - layout.bounds.minX * layout.scale
@@ -843,6 +910,7 @@ export function buildDesignSvgExport(project: Project, options: DesignSvgExportO
     palette: options.colorMode === 'monochrome' ? MONO_PALETTE : COLOR_PALETTE,
     fills: false,
     units,
+    textMode: 'skeleton',
   }
 
   const world = buildWorldContent(project, ctx, {

--- a/src/engine/designPrint/svg.ts
+++ b/src/engine/designPrint/svg.ts
@@ -38,10 +38,12 @@ import type { Point, Project, SketchFeature, SketchProfile } from '../../types/p
 import { formatAngle, formatLength } from '../../utils/units'
 import type { Units } from '../../utils/units'
 import type { ToolpathResult } from '../toolpaths/types'
-import { PAPER_PRESETS, formatScaleRatio } from './layout'
+import { PAPER_PRESETS, formatScaleRatio, resolvePrintBounds, unitToMm } from './layout'
 import type {
+  DesignPrintContent,
   DesignPrintLayout,
   DesignPrintOptions,
+  DesignSvgExportOptions,
   PrintToolpathVisibility,
 } from './types'
 
@@ -240,7 +242,8 @@ interface WorldContext {
   /** Paper mm per world unit. */
   scale: number
   palette: PrintPalette
-  mono: boolean
+  /** Tinted fills inside closed profiles; off for monochrome and SVG export. */
+  fills: boolean
   units: Units
 }
 
@@ -385,7 +388,12 @@ function featureStroke(feature: SketchFeature, palette: PrintPalette): { stroke:
   }
 }
 
-function buildFeatures(project: Project, ctx: WorldContext): string[] {
+/** XML-safe element id for a feature's export group. */
+function featureGroupId(id: string): string {
+  return `feature-${id.replace(/[^A-Za-z0-9_.-]+/g, '-')}`
+}
+
+function buildFeatures(project: Project, ctx: WorldContext, groupPerFeature = false): string[] {
   const parts: string[] = []
 
   for (const feature of project.features) {
@@ -395,6 +403,7 @@ function buildFeatures(project: Project, ctx: WorldContext): string[] {
     const construction = feature.operation === 'construction'
     const strokeWidth = fmt(mm(ctx, construction ? STROKE_CONSTRUCTION_MM : STROKE_FEATURE_MM))
     const dashAttr = dashed || construction ? ` stroke-dasharray="${dash(ctx, 2, 1.4)}"` : ''
+    const featureParts: string[] = []
 
     // Imported models print their full silhouette path set when available;
     // sketch.profile only mirrors the largest silhouette loop.
@@ -403,21 +412,30 @@ function buildFeatures(project: Project, ctx: WorldContext): string[] {
       for (const path of silhouettes) {
         if (path.length < 2) continue
         const points = path.map((p) => `${fmt(p.x)},${fmt(p.y)}`).join(' ')
-        parts.push(
+        featureParts.push(
           `<polygon class="pc-feature" data-op="${feature.operation}" points="${points}"` +
-            ` fill="${ctx.mono ? 'none' : hexToRgba(stroke, 0.08)}" stroke="${stroke}" stroke-width="${strokeWidth}"/>`,
+            ` fill="${ctx.fills ? hexToRgba(stroke, 0.08) : 'none'}" stroke="${stroke}" stroke-width="${strokeWidth}"/>`,
         )
       }
-      continue
+    } else {
+      for (const profile of getFeatureGeometryProfiles(feature)) {
+        const fill =
+          profile.closed && !construction && ctx.fills ? hexToRgba(stroke, 0.08) : 'none'
+        featureParts.push(
+          `<path class="pc-feature" data-op="${feature.operation}" d="${profileToPathD(profile)}"` +
+            ` fill="${fill}" stroke="${stroke}" stroke-width="${strokeWidth}"${dashAttr}/>`,
+        )
+      }
     }
 
-    for (const profile of getFeatureGeometryProfiles(feature)) {
-      const fill =
-        profile.closed && !construction && !ctx.mono ? hexToRgba(stroke, 0.08) : 'none'
+    if (featureParts.length === 0) continue
+    if (groupPerFeature) {
       parts.push(
-        `<path class="pc-feature" data-op="${feature.operation}" d="${profileToPathD(profile)}"` +
-          ` fill="${fill}" stroke="${stroke}" stroke-width="${strokeWidth}"${dashAttr}/>`,
+        `<g id="${escapeXml(featureGroupId(feature.id))}" data-name="${escapeXml(feature.name)}">` +
+          `${featureParts.join('')}</g>`,
       )
+    } else {
+      parts.push(...featureParts)
     }
   }
 
@@ -450,27 +468,31 @@ function buildFeatureLabels(project: Project, ctx: WorldContext): string[] {
   return parts.length > 0 ? [`<g class="pc-feature-labels">${parts.join('')}</g>`] : []
 }
 
-function buildTabsAndClamps(project: Project, ctx: WorldContext, options: DesignPrintOptions): string[] {
+function buildTabsAndClamps(
+  project: Project,
+  ctx: WorldContext,
+  content: Pick<DesignPrintContent, 'tabs' | 'clamps'>,
+): string[] {
   const parts: string[] = []
   const strokeWidth = fmt(mm(ctx, STROKE_FIXTURE_MM))
 
-  if (options.content.tabs) {
+  if (content.tabs) {
     for (const tab of project.tabs) {
       if (!tab.visible) continue
       parts.push(
         `<path class="pc-tab" d="${profileToPathD(rectProfile(tab.x, tab.y, tab.w, tab.h))}"` +
-          ` fill="${ctx.mono ? 'none' : hexToRgba(ctx.palette.tab, 0.08)}" stroke="${ctx.palette.tab}"` +
+          ` fill="${ctx.fills ? hexToRgba(ctx.palette.tab, 0.08) : 'none'}" stroke="${ctx.palette.tab}"` +
           ` stroke-width="${strokeWidth}" stroke-dasharray="${dash(ctx, 1.8, 1.2)}"/>`,
       )
     }
   }
 
-  if (options.content.clamps) {
+  if (content.clamps) {
     for (const clamp of project.clamps) {
       if (!clamp.visible) continue
       parts.push(
         `<path class="pc-clamp" d="${profileToPathD(rectProfile(clamp.x, clamp.y, clamp.w, clamp.h))}"` +
-          ` fill="${ctx.mono ? 'none' : hexToRgba(ctx.palette.clamp, 0.08)}" stroke="${ctx.palette.clamp}"` +
+          ` fill="${ctx.fills ? hexToRgba(ctx.palette.clamp, 0.08) : 'none'}" stroke="${ctx.palette.clamp}"` +
           ` stroke-width="${strokeWidth}" stroke-dasharray="${dash(ctx, 1.8, 1.2)}"/>`,
       )
     }
@@ -694,6 +716,44 @@ function buildFooter(
   ]
 }
 
+interface WorldContentArgs {
+  /** Content layer toggles; page-only flags (footer) are ignored here. */
+  content: DesignPrintContent
+  extras: DesignPrintSvgExtras
+  /** World-space window limiting the grid extent. */
+  gridWindow: { minX: number; maxX: number; minY: number; maxY: number }
+  /** Wrap each feature in a `<g id data-name>` group (vector-editor layers). */
+  featureGroups?: boolean
+}
+
+/**
+ * Assemble the world-space design content (grid, backdrop, stock, features,
+ * tabs/clamps, toolpaths, origin, dimensions, labels) independent of any page
+ * scaffolding, so both the print document and the geometry-only SVG export
+ * draw the same scene.
+ */
+function buildWorldContent(project: Project, ctx: WorldContext, args: WorldContentArgs): string[] {
+  const world: string[] = []
+  if (args.content.grid) {
+    world.push(...buildGrid(project, ctx, args.gridWindow))
+  }
+  if (args.content.backdrop) {
+    world.push(...buildBackdrop(project))
+  }
+  world.push(...buildStock(project, ctx))
+  world.push(...buildFeatures(project, ctx, args.featureGroups === true))
+  world.push(...buildTabsAndClamps(project, ctx, args.content))
+  if (args.content.toolpaths) {
+    world.push(...buildToolpaths(ctx, args.extras))
+  }
+  world.push(...buildOrigin(project, ctx))
+  world.push(...buildDimensions(project, ctx))
+  if (args.content.featureLabels) {
+    world.push(...buildFeatureLabels(project, ctx))
+  }
+  return world
+}
+
 /**
  * Render the full print document as an SVG string. The SVG is self-contained
  * (inline styles only) and sized in physical millimetres unless
@@ -710,7 +770,7 @@ export function buildDesignPrintSvg(
   const ctx: WorldContext = {
     scale: layout.scale,
     palette,
-    mono: options.colorMode === 'monochrome',
+    fills: options.colorMode !== 'monochrome',
     units,
   }
 
@@ -725,24 +785,11 @@ export function buildDesignPrintSvg(
     maxY: (layout.drawableYMm + layout.drawableHeightMm - ty) / layout.scale,
   }
 
-  const world: string[] = []
-  if (options.content.grid) {
-    world.push(...buildGrid(project, ctx, worldWindow))
-  }
-  if (options.content.backdrop) {
-    world.push(...buildBackdrop(project))
-  }
-  world.push(...buildStock(project, ctx))
-  world.push(...buildFeatures(project, ctx))
-  world.push(...buildTabsAndClamps(project, ctx, options))
-  if (options.content.toolpaths) {
-    world.push(...buildToolpaths(ctx, extras))
-  }
-  world.push(...buildOrigin(project, ctx))
-  world.push(...buildDimensions(project, ctx))
-  if (options.content.featureLabels) {
-    world.push(...buildFeatureLabels(project, ctx))
-  }
+  const world = buildWorldContent(project, ctx, {
+    content: options.content,
+    extras,
+    gridWindow: worldWindow,
+  })
 
   const sizeAttrs = extras.physicalSize === false
     ? ''
@@ -768,4 +815,54 @@ export function buildDesignPrintSvg(
   parts.push(...buildFooter(project, options, layout, palette, extras))
   parts.push(`</svg>`)
   return parts.join('\n')
+}
+
+/**
+ * Render the design as a standalone editable SVG at true 1:1 physical scale
+ * (issue #257): tight viewBox around the exported bounds, physical mm size,
+ * no paper/margins/footer/background/clipping, per-feature `<g>` groups, and
+ * outlines only (no tinted fills). Content semantics match printing: hidden
+ * features and hidden construction geometry are omitted, construction prints
+ * dashed and unfilled, and dimensions follow `project.meta.showDimensions`.
+ */
+export function buildDesignSvgExport(project: Project, options: DesignSvgExportOptions): string {
+  const units = project.meta.units
+  const unitMm = unitToMm(units)
+  const bounds = resolvePrintBounds(project, options.area, null, {
+    backdrop: false,
+    tabs: options.content.tabs,
+    clamps: options.content.clamps,
+  })
+  const width = Math.max(bounds.maxX - bounds.minX, 1e-6)
+  const height = Math.max(bounds.maxY - bounds.minY, 1e-6)
+
+  // SVG user units are world units; stroke widths and lettering divide by the
+  // physical scale so they come out in real millimetres, same as printing 1:1.
+  const ctx: WorldContext = {
+    scale: unitMm,
+    palette: options.colorMode === 'monochrome' ? MONO_PALETTE : COLOR_PALETTE,
+    fills: false,
+    units,
+  }
+
+  const world = buildWorldContent(project, ctx, {
+    content: {
+      ...options.content,
+      backdrop: false,
+      toolpaths: false,
+      footer: false,
+    },
+    extras: {},
+    gridWindow: bounds,
+    featureGroups: true,
+  })
+
+  // The width/height attributes give the world-unit viewBox its physical
+  // size: 1 project unit = 1 mm (or 1 in), independent of any print scale.
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${fmt(width * unitMm)}mm" height="${fmt(height * unitMm)}mm"` +
+      ` viewBox="${fmt(bounds.minX)} ${fmt(bounds.minY)} ${fmt(width)} ${fmt(height)}">`,
+    ...world,
+    `</svg>`,
+  ].join('\n')
 }

--- a/src/engine/designPrint/types.ts
+++ b/src/engine/designPrint/types.ts
@@ -123,6 +123,41 @@ export interface PrintToolpathVisibility {
   retractions: boolean
 }
 
+/** Which world-space region gets exported as SVG (no canvas-view mode). */
+export type DesignSvgExportArea = Exclude<PrintAreaMode, 'view'>
+
+/** Optional content layers in the SVG export beyond the design geometry. */
+export interface DesignSvgExportContent {
+  grid: boolean
+  featureLabels: boolean
+  tabs: boolean
+  clamps: boolean
+}
+
+/**
+ * Options for the geometry-only SVG export (issue #257). The export is always
+ * true 1:1 physical scale — there is no paper, margin, or scale option.
+ */
+export interface DesignSvgExportOptions {
+  area: DesignSvgExportArea
+  colorMode: PrintColorMode
+  content: DesignSvgExportContent
+}
+
+/** Default SVG export options; content toggles follow project visibility. */
+export function defaultDesignSvgExportOptions(project: Project): DesignSvgExportOptions {
+  return {
+    area: 'visible',
+    colorMode: 'color',
+    content: {
+      grid: false,
+      featureLabels: false,
+      tabs: project.tabs.some((tab) => tab.visible),
+      clamps: project.clamps.some((clamp) => clamp.visible),
+    },
+  }
+}
+
 /** Default margin in project units (10 mm / 0.5 in). */
 export function defaultPrintMargin(units: Units): number {
   return units === 'inch' ? 0.5 : 10

--- a/src/engine/modelExport/index.ts
+++ b/src/engine/modelExport/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { stlExportFormat } from './stl'
+import { svgExportFormat } from './svg'
 import type { ModelExportFormat } from './types'
 
 export {
@@ -36,8 +37,12 @@ export {
   writeBinaryStl,
   type STLExportOptions,
 } from './stl'
+export { SVG_DEFAULT_OPTIONS, svgExportFormat, type SvgExportOptions } from './svg'
 
-export const MODEL_EXPORT_FORMATS: ModelExportFormat[] = [stlExportFormat as ModelExportFormat]
+export const MODEL_EXPORT_FORMATS: ModelExportFormat[] = [
+  stlExportFormat as ModelExportFormat,
+  svgExportFormat as ModelExportFormat,
+]
 
 export function getModelExportFormat(id: string): ModelExportFormat | null {
   return MODEL_EXPORT_FORMATS.find((format) => format.id === id) ?? null

--- a/src/engine/modelExport/stl.ts
+++ b/src/engine/modelExport/stl.ts
@@ -147,9 +147,13 @@ export const stlExportFormat: ModelExportFormat<STLExportOptions> = {
   name: 'STL (Stereolithography)',
   extension: 'stl',
   mimeType: 'model/stl',
+  kind: '3d',
   defaultOptions: STL_DEFAULT_OPTIONS,
   renderOptions: () => null, // Provided by the dialog itself (avoids React import in this file).
   export(input: ModelExportInput, options: STLExportOptions): ModelExportOutput {
+    if (!input.mesh) {
+      throw new Error('STL export requires an assembled mesh.')
+    }
     if (options.format === 'ascii') {
       return {
         data: writeAsciiStl(input.mesh, sanitizeSolidName(input.project.meta.name)),

--- a/src/engine/modelExport/svg.test.ts
+++ b/src/engine/modelExport/svg.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the SVG entry in the model-export format registry: it is a '2d'
+ * text format that renders from the project without an assembled mesh.
+ *
+ * Run with: npx tsx src/engine/modelExport/svg.test.ts
+ */
+
+import { newProject } from '../../types/project'
+import { STL_DEFAULT_OPTIONS, stlExportFormat } from './stl'
+import { SVG_DEFAULT_OPTIONS, svgExportFormat } from './svg'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+// ── Format descriptor ────────────────────────────────────────
+
+assert(svgExportFormat.id === 'svg', 'svg format id')
+assert(svgExportFormat.kind === '2d', 'svg is a 2d format')
+assert(svgExportFormat.extension === 'svg', 'svg extension')
+assert(svgExportFormat.mimeType === 'image/svg+xml', 'svg mime type')
+assert(stlExportFormat.kind === '3d', 'stl stays a 3d format')
+
+// ── Export without a mesh ────────────────────────────────────
+
+{
+  const project = newProject('SvgFormatTest', 'mm')
+  const output = await svgExportFormat.export({ project }, SVG_DEFAULT_OPTIONS)
+  assert(output.encoding === 'text', 'svg export is text-encoded')
+  assert(typeof output.data === 'string', 'svg export data is a string')
+  const data = output.data as string
+  assert(data.startsWith('<svg'), 'svg export emits an svg document')
+  assert(data.includes('viewBox='), 'svg export carries a viewBox')
+}
+
+// ── 3D formats still require the mesh ────────────────────────
+
+{
+  const project = newProject('StlGuardTest', 'mm')
+  let threw = false
+  try {
+    await stlExportFormat.export({ project }, STL_DEFAULT_OPTIONS)
+  } catch {
+    threw = true
+  }
+  assert(threw, 'stl export without a mesh throws instead of writing garbage')
+}
+
+console.log('modelExport svg format tests passed')

--- a/src/engine/modelExport/svg.ts
+++ b/src/engine/modelExport/svg.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * SVG export format (issue #257): the 2D design view as an editable vector
+ * drawing at true 1:1 physical scale, rendered by the designPrint engine.
+ * A '2d' format — it draws from the project directly and needs no mesh.
+ */
+
+import { buildDesignSvgExport } from '../designPrint'
+import type { DesignSvgExportOptions } from '../designPrint'
+import type { ModelExportFormat, ModelExportInput, ModelExportOutput } from './types'
+
+export type SvgExportOptions = DesignSvgExportOptions
+
+/**
+ * Static fallback defaults; the dialog seeds its state from
+ * `defaultDesignSvgExportOptions(project)` so toggles follow the project.
+ */
+export const SVG_DEFAULT_OPTIONS: SvgExportOptions = {
+  area: 'visible',
+  colorMode: 'color',
+  content: {
+    grid: false,
+    featureLabels: false,
+    tabs: true,
+    clamps: true,
+  },
+}
+
+export const svgExportFormat: ModelExportFormat<SvgExportOptions> = {
+  id: 'svg',
+  name: 'SVG (2D vector drawing)',
+  extension: 'svg',
+  mimeType: 'image/svg+xml',
+  kind: '2d',
+  defaultOptions: SVG_DEFAULT_OPTIONS,
+  renderOptions: () => null, // Provided by the dialog itself (avoids React import in this file).
+  export(input: ModelExportInput, options: SvgExportOptions): ModelExportOutput {
+    return {
+      data: buildDesignSvgExport(input.project, options),
+      encoding: 'text',
+    }
+  },
+}

--- a/src/engine/modelExport/types.ts
+++ b/src/engine/modelExport/types.ts
@@ -60,7 +60,8 @@ export interface ModelExportAssembleResult {
 
 export interface ModelExportInput {
   project: Project
-  mesh: ExportTriangleMesh
+  /** Assembled solid mesh; present only for `kind: '3d'` formats. */
+  mesh?: ExportTriangleMesh
 }
 
 export interface ModelExportOutput {
@@ -78,6 +79,11 @@ export interface ModelExportFormat<TOptions = unknown> {
   extension: string
   /** MIME type used by the browser blob save fallback. */
   mimeType: string
+  /**
+   * '3d' formats consume the assembled triangle mesh; '2d' formats render
+   * from the project directly and skip mesh assembly entirely.
+   */
+  kind: '2d' | '3d'
   defaultOptions: TOptions
   /** React node for the format-specific option controls in the dialog. */
   renderOptions: (props: {


### PR DESCRIPTION
Closes #257

Adds **SVG** as a format choice in the existing **Export Model** dialog, exporting the 2D design view as an editable vector SVG at true 1:1 physical scale — reusing the `src/engine/designPrint/` renderer from #254.

## Engine

- `designPrint/svg.ts`: extracted the world-content assembly (grid/backdrop/stock/features/tabs/clamps/toolpaths/origin/dimensions/labels) into `buildWorldContent`, shared by the print page and the new export.
- New `buildDesignSvgExport(project, options)`:
  - tight `viewBox` equal to the selected world bounds; `width`/`height` in physical mm at true 1:1 (1 project unit = 1 mm / 1 in), independent of any print scale
  - no paper, margins, footer, background rect, or clip path
  - per-feature `<g id="feature-…" data-name="…">` groups so layers stay selectable/editable in vector editors
  - outlines only (no tinted fills) via a new `fills` flag on the render context; color/monochrome palettes reused
  - construction dashed/unfilled, hidden features omitted, dimensions gated on `showDimensions` — same semantics as printing
- `modelExport/`: format descriptors now carry `kind: '2d' | '3d'` and `ModelExportInput.mesh` is optional (present for 3D formats; STL throws if missing). Registered `svgExportFormat` (`encoding: 'text'`, extension `svg`).

## UI (`ModelExportDialog`)

- 2D formats skip mesh assembly, the triangle-count gate, and the mesh summary/curve-quality/STL panels; instead show export area (visible/stock extents), color/monochrome, and content toggles (tabs, clamps, feature labels, grid) with defaults matching the print dialog, plus an exported-size summary.
- Shared file-name field kept. The remembered last-export path is now reused only when its extension matches the selected format — it is written to without a dialog, so a remembered `.stl` target is never silently overwritten with SVG text.

## Tests

- `designPrint.test.ts`: viewBox/physical-size at 1:1 (mm + inch), no footer/background/clip, per-feature group ids, hidden features/construction omitted, construction dashed+unfilled, dimensions gated on `showDimensions`, outlines-only, content toggles + bounds following enabled layers, stock-extents area.
- New `modelExport/svg.test.ts`: svg format is `kind: '2d'`, text-encoded, exports without a mesh; STL still requires the mesh.
- `npm run build` green (lint + tsc + structural tests + vite).

## Out of scope (per issue)

- Print-page SVG flavor, "current sketch view" export area, DXF, machine-usable toolpath vectors.