### PR TITLE
feat: parameter reference icons for the operation properties panel (#266)

### DIFF
--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -19,7 +19,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 - `canvas/` — 2D sketch canvas: drawing, snapping, panning/zoom, pointer handling, and creation workflow panels including gear/parameter reference diagrams. Dimension annotations + tape measure render via `canvas/dimensionRendering.ts` (pure geometry in `sketch/dimensions.ts`); `canvas/operationSnapshot.ts` renders static operation booklet images.
 - `viewport3d/` — Three.js 3D preview of the CSG-derived model, including toolpath overlay helpers
 - `simulation/` — voxel toolpath simulation viewport and playback controls
-- `cam/` — CAM panels (tools, operations, parameters)
+- `cam/` — CAM panels (tools, operations, parameters); per-parameter reference icons via `OperationParameterReference`
 - `feature-tree/` — sketch feature tree UI (reordering, visibility, grouping) plus the extracted feature/tab/clamp context menu
 - `layout/` — app shell (toolbars, sidebars, mode switching); toolbar internals are documented in `layout/toolbar/INDEX.md`
 - `project/` — project-level UI (new/open/save, stock, machine, units)

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -22,6 +22,7 @@ import { useProjectStore } from '../../store/projectStore'
 import { loadBundledToolLibrary, type ToolLibraryEntry } from '../../toolLibrary'
 import { Select } from '../Select'
 import { OperationAddMenu } from './OperationAddMenu'
+import { OperationParameterReference } from './OperationParameterReference'
 import { DisclosureSection } from '../common/DisclosureSection'
 import type {
   DrillType,
@@ -1092,7 +1093,7 @@ export function CAMPanel({
       return <div className="panel-empty">Select an operation to edit its parameters.</div>
     }
     return (
-      <div key={`${selectedOperation.id}-${selectedOperation.toolRef ?? ''}`} className="properties-panel cam-tool-properties">
+      <div key={`${selectedOperation.id}-${selectedOperation.toolRef ?? ''}`} className="properties-panel cam-tool-properties cam-operation-properties">
                     <div className="properties-group">
                   <label className="properties-field">
                     <span>Name</span>
@@ -1131,6 +1132,7 @@ export function CAMPanel({
                         min={0.0001}
                         onCommit={(value) => updateOperation(selectedOperation.id, { maxCarveDepth: value })}
                       />
+                      <OperationParameterReference kind="maxDepth" />
                     </label>
                   ) : null}
                   {selectedOperation.kind === 'follow_line' ? (
@@ -1142,6 +1144,7 @@ export function CAMPanel({
                         min={0.0001}
                         onCommit={(value) => updateOperation(selectedOperation.id, { carveDepth: value })}
                       />
+                      <OperationParameterReference kind="maxDepth" />
                     </label>
                   ) : null}
                   <label className="properties-field">
@@ -1276,6 +1279,7 @@ export function CAMPanel({
                         min={0.0001}
                         onCommit={(value) => updateOperation(selectedOperation.id, { stepdown: value })}
                       />
+                      <OperationParameterReference kind="stepdown" />
                     </label>
                   ) : null}
                   {selectedOperation.kind !== 'follow_line'
@@ -1294,6 +1298,7 @@ export function CAMPanel({
                         min={0.001}
                         onCommit={(value) => updateOperation(selectedOperation.id, { stepover: value })}
                       />
+                      <OperationParameterReference kind="stepover" />
                     </label>
                   ) : null}
                   <DisclosureSection title="Advanced" storageKey="cam-operation-advanced">
@@ -1318,6 +1323,7 @@ export function CAMPanel({
                           })
                         }}
                       />
+                      <OperationParameterReference kind="pattern" />
                     </label>
                   ) : null}
                   {selectedOperation.kind === 'finish_surface' ? (
@@ -1331,6 +1337,7 @@ export function CAMPanel({
                         ]}
                         onChange={(value) => updateOperation(selectedOperation.id, { pocketPattern: value })}
                       />
+                      <OperationParameterReference kind="pattern" />
                     </label>
                   ) : null}
                   {selectedOperation.kind === 'finish_surface_cleanup' ? (
@@ -1344,6 +1351,7 @@ export function CAMPanel({
                         ]}
                         onChange={(value) => updateOperation(selectedOperation.id, { pocketPattern: value })}
                       />
+                      <OperationParameterReference kind="pattern" />
                     </label>
                   ) : null}
                   {(selectedOperation.kind === 'pocket' || selectedOperation.kind === 'surface_clean' || selectedOperation.kind === 'finish_surface' || selectedOperation.kind === 'finish_surface_cleanup') && selectedOperation.pocketPattern === 'parallel' ? (
@@ -1353,6 +1361,7 @@ export function CAMPanel({
                         value={selectedOperation.pocketAngle}
                         onCommit={(value) => updateOperation(selectedOperation.id, { pocketAngle: value })}
                       />
+                      <OperationParameterReference kind="rasterAngle" />
                     </label>
                   ) : null}
                   {(selectedOperation.kind === 'pocket' || selectedOperation.kind === 'edge_route_inside' || selectedOperation.kind === 'edge_route_outside' || selectedOperation.kind === 'v_carve' || selectedOperation.kind === 'surface_clean' || selectedOperation.kind === 'rough_surface' || selectedOperation.kind === 'finish_surface' || selectedOperation.kind === 'finish_surface_cleanup') ? (
@@ -1366,6 +1375,7 @@ export function CAMPanel({
                         ]}
                         onChange={(value) => updateOperation(selectedOperation.id, { cutDirection: value })}
                       />
+                      <OperationParameterReference kind="cutDirection" />
                     </label>
                   ) : null}
                   {(selectedOperation.kind === 'pocket'
@@ -1381,6 +1391,7 @@ export function CAMPanel({
                         ]}
                         onChange={(value) => updateOperation(selectedOperation.id, { machiningOrder: value })}
                       />
+                      <OperationParameterReference kind="machiningOrder" />
                     </label>
                   ) : null}
                   {selectedOperation.kind === 'drilling' ? (
@@ -1397,6 +1408,7 @@ export function CAMPanel({
                           ]}
                           onChange={(value) => updateOperation(selectedOperation.id, { drillType: value })}
                         />
+                        <OperationParameterReference kind="drillType" />
                       </label>
                       {(selectedOperation.drillType === 'peck' || selectedOperation.drillType === 'chip_breaking') ? (
                         <label className="properties-field">
@@ -1407,6 +1419,7 @@ export function CAMPanel({
                             min={0}
                             onCommit={(value) => updateOperation(selectedOperation.id, { peckDepth: value })}
                           />
+                          <OperationParameterReference kind="peckDepth" />
                         </label>
                       ) : null}
                       {selectedOperation.drillType === 'dwell' ? (
@@ -1417,6 +1430,7 @@ export function CAMPanel({
                             min={0}
                             onCommit={(value) => updateOperation(selectedOperation.id, { dwellTime: value })}
                           />
+                          <OperationParameterReference kind="dwell" />
                         </label>
                       ) : null}
                       <label className="properties-field">
@@ -1427,6 +1441,7 @@ export function CAMPanel({
                           min={0}
                           onCommit={(value) => updateOperation(selectedOperation.id, { retractHeight: value })}
                         />
+                        <OperationParameterReference kind="retractHeight" />
                       </label>
                     </>
                   ) : null}
@@ -1467,6 +1482,7 @@ export function CAMPanel({
                       min={0.0001}
                       onCommit={(value) => updateOperation(selectedOperation.id, { feed: value })}
                     />
+                    <OperationParameterReference kind="feed" />
                   </label>
                   <label className="properties-field">
                     <span>Plunge Feed</span>
@@ -1476,6 +1492,7 @@ export function CAMPanel({
                       min={0.0001}
                       onCommit={(value) => updateOperation(selectedOperation.id, { plungeFeed: value })}
                     />
+                    <OperationParameterReference kind="plungeFeed" />
                   </label>
                   {selectedOperation.kind === 'pocket'
                     && (selectedOperation.pass === 'rough'
@@ -1493,6 +1510,7 @@ export function CAMPanel({
                           pocketSlotFeedPercent: Math.min(100, Math.max(1, Math.round(value))),
                         })}
                       />
+                      <OperationParameterReference kind="slotFeed" />
                     </label>
                   ) : null}
                   <label className="properties-field">
@@ -1502,6 +1520,7 @@ export function CAMPanel({
                       min={1}
                       onCommit={(value) => updateOperation(selectedOperation.id, { rpm: Math.round(value) })}
                     />
+                    <OperationParameterReference kind="rpm" />
                   </label>
                   {selectedOperation.kind !== 'follow_line'
                     && selectedOperation.kind !== 'v_carve'
@@ -1517,6 +1536,7 @@ export function CAMPanel({
                           min={0}
                           onCommit={(value) => updateOperation(selectedOperation.id, { stockToLeaveRadial: value })}
                         />
+                        <OperationParameterReference kind="stockRadial" />
                       </label>
                       <label className="properties-field">
                         <span>Stock To Leave Axial</span>
@@ -1526,6 +1546,7 @@ export function CAMPanel({
                           min={0}
                           onCommit={(value) => updateOperation(selectedOperation.id, { stockToLeaveAxial: value })}
                         />
+                        <OperationParameterReference kind="stockAxial" />
                       </label>
                     </>
                   ) : null}
@@ -1541,6 +1562,7 @@ export function CAMPanel({
                               min={0}
                               onCommit={(value) => updateOperation(selectedOperation.id, { stockToLeaveRadial: value })}
                             />
+                            <OperationParameterReference kind="stockRadial" />
                           </label>
                           <label
                             className="properties-check"
@@ -1577,6 +1599,7 @@ export function CAMPanel({
                                   min={0.0001}
                                   onCommit={(value) => updateOperation(selectedOperation.id, { waterlineMicroStepover: value })}
                                 />
+                                <OperationParameterReference kind="adaptiveSpacing" />
                               </label>
                               <label
                                 className="properties-field"
@@ -1589,6 +1612,7 @@ export function CAMPanel({
                                   max={512}
                                   onCommit={(value) => updateOperation(selectedOperation.id, { waterlineMaxRingsPerBand: Math.floor(value) })}
                                 />
+                                <OperationParameterReference kind="maxRings" />
                               </label>
                             </>
                           ) : null}
@@ -1602,6 +1626,7 @@ export function CAMPanel({
                           min={0}
                           onCommit={(value) => updateOperation(selectedOperation.id, { stockToLeaveAxial: value })}
                         />
+                        <OperationParameterReference kind="stockAxial" />
                       </label>
                     </>
                   ) : null}

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -1323,7 +1323,7 @@ export function CAMPanel({
                           })
                         }}
                       />
-                      <OperationParameterReference kind="pattern" />
+                      <OperationParameterReference kind="pattern" variant={selectedOperation.pocketPattern} />
                     </label>
                   ) : null}
                   {selectedOperation.kind === 'finish_surface' ? (
@@ -1337,7 +1337,7 @@ export function CAMPanel({
                         ]}
                         onChange={(value) => updateOperation(selectedOperation.id, { pocketPattern: value })}
                       />
-                      <OperationParameterReference kind="pattern" />
+                      <OperationParameterReference kind="pattern" variant={selectedOperation.pocketPattern} />
                     </label>
                   ) : null}
                   {selectedOperation.kind === 'finish_surface_cleanup' ? (
@@ -1351,7 +1351,7 @@ export function CAMPanel({
                         ]}
                         onChange={(value) => updateOperation(selectedOperation.id, { pocketPattern: value })}
                       />
-                      <OperationParameterReference kind="pattern" />
+                      <OperationParameterReference kind="pattern" variant={selectedOperation.pocketPattern} />
                     </label>
                   ) : null}
                   {(selectedOperation.kind === 'pocket' || selectedOperation.kind === 'surface_clean' || selectedOperation.kind === 'finish_surface' || selectedOperation.kind === 'finish_surface_cleanup') && selectedOperation.pocketPattern === 'parallel' ? (
@@ -1375,7 +1375,7 @@ export function CAMPanel({
                         ]}
                         onChange={(value) => updateOperation(selectedOperation.id, { cutDirection: value })}
                       />
-                      <OperationParameterReference kind="cutDirection" />
+                      <OperationParameterReference kind="cutDirection" variant={selectedOperation.cutDirection ?? 'conventional'} />
                     </label>
                   ) : null}
                   {(selectedOperation.kind === 'pocket'
@@ -1391,7 +1391,7 @@ export function CAMPanel({
                         ]}
                         onChange={(value) => updateOperation(selectedOperation.id, { machiningOrder: value })}
                       />
-                      <OperationParameterReference kind="machiningOrder" />
+                      <OperationParameterReference kind="machiningOrder" variant={selectedOperation.machiningOrder ?? 'level_first'} />
                     </label>
                   ) : null}
                   {selectedOperation.kind === 'drilling' ? (
@@ -1408,7 +1408,7 @@ export function CAMPanel({
                           ]}
                           onChange={(value) => updateOperation(selectedOperation.id, { drillType: value })}
                         />
-                        <OperationParameterReference kind="drillType" />
+                        <OperationParameterReference kind="drillType" variant={selectedOperation.drillType ?? 'simple'} />
                       </label>
                       {(selectedOperation.drillType === 'peck' || selectedOperation.drillType === 'chip_breaking') ? (
                         <label className="properties-field">

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -1455,6 +1455,7 @@ export function CAMPanel({
                           onChange={(event) => updateOperation(selectedOperation.id, { finishWalls: event.target.checked })}
                         />
                         <span>Finish Walls</span>
+                        <OperationParameterReference kind="finishWalls" />
                       </label>
                       <label className="properties-check">
                         <input
@@ -1463,6 +1464,7 @@ export function CAMPanel({
                           onChange={(event) => updateOperation(selectedOperation.id, { finishFloor: event.target.checked })}
                         />
                         <span>Finish Floor</span>
+                        <OperationParameterReference kind="finishFloor" />
                       </label>
                     </>
                   ) : null}
@@ -1585,6 +1587,7 @@ export function CAMPanel({
                               }}
                             />
                             <span>Adaptive refinement</span>
+                            <OperationParameterReference kind="adaptiveRefinement" />
                           </label>
                           {(selectedOperation.waterlineAdaptiveRefinement ?? true) ? (
                             <>

--- a/src/components/cam/OperationParameterReference.test.ts
+++ b/src/components/cam/OperationParameterReference.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for OperationParameterReference pure data.
+ *
+ * Run with: npx tsx src/components/cam/OperationParameterReference.test.ts
+ */
+
+import { OPERATION_PARAM_REF_KINDS, operationParamRefLabel } from './operationParamRefData'
+import type { OperationParamRefKind } from './operationParamRefData'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function testNoDuplicateKinds(): void {
+  const seen = new Set<string>()
+  for (const kind of OPERATION_PARAM_REF_KINDS) {
+    assert(!seen.has(kind), `duplicate kind: ${kind}`)
+    seen.add(kind)
+  }
+}
+
+function testAllKindsHaveNonEmptyLabel(): void {
+  for (const kind of OPERATION_PARAM_REF_KINDS) {
+    const label = operationParamRefLabel(kind as OperationParamRefKind)
+    assert(typeof label === 'string' && label.length > 0, `empty label for kind: ${kind}`)
+  }
+}
+
+function testAllLabelsAreUnique(): void {
+  const labels = new Set<string>()
+  for (const kind of OPERATION_PARAM_REF_KINDS) {
+    const label = operationParamRefLabel(kind as OperationParamRefKind)
+    assert(!labels.has(label), `duplicate label for kind ${kind}: ${label}`)
+    labels.add(label)
+  }
+}
+
+function testLabelRecordIsExhaustive(): void {
+  // TypeScript verifies exhaustiveness at compile time; this is a runtime
+  // sanity check that every kind in the array has a corresponding label entry.
+  assert(OPERATION_PARAM_REF_KINDS.length === 22, `expected 22 kinds, got ${OPERATION_PARAM_REF_KINDS.length}`)
+}
+
+testNoDuplicateKinds()
+testAllKindsHaveNonEmptyLabel()
+testAllLabelsAreUnique()
+testLabelRecordIsExhaustive()
+
+console.log('OperationParameterReference tests passed')

--- a/src/components/cam/OperationParameterReference.test.ts
+++ b/src/components/cam/OperationParameterReference.test.ts
@@ -15,13 +15,24 @@
  */
 
 /**
- * Tests for OperationParameterReference pure data.
+ * Tests for OperationParameterReference: the pure kind/label data plus a
+ * render check that every exported kind actually produces an SVG diagram.
  *
  * Run with: npx tsx src/components/cam/OperationParameterReference.test.ts
  */
 
+import * as React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { OperationParameterReference } from './OperationParameterReference'
 import { OPERATION_PARAM_REF_KINDS, operationParamRefLabel } from './operationParamRefData'
 import type { OperationParamRefKind } from './operationParamRefData'
+
+// The component is authored with the automatic JSX runtime (like the app), but
+// the standalone test runner (tsx) transpiles this file with the classic
+// runtime, which expects a global `React`. Provide it so renderToStaticMarkup
+// can invoke the component. Harmless if a runner ever uses the automatic runtime.
+const globalWithReact = globalThis as typeof globalThis & { React?: typeof React }
+globalWithReact.React = React
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
@@ -37,7 +48,7 @@ function testNoDuplicateKinds(): void {
 
 function testAllKindsHaveNonEmptyLabel(): void {
   for (const kind of OPERATION_PARAM_REF_KINDS) {
-    const label = operationParamRefLabel(kind as OperationParamRefKind)
+    const label = operationParamRefLabel(kind)
     assert(typeof label === 'string' && label.length > 0, `empty label for kind: ${kind}`)
   }
 }
@@ -45,21 +56,57 @@ function testAllKindsHaveNonEmptyLabel(): void {
 function testAllLabelsAreUnique(): void {
   const labels = new Set<string>()
   for (const kind of OPERATION_PARAM_REF_KINDS) {
-    const label = operationParamRefLabel(kind as OperationParamRefKind)
+    const label = operationParamRefLabel(kind)
     assert(!labels.has(label), `duplicate label for kind ${kind}: ${label}`)
     labels.add(label)
   }
 }
 
-function testLabelRecordIsExhaustive(): void {
-  // TypeScript verifies exhaustiveness at compile time; this is a runtime
-  // sanity check that every kind in the array has a corresponding label entry.
-  assert(OPERATION_PARAM_REF_KINDS.length === 22, `expected 22 kinds, got ${OPERATION_PARAM_REF_KINDS.length}`)
+function renderKind(kind: OperationParamRefKind, variant?: string): string {
+  return renderToStaticMarkup(React.createElement(OperationParameterReference, { kind, variant }))
+}
+
+// Every exported kind must render an accessible SVG diagram. This is what
+// catches a kind that is listed but has no `case` in the component switch.
+function testEveryKindRendersSvg(): void {
+  assert(OPERATION_PARAM_REF_KINDS.length > 0, 'kind list is empty')
+  for (const kind of OPERATION_PARAM_REF_KINDS) {
+    const html = renderKind(kind)
+    assert(html.includes('<svg'), `kind ${kind} did not render an <svg>`)
+    assert(html.includes('class="op-param-ref"'), `kind ${kind} missing the op-param-ref frame`)
+    assert(html.includes(`aria-label="${operationParamRefLabel(kind)}"`), `kind ${kind} aria-label mismatch`)
+    assert(
+      html.includes('<path') || html.includes('<circle') || html.includes('<rect'),
+      `kind ${kind} rendered no geometry`,
+    )
+  }
+}
+
+// Dropdown-backed kinds must render for every real option value (each branch of
+// the value-aware switch produces geometry).
+function testVariantKindsRenderEveryOption(): void {
+  const cases: Array<[OperationParamRefKind, readonly string[]]> = [
+    ['pattern', ['offset', 'parallel', 'waterline']],
+    ['cutDirection', ['conventional', 'climb']],
+    ['machiningOrder', ['level_first', 'feature_first']],
+    ['drillType', ['simple', 'peck', 'dwell', 'chip_breaking']],
+  ]
+  for (const [kind, variants] of cases) {
+    for (const variant of variants) {
+      const html = renderKind(kind, variant)
+      assert(html.includes('<svg'), `kind ${kind} variant ${variant} did not render an <svg>`)
+      assert(
+        html.includes('gear-reference__accent'),
+        `kind ${kind} variant ${variant} rendered no accent geometry`,
+      )
+    }
+  }
 }
 
 testNoDuplicateKinds()
 testAllKindsHaveNonEmptyLabel()
 testAllLabelsAreUnique()
-testLabelRecordIsExhaustive()
+testEveryKindRendersSvg()
+testVariantKindsRenderEveryOption()
 
 console.log('OperationParameterReference tests passed')

--- a/src/components/cam/OperationParameterReference.tsx
+++ b/src/components/cam/OperationParameterReference.tsx
@@ -17,6 +17,8 @@
 import type { ReactNode } from 'react'
 import { type OperationParamRefKind, operationParamRefLabel } from './operationParamRefData'
 
+// All diagrams are drawn on a shared 58×34 stage and normalized to fill roughly
+// x∈[6,52], y∈[5,29] so every icon carries a consistent visual weight.
 function OpParamRefFrame({
   children,
   label,
@@ -59,61 +61,62 @@ export function OperationParameterReference({
     case 'stepdown':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M10 6H48V28H10Z" />
-          <path className="gear-reference__guide" d="M10 13H48M10 20H48" />
-          <path className="gear-reference__accent" d="M44 7V12" />
-          <path className="gear-reference__accent-fill" d="M44 6l-2.2 3h4.4zM44 13l-2.2-3h4.4z" />
+          <path className="gear-reference__outline" d="M6 5H52V29H6Z" />
+          <path className="gear-reference__guide" d="M6 13H52M6 21H52" />
+          <path className="gear-reference__accent" d="M47 6V12" />
+          <path className="gear-reference__accent-fill" d="M47 5l-2.4 3.3h4.8zM47 13l-2.4-3.3h4.8z" />
         </OpParamRefFrame>
       )
 
     case 'stepover':
       return (
         <OpParamRefFrame label={label}>
-          <circle className="gear-reference__guide" cx="18" cy="17" r="6" />
-          <circle className="gear-reference__outline" cx="32" cy="17" r="6" />
-          <circle className="gear-reference__outline" cx="18" cy="17" r="6" />
-          <path className="gear-reference__accent" d="M24 17h8" />
-          <path className="gear-reference__accent-fill" d="M23 17l3-2.2v4.4zM33 17l-3-2.2v4.4z" />
+          <circle className="gear-reference__guide" cx="20" cy="17" r="10" />
+          <circle className="gear-reference__outline" cx="38" cy="17" r="10" />
+          <circle className="gear-reference__outline" cx="20" cy="17" r="10" />
+          <path className="gear-reference__accent" d="M24 17h10" />
+          <path className="gear-reference__accent-fill" d="M20 17l3.3-2.4v4.8zM38 17l-3.3-2.4v4.8z" />
         </OpParamRefFrame>
       )
 
     case 'maxDepth':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M10 6H48V28H10Z" />
-          <path className="gear-reference__guide" d="M10 10H48" />
-          <path className="gear-reference__accent" d="M44 6v22" />
-          <path className="gear-reference__accent-fill" d="M44 4l-2.5 3.5h5zM44 30l-2.5-3.5h5z" />
+          <path className="gear-reference__outline" d="M6 6H52V28H6Z" />
+          <path className="gear-reference__guide" d="M6 10H52" />
+          <path className="gear-reference__accent" d="M47 6v22" />
+          <path className="gear-reference__accent-fill" d="M47 4l-2.6 3.6h5.2zM47 30l-2.6-3.6h5.2z" />
         </OpParamRefFrame>
       )
 
     case 'retractHeight':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M10 18H48V28H10Z" />
-          <path className="gear-reference__guide" d="M10 6h38" strokeDasharray="2 2" />
-          <path className="gear-reference__accent" d="M44 7v11" />
-          <path className="gear-reference__accent-fill" d="M44 5l-2.5 3.5h5zM44 19l-2.5-3.5h5z" />
+          <path className="gear-reference__outline" d="M6 20H52V28H6Z" />
+          <path className="gear-reference__guide" d="M6 6h46" strokeDasharray="2 2" />
+          <path className="gear-reference__accent" d="M47 7v12" />
+          <path className="gear-reference__accent-fill" d="M47 5l-2.6 3.6h5.2zM47 20l-2.6-3.6h5.2z" />
         </OpParamRefFrame>
       )
 
     case 'peckDepth':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M24 4v26h-4V4h4zM25 30h-6v-2h6zM25 4h-6V2h6z" />
-          <path className="gear-reference__guide" d="M40 5h8M40 11h8M40 17h8M40 23h8" />
-          <path className="gear-reference__accent" d="M44 18v5" />
-          <path className="gear-reference__accent-fill" d="M44 17l-2.2 3h4.4zM44 24l-2.2-3h4.4z" />
+          <path className="gear-reference__outline" d="M18 5v23M40 5v23" />
+          <path className="gear-reference__guide" d="M18 5h22" />
+          <path className="gear-reference__guide" d="M18 13h22M18 21h22" />
+          <path className="gear-reference__accent" d="M29 6v6" />
+          <path className="gear-reference__accent-fill" d="M29 5l-2.2 3h4.4zM29 13l-2.2-3h4.4z" />
         </OpParamRefFrame>
       )
 
     case 'feed':
       return (
         <OpParamRefFrame label={label}>
-          <circle className="gear-reference__outline" cx="20" cy="17" r="7" />
-          <path className="gear-reference__guide" d="M10 27h38" />
-          <path className="gear-reference__accent" d="M27 17h15" />
-          <path className="gear-reference__accent-fill" d="M43 17l-4.5-2.6v5.2z" />
+          <circle className="gear-reference__outline" cx="17" cy="17" r="9" />
+          <path className="gear-reference__guide" d="M6 28h46" />
+          <path className="gear-reference__accent" d="M28 17h20" />
+          <path className="gear-reference__accent-fill" d="M50 17l-5-3v6z" />
         </OpParamRefFrame>
       )
 
@@ -121,42 +124,43 @@ export function OperationParameterReference({
       // An endmill (tool) plunging straight down into the stock.
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M8 24H50V30H8Z" />
-          <path className="gear-reference__outline" d="M24 5h10v13h-10z" />
-          <path className="gear-reference__guide" d="M27 7v9M31 7v9" />
-          <path className="gear-reference__accent" d="M40 8v13" />
-          <path className="gear-reference__accent-fill" d="M40 23l-2.7-4.6h5.4z" />
+          <path className="gear-reference__outline" d="M6 24H52V30H6Z" />
+          <path className="gear-reference__outline" d="M22 4h12v15h-12z" />
+          <path className="gear-reference__guide" d="M26 6v12M30 6v12" />
+          <path className="gear-reference__accent" d="M44 6v15" />
+          <path className="gear-reference__accent-fill" d="M44 23l-3-5h6z" />
         </OpParamRefFrame>
       )
 
     case 'slotFeed':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__guide" d="M10 12v10h38V12z" />
-          <circle className="gear-reference__outline" cx="29" cy="17" r="6" />
-          <path className="gear-reference__accent" d="M37 17h7" />
-          <path className="gear-reference__accent-fill" d="M45 17l-4.5-2.6v5.2z" />
+          <path className="gear-reference__guide" d="M6 9v16h46V9z" />
+          <circle className="gear-reference__outline" cx="26" cy="17" r="8" />
+          <path className="gear-reference__accent" d="M35 17h13" />
+          <path className="gear-reference__accent-fill" d="M50 17l-5-3v6z" />
         </OpParamRefFrame>
       )
 
     case 'rpm':
       return (
         <OpParamRefFrame label={label}>
-          <circle className="gear-reference__outline" cx="29" cy="17" r="9" />
-          <path className="gear-reference__guide" d="M29 2v5M29 27v5M11 17h5M42 17h5" />
-          <path className="gear-reference__accent" d="M35 10A12 12 0 0 1 38 22" />
-          <path className="gear-reference__accent-fill" d="M39 23l-2.5-4.8 5 .5z" />
+          <circle className="gear-reference__outline" cx="28" cy="17" r="11" />
+          <path className="gear-reference__guide" d="M28 3v4M28 27v4M13 17h4M39 17h4" />
+          <path className="gear-reference__accent" d="M37 8A13 13 0 0 1 40 23" />
+          <path className="gear-reference__accent-fill" d="M41 24l-2.4-5 5 .2z" />
         </OpParamRefFrame>
       )
 
     case 'dwell':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M24 4v10h-4V4h4zM25 14h-6v-2h6zM25 4h-6V2h6z" />
-          <path className="gear-reference__guide" d="M10 28h38" />
-          <path className="gear-reference__accent" d="M33 14A6 6 0 0 1 44 14" />
-          <path className="gear-reference__accent-fill" d="M33 14l-2.5 5 5-.5z" />
-          <circle className="gear-reference__accent-fill" cx="44" cy="14" r="1.5" />
+          <path className="gear-reference__outline" d="M18 5v20M38 5v20" />
+          <path className="gear-reference__guide" d="M18 5h20" />
+          <path className="gear-reference__accent" d="M28 6v16" />
+          <path className="gear-reference__accent-fill" d="M28 24l-2.6-4.5h5.2z" />
+          <circle className="gear-reference__accent" cx="46" cy="11" r="4.5" />
+          <path className="gear-reference__accent" d="M46 11v-3M46 11l2.2 1.3" />
         </OpParamRefFrame>
       )
 
@@ -164,16 +168,16 @@ export function OperationParameterReference({
       const climb = variant === 'climb'
       return (
         <OpParamRefFrame label={label}>
-          <rect className="gear-reference__outline" x="19" y="11" width="20" height="14" rx="2" />
+          <rect className="gear-reference__outline" x="13" y="10" width="32" height="18" rx="2" />
           {climb ? (
             <>
-              <path className="gear-reference__accent" d="M37 7H21" />
-              <path className="gear-reference__accent-fill" d="M21 7l4-2.4v4.8z" />
+              <path className="gear-reference__accent" d="M40 6H18" />
+              <path className="gear-reference__accent-fill" d="M18 6l4.5-2.7v5.4z" />
             </>
           ) : (
             <>
-              <path className="gear-reference__accent" d="M21 7h16" />
-              <path className="gear-reference__accent-fill" d="M37 7l-4-2.4v4.8z" />
+              <path className="gear-reference__accent" d="M18 6h22" />
+              <path className="gear-reference__accent-fill" d="M40 6l-4.5-2.7v5.4z" />
             </>
           )}
         </OpParamRefFrame>
@@ -184,28 +188,28 @@ export function OperationParameterReference({
       if (variant === 'parallel') {
         return (
           <OpParamRefFrame label={label}>
-            <path className="gear-reference__outline" d="M10 6h38v22H10z" />
-            <path className="gear-reference__accent" d="M14 11h30M14 17h30M14 23h30" />
-            <path className="gear-reference__guide" d="M44 11v6M14 17v6" />
+            <path className="gear-reference__outline" d="M6 5h46v24H6z" />
+            <path className="gear-reference__accent" d="M11 10h36M11 17h36M11 24h36" />
+            <path className="gear-reference__guide" d="M47 10v7M11 17v7" />
           </OpParamRefFrame>
         )
       }
       if (variant === 'waterline') {
         return (
           <OpParamRefFrame label={label}>
-            <path className="gear-reference__outline" d="M10 6h38v22H10z" />
-            <path className="gear-reference__accent" d="M29 17m-9 0a9 8 0 1 0 18 0a9 8 0 1 0-18 0" />
-            <path className="gear-reference__accent" d="M29 17m-5 0a5 4 0 1 0 10 0a5 4 0 1 0-10 0" />
-            <circle className="gear-reference__accent-fill" cx="29" cy="17" r="1.3" />
+            <path className="gear-reference__outline" d="M6 5h46v24H6z" />
+            <path className="gear-reference__accent" d="M29 17m-11 0a11 9 0 1 0 22 0a11 9 0 1 0-22 0" />
+            <path className="gear-reference__accent" d="M29 17m-6 0a6 5 0 1 0 12 0a6 5 0 1 0-12 0" />
+            <circle className="gear-reference__accent-fill" cx="29" cy="17" r="1.5" />
           </OpParamRefFrame>
         )
       }
       // offset (default)
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M10 6h38v22H10z" />
-          <path className="gear-reference__accent" d="M15 11h28v12H15z" />
-          <path className="gear-reference__guide" d="M21 15h16v4H21z" />
+          <path className="gear-reference__outline" d="M6 5h46v24H6z" />
+          <path className="gear-reference__accent" d="M12 10h34v14H12z" />
+          <path className="gear-reference__guide" d="M20 15h18v4H20z" />
         </OpParamRefFrame>
       )
     }
@@ -214,21 +218,21 @@ export function OperationParameterReference({
       const featureFirst = variant === 'feature_first'
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__guide" d="M14 9h12v16H14zM32 9h12v16H32z" />
-          <path className="gear-reference__guide" d="M14 17h12M32 17h12" />
+          <path className="gear-reference__guide" d="M8 6h19v22H8zM31 6h19v22H31z" />
+          <path className="gear-reference__guide" d="M8 17h19M31 17h19" />
           {featureFirst ? (
             <>
-              <path className="gear-reference__accent" d="M20 11v9" />
-              <path className="gear-reference__accent-fill" d="M20 22l-2-3.5h4z" />
-              <path className="gear-reference__accent" d="M27 14h5" />
-              <path className="gear-reference__accent-fill" d="M33 14l-3-2v4z" />
+              <path className="gear-reference__accent" d="M17 9v9" />
+              <path className="gear-reference__accent-fill" d="M17 20l-2.4-4.2h4.8z" />
+              <path className="gear-reference__accent" d="M28 13h5" />
+              <path className="gear-reference__accent-fill" d="M34 13l-3.5-2.2v4.4z" />
             </>
           ) : (
             <>
-              <path className="gear-reference__accent" d="M15 13h26" />
-              <path className="gear-reference__accent-fill" d="M43 13l-3-2v4z" />
-              <path className="gear-reference__accent" d="M15 21h26" />
-              <path className="gear-reference__accent-fill" d="M43 21l-3-2v4z" />
+              <path className="gear-reference__accent" d="M11 12h27" />
+              <path className="gear-reference__accent-fill" d="M41 12l-3.5-2.2v4.4z" />
+              <path className="gear-reference__accent" d="M11 22h27" />
+              <path className="gear-reference__accent-fill" d="M41 22l-3.5-2.2v4.4z" />
             </>
           )}
         </OpParamRefFrame>
@@ -238,99 +242,98 @@ export function OperationParameterReference({
     case 'rasterAngle':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M10 6h38v22H10z" />
-          <path className="gear-reference__guide" d="M10 17h38" />
-          <path className="gear-reference__accent" d="M18 25l14-16M23 25l14-16M28 25l14-16" />
-          <path className="gear-reference__accent-fill" d="M39 20l-1-2 2-.5z" />
+          <path className="gear-reference__outline" d="M6 5h46v24H6z" />
+          <path className="gear-reference__guide" d="M6 17h46" />
+          <path className="gear-reference__accent" d="M13 27l17-21M22 27l17-21M31 27l17-21" />
+          <path className="gear-reference__accent-fill" d="M46 8l-1.6-2.6 3.1-.5z" />
         </OpParamRefFrame>
       )
 
     case 'finishWalls':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__guide" d="M10 8h38v18H10z" />
-          <path className="gear-reference__guide" d="M12 17h34" />
-          <path className="gear-reference__accent" d="M10 8v18M48 8v18" />
+          <path className="gear-reference__guide" d="M6 6h46v22H6z" />
+          <path className="gear-reference__guide" d="M9 17h40" />
+          <path className="gear-reference__accent" d="M6 6v22M52 6v22" />
         </OpParamRefFrame>
       )
 
     case 'finishFloor':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__guide" d="M10 8h38v18H10z" />
-          <path className="gear-reference__guide" d="M10 10v14M48 10v14" />
-          <path className="gear-reference__accent" d="M11 26h36" />
+          <path className="gear-reference__guide" d="M6 6h46v22H6z" />
+          <path className="gear-reference__guide" d="M6 9v16M52 9v16" />
+          <path className="gear-reference__accent" d="M8 28h44" />
         </OpParamRefFrame>
       )
 
     case 'stockRadial':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__guide" d="M14 10h30v14H14z" />
-          <path className="gear-reference__outline" d="M18 14h22v6H18z" />
-          <path className="gear-reference__accent" d="M40 17h5" />
-          <path className="gear-reference__accent-fill" d="M39 17l3-2.2v4.4zM46 17l-3-2.2v4.4z" />
+          <path className="gear-reference__guide" d="M8 7h42v20H8z" />
+          <path className="gear-reference__outline" d="M14 12h24v10H14z" />
+          <path className="gear-reference__accent" d="M39 17h10" />
+          <path className="gear-reference__accent-fill" d="M38 17l3-2.2v4.4zM50 17l-3-2.2v4.4z" />
         </OpParamRefFrame>
       )
 
     case 'stockAxial':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M10 6H48V28H10Z" />
-          <path className="gear-reference__guide" d="M10 22h38" />
-          <path className="gear-reference__accent" d="M12 22h36" />
-          <path className="gear-reference__accent-fill" d="M44 22l-2.2 3h4.4zM44 28l-2.2-3h4.4z" />
-          <path className="gear-reference__guide" d="M44 23v4" />
+          <path className="gear-reference__outline" d="M6 5H52V29H6Z" />
+          <path className="gear-reference__guide" d="M6 22H52" />
+          <path className="gear-reference__accent" d="M10 25.5h34" />
+          <path className="gear-reference__accent" d="M47 22v7" />
+          <path className="gear-reference__accent-fill" d="M47 22l-2 3h4zM47 29l-2-3h4z" />
         </OpParamRefFrame>
       )
 
     case 'adaptiveSpacing':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__guide" d="M29 17m-6 0a6 6 0 1 0 12 0a6 6 0 1 0-12 0" />
-          <path className="gear-reference__guide" d="M29 17m-2 0a2 2 0 1 0 4 0a2 2 0 1 0-4 0" />
-          <path className="gear-reference__outline" d="M29 17m-4 0a4 4 0 1 0 8 0a4 4 0 1 0-8 0" />
-          <path className="gear-reference__accent" d="M31 13v3" />
-          <path className="gear-reference__accent-fill" d="M31 12l-2.2 3h4.4zM31 17l-2.2-3h4.4z" />
+          <path className="gear-reference__guide" d="M29 17m-11 0a11 10 0 1 0 22 0a11 10 0 1 0-22 0" />
+          <path className="gear-reference__outline" d="M29 17m-7 0a7 6 0 1 0 14 0a7 6 0 1 0-14 0" />
+          <path className="gear-reference__guide" d="M29 17m-3 0a3 3 0 1 0 6 0a3 3 0 1 0-6 0" />
+          <path className="gear-reference__accent" d="M31 5v7" />
+          <path className="gear-reference__accent-fill" d="M31 4l-2.2 3h4.4zM31 13l-2.2-3h4.4z" />
         </OpParamRefFrame>
       )
 
     case 'adaptiveRefinement':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__guide" d="M10 26L29 8L48 26" />
-          <path className="gear-reference__outline" d="M29 8l4 4.5M25 8l3 4.5M21 8l4.5 4.5M33 8l2.5 4.5M17 8l4 4.5" />
-          <path className="gear-reference__guide" d="M10 26h38" />
-          <path className="gear-reference__accent" d="M14 26l3-4.5M18 26l2.5-4.5M22 26l3-4.5M26 26l2.5-4.5" />
-          <path className="gear-reference__accent" d="M30 26l2-4M34 26l2.5-4M38 26l3-4M42 26l2.5-4" />
+          <path className="gear-reference__guide" d="M6 29L29 6L52 29" />
+          <path className="gear-reference__guide" d="M6 29h46" />
+          <path className="gear-reference__accent" d="M12 29l4.5-6.5M17 29l4-6.5M22 29l4.5-6.5M27 29l4-6.5" />
+          <path className="gear-reference__accent" d="M31 29l4-6.5M36 29l4.5-6.5M41 29l4-6.5M46 29l4.5-6.5" />
         </OpParamRefFrame>
       )
 
     case 'maxRings':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__guide" d="M29 17m-9 0a9 9 0 1 0 18 0a9 9 0 1 0-18 0" />
-          <path className="gear-reference__guide" d="M29 17m-5 0a5 5 0 1 0 10 0a5 5 0 1 0-10 0" />
-          <path className="gear-reference__guide" d="M29 17m-1 0a1 1 0 1 0 2 0a1 1 0 1 0-2 0" />
-          <path className="gear-reference__accent" d="M24 10c-2.5 2.5-2.5 8 0 12" />
-          <path className="gear-reference__accent" d="M34 10c2.5 2.5 2.5 8 0 12" />
-          <path className="gear-reference__accent-fill" d="M24 9l-2.5 3.5h5z" />
+          <path className="gear-reference__guide" d="M29 17m-12 0a12 11 0 1 0 24 0a12 11 0 1 0-24 0" />
+          <path className="gear-reference__guide" d="M29 17m-7.5 0a7.5 6.5 0 1 0 15 0a7.5 6.5 0 1 0-15 0" />
+          <path className="gear-reference__guide" d="M29 17m-3 0a3 2.5 0 1 0 6 0a3 2.5 0 1 0-6 0" />
+          <path className="gear-reference__accent" d="M21 6c-3.5 3-3.5 19 0 22" />
+          <path className="gear-reference__accent" d="M37 6c3.5 3 3.5 19 0 22" />
+          <path className="gear-reference__accent-fill" d="M21 5l-2.6 3.6h5.2z" />
         </OpParamRefFrame>
       )
 
     case 'drillType': {
       const hole = (
         <>
-          <path className="gear-reference__outline" d="M22 8v18M36 8v18" />
-          <path className="gear-reference__guide" d="M22 8h14" />
+          <path className="gear-reference__outline" d="M18 4v24M40 4v24" />
+          <path className="gear-reference__guide" d="M18 4h22" />
         </>
       )
       if (variant === 'peck') {
         return (
           <OpParamRefFrame label={label}>
             {hole}
-            <path className="gear-reference__accent" d="M29 9v4M29 15v4M29 21v3" />
-            <path className="gear-reference__accent-fill" d="M29 25l-2.4-4.2h4.8z" />
+            <path className="gear-reference__accent" d="M29 5v5M29 12v5M29 19v4" />
+            <path className="gear-reference__accent-fill" d="M29 26l-2.6-4.5h5.2z" />
           </OpParamRefFrame>
         )
       }
@@ -338,8 +341,8 @@ export function OperationParameterReference({
         return (
           <OpParamRefFrame label={label}>
             {hole}
-            <path className="gear-reference__accent" d="M29 9v3M29 13.5v2.5M29 17.5v2.5M29 21.5v2.5" />
-            <path className="gear-reference__accent-fill" d="M29 25l-2.4-4.2h4.8z" />
+            <path className="gear-reference__accent" d="M29 5v4M29 11v3M29 16v3M29 21v3" />
+            <path className="gear-reference__accent-fill" d="M29 26l-2.6-4.5h5.2z" />
           </OpParamRefFrame>
         )
       }
@@ -347,10 +350,10 @@ export function OperationParameterReference({
         return (
           <OpParamRefFrame label={label}>
             {hole}
-            <path className="gear-reference__accent" d="M29 9v12" />
-            <path className="gear-reference__accent-fill" d="M29 25l-2.4-4.2h4.8z" />
-            <circle className="gear-reference__accent" cx="40" cy="22" r="3" />
-            <path className="gear-reference__accent" d="M40 22v-2" />
+            <path className="gear-reference__accent" d="M29 5v16" />
+            <path className="gear-reference__accent-fill" d="M29 26l-2.6-4.5h5.2z" />
+            <circle className="gear-reference__accent" cx="46" cy="10" r="4.5" />
+            <path className="gear-reference__accent" d="M46 10v-3M46 10l2.2 1.3" />
           </OpParamRefFrame>
         )
       }
@@ -358,8 +361,8 @@ export function OperationParameterReference({
       return (
         <OpParamRefFrame label={label}>
           {hole}
-          <path className="gear-reference__accent" d="M29 9v15" />
-          <path className="gear-reference__accent-fill" d="M29 25l-2.4-4.2h4.8z" />
+          <path className="gear-reference__accent" d="M29 5v16" />
+          <path className="gear-reference__accent-fill" d="M29 26l-2.6-4.5h5.2z" />
         </OpParamRefFrame>
       )
     }

--- a/src/components/cam/OperationParameterReference.tsx
+++ b/src/components/cam/OperationParameterReference.tsx
@@ -37,7 +37,22 @@ function OpParamRefFrame({
   )
 }
 
-export function OperationParameterReference({ kind }: { kind: OperationParamRefKind }) {
+/**
+ * Small schematic reference diagram for an operation parameter, shown in the
+ * third column of the operation properties panel. Mirrors the gear creation
+ * reference column and reuses its `gear-reference__*` SVG element classes.
+ *
+ * For parameters backed by a dropdown, pass the current selection as `variant`
+ * so the diagram reflects the chosen value (e.g. offset vs parallel pattern,
+ * climb vs conventional cut direction).
+ */
+export function OperationParameterReference({
+  kind,
+  variant,
+}: {
+  kind: OperationParamRefKind
+  variant?: string
+}) {
   const label = operationParamRefLabel(kind)
 
   switch (kind) {
@@ -103,13 +118,14 @@ export function OperationParameterReference({ kind }: { kind: OperationParamRefK
       )
 
     case 'plungeFeed':
+      // An endmill (tool) plunging straight down into the stock.
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M10 22H48V28H10Z" />
-          <circle className="gear-reference__guide" cx="29" cy="12" r="5" />
-          <path className="gear-reference__guide" d="M25 17h8" />
-          <path className="gear-reference__accent" d="M29 17v5" />
-          <path className="gear-reference__accent-fill" d="M29 23l-2.6-4.5h5.2z" />
+          <path className="gear-reference__outline" d="M8 24H50V30H8Z" />
+          <path className="gear-reference__outline" d="M24 5h10v13h-10z" />
+          <path className="gear-reference__guide" d="M27 7v9M31 7v9" />
+          <path className="gear-reference__accent" d="M40 8v13" />
+          <path className="gear-reference__accent-fill" d="M40 23l-2.7-4.6h5.4z" />
         </OpParamRefFrame>
       )
 
@@ -144,33 +160,80 @@ export function OperationParameterReference({ kind }: { kind: OperationParamRefK
         </OpParamRefFrame>
       )
 
-    case 'cutDirection':
+    case 'cutDirection': {
+      const climb = variant === 'climb'
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M12 10h34v14H12z" />
-          <path className="gear-reference__accent" d="M18 24h22" />
-          <path className="gear-reference__accent-fill" d="M41 24l-4.5-2.6v5.2z" />
-          <path className="gear-reference__guide" d="M28 17v-3a4 4 0 0 0-3-4" />
+          <rect className="gear-reference__outline" x="19" y="11" width="20" height="14" rx="2" />
+          {climb ? (
+            <>
+              <path className="gear-reference__accent" d="M37 7H21" />
+              <path className="gear-reference__accent-fill" d="M21 7l4-2.4v4.8z" />
+            </>
+          ) : (
+            <>
+              <path className="gear-reference__accent" d="M21 7h16" />
+              <path className="gear-reference__accent-fill" d="M37 7l-4-2.4v4.8z" />
+            </>
+          )}
         </OpParamRefFrame>
       )
+    }
 
-    case 'pattern':
+    case 'pattern': {
+      if (variant === 'parallel') {
+        return (
+          <OpParamRefFrame label={label}>
+            <path className="gear-reference__outline" d="M10 6h38v22H10z" />
+            <path className="gear-reference__accent" d="M14 11h30M14 17h30M14 23h30" />
+            <path className="gear-reference__guide" d="M44 11v6M14 17v6" />
+          </OpParamRefFrame>
+        )
+      }
+      if (variant === 'waterline') {
+        return (
+          <OpParamRefFrame label={label}>
+            <path className="gear-reference__outline" d="M10 6h38v22H10z" />
+            <path className="gear-reference__accent" d="M29 17m-9 0a9 8 0 1 0 18 0a9 8 0 1 0-18 0" />
+            <path className="gear-reference__accent" d="M29 17m-5 0a5 4 0 1 0 10 0a5 4 0 1 0-10 0" />
+            <circle className="gear-reference__accent-fill" cx="29" cy="17" r="1.3" />
+          </OpParamRefFrame>
+        )
+      }
+      // offset (default)
       return (
         <OpParamRefFrame label={label}>
           <path className="gear-reference__outline" d="M10 6h38v22H10z" />
-          <path className="gear-reference__accent" d="M29 17m-3 0a3 3 0 1 0 6 0a3 3 0 1 0-6 0" />
-          <path className="gear-reference__guide" d="M29 17m-8 0a8 8 0 1 0 16 0a8 8 0 1 0-16 0" />
+          <path className="gear-reference__accent" d="M15 11h28v12H15z" />
+          <path className="gear-reference__guide" d="M21 15h16v4H21z" />
         </OpParamRefFrame>
       )
+    }
 
-    case 'machiningOrder':
+    case 'machiningOrder': {
+      const featureFirst = variant === 'feature_first'
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__guide" d="M14 10h10v14H14zM24 10h10v14H24zM34 10h10v14H34z" />
-          <path className="gear-reference__accent" d="M19 17l5-3v6zM25 13l5 3-5 3" />
-          <path className="gear-reference__accent-fill" d="M31 11l-2.5 3.5h5z" />
+          <path className="gear-reference__guide" d="M14 9h12v16H14zM32 9h12v16H32z" />
+          <path className="gear-reference__guide" d="M14 17h12M32 17h12" />
+          {featureFirst ? (
+            <>
+              <path className="gear-reference__accent" d="M20 11v9" />
+              <path className="gear-reference__accent-fill" d="M20 22l-2-3.5h4z" />
+              <path className="gear-reference__accent" d="M27 14h5" />
+              <path className="gear-reference__accent-fill" d="M33 14l-3-2v4z" />
+            </>
+          ) : (
+            <>
+              <path className="gear-reference__accent" d="M15 13h26" />
+              <path className="gear-reference__accent-fill" d="M43 13l-3-2v4z" />
+              <path className="gear-reference__accent" d="M15 21h26" />
+              <path className="gear-reference__accent-fill" d="M43 21l-3-2v4z" />
+            </>
+          )}
         </OpParamRefFrame>
       )
+    }
 
     case 'rasterAngle':
       return (
@@ -185,20 +248,18 @@ export function OperationParameterReference({ kind }: { kind: OperationParamRefK
     case 'finishWalls':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M10 8h38v18H10z" />
+          <path className="gear-reference__guide" d="M10 8h38v18H10z" />
           <path className="gear-reference__guide" d="M12 17h34" />
           <path className="gear-reference__accent" d="M10 8v18M48 8v18" />
-          <path className="gear-reference__accent" d="M10 8h38M10 26h38" />
         </OpParamRefFrame>
       )
 
     case 'finishFloor':
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M10 8h38v18H10z" />
+          <path className="gear-reference__guide" d="M10 8h38v18H10z" />
           <path className="gear-reference__guide" d="M10 10v14M48 10v14" />
-          <path className="gear-reference__accent" d="M12 26h34" />
-          <path className="gear-reference__accent" d="M12 8h34" />
+          <path className="gear-reference__accent" d="M11 26h36" />
         </OpParamRefFrame>
       )
 
@@ -257,15 +318,50 @@ export function OperationParameterReference({ kind }: { kind: OperationParamRefK
         </OpParamRefFrame>
       )
 
-    case 'drillType':
+    case 'drillType': {
+      const hole = (
+        <>
+          <path className="gear-reference__outline" d="M22 8v18M36 8v18" />
+          <path className="gear-reference__guide" d="M22 8h14" />
+        </>
+      )
+      if (variant === 'peck') {
+        return (
+          <OpParamRefFrame label={label}>
+            {hole}
+            <path className="gear-reference__accent" d="M29 9v4M29 15v4M29 21v3" />
+            <path className="gear-reference__accent-fill" d="M29 25l-2.4-4.2h4.8z" />
+          </OpParamRefFrame>
+        )
+      }
+      if (variant === 'chip_breaking') {
+        return (
+          <OpParamRefFrame label={label}>
+            {hole}
+            <path className="gear-reference__accent" d="M29 9v3M29 13.5v2.5M29 17.5v2.5M29 21.5v2.5" />
+            <path className="gear-reference__accent-fill" d="M29 25l-2.4-4.2h4.8z" />
+          </OpParamRefFrame>
+        )
+      }
+      if (variant === 'dwell') {
+        return (
+          <OpParamRefFrame label={label}>
+            {hole}
+            <path className="gear-reference__accent" d="M29 9v12" />
+            <path className="gear-reference__accent-fill" d="M29 25l-2.4-4.2h4.8z" />
+            <circle className="gear-reference__accent" cx="40" cy="22" r="3" />
+            <path className="gear-reference__accent" d="M40 22v-2" />
+          </OpParamRefFrame>
+        )
+      }
+      // simple (default)
       return (
         <OpParamRefFrame label={label}>
-          <path className="gear-reference__outline" d="M25 2h8v12h-8z" />
-          <path className="gear-reference__guide" d="M25 14l-4 8h16l-4-8" />
-          <path className="gear-reference__guide" d="M29 14v6" />
-          <path className="gear-reference__accent" d="M27 3v10M31 3v10" />
-          <path className="gear-reference__accent-fill" d="M29 22l-2.5-5h5z" />
+          {hole}
+          <path className="gear-reference__accent" d="M29 9v15" />
+          <path className="gear-reference__accent-fill" d="M29 25l-2.4-4.2h4.8z" />
         </OpParamRefFrame>
       )
+    }
   }
 }

--- a/src/components/cam/OperationParameterReference.tsx
+++ b/src/components/cam/OperationParameterReference.tsx
@@ -1,0 +1,271 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactNode } from 'react'
+import { type OperationParamRefKind, operationParamRefLabel } from './operationParamRefData'
+
+function OpParamRefFrame({
+  children,
+  label,
+}: {
+  children: ReactNode
+  label: string
+}) {
+  return (
+    <svg
+      className="op-param-ref"
+      viewBox="0 0 58 34"
+      role="img"
+      aria-label={label}
+      focusable="false"
+    >
+      {children}
+    </svg>
+  )
+}
+
+export function OperationParameterReference({ kind }: { kind: OperationParamRefKind }) {
+  const label = operationParamRefLabel(kind)
+
+  switch (kind) {
+    case 'stepdown':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M10 6H48V28H10Z" />
+          <path className="gear-reference__guide" d="M10 13H48M10 20H48" />
+          <path className="gear-reference__accent" d="M44 7V12" />
+          <path className="gear-reference__accent-fill" d="M44 6l-2.2 3h4.4zM44 13l-2.2-3h4.4z" />
+        </OpParamRefFrame>
+      )
+
+    case 'stepover':
+      return (
+        <OpParamRefFrame label={label}>
+          <circle className="gear-reference__guide" cx="18" cy="17" r="6" />
+          <circle className="gear-reference__outline" cx="32" cy="17" r="6" />
+          <circle className="gear-reference__outline" cx="18" cy="17" r="6" />
+          <path className="gear-reference__accent" d="M24 17h8" />
+          <path className="gear-reference__accent-fill" d="M23 17l3-2.2v4.4zM33 17l-3-2.2v4.4z" />
+        </OpParamRefFrame>
+      )
+
+    case 'maxDepth':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M10 6H48V28H10Z" />
+          <path className="gear-reference__guide" d="M10 10H48" />
+          <path className="gear-reference__accent" d="M44 6v22" />
+          <path className="gear-reference__accent-fill" d="M44 4l-2.5 3.5h5zM44 30l-2.5-3.5h5z" />
+        </OpParamRefFrame>
+      )
+
+    case 'retractHeight':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M10 18H48V28H10Z" />
+          <path className="gear-reference__guide" d="M10 6h38" strokeDasharray="2 2" />
+          <path className="gear-reference__accent" d="M44 7v11" />
+          <path className="gear-reference__accent-fill" d="M44 5l-2.5 3.5h5zM44 19l-2.5-3.5h5z" />
+        </OpParamRefFrame>
+      )
+
+    case 'peckDepth':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M24 4v26h-4V4h4zM25 30h-6v-2h6zM25 4h-6V2h6z" />
+          <path className="gear-reference__guide" d="M40 5h8M40 11h8M40 17h8M40 23h8" />
+          <path className="gear-reference__accent" d="M44 18v5" />
+          <path className="gear-reference__accent-fill" d="M44 17l-2.2 3h4.4zM44 24l-2.2-3h4.4z" />
+        </OpParamRefFrame>
+      )
+
+    case 'feed':
+      return (
+        <OpParamRefFrame label={label}>
+          <circle className="gear-reference__outline" cx="20" cy="17" r="7" />
+          <path className="gear-reference__guide" d="M10 27h38" />
+          <path className="gear-reference__accent" d="M27 17h15" />
+          <path className="gear-reference__accent-fill" d="M43 17l-4.5-2.6v5.2z" />
+        </OpParamRefFrame>
+      )
+
+    case 'plungeFeed':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M10 22H48V28H10Z" />
+          <circle className="gear-reference__guide" cx="29" cy="12" r="5" />
+          <path className="gear-reference__guide" d="M25 17h8" />
+          <path className="gear-reference__accent" d="M29 17v5" />
+          <path className="gear-reference__accent-fill" d="M29 23l-2.6-4.5h5.2z" />
+        </OpParamRefFrame>
+      )
+
+    case 'slotFeed':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__guide" d="M10 12v10h38V12z" />
+          <circle className="gear-reference__outline" cx="29" cy="17" r="6" />
+          <path className="gear-reference__accent" d="M37 17h7" />
+          <path className="gear-reference__accent-fill" d="M45 17l-4.5-2.6v5.2z" />
+        </OpParamRefFrame>
+      )
+
+    case 'rpm':
+      return (
+        <OpParamRefFrame label={label}>
+          <circle className="gear-reference__outline" cx="29" cy="17" r="9" />
+          <path className="gear-reference__guide" d="M29 2v5M29 27v5M11 17h5M42 17h5" />
+          <path className="gear-reference__accent" d="M35 10A12 12 0 0 1 38 22" />
+          <path className="gear-reference__accent-fill" d="M39 23l-2.5-4.8 5 .5z" />
+        </OpParamRefFrame>
+      )
+
+    case 'dwell':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M24 4v10h-4V4h4zM25 14h-6v-2h6zM25 4h-6V2h6z" />
+          <path className="gear-reference__guide" d="M10 28h38" />
+          <path className="gear-reference__accent" d="M33 14A6 6 0 0 1 44 14" />
+          <path className="gear-reference__accent-fill" d="M33 14l-2.5 5 5-.5z" />
+          <circle className="gear-reference__accent-fill" cx="44" cy="14" r="1.5" />
+        </OpParamRefFrame>
+      )
+
+    case 'cutDirection':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M12 10h34v14H12z" />
+          <path className="gear-reference__accent" d="M18 24h22" />
+          <path className="gear-reference__accent-fill" d="M41 24l-4.5-2.6v5.2z" />
+          <path className="gear-reference__guide" d="M28 17v-3a4 4 0 0 0-3-4" />
+        </OpParamRefFrame>
+      )
+
+    case 'pattern':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M10 6h38v22H10z" />
+          <path className="gear-reference__accent" d="M29 17m-3 0a3 3 0 1 0 6 0a3 3 0 1 0-6 0" />
+          <path className="gear-reference__guide" d="M29 17m-8 0a8 8 0 1 0 16 0a8 8 0 1 0-16 0" />
+        </OpParamRefFrame>
+      )
+
+    case 'machiningOrder':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__guide" d="M14 10h10v14H14zM24 10h10v14H24zM34 10h10v14H34z" />
+          <path className="gear-reference__accent" d="M19 17l5-3v6zM25 13l5 3-5 3" />
+          <path className="gear-reference__accent-fill" d="M31 11l-2.5 3.5h5z" />
+        </OpParamRefFrame>
+      )
+
+    case 'rasterAngle':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M10 6h38v22H10z" />
+          <path className="gear-reference__guide" d="M10 17h38" />
+          <path className="gear-reference__accent" d="M18 25l14-16M23 25l14-16M28 25l14-16" />
+          <path className="gear-reference__accent-fill" d="M39 20l-1-2 2-.5z" />
+        </OpParamRefFrame>
+      )
+
+    case 'finishWalls':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M10 8h38v18H10z" />
+          <path className="gear-reference__guide" d="M12 17h34" />
+          <path className="gear-reference__accent" d="M10 8v18M48 8v18" />
+          <path className="gear-reference__accent" d="M10 8h38M10 26h38" />
+        </OpParamRefFrame>
+      )
+
+    case 'finishFloor':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M10 8h38v18H10z" />
+          <path className="gear-reference__guide" d="M10 10v14M48 10v14" />
+          <path className="gear-reference__accent" d="M12 26h34" />
+          <path className="gear-reference__accent" d="M12 8h34" />
+        </OpParamRefFrame>
+      )
+
+    case 'stockRadial':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__guide" d="M14 10h30v14H14z" />
+          <path className="gear-reference__outline" d="M18 14h22v6H18z" />
+          <path className="gear-reference__accent" d="M40 17h5" />
+          <path className="gear-reference__accent-fill" d="M39 17l3-2.2v4.4zM46 17l-3-2.2v4.4z" />
+        </OpParamRefFrame>
+      )
+
+    case 'stockAxial':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M10 6H48V28H10Z" />
+          <path className="gear-reference__guide" d="M10 22h38" />
+          <path className="gear-reference__accent" d="M12 22h36" />
+          <path className="gear-reference__accent-fill" d="M44 22l-2.2 3h4.4zM44 28l-2.2-3h4.4z" />
+          <path className="gear-reference__guide" d="M44 23v4" />
+        </OpParamRefFrame>
+      )
+
+    case 'adaptiveSpacing':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__guide" d="M29 17m-6 0a6 6 0 1 0 12 0a6 6 0 1 0-12 0" />
+          <path className="gear-reference__guide" d="M29 17m-2 0a2 2 0 1 0 4 0a2 2 0 1 0-4 0" />
+          <path className="gear-reference__outline" d="M29 17m-4 0a4 4 0 1 0 8 0a4 4 0 1 0-8 0" />
+          <path className="gear-reference__accent" d="M31 13v3" />
+          <path className="gear-reference__accent-fill" d="M31 12l-2.2 3h4.4zM31 17l-2.2-3h4.4z" />
+        </OpParamRefFrame>
+      )
+
+    case 'adaptiveRefinement':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__guide" d="M10 26L29 8L48 26" />
+          <path className="gear-reference__outline" d="M29 8l4 4.5M25 8l3 4.5M21 8l4.5 4.5M33 8l2.5 4.5M17 8l4 4.5" />
+          <path className="gear-reference__guide" d="M10 26h38" />
+          <path className="gear-reference__accent" d="M14 26l3-4.5M18 26l2.5-4.5M22 26l3-4.5M26 26l2.5-4.5" />
+          <path className="gear-reference__accent" d="M30 26l2-4M34 26l2.5-4M38 26l3-4M42 26l2.5-4" />
+        </OpParamRefFrame>
+      )
+
+    case 'maxRings':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__guide" d="M29 17m-9 0a9 9 0 1 0 18 0a9 9 0 1 0-18 0" />
+          <path className="gear-reference__guide" d="M29 17m-5 0a5 5 0 1 0 10 0a5 5 0 1 0-10 0" />
+          <path className="gear-reference__guide" d="M29 17m-1 0a1 1 0 1 0 2 0a1 1 0 1 0-2 0" />
+          <path className="gear-reference__accent" d="M24 10c-2.5 2.5-2.5 8 0 12" />
+          <path className="gear-reference__accent" d="M34 10c2.5 2.5 2.5 8 0 12" />
+          <path className="gear-reference__accent-fill" d="M24 9l-2.5 3.5h5z" />
+        </OpParamRefFrame>
+      )
+
+    case 'drillType':
+      return (
+        <OpParamRefFrame label={label}>
+          <path className="gear-reference__outline" d="M25 2h8v12h-8z" />
+          <path className="gear-reference__guide" d="M25 14l-4 8h16l-4-8" />
+          <path className="gear-reference__guide" d="M29 14v6" />
+          <path className="gear-reference__accent" d="M27 3v10M31 3v10" />
+          <path className="gear-reference__accent-fill" d="M29 22l-2.5-5h5z" />
+        </OpParamRefFrame>
+      )
+  }
+}

--- a/src/components/cam/operationParamRefData.ts
+++ b/src/components/cam/operationParamRefData.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const OPERATION_PARAM_REF_KINDS = [
+  'stepdown',
+  'stepover',
+  'maxDepth',
+  'retractHeight',
+  'peckDepth',
+  'feed',
+  'plungeFeed',
+  'slotFeed',
+  'rpm',
+  'dwell',
+  'cutDirection',
+  'pattern',
+  'machiningOrder',
+  'rasterAngle',
+  'finishWalls',
+  'finishFloor',
+  'stockRadial',
+  'stockAxial',
+  'adaptiveSpacing',
+  'adaptiveRefinement',
+  'maxRings',
+  'drillType',
+] as const
+
+export type OperationParamRefKind = typeof OPERATION_PARAM_REF_KINDS[number]
+
+const OP_PARAM_REF_LABELS: Record<OperationParamRefKind, string> = {
+  stepdown: 'Stepdown reference',
+  stepover: 'Stepover reference',
+  maxDepth: 'Max depth reference',
+  retractHeight: 'Retract height reference',
+  peckDepth: 'Peck depth reference',
+  feed: 'Feed reference',
+  plungeFeed: 'Plunge feed reference',
+  slotFeed: 'Slot feed reference',
+  rpm: 'RPM reference',
+  dwell: 'Dwell reference',
+  cutDirection: 'Cut direction reference',
+  pattern: 'Pattern reference',
+  machiningOrder: 'Machining order reference',
+  rasterAngle: 'Raster angle reference',
+  finishWalls: 'Finish walls reference',
+  finishFloor: 'Finish floor reference',
+  stockRadial: 'Stock radial reference',
+  stockAxial: 'Stock axial reference',
+  adaptiveSpacing: 'Adaptive spacing reference',
+  adaptiveRefinement: 'Adaptive refinement reference',
+  maxRings: 'Max rings reference',
+  drillType: 'Drill type reference',
+}
+
+export function operationParamRefLabel(kind: OperationParamRefKind): string {
+  return OP_PARAM_REF_LABELS[kind]
+}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2025,7 +2025,8 @@
 }
 
 /* Match the gear/creation reference frame (50×34) so the diagrams read at the
-   same size as the feature-creation dialogs. */
+   same size as the feature-creation dialogs. Illustrative only — never a click
+   target (so it can't accidentally toggle a checkbox row's input). */
 .op-param-ref {
   grid-column: 3;
   justify-self: end;
@@ -2035,6 +2036,14 @@
   border: 1px solid rgba(200, 156, 98, 0.22);
   border-radius: 6px;
   background: rgba(7, 12, 17, 0.72);
+  pointer-events: none;
+}
+
+/* Checkbox-backed parameters (Finish Walls/Floor, Adaptive refinement) live in
+   flex `.properties-check` rows, not the grid — push their reference to the same
+   right-hand rail as the field icons. */
+.cam-operation-properties .properties-check .op-param-ref {
+  margin-left: auto;
 }
 
 /* Action messages (e.g. "✓ Target updated") are plain <span> children, so the

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1832,7 +1832,7 @@
   height: 15px;
 }
 
-.properties-field > :not(span):not(.properties-field-label-row) {
+.properties-field > :not(span):not(.properties-field-label-row):not(.op-param-ref) {
   grid-column: 2;
 }
 
@@ -2018,6 +2018,30 @@
   opacity: 1;
 }
 
+/* ── Operation parameter reference column ──────────────────── */
+
+.cam-operation-properties .properties-field {
+  grid-template-columns: minmax(74px, 88px) minmax(0, 1fr) 30px;
+}
+
+.op-param-ref {
+  grid-column: 3;
+  justify-self: end;
+  align-self: center;
+  width: 30px;
+  height: 22px;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  background: #0f1820;
+}
+
+/* Action messages (e.g. "✓ Target updated") are plain <span> children, so the
+   reserved third column would otherwise pull them into the 30px icon rail.
+   Force them onto their own full-width row instead. */
+.cam-operation-properties .properties-field > .cam-field-message {
+  grid-column: 1 / -1;
+}
+
 .properties-field .cam-field-message,
 .properties-field .cam-field-note-list {
   margin-top: 2px;
@@ -2113,6 +2137,14 @@
 
   .properties-field > :not(span) {
     grid-column: auto;
+  }
+
+  .cam-operation-properties .properties-field {
+    grid-template-columns: 1fr;
+  }
+
+  .op-param-ref {
+    display: none;
   }
 }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2021,18 +2021,20 @@
 /* ── Operation parameter reference column ──────────────────── */
 
 .cam-operation-properties .properties-field {
-  grid-template-columns: minmax(74px, 88px) minmax(0, 1fr) 30px;
+  grid-template-columns: minmax(74px, 88px) minmax(0, 1fr) 50px;
 }
 
+/* Match the gear/creation reference frame (50×34) so the diagrams read at the
+   same size as the feature-creation dialogs. */
 .op-param-ref {
   grid-column: 3;
   justify-self: end;
   align-self: center;
-  width: 30px;
-  height: 22px;
-  border: 1px solid var(--line-strong);
-  border-radius: 5px;
-  background: #0f1820;
+  width: 50px;
+  height: 34px;
+  border: 1px solid rgba(200, 156, 98, 0.22);
+  border-radius: 6px;
+  background: rgba(7, 12, 17, 0.72);
 }
 
 /* Action messages (e.g. "✓ Target updated") are plain <span> children, so the


### PR DESCRIPTION
## Summary

Adds a third **reference column** to the operation properties panel, mirroring the gear/creation parameter-reference pattern (issues #218 / #259). Each machining parameter now shows a small inline-SVG diagram illustrating the quantity it controls.

Closes #266.

## What changed

- **New `OperationParameterReference` component** (`src/components/cam/OperationParameterReference.tsx`) + a pure `operationParamRefData.ts` (kinds + aria-labels), reusing the shared `gear-reference__outline/guide/accent/accent-fill` SVG classes so the visual language matches the gear and creation-dialog references.
- **22 parameter diagrams**: stepdown, stepover, max depth, retract height, peck depth, feed, plunge feed, slot feed, RPM, dwell, cut direction, pattern, machining order, raster angle, finish walls/floor, stock-to-leave radial/axial, adaptive spacing/refinement, max rings, drill type.
- **Wiring** in `renderOperationProperties()` only — each relevant `.properties-field` gets a `<OperationParameterReference kind="…" />` as its third child. Identity/meta rows (Name, Kind, Target, Tool, buttons, warnings) and `.properties-check` rows are intentionally left blank.
- **CSS** (`layout.css`): a uniform **30px icon rail** reserved on every operation field (empty cell where there's no diagram), scoped to a new `cam-operation-properties` class so tool/machine/feature panels are untouched. The `.op-param-ref` element is excluded from the existing "controls → column 2" rule.

## Fits the expanded view + responsive

- The **Expanded "Operation Properties" modal** reuses the same render function, so the rail appears there automatically; each field stays `display:grid` inside the masonry columns.
- Under the existing `@media (max-width: 399px)` breakpoint the rail is hidden and fields collapse to a single column.
- Action messages (e.g. "✓ Target updated") are forced full-width so the reserved rail can't squeeze them.

## Verification

- `npm run build` — green (ESLint, `tsc -b`, all 93 test suites incl. the new `OperationParameterReference.test.ts`, vite build).
- New unit test asserts kind/label completeness and uniqueness.

## Notes for review

The diagrams are schematic (matching the gear style) rather than pixel-perfect illustrations — happy to refine any specific icon. Visual review of the docked panel + expanded modal is welcome.
