### PR TITLE
Enforce Playwright e2e coverage

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -23,3 +23,36 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright e2e
+        run: npm run test:e2e
+
+      - name: Upload Playwright failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,13 +34,16 @@ Abandoned work: close the issue with a short reason; the board moves it to `Done
 ```bash
 npm run build          # Full build (lint + icon generation + tsc + tests + vite). Run this before committing.
 npm test               # Run the structural test suite (every src/**/*.test.ts via tsx)
+npm run test:e2e       # Playwright browser smoke (PR CI gate; starts its own Vite dev server)
 npm run dev            # Vite dev server (do NOT start this unless asked — the user runs it themselves)
 npm run lint           # ESLint over supported source only: src, vite.config.ts, and build/test scripts
 npm run lint:scripts   # Optional: lint the one-off diagnostic scripts in scripts/ (not a quality gate)
 npm run sync-icons     # Regenerate public/icons.svg from src/assets/icons/*.svg
 ```
 
-Always run `npm run build` from the project root to verify changes compile before committing. `npm run lint` and `npm test` run automatically as part of the build, so a lint failure or failing structural test will fail the build. Do not start the dev/preview server unless asked.
+Always run `npm run build` from the project root to verify changes compile before committing. `npm run lint` and `npm test` run automatically as part of the build, so a lint failure or failing structural test will fail the build. Do not start the dev/preview server unless asked; `npm run test:e2e` owns its temporary dev server when you intentionally run the browser smoke.
+
+`npm run test:e2e` is a separate PR CI gate, not part of `npm run build`. User-facing UI or workflow changes should add or extend an `e2e/*.smoke.spec.ts` test when the behavior depends on rendered DOM, menu wiring, dialogs, or browser-only boot paths. If lower-level structural tests are sufficient, say so in the PR description so the lack of e2e coverage is deliberate.
 
 ## Git & Branching
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,6 +1,6 @@
 # e2e — Browser Smoke (Playwright)
 
-Thin, repeatable browser smoke run before manual testing sessions.
+Thin, repeatable browser smoke run before manual testing sessions and in PR CI.
 Covers DOM render + menu→action wiring. Does **NOT** assert geometry,
 pixels, or WebGL canvas contents — those are owned by `npm test`.
 
@@ -15,6 +15,14 @@ discovers all `e2e/*.spec.ts` files. The fixture auto-navigates to the
 app, waits for the canvas, and fails the test on **any** `console.error`
 or uncaught page error.
 
+## CI gate
+
+Pull requests run `npm run test:e2e` in a dedicated workflow job. CI installs
+Chromium with Playwright, forbids committed `.only` tests, keeps traces on
+failure, and uploads `playwright-report/` / `test-results/` when the job fails.
+The e2e job is separate from `npm run build` so the build script stays
+browser-free while PRs still exercise the browser smoke.
+
 ## Scaffolding (read before writing a test)
 
 | File | Role |
@@ -23,6 +31,12 @@ or uncaught page error.
 | `selectors.ts` | **Single source of truth** for DOM selectors. Logical name → `Locator`. When the UI moves a class, update it **here** — every spec picks it up. |
 | `helpers.ts` | Generic primitives: `seedProject`, `getProject`, `getPendingMove`, `completePendingMove`, `openRowContextMenu`, `clickMenuItem`, `rowByName`, `featureRowCount`, `assertNoConsoleErrors`. Domain-agnostic. |
 | `featureReferences.helpers.ts` | FR-specific helpers (e.g. `seedLinkedProject`). Built on the generic primitives. A new feature area gets its own `<area>.helpers.ts`. |
+| `camOperations.helpers.ts` | CAM-specific fixture helpers for operation workflow smoke tests. |
+
+Current smoke targets:
+
+- `featureReferences.smoke.spec.ts` — linked-feature tree badges, context menu wiring, properties grouping, and load round-trip.
+- `camOperations.smoke.spec.ts` — feature-row quick operation wiring into CAM operation state.
 
 ## Adding a test
 
@@ -36,6 +50,11 @@ The canonical shape for a new feature-area smoke:
 6. **Assert via the DOM** — never canvas contents, never geometry values
 7. **Console-error guard is automatic** (from the fixture — no per-test boilerplate)
 8. **Area-specific selectors** that don't yet exist in `selectors.ts` are added there; everything else is handled by the existing scaffolding.
+
+User-facing UI or workflow changes should add or extend an e2e smoke when the
+behavior depends on rendered DOM, menu wiring, dialogs, or browser-only boot
+paths. If store/unit coverage is enough, call that out in the PR description so
+the omission is intentional.
 
 ### Worked example — hypothetical "CAM operations" smoke
 
@@ -70,4 +89,3 @@ future change adds Tauri IPC calls at boot time that are not guarded by
 - No screenshot/pixel diffing; no WebGL canvas-content assertions.
 - No Tauri native file-dialog flows — project state is seeded via the
   guarded `window.__pcTest` dev seam.
-- No CI integration.

--- a/e2e/camOperations.helpers.ts
+++ b/e2e/camOperations.helpers.ts
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Page } from '@playwright/test'
+import { seedProject } from './helpers'
+
+function resolvedRectProfile(cx: number, cy: number, w: number, h: number) {
+  return {
+    start: { x: cx, y: cy },
+    segments: [
+      { type: 'line' as const, to: { x: cx + w, y: cy } },
+      { type: 'line' as const, to: { x: cx + w, y: cy + h } },
+      { type: 'line' as const, to: { x: cx, y: cy + h } },
+      { type: 'line' as const, to: { x: cx, y: cy } },
+    ],
+    closed: true,
+  }
+}
+
+function buildCamQuickOperationProjectJson(): string {
+  const now = '2026-01-01T00:00:00.000Z'
+  const stockW = 180
+  const stockH = 120
+  const featureProfile = resolvedRectProfile(30, 30, 60, 40)
+
+  return JSON.stringify({
+    version: '2.0',
+    meta: {
+      name: 'CAM Quick Operation E2E Fixture',
+      created: now,
+      modified: now,
+      units: 'inch',
+      showFeatureInfo: true,
+      showDimensions: true,
+      copyMode: 'reference',
+      maxTravelZ: 2,
+      operationClearanceZ: 0.2,
+      clampClearanceXY: 0.5,
+      clampClearanceZ: 0.2,
+      machineDefinitions: [],
+      selectedMachineId: null,
+    },
+    grid: {
+      extent: 200,
+      majorSpacing: 1,
+      minorSpacing: 0.25,
+      snapEnabled: false,
+      snapIncrement: 0.25,
+      visible: true,
+    },
+    stock: {
+      profile: resolvedRectProfile(0, 0, stockW, stockH),
+      thickness: 2,
+      material: 'aluminum_6061',
+      color: '#b9a83c',
+      visible: true,
+      origin: { x: 0, y: 0 },
+    },
+    origin: { name: 'Origin', x: stockW / 2, y: stockH / 2, z: 2, visible: true },
+    backdrop: null,
+    dimensions: {},
+    annotations: [],
+    modelAssets: {},
+    featureDefinitions: {
+      'def-machinable-add': {
+        id: 'def-machinable-add',
+        kind: 'rect',
+        profile: resolvedRectProfile(0, 0, 60, 40),
+        dimensions: [],
+        text: null,
+        stl: null,
+        operation: 'add',
+      },
+    },
+    features: [
+      {
+        id: 'f-machinable-add',
+        name: 'Machinable Add',
+        kind: 'rect',
+        folderId: null,
+        sketch: {
+          profile: featureProfile,
+          origin: { x: 0, y: 0 },
+          orientationAngle: 0,
+          dimensions: [],
+          constraints: [],
+        },
+        operation: 'add',
+        z_top: 5,
+        z_bottom: 0,
+        visible: true,
+        locked: false,
+        definitionId: 'def-machinable-add',
+        transform: { a: 1, b: 0, c: 0, d: 1, e: 30, f: 30 },
+      },
+    ],
+    featureFolders: [],
+    featureTree: [],
+    global_constraints: [],
+    tools: [],
+    operations: [],
+    tabs: [],
+    clamps: [],
+    ai_history: [],
+  })
+}
+
+const CAM_QUICK_OPERATION_FIXTURE_JSON = buildCamQuickOperationProjectJson()
+
+export async function seedCamQuickOperationProject(page: Page): Promise<void> {
+  await seedProject(page, CAM_QUICK_OPERATION_FIXTURE_JSON)
+}

--- a/e2e/camOperations.smoke.spec.ts
+++ b/e2e/camOperations.smoke.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures'
+import { seedCamQuickOperationProject } from './camOperations.helpers'
+import {
+  clickMenuItem,
+  getProject,
+  openRowContextMenu,
+  rowByName,
+} from './helpers'
+
+interface OperationSnapshot {
+  kind?: unknown
+  pass?: unknown
+  target?: {
+    source?: unknown
+    featureIds?: unknown
+  }
+}
+
+test.describe('CAM operation browser smoke', () => {
+  test('feature-row quick operation creates a CAM operation', async ({ app, ui }) => {
+    await seedCamQuickOperationProject(app.page)
+
+    const row = rowByName(app.page, 'Machinable Add')
+    const menu = await openRowContextMenu(app.page, row)
+    await ui.contextMenu.item(menu, 'Create operation').hover()
+
+    const submenu = ui.contextMenu.submenu(app.page)
+    await expect(submenu).toBeVisible()
+    await expect(ui.contextMenu.item(submenu, 'Create Outside Route')).toBeVisible()
+
+    await clickMenuItem(submenu, 'Create Outside Route')
+
+    await expect(ui.operations.countBadge(app.page)).toHaveText('1')
+    await expect(ui.operations.rowByName(app.page, 'Edge route outside Rough')).toBeVisible()
+
+    const project = await getProject(app.page)
+    const operations = project.operations as OperationSnapshot[]
+    expect(operations).toHaveLength(1)
+    expect(operations[0].kind).toBe('edge_route_outside')
+    expect(operations[0].pass).toBe('rough')
+    expect(operations[0].target?.source).toBe('features')
+    expect(operations[0].target?.featureIds).toEqual(['f-machinable-add'])
+  })
+})

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -68,6 +68,9 @@ export const contextMenu = {
   /** The open context menu container. */
   container: (page: Page) => page.locator('.feature-context-menu'),
 
+  /** The open context-menu flyout submenu. */
+  submenu: (page: Page) => page.locator('.feature-context-menu__submenu'),
+
   /** A menu item by its label text. */
   item: (menu: Locator, label: string) =>
     menu.locator('.feature-context-menu__item', { hasText: label }),
@@ -86,6 +89,21 @@ export const properties = {
   /** Exact text match within the panel. */
   exactText: (page: Page, text: string) =>
     page.locator('.properties-panel').getByText(text, { exact: true }),
+}
+
+// ── CAM operations ──────────────────────────────────────────────────
+
+export const operations = {
+  /** Visible operation-count badge in the CAM panel. */
+  countBadge: (page: Page) =>
+    page.locator('.cam-panel .cam-section--tree .cam-section-header .feature-count'),
+
+  /** Rendered CAM operation rows. */
+  rows: (page: Page) => page.locator('.cam-operation-tree .tree-row--feature'),
+
+  /** A specific CAM operation row by its label text. */
+  rowByName: (page: Page, name: string) =>
+    page.locator('.cam-operation-tree .tree-row--feature').filter({ hasText: name }),
 }
 
 // ── Canvas ──────────────────────────────────────────────────────────

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,23 +1,29 @@
 import { defineConfig } from '@playwright/test'
 
+const isCI = Boolean(process.env.CI)
+
 export default defineConfig({
   testDir: './e2e',
-  forbidOnly: false,
+  forbidOnly: isCI,
   retries: 0,
   workers: 1,
   timeout: 60000,
+  reporter: isCI
+    ? [['github'], ['html', { outputFolder: 'playwright-report', open: 'never' }]]
+    : 'list',
   expect: { timeout: 10000 },
   use: {
     // Dev server is used (not preview) because the __pcTest seam is guarded
     // by import.meta.env.DEV and is tree-shaken from production builds.
     baseURL: 'http://localhost:1420',
     headless: true,
+    trace: isCI ? 'retain-on-failure' : 'off',
     viewport: { width: 1440, height: 900 },
   },
   webServer: {
     command: 'npm run dev -- --port 1420 --strictPort',
     url: 'http://localhost:1420',
-    reuseExistingServer: true,
+    reuseExistingServer: !isCI,
     timeout: 30000,
   },
 })


### PR DESCRIPTION
## Summary

- Add a dedicated PR CI job that installs Chromium and runs `npm run test:e2e`
- Make Playwright CI-strict with `forbidOnly`, failure traces, and HTML report artifacts
- Document e2e as a PR gate and add a CAM quick-operation browser smoke to grow coverage beyond feature references

Closes #268

## Verification

- npm run test:e2e
- npm run build
