### PR TITLE
fix: decouple 3D preview model rebuild from selection

### DIFF
--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -22,7 +22,7 @@ import type { ToolpathVisibility } from '../toolpathVisibility'
 import type { ToolpathResult } from '../../engine/toolpaths/types'
 import { useProjectStore } from '../../store/projectStore'
 import { modelFeatures } from '../../store/helpers/featureRoles'
-import { buildOriginTriad, buildScene } from '../../engine/csg'
+import { applyClampHighlight, applyTabHighlight, buildOriginTriad, buildScene } from '../../engine/csg'
 import { getStockBounds, rectProfile } from '../../types/project'
 import { getFeatureGeometryProfiles } from '../../text'
 import { buildToolpathLinePositionChunks, toolpathPointToWorldTuple } from './toolpathOverlay'
@@ -676,6 +676,10 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
   const controlsRef = useRef<ReturnType<typeof createOrbitControls> | null>(null)
   const frameRef = useRef<number>(0)
   const objectsRef = useRef<THREE.Object3D[]>([])
+  // The most recently built fixture meshes, keyed by id, so selection/collision
+  // highlight can recolor them in place without a full scene rebuild (issue #261).
+  const clampMeshesRef = useRef<Map<string, THREE.Mesh>>(new Map())
+  const tabMeshesRef = useRef<Map<string, THREE.Mesh>>(new Map())
   const toolpathObjectsRef = useRef<THREE.Object3D[]>([])
   const originObjectRef = useRef<THREE.Object3D | null>(null)
   const buildRequestRef = useRef(0)
@@ -872,6 +876,34 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
     originObjectRef.current = null
   }, [])
 
+  // Selection/collision only tint fixtures — recolor the already-built clamp/tab
+  // meshes in place rather than rebuilding the CSG model (issue #261). Keyed on
+  // primitives so this stays cheap and never triggers the scene-build effect.
+  const selectedClampId = selection.selectedNode?.type === 'clamp' ? selection.selectedNode.clampId : null
+  const selectedTabId = selection.selectedNode?.type === 'tab' ? selection.selectedNode.tabId : null
+  const applyFixtureHighlights = useCallback(() => {
+    const collidingClampIdSet = new Set(collidingClampIds)
+    for (const [id, mesh] of clampMeshesRef.current) {
+      applyClampHighlight(mesh, id === selectedClampId, collidingClampIdSet.has(id))
+    }
+    for (const [id, mesh] of tabMeshesRef.current) {
+      applyTabHighlight(mesh, id === selectedTabId)
+    }
+  }, [collidingClampIds, selectedClampId, selectedTabId])
+
+  // Mirror the latest highlighter into a ref so the async scene-build callback can
+  // apply the CURRENT selection/collision to freshly-built fixtures without listing
+  // it as a dependency (which would rebuild the model on every selection change).
+  const applyFixtureHighlightsRef = useRef(applyFixtureHighlights)
+  useEffect(() => {
+    applyFixtureHighlightsRef.current = applyFixtureHighlights
+  }, [applyFixtureHighlights])
+
+  // Recolor fixtures whenever selection/collision changes — no model rebuild.
+  useEffect(() => {
+    applyFixtureHighlights()
+  }, [applyFixtureHighlights])
+
   useEffect(() => {
     const scene = sceneRef.current
     if (!scene) return
@@ -882,12 +914,7 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
 
     const timeout = window.setTimeout(() => {
       void (async () => {
-        const nextSceneObjects = await buildScene(
-          project,
-          selection.selectedNode?.type === 'clamp' ? selection.selectedNode.clampId : null,
-          selection.selectedNode?.type === 'tab' ? selection.selectedNode.tabId : null,
-          collidingClampIds,
-        )
+        const nextSceneObjects = await buildScene(project)
 
         if (cancelled || buildRequestRef.current !== buildRequestId) {
           nextSceneObjects.stockMesh.geometry.dispose()
@@ -942,6 +969,13 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
           scene.add(clampMesh)
           objectsRef.current.push(clampMesh)
         }
+
+        // Track the freshly-built fixtures and immediately tint them to the
+        // current selection/collision — buildScene builds them unhighlighted,
+        // and selection may not have changed since the last rebuild (issue #261).
+        clampMeshesRef.current = nextSceneObjects.clampMeshes
+        tabMeshesRef.current = nextSceneObjects.tabMeshes
+        applyFixtureHighlightsRef.current()
 
           const controls = controlsRef.current
         if (controls) {
@@ -1006,7 +1040,10 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
       cancelled = true
       window.clearTimeout(timeout)
     }
-  }, [clearRenderedObjects, collidingClampIds, disposeObjectMaterial, originVisible, project, rebuildGridHelpers, selection.selectedNode])
+    // Keyed on geometry inputs only. Selection and collision no longer rebuild
+    // the CSG model — a separate effect recolors fixtures via applyFixtureHighlights
+    // (issue #261). applyFixtureHighlightsRef is a stable ref, so it's omitted.
+  }, [clearRenderedObjects, disposeObjectMaterial, originVisible, project, rebuildGridHelpers])
 
   useEffect(() => {
     const scene = sceneRef.current

--- a/src/engine/csg.ts
+++ b/src/engine/csg.ts
@@ -570,6 +570,33 @@ export function buildFeatureMesh(
   return mesh
 }
 
+/**
+ * Update a clamp mesh's highlight to reflect selection/collision state.
+ *
+ * Selection and collision only change the fixture's color + opacity, never its
+ * geometry, so this is a cheap recolor that can run without rebuilding the CSG
+ * model (issue #261). `buildClampMesh` calls it for the initial appearance and
+ * Viewport3D calls it again on selection/collision changes.
+ */
+export function applyClampHighlight(mesh: THREE.Mesh, selected: boolean, colliding: boolean): void {
+  const material = mesh.material
+  if (!(material instanceof THREE.MeshStandardMaterial)) return
+  material.color.set(
+    colliding
+      ? (selected ? '#ff9c9c' : '#d46b6b')
+      : (selected ? '#9db9ff' : '#6c89d1'),
+  )
+  material.opacity = colliding ? (selected ? 0.8 : 0.68) : (selected ? 0.72 : 0.58)
+}
+
+/** Update a tab mesh's highlight to reflect selection state (see {@link applyClampHighlight}). */
+export function applyTabHighlight(mesh: THREE.Mesh, selected: boolean): void {
+  const material = mesh.material
+  if (!(material instanceof THREE.MeshStandardMaterial)) return
+  material.color.set(selected ? '#c7ef94' : '#9ccd67')
+  material.opacity = selected ? 0.72 : 0.56
+}
+
 export function buildClampMesh(clamp: Clamp, selected = false, colliding = false): THREE.Mesh {
   const shape = profileToShape(rectProfile(clamp.x, clamp.y, clamp.w, clamp.h))
   const geometry = new THREE.ExtrudeGeometry(shape, {
@@ -579,18 +606,14 @@ export function buildClampMesh(clamp: Clamp, selected = false, colliding = false
   geometry.rotateX(-Math.PI / 2)
 
   const material = new THREE.MeshStandardMaterial({
-    color:
-      colliding
-        ? (selected ? new THREE.Color('#ff9c9c') : new THREE.Color('#d46b6b'))
-        : (selected ? new THREE.Color('#9db9ff') : new THREE.Color('#6c89d1')),
     transparent: true,
-    opacity: colliding ? (selected ? 0.8 : 0.68) : (selected ? 0.72 : 0.58),
     roughness: 0.72,
     metalness: 0.08,
     side: THREE.DoubleSide,
   })
 
   const mesh = new THREE.Mesh(geometry, material)
+  applyClampHighlight(mesh, selected, colliding)
   mesh.scale.z = -1
   return mesh
 }
@@ -607,15 +630,14 @@ export function buildTabMesh(tab: Tab, selected = false): THREE.Mesh {
   geometry.translate(0, zStart, 0)
 
   const material = new THREE.MeshStandardMaterial({
-    color: selected ? new THREE.Color('#c7ef94') : new THREE.Color('#9ccd67'),
     transparent: true,
-    opacity: selected ? 0.72 : 0.56,
     roughness: 0.74,
     metalness: 0.06,
     side: THREE.DoubleSide,
   })
 
   const mesh = new THREE.Mesh(geometry, material)
+  applyTabHighlight(mesh, selected)
   mesh.scale.z = -1
   return mesh
 }
@@ -943,19 +965,17 @@ export interface SceneObjects {
   clampMeshes: Map<string, THREE.Mesh>
 }
 
-export async function buildScene(
-  project: Project,
-  selectedClampId: string | null = null,
-  selectedTabId: string | null = null,
-  collidingClampIds: string[] = [],
-): Promise<SceneObjects> {
+export async function buildScene(project: Project): Promise<SceneObjects> {
   // Construction geometry is sketch-only — it never reaches the 3D model,
   // feature meshes, or open-feature lines (issue #199). Regions stay: they
   // render display-only walls below.
+  //
+  // Fixtures are built unhighlighted: selection/collision only tint the clamp
+  // and tab meshes, which Viewport3D recolors via applyClampHighlight /
+  // applyTabHighlight without rebuilding this (expensive) CSG model (issue #261).
   const visibleFeatures = modelFeatures(project.features).filter((feature) => feature.visible)
   const visibleTabs = project.tabs.filter((tab) => tab.visible)
   const visibleClamps = project.clamps.filter((clamp) => clamp.visible)
-  const collidingClampIdSet = new Set(collidingClampIds)
   const stockMesh = buildStockMesh(project.stock)
   const stockWireframe = buildStockWireframe(project.stock)
   const featureMeshes = new Map<string, THREE.Object3D>()
@@ -1008,14 +1028,11 @@ export async function buildScene(
   stockWireframe.visible = showStockReference
 
   for (const tab of visibleTabs) {
-    tabMeshes.set(tab.id, buildTabMesh(tab, tab.id === selectedTabId))
+    tabMeshes.set(tab.id, buildTabMesh(tab))
   }
 
   for (const clamp of visibleClamps) {
-    clampMeshes.set(
-      clamp.id,
-      buildClampMesh(clamp, clamp.id === selectedClampId, collidingClampIdSet.has(clamp.id)),
-    )
+    clampMeshes.set(clamp.id, buildClampMesh(clamp))
   }
 
   return { stockMesh, stockWireframe, modelMesh, featureMeshes, openFeatureLines, tabMeshes, clampMeshes }

--- a/src/engine/viewport3dSelectionDecoupling.test.ts
+++ b/src/engine/viewport3dSelectionDecoupling.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference types="node" />
+
+/**
+ * Guard test: 3D-preview selection is decoupled from the CSG model rebuild
+ * (issue #261).
+ *
+ * The expensive `buildBooleanModel` (manifold union/difference of every feature)
+ * depends only on geometry, never on selection. Selecting a feature/clamp/tab
+ * must therefore recolor the affected fixture in place, NOT rebuild the model.
+ * This test locks that at two seams:
+ *   1. (runtime) applyClampHighlight / applyTabHighlight mutate an already-built
+ *      fixture mesh's material in place — same mesh, same material instance, only
+ *      color + opacity change. That is the cheap update that replaces a rebuild.
+ *   2. (structural) buildScene takes only `project` — it cannot consume selection
+ *      or collision — and the Viewport3D scene-build effect is keyed on geometry
+ *      inputs only (no `selection.selectedNode`), with a separate highlight effect.
+ *
+ * Run with: npx tsx src/engine/viewport3dSelectionDecoupling.test.ts
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as THREE from 'three'
+import type { Clamp, Tab } from '../types/project'
+import {
+  applyClampHighlight,
+  applyTabHighlight,
+  buildClampMesh,
+  buildTabMesh,
+} from './csg'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function standardMaterial(mesh: THREE.Mesh): THREE.MeshStandardMaterial {
+  const material = mesh.material
+  assert(material instanceof THREE.MeshStandardMaterial, 'fixture mesh uses a MeshStandardMaterial')
+  return material
+}
+
+// ── 1. Runtime: highlight is an in-place recolor, not a rebuild ───────────────
+
+const clamp: Clamp = {
+  id: 'clamp-1',
+  name: 'Clamp 1',
+  type: 'step_clamp',
+  x: 0,
+  y: 0,
+  w: 20,
+  h: 10,
+  height: 15,
+  visible: true,
+}
+
+// A clamp built unhighlighted (as buildScene now builds it).
+const clampMesh = buildClampMesh(clamp)
+const clampMaterial = standardMaterial(clampMesh)
+const clampGeometry = clampMesh.geometry
+const unselectedColor = clampMaterial.color.getHexString()
+const unselectedOpacity = clampMaterial.opacity
+
+// Selecting the clamp must NOT allocate a new mesh/material/geometry — it just
+// recolors the existing material. That is what makes it cheaper than a rebuild.
+applyClampHighlight(clampMesh, true, false)
+assert(clampMesh.material === clampMaterial, 'clamp highlight reuses the same material instance (no rebuild)')
+assert(clampMesh.geometry === clampGeometry, 'clamp highlight leaves geometry untouched (no rebuild)')
+const selectedColor = clampMaterial.color.getHexString()
+assert(selectedColor !== unselectedColor, 'selecting a clamp changes its color in place')
+assert(clampMaterial.opacity !== unselectedOpacity, 'selecting a clamp changes its opacity in place')
+
+// Collision is likewise a cheap recolor and is distinct from plain selection.
+applyClampHighlight(clampMesh, false, true)
+assert(
+  clampMaterial.color.getHexString() !== unselectedColor,
+  'a colliding clamp recolors without a rebuild',
+)
+assert(
+  clampMaterial.color.getHexString() !== selectedColor,
+  'colliding and selected clamps are visually distinct',
+)
+
+// Returning to the neutral state restores the original appearance exactly.
+applyClampHighlight(clampMesh, false, false)
+assert(clampMaterial.color.getHexString() === unselectedColor, 'clearing highlight restores clamp color')
+assert(clampMaterial.opacity === unselectedOpacity, 'clearing highlight restores clamp opacity')
+
+const tab: Tab = {
+  id: 'tab-1',
+  name: 'Tab 1',
+  x: 0,
+  y: 0,
+  w: 8,
+  h: 8,
+  z_top: 4,
+  z_bottom: 0,
+  visible: true,
+}
+
+const tabMesh = buildTabMesh(tab)
+const tabMaterial = standardMaterial(tabMesh)
+const tabUnselectedColor = tabMaterial.color.getHexString()
+const tabUnselectedOpacity = tabMaterial.opacity
+
+applyTabHighlight(tabMesh, true)
+assert(tabMesh.material === tabMaterial, 'tab highlight reuses the same material instance (no rebuild)')
+assert(tabMaterial.color.getHexString() !== tabUnselectedColor, 'selecting a tab changes its color in place')
+assert(tabMaterial.opacity !== tabUnselectedOpacity, 'selecting a tab changes its opacity in place')
+
+applyTabHighlight(tabMesh, false)
+assert(tabMaterial.color.getHexString() === tabUnselectedColor, 'clearing highlight restores tab color')
+assert(tabMaterial.opacity === tabUnselectedOpacity, 'clearing highlight restores tab opacity')
+
+// ── 2. Structural: buildScene cannot consume selection; effect is geometry-keyed ─
+
+const here = dirname(fileURLToPath(import.meta.url))
+const root = resolve(here, '../..')
+const csgSource = readFileSync(resolve(root, 'src/engine/csg.ts'), 'utf8')
+const viewportSource = readFileSync(
+  resolve(root, 'src/components/viewport3d/Viewport3D.tsx'),
+  'utf8',
+)
+
+// buildScene takes ONLY project — no selectedClampId/selectedTabId/collidingClampIds.
+assert(
+  /export async function buildScene\(project: Project\): Promise<SceneObjects>/.test(csgSource),
+  'buildScene must take only `project` so selection cannot feed the CSG model rebuild',
+)
+assert(
+  !/buildScene\([^)]*selected/i.test(csgSource) && !/buildScene\([^)]*colliding/i.test(csgSource),
+  'buildScene must not receive any selection/collision arguments',
+)
+
+// The cheap in-place highlight helpers must exist as the rebuild's replacement.
+assert(
+  /export function applyClampHighlight\(/.test(csgSource),
+  'csg.ts must export applyClampHighlight for in-place clamp recolor',
+)
+assert(
+  /export function applyTabHighlight\(/.test(csgSource),
+  'csg.ts must export applyTabHighlight for in-place tab recolor',
+)
+
+// The model-rebuild path in Viewport3D calls buildScene with project alone.
+assert(
+  /await buildScene\(project\)/.test(viewportSource),
+  'Viewport3D scene-build must call buildScene(project) with no selection arguments',
+)
+
+// The scene-build effect must be keyed on geometry inputs only — selection is
+// explicitly excluded so it can never re-trigger the rebuild.
+assert(
+  viewportSource.includes(
+    '}, [clearRenderedObjects, disposeObjectMaterial, originVisible, project, rebuildGridHelpers])',
+  ),
+  'Viewport3D scene-build effect must be keyed on geometry inputs only (no selection.selectedNode)',
+)
+
+// A separate lightweight effect recolors fixtures on selection/collision change.
+assert(
+  /applyFixtureHighlights\(\)\s*\n\s*\},\s*\[applyFixtureHighlights\]/.test(viewportSource),
+  'Viewport3D must recolor fixtures in a dedicated selection-keyed effect, not by rebuilding',
+)
+
+console.log('viewport3dSelectionDecoupling.test.ts passed')


### PR DESCRIPTION
Closes #261

## Problem

The 3D preview rebuilt the **entire CSG boolean model on every selection change**, even though the model doesn't depend on selection.

The scene-build `useEffect` in `Viewport3D.tsx` listed `selection.selectedNode` (and `collidingClampIds`) in its dependency array, so every click re-ran `buildScene → buildBooleanModel` — the manifold union/difference of all features. That boolean model depends only on geometry; selection merely tints the selected clamp/tab. Selecting a **feature** passed `null` for both fixture ids (identical model inputs) yet rebuilt the whole model for zero visual change.

**Measured:** ~500 ms on a typical project, ~2300 ms on a heavy import. Because all three centre views are always mounted (`AppShell.tsx`), the freeze also stalled the sketch view on every click.

## Fix (root-cause decoupling)

- **`csg.ts`** — extract fixture coloring into pure `applyClampHighlight(mesh, selected, colliding)` / `applyTabHighlight(mesh, selected)` helpers that mutate an already-built mesh's material **in place** (same colors/opacity as before). `buildClampMesh`/`buildTabMesh` call them for the initial appearance and **keep their `selected`/`colliding` params**, so `SimulationViewport.tsx` (the other `buildClampMesh` caller) is unchanged.
- **`csg.ts`** — `buildScene(project)` drops the `selectedClampId`/`selectedTabId`/`collidingClampIds` params and builds fixtures unhighlighted.
- **`Viewport3D.tsx`** — the scene-build effect is now keyed on geometry inputs only (`selection.selectedNode` and `collidingClampIds` removed); it keeps the **150 ms debounce + `buildRequestRef` cancellation** and stores the returned `clampMeshes`/`tabMeshes` maps in refs. A separate lightweight effect recolors those already-built meshes on selection/collision change — no rebuild. After each rebuild the current highlight is re-applied (via a ref-held latest-highlighter) so freshly-built fixtures reflect the current selection even when selection didn't change.

Deferral (gating the rebuild on the 3D tab being visible) was explicitly **not** used — it makes switching to the 3D tab slow and would need a spinner.

## Why this is airtight

Selecting a feature/clamp/tab only ever updates the `selection` slice (`selectFeature`/`selectTab`/`selectClamp` return `selection`-related partials, never a new `project`). So none of the scene-build effect's deps — `clearRenderedObjects`, `disposeObjectMaterial`, `originVisible`, `project`, `rebuildGridHelpers` (all stable across selection) — change, and `buildBooleanModel` cannot run on a selection change. Collision changes are likewise a cheap recolor now.

## Tests

`src/engine/viewport3dSelectionDecoupling.test.ts`:
- **Runtime:** `applyClampHighlight`/`applyTabHighlight` recolor an already-built fixture **in place** — same mesh + same material instance, only color/opacity change (proving the highlight is a recolor, not a rebuild); collision vs selection are visually distinct; clearing restores the original appearance.
- **Structural:** `buildScene` takes only `project` (can't consume selection/collision); the Viewport3D scene-build effect is keyed on geometry inputs only; a dedicated selection-keyed highlight effect exists.

`npm run build` (lint + tsc + all 89 test files + vite) is green.
