### PR TITLE
Add creation parameter reference diagrams

### DIFF
--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -16,7 +16,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 
 ## Subfolders (by area)
 - `common/` — shared cross-panel UI primitives. `DisclosureSection` is the reusable collapsible "Advanced" section (progressive disclosure); its open/collapsed state persists via the pure helpers in `common/disclosureState.ts`.
-- `canvas/` — 2D sketch canvas: drawing, snapping, panning/zoom, pointer handling, and creation workflow panels including gear parameters. Dimension annotations + tape measure render via `canvas/dimensionRendering.ts` (pure geometry in `sketch/dimensions.ts`); `canvas/operationSnapshot.ts` renders static operation booklet images.
+- `canvas/` — 2D sketch canvas: drawing, snapping, panning/zoom, pointer handling, and creation workflow panels including gear/parameter reference diagrams. Dimension annotations + tape measure render via `canvas/dimensionRendering.ts` (pure geometry in `sketch/dimensions.ts`); `canvas/operationSnapshot.ts` renders static operation booklet images.
 - `viewport3d/` — Three.js 3D preview of the CSG-derived model, including toolpath overlay helpers
 - `simulation/` — voxel toolpath simulation viewport and playback controls
 - `cam/` — CAM panels (tools, operations, parameters)

--- a/src/components/canvas/CreationParameterReferences.tsx
+++ b/src/components/canvas/CreationParameterReferences.tsx
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KeyboardEvent, ReactNode } from 'react'
+import type { PendingAddTool } from '../../store/types'
+
+type PendingNgon = Extract<NonNullable<PendingAddTool>, { shape: 'ngon' }>
+type PendingRectCorner = Extract<NonNullable<PendingAddTool>, { shape: 'roundrect' | 'chamferrect' }>
+
+interface NgonParameterPanelProps {
+  pendingAdd: PendingNgon
+  setPendingNgonSides: (sides: number) => void
+}
+
+interface RectCornerParameterPanelProps {
+  pendingAdd: PendingRectCorner
+  setPendingRectCorner: (corner: number) => void
+}
+
+interface CreationParameterFieldProps {
+  children: ReactNode
+  label: string
+  reference: ReactNode
+}
+
+function stopPanelKey(event: KeyboardEvent<HTMLInputElement>): void {
+  event.stopPropagation()
+}
+
+function clampNgonSides(value: string, fallback: number): number {
+  const parsed = Math.round(Number(value))
+  return Number.isNaN(parsed) ? fallback : Math.max(3, Math.min(50, parsed))
+}
+
+function clampCorner(value: string, fallback: number): number {
+  const parsed = Number(value)
+  return Number.isNaN(parsed) || parsed < 0 ? fallback : parsed
+}
+
+function CreationParameterField({ children, label, reference }: CreationParameterFieldProps) {
+  return (
+    <label className="canvas-workflow-panel__field canvas-workflow-panel__field--reference">
+      <span>{label}</span>
+      {children}
+      {reference}
+    </label>
+  )
+}
+
+function CreationReferenceFrame({
+  children,
+  label,
+}: {
+  children: ReactNode
+  label: string
+}) {
+  return (
+    <svg
+      className="canvas-workflow-panel__parameter-reference"
+      viewBox="0 0 58 34"
+      role="img"
+      aria-label={label}
+      focusable="false"
+    >
+      {children}
+    </svg>
+  )
+}
+
+function polygonPath(sides: number): string {
+  const displaySides = Math.max(3, Math.min(16, sides))
+  const points = Array.from({ length: displaySides }, (_, index) => {
+    const angle = -Math.PI / 2 + (index * Math.PI * 2) / displaySides
+    return `${(29 + Math.cos(angle) * 11).toFixed(2)} ${(17 + Math.sin(angle) * 11).toFixed(2)}`
+  })
+  return `M${points.join('L')}Z`
+}
+
+function NgonSidesReference({ sides }: { sides: number }) {
+  return (
+    <CreationReferenceFrame label="Polygon side count reference">
+      <path className="gear-reference__guide" d="M29 5v24M16 17h26" />
+      <path className="gear-reference__outline" d={polygonPath(sides)} />
+      <path className="gear-reference__accent" d="M29 6L38.5 12.5" />
+      <circle className="gear-reference__accent-fill" cx="29" cy="6" r="1.5" />
+      <circle className="gear-reference__accent-fill" cx="38.5" cy="12.5" r="1.5" />
+    </CreationReferenceFrame>
+  )
+}
+
+function RectCornerReference({ kind }: { kind: PendingRectCorner['shape'] }) {
+  if (kind === 'roundrect') {
+    return (
+      <CreationReferenceFrame label="Rounded rectangle corner radius reference">
+        <path className="gear-reference__outline" d="M10 28V11Q10 6 15 6H48" />
+        <path className="gear-reference__guide" d="M21 17L10 17M21 17V6" />
+        <path className="gear-reference__accent" d="M10 17A11 11 0 0 1 21 6" />
+        <circle className="gear-reference__accent-fill" cx="21" cy="17" r="1.5" />
+      </CreationReferenceFrame>
+    )
+  }
+
+  return (
+    <CreationReferenceFrame label="Chamfered rectangle corner reference">
+      <path className="gear-reference__outline" d="M10 28V16L20 6H48" />
+      <path className="gear-reference__guide" d="M10 16H20V6" />
+      <path className="gear-reference__accent" d="M10 16L20 6" />
+      <path className="gear-reference__accent-fill" d="M10 16l4-1-3-3zM20 6l-4 1 3 3z" />
+    </CreationReferenceFrame>
+  )
+}
+
+export function NgonParameterPanel({ pendingAdd, setPendingNgonSides }: NgonParameterPanelProps) {
+  return (
+    <div className="canvas-workflow-panel__meta canvas-workflow-panel__parameter-fields">
+      <CreationParameterField label="Sides (3-50)" reference={<NgonSidesReference sides={pendingAdd.sides} />}>
+        <input
+          key={pendingAdd.session}
+          className="canvas-workflow-panel__count-input"
+          type="text"
+          inputMode="numeric"
+          defaultValue={pendingAdd.sides}
+          onBlur={(event) => {
+            const clamped = clampNgonSides(event.currentTarget.value, pendingAdd.sides)
+            setPendingNgonSides(clamped)
+            event.currentTarget.value = String(clamped)
+          }}
+          onKeyDown={(event) => {
+            stopPanelKey(event)
+            if (event.key === 'Enter') {
+              const clamped = clampNgonSides(event.currentTarget.value, pendingAdd.sides)
+              setPendingNgonSides(clamped)
+              event.currentTarget.value = String(clamped)
+            }
+          }}
+        />
+      </CreationParameterField>
+    </div>
+  )
+}
+
+export function RectCornerParameterPanel({ pendingAdd, setPendingRectCorner }: RectCornerParameterPanelProps) {
+  return (
+    <div className="canvas-workflow-panel__meta canvas-workflow-panel__parameter-fields">
+      <CreationParameterField
+        label={pendingAdd.shape === 'roundrect' ? 'Corner radius' : 'Chamfer'}
+        reference={<RectCornerReference kind={pendingAdd.shape} />}
+      >
+        <input
+          key={pendingAdd.session}
+          className="canvas-workflow-panel__count-input"
+          type="text"
+          inputMode="decimal"
+          defaultValue={pendingAdd.corner}
+          onBlur={(event) => {
+            const clamped = clampCorner(event.currentTarget.value, pendingAdd.corner)
+            setPendingRectCorner(clamped)
+            event.currentTarget.value = String(clamped)
+          }}
+          onKeyDown={(event) => {
+            stopPanelKey(event)
+            if (event.key === 'Enter') {
+              const clamped = clampCorner(event.currentTarget.value, pendingAdd.corner)
+              setPendingRectCorner(clamped)
+              event.currentTarget.value = String(clamped)
+            }
+          }}
+        />
+      </CreationParameterField>
+    </div>
+  )
+}

--- a/src/components/canvas/CreationParameterReferences.tsx
+++ b/src/components/canvas/CreationParameterReferences.tsx
@@ -17,8 +17,8 @@
 import type { KeyboardEvent, ReactNode } from 'react'
 import type { PendingAddTool } from '../../store/types'
 
-type PendingNgon = Extract<NonNullable<PendingAddTool>, { shape: 'ngon' }>
-type PendingRectCorner = Extract<NonNullable<PendingAddTool>, { shape: 'roundrect' | 'chamferrect' }>
+type PendingNgon = Extract<PendingAddTool, { shape: 'ngon' }>
+type PendingRectCorner = Extract<PendingAddTool, { shape: 'roundrect' | 'chamferrect' }>
 
 interface NgonParameterPanelProps {
   pendingAdd: PendingNgon
@@ -40,14 +40,28 @@ function stopPanelKey(event: KeyboardEvent<HTMLInputElement>): void {
   event.stopPropagation()
 }
 
-function clampNgonSides(value: string, fallback: number): number {
-  const parsed = Math.round(Number(value))
-  return Number.isNaN(parsed) ? fallback : Math.max(3, Math.min(50, parsed))
+function parseNumber(value: string, fallback: number): number {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
 }
 
-function clampCorner(value: string, fallback: number): number {
-  const parsed = Number(value)
-  return Number.isNaN(parsed) || parsed < 0 ? fallback : parsed
+function commitNumber(
+  value: string,
+  fallback: number,
+  commit: (value: number) => void,
+  normalize: (value: number, fallback: number) => number = (next) => next,
+): string {
+  const next = normalize(parseNumber(value, fallback), fallback)
+  commit(next)
+  return String(next)
+}
+
+function normalizeNgonSides(value: number): number {
+  return Math.max(3, Math.min(50, Math.round(value)))
+}
+
+function normalizeCorner(value: number, fallback: number): number {
+  return value < 0 ? fallback : value
 }
 
 function CreationParameterField({ children, label, reference }: CreationParameterFieldProps) {
@@ -134,16 +148,22 @@ export function NgonParameterPanel({ pendingAdd, setPendingNgonSides }: NgonPara
           inputMode="numeric"
           defaultValue={pendingAdd.sides}
           onBlur={(event) => {
-            const clamped = clampNgonSides(event.currentTarget.value, pendingAdd.sides)
-            setPendingNgonSides(clamped)
-            event.currentTarget.value = String(clamped)
+            event.currentTarget.value = commitNumber(
+              event.currentTarget.value,
+              pendingAdd.sides,
+              setPendingNgonSides,
+              normalizeNgonSides,
+            )
           }}
           onKeyDown={(event) => {
             stopPanelKey(event)
             if (event.key === 'Enter') {
-              const clamped = clampNgonSides(event.currentTarget.value, pendingAdd.sides)
-              setPendingNgonSides(clamped)
-              event.currentTarget.value = String(clamped)
+              event.currentTarget.value = commitNumber(
+                event.currentTarget.value,
+                pendingAdd.sides,
+                setPendingNgonSides,
+                normalizeNgonSides,
+              )
             }
           }}
         />
@@ -166,16 +186,22 @@ export function RectCornerParameterPanel({ pendingAdd, setPendingRectCorner }: R
           inputMode="decimal"
           defaultValue={pendingAdd.corner}
           onBlur={(event) => {
-            const clamped = clampCorner(event.currentTarget.value, pendingAdd.corner)
-            setPendingRectCorner(clamped)
-            event.currentTarget.value = String(clamped)
+            event.currentTarget.value = commitNumber(
+              event.currentTarget.value,
+              pendingAdd.corner,
+              setPendingRectCorner,
+              normalizeCorner,
+            )
           }}
           onKeyDown={(event) => {
             stopPanelKey(event)
             if (event.key === 'Enter') {
-              const clamped = clampCorner(event.currentTarget.value, pendingAdd.corner)
-              setPendingRectCorner(clamped)
-              event.currentTarget.value = String(clamped)
+              event.currentTarget.value = commitNumber(
+                event.currentTarget.value,
+                pendingAdd.corner,
+                setPendingRectCorner,
+                normalizeCorner,
+              )
             }
           }}
         />

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -44,6 +44,7 @@ import type { OperationDimEdit } from './manualEntry'
 import { useDimensionEditWorkflow } from './useDimensionEditWorkflow'
 import { ConstraintEditPanel } from './ConstraintEditPanel'
 import { DrivingDimensionPanel } from './DrivingDimensionPanel'
+import { NgonParameterPanel, RectCornerParameterPanel } from './CreationParameterReferences'
 import { GearParameterPanel } from './GearParameterPanel'
 import { useDrivingDimensionWorkflow } from './useDrivingDimensionWorkflow'
 import { useConstraintWorkflow } from './useConstraintWorkflow'
@@ -3397,58 +3398,10 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           )}
           {pendingAdd.shape === 'gear' && !creation.creationDimEditActive && (<GearParameterPanel pendingAdd={pendingAdd} units={project.meta.units} setPendingGearParams={setPendingGearParams} />)}
           {pendingAdd.shape === 'ngon' && !creation.creationDimEditActive && (
-            <div className="canvas-workflow-panel__meta">
-              <label className="canvas-workflow-panel__field">
-                <span>Sides (3–50)</span>
-                <input
-                  key={'sides' in pendingAdd ? pendingAdd.session : undefined}
-                  className="canvas-workflow-panel__count-input"
-                  type="text"
-                  inputMode="numeric"
-                  defaultValue={'sides' in pendingAdd ? pendingAdd.sides : 6}
-                  onBlur={(e) => {
-                    const n = Math.round(Number(e.target.value))
-                    const clamped = Number.isNaN(n) ? ('sides' in pendingAdd ? pendingAdd.sides : 6) : Math.max(3, Math.min(50, n))
-                    setPendingNgonSides(clamped)
-                    e.target.value = String(clamped)
-                  }}
-                  onKeyDown={(e) => {
-                    e.stopPropagation()
-                    if (e.key === 'Enter') {
-                      const n = Math.round(Number(e.currentTarget.value))
-                      if (!Number.isNaN(n)) setPendingNgonSides(Math.max(3, Math.min(50, n)))
-                    }
-                  }}
-                />
-              </label>
-            </div>
+            <NgonParameterPanel pendingAdd={pendingAdd} setPendingNgonSides={setPendingNgonSides} />
           )}
           {(pendingAdd.shape === 'roundrect' || pendingAdd.shape === 'chamferrect') && !creation.creationDimEditActive && (
-            <div className="canvas-workflow-panel__meta">
-              <label className="canvas-workflow-panel__field">
-                <span>{pendingAdd.shape === 'roundrect' ? 'Corner radius' : 'Chamfer'}</span>
-                <input
-                  key={'corner' in pendingAdd ? pendingAdd.session : undefined}
-                  className="canvas-workflow-panel__count-input"
-                  type="text"
-                  inputMode="decimal"
-                  defaultValue={'corner' in pendingAdd ? pendingAdd.corner : (project.meta.units === 'mm' ? 5 : 0.2)}
-                  onBlur={(e) => {
-                    const v = Number(e.target.value)
-                    const clamped = Number.isNaN(v) || v < 0 ? ('corner' in pendingAdd ? pendingAdd.corner : 0) : v
-                    setPendingRectCorner(clamped)
-                    e.target.value = String(clamped)
-                  }}
-                  onKeyDown={(e) => {
-                    e.stopPropagation()
-                    if (e.key === 'Enter') {
-                      const v = Number(e.currentTarget.value)
-                      if (!Number.isNaN(v) && v >= 0) setPendingRectCorner(v)
-                    }
-                  }}
-                />
-              </label>
-            </div>
+            <RectCornerParameterPanel pendingAdd={pendingAdd} setPendingRectCorner={setPendingRectCorner} />
           )}
           {pendingDraftHasSelfIntersection ? (
             <div className="sketch-banner-warning">This profile self-intersects. 3D/CAM results may be invalid.</div>

--- a/src/styles/canvas-workflow.css
+++ b/src/styles/canvas-workflow.css
@@ -108,24 +108,28 @@
   font-size: 12px;
 }
 
-.canvas-workflow-panel__gear-fields {
+.canvas-workflow-panel__gear-fields,
+.canvas-workflow-panel__parameter-fields {
   display: grid;
   align-items: stretch;
   gap: 6px;
   width: 100%;
 }
 
-.canvas-workflow-panel__field--gear {
+.canvas-workflow-panel__field--gear,
+.canvas-workflow-panel__field--reference {
   grid-template-columns: minmax(94px, 1fr) minmax(84px, 104px) 50px;
   gap: 8px;
   min-height: 38px;
 }
 
-.canvas-workflow-panel__field--gear > span {
+.canvas-workflow-panel__field--gear > span,
+.canvas-workflow-panel__field--reference > span {
   min-width: 0;
 }
 
-.canvas-workflow-panel__gear-reference {
+.canvas-workflow-panel__gear-reference,
+.canvas-workflow-panel__parameter-reference {
   width: 50px;
   height: 34px;
   border: 1px solid rgba(200, 156, 98, 0.22);


### PR DESCRIPTION
## Summary
- Add compact reference diagrams for regular polygon side count and rounded/chamfered rectangle corner parameters
- Move those creation fields into a focused canvas parameter-reference component
- Reuse the gear dialog reference-column styling for consistent creation panel layout

Closes #259

## Verification
- npm run build