### PR TITLE
Stream worker progress so the manager can poll instead of kill

### DIFF
--- a/.agents/skills/manager-delegate/SKILL.md
+++ b/.agents/skills/manager-delegate/SKILL.md
@@ -27,6 +27,9 @@ This skill automates that documented flow; it does not replace those rules.
 3. **Request permission (see below), then dispatch.** Pipe the prompt into
    `scripts/dispatch-task.sh`. It creates the worktree+branch, runs the worker,
    runs an independent build gate, and reports — it does **not** merge.
+   Run it in the background (redirect output to a file) and watch the slice's
+   progress log instead of blocking a foreground call on the whole run (see
+   "Watching a dispatched worker" below).
 4. **Review the real diff, not the report.** The worker ends with a
    `STATUS/COMMIT/CHANGED_FILES/CHECKS/RISKS` block — that is a report, not
    acceptance. Inspect the actual worktree diff, the commit, and the build/test
@@ -56,6 +59,30 @@ yourself or abandoning the delegation.
 The user's explicit approval is required before any credential-backed dispatch
 (AGENTS.md §"Credential & token handling").
 
+## Watching a dispatched worker — judge idle time, never wall-clock
+
+The worker streams its activity into a per-slice progress log at
+`$PURECUT_WORKTREE_BASE/SLUG.progress.log` (path echoed at dispatch time; the
+raw event stream is kept beside it at `….progress.log.ndjson`). Long slices
+are normal: a healthy worker can run 10+ minutes while emitting a steady drip
+of `[note]`/`[tool]`/`[gen]` lines.
+
+- Dispatch in the background with output redirected to a file; do not block a
+  foreground shell call (with its own timeout) on the whole slice.
+- Poll `scripts/worker-status.sh --slug SLUG` every 30–60s. It is instant and
+  bounded — safe to call as often as needed.
+- **Patience rule: never kill a worker because of total elapsed time.** Act
+  only on the probe's state:
+  - `running` — leave it alone, whatever the runtime.
+  - `stale` (no progress for 5+ minutes) — inspect the log tail and the
+    worktree diff before deciding; a build or install step can legitimately
+    be quiet for a while. Kill only if clearly wedged.
+  - `verifying` — worker done, independent build gate running.
+  - `done` — read the dispatch report and start the review.
+- `[tool]` lines are tool calls observed by the harness — the model cannot
+  fake or forget them, so they are the reliable liveness signal. `[note]`
+  lines are the worker narrating its phases.
+
 ## Commands
 
 ```
@@ -68,9 +95,13 @@ scripts/dispatch-task.sh --issue NN --task-slug SLUG [--base BRANCH] < prompt.md
 # Read-only review of an existing worktree (optional helper).
 scripts/dispatch-task.sh --mode review --worktree DIR < prompt.md
 
+# Poll a running dispatch (instant; see "Watching a dispatched worker").
+scripts/worker-status.sh --slug SLUG
+
 # Merge an approved slice and tear down its worktree (--no-ff).
 scripts/finish-task.sh --slug SLUG [--base BRANCH]
 #   refuses to merge into main/master without --allow-main.
+#   also removes the slice's progress log artifacts.
 ```
 
 The leaf launcher `scripts/run-claude-deepseek-agent.sh` (credential scrub,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ The full manager loop (plan → dispatch → review → merge) is packaged as th
      --output-format json < work/slice-prompt.md
    ```
    - `--worktree DIR` is **required for `--mode implement`**: the launcher `cd`s into it so the worker operates there by default. This sets the working directory only — it is **not** a sandbox; a `bypassPermissions` worker can still reach any absolute path, so staying in the worktree is a prompt-and-review convention, not a technical boundary. Bound the real risk with a capped, rotatable key and the post-hoc review in step 4. `--worktree` is optional for `--mode review` (read-only, `--permission-mode plan`), which is the safer default — prefer it whenever the slice doesn't need to write.
-   - For slices that run for minutes, dispatch in the background and read the result when it exits, rather than blocking on a foreground call.
+   - For slices that run for minutes, dispatch in the background rather than blocking on a foreground call. Pass `--progress-log FILE` (`dispatch-task.sh` sets one automatically at `$PURECUT_WORKTREE_BASE/SLUG.progress.log`) and poll `scripts/worker-status.sh --slug SLUG` — judge the worker by idle time since its last progress entry, never by total runtime, and never kill a worker whose status is `running`.
 4. **Review the real artifacts, not the report.** The worker ends with a `STATUS/COMMIT/CHANGED_FILES/CHECKS/RISKS` completion block — that is a *report, not acceptance*. Inspect the actual worktree diff, the commit, and the test output before accepting or merging.
 
 ### Credential & token handling

--- a/scripts/claude-deepseek-agent-prompt.md
+++ b/scripts/claude-deepseek-agent-prompt.md
@@ -26,6 +26,7 @@ Required invariants: [INVARIANTS]
 Required checks: [REQUIRED_CHECKS]
 
 Rules:
+- Narrate your progress: before each phase (reading context, editing a group of files, running a check, committing), print one short line saying what you are about to do. These lines stream to the manager while you work; do not batch them up for the end.
 - Make the smallest change that satisfies the slice.
 - Do not perform unrelated cleanup or change public/frozen contracts unless this slice explicitly permits it.
 - Do not edit the detailed integration handoff unless this slice explicitly assigns documentation.

--- a/scripts/dispatch-task.sh
+++ b/scripts/dispatch-task.sh
@@ -42,7 +42,15 @@ Options:
   --mode MODE         implement (default) or review.
   --worktree DIR      Existing worktree to review (review mode only).
   --skip-build        Skip the post-worker build gate (implement mode).
+  --progress-log FILE Progress log path (default in implement mode:
+                      $PURECUT_WORKTREE_BASE/SLUG.progress.log; review mode
+                      only streams progress when this is set explicitly).
   --help              Show this help.
+
+Progress: the worker streams one-line progress entries into the progress log
+as it works. Dispatch in the background and poll scripts/worker-status.sh
+--slug SLUG (instant, bounded) instead of blocking on — or killing — a long
+foreground run. Judge the worker by idle time in the log, not total runtime.
 
 Permissions: this command reads .env.agent, connects to the DeepSeek endpoint,
 and (implement) runs a bypassPermissions worker. Get explicit approval first.
@@ -57,19 +65,28 @@ slug=""
 base="$DEFAULT_BASE"
 review_worktree=""
 skip_build=false
+progress_log=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --issue)      [[ $# -ge 2 ]] || fail "--issue requires a number"; issue="$2"; shift 2 ;;
-    --task-slug)  [[ $# -ge 2 ]] || fail "--task-slug requires a value"; slug="$2"; shift 2 ;;
-    --base)       [[ $# -ge 2 ]] || fail "--base requires a branch"; base="$2"; shift 2 ;;
-    --mode)       [[ $# -ge 2 ]] || fail "--mode requires implement or review"; mode="$2"; shift 2 ;;
-    --worktree)   [[ $# -ge 2 ]] || fail "--worktree requires a directory"; review_worktree="$2"; shift 2 ;;
-    --skip-build) skip_build=true; shift ;;
-    --help|-h)    usage; exit 0 ;;
-    *)            fail "unknown option: $1" ;;
+    --issue)        [[ $# -ge 2 ]] || fail "--issue requires a number"; issue="$2"; shift 2 ;;
+    --task-slug)    [[ $# -ge 2 ]] || fail "--task-slug requires a value"; slug="$2"; shift 2 ;;
+    --base)         [[ $# -ge 2 ]] || fail "--base requires a branch"; base="$2"; shift 2 ;;
+    --mode)         [[ $# -ge 2 ]] || fail "--mode requires implement or review"; mode="$2"; shift 2 ;;
+    --worktree)     [[ $# -ge 2 ]] || fail "--worktree requires a directory"; review_worktree="$2"; shift 2 ;;
+    --skip-build)   skip_build=true; shift ;;
+    --progress-log) [[ $# -ge 2 ]] || fail "--progress-log requires a file path"; progress_log="$2"; shift 2 ;;
+    --help|-h)      usage; exit 0 ;;
+    *)              fail "unknown option: $1" ;;
   esac
 done
+
+# Append a lifecycle marker to the progress log so worker-status.sh can tell
+# "worker finished, gate running" from "dispatch fully done". Best-effort only.
+progress_mark() {
+  [[ -n "$progress_log" ]] || return 0
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$progress_log" 2>/dev/null || true
+}
 
 [[ -x "$LEAF" ]] || fail "leaf launcher not found or not executable: $LEAF"
 # Without redirection the worker's `claude --print` would block on the terminal.
@@ -94,8 +111,12 @@ if [[ "$mode" == "review" ]]; then
   [[ -n "$review_worktree" ]] || fail "review mode requires --worktree DIR (an existing worktree)"
   [[ -d "$review_worktree" ]] || fail "--worktree is not a directory: $review_worktree"
   printf '== review worker (read-only) in %s ==\n' "$review_worktree" >&2
-  "$LEAF" --mode review --worktree "$review_worktree" --output-format text < "$prompt_file"
-  exit 0
+  leaf_args=(--mode review --worktree "$review_worktree" --output-format text)
+  [[ -n "$progress_log" ]] && leaf_args+=(--progress-log "$progress_log")
+  review_status=0
+  "$LEAF" "${leaf_args[@]}" < "$prompt_file" || review_status=$?
+  progress_mark "[dispatch] done worker_exit=$review_status build=n/a"
+  exit "$review_status"
 fi
 
 # ---- implement mode ----
@@ -120,10 +141,17 @@ printf '== creating worktree %s on %s (from %s) ==\n' "$worktree_dir" "$branch" 
 git -C "$REPO_ROOT" worktree add "$worktree_dir" -b "$branch" "$base" \
   || fail "failed to create worktree"
 
+# Per-slice progress log: the worker streams one-line entries here as it works,
+# so a backgrounded dispatch can be polled (worker-status.sh) instead of killed
+# for looking silent.
+[[ -n "$progress_log" ]] || progress_log="$WORKTREE_BASE/$slug.progress.log"
+printf '== progress log: %s ==\n' "$progress_log" >&2
+printf '== poll with: scripts/worker-status.sh --slug %s ==\n' "$slug" >&2
+
 printf '== dispatching implement worker (bypass) ==\n' >&2
 worker_status=0
 "$LEAF" --mode implement --allow-bypass --worktree "$worktree_dir" \
-  --output-format text < "$prompt_file" || worker_status=$?
+  --output-format text --progress-log "$progress_log" < "$prompt_file" || worker_status=$?
 if [[ "$worker_status" -ne 0 ]]; then
   printf '\n!! worker exited non-zero (%s); worktree left in place for inspection !!\n' \
     "$worker_status" >&2
@@ -133,6 +161,7 @@ fi
 build_result="skipped"
 if [[ "$skip_build" == false ]]; then
   printf '== build gate: npm run build in worktree ==\n' >&2
+  progress_mark "[gate] npm run build starting"
   if [[ ! -d "$worktree_dir/node_modules" ]]; then
     printf '   node_modules missing; running npm install\n' >&2
     ( cd "$worktree_dir" && npm install ) || build_result="install-failed"
@@ -141,6 +170,7 @@ if [[ "$skip_build" == false ]]; then
     if ( cd "$worktree_dir" && npm run build ); then build_result="passed"; else build_result="FAILED"; fi
   fi
 fi
+progress_mark "[dispatch] done worker_exit=$worker_status build=$build_result"
 
 # ---- report ----
 last_commit="$(git -C "$worktree_dir" log -1 --oneline 2>/dev/null || echo '(none)')"
@@ -157,6 +187,7 @@ worktree:     $worktree_dir
 base:         $base
 worker exit:  $worker_status
 build gate:   $build_result
+progress log: $progress_log
 last commit:  $last_commit
 
 uncommitted (should be empty if worker committed):

--- a/scripts/finish-task.sh
+++ b/scripts/finish-task.sh
@@ -97,6 +97,8 @@ git -C "$REPO_ROOT" worktree remove "$worktree_dir" \
   || fail "merge succeeded but worktree removal failed (not clean?): $worktree_dir"
 git -C "$REPO_ROOT" branch -d "$task_branch" \
   || printf 'note: could not delete branch %s (delete manually if desired)\n' "$task_branch" >&2
+# Progress artifacts written by dispatch-task.sh live beside the worktree.
+rm -f "$WORKTREE_BASE/$slug.progress.log" "$WORKTREE_BASE/$slug.progress.log.ndjson"
 
 cat <<EOF
 

--- a/scripts/run-claude-deepseek-agent.sh
+++ b/scripts/run-claude-deepseek-agent.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+readonly PROGRESS_FILTER="$SCRIPT_DIR/worker-progress-filter.jq"
 
 usage() {
   cat <<'EOF'
@@ -18,6 +19,13 @@ Options:
                          --mode implement; optional for review (defaults to cwd).
   --allow-bypass         Required with --mode implement.
   --output-format FORMAT Claude print output: text or json (default: text).
+  --progress-log FILE    Append one-line timestamped progress entries to FILE
+                         while the worker runs (mirrored to stderr), so a
+                         manager can tail the log instead of staring at a
+                         silent pipe. Runs claude in stream-json mode
+                         internally; stdout still carries only the final
+                         result in the requested --output-format. The raw
+                         event stream is kept at FILE.ndjson for forensics.
   --help                 Show this help.
 
 Credentials are loaded from DEEPSEEK_AGENT_ENV_FILE when set, otherwise the
@@ -73,6 +81,7 @@ mode=""
 worktree=""
 allow_bypass=false
 output_format="text"
+progress_log=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -95,6 +104,11 @@ while [[ $# -gt 0 ]]; do
       output_format="$2"
       shift 2
       ;;
+    --progress-log)
+      [[ $# -ge 2 ]] || fail "--progress-log requires a file path"
+      progress_log="$2"
+      shift 2
+      ;;
     --help|-h)
       usage
       exit 0
@@ -114,6 +128,13 @@ case "$output_format" in
   text|json) ;;
   *) fail "--output-format must be text or json" ;;
 esac
+
+if [[ -n "$progress_log" ]]; then
+  command -v jq >/dev/null 2>&1 || fail "--progress-log requires jq on PATH"
+  [[ -f "$PROGRESS_FILTER" ]] || fail "progress filter not found: $PROGRESS_FILTER"
+  mkdir -p "$(dirname "$progress_log")" 2>/dev/null \
+    || fail "cannot create progress log directory for: $progress_log"
+fi
 
 # The prompt must be piped in on stdin; without redirection `claude --print` would
 # block waiting on the terminal. Fail fast with a clear message instead of hanging.
@@ -179,13 +200,21 @@ claude_args=(
   --print
   --no-session-persistence
   --effort "$CLAUDE_CODE_EFFORT_LEVEL"
-  --output-format "$output_format"
 )
 
 if [[ "$mode" == "implement" ]]; then
   claude_args+=(--permission-mode bypassPermissions)
 else
   claude_args+=(--permission-mode plan)
+fi
+
+if [[ -n "$progress_log" ]]; then
+  # Stream events so progress can be distilled live; the final result is
+  # re-emitted on stdout in the requested --output-format below, so callers
+  # see the same stdout contract as a non-streaming run.
+  claude_args+=(--output-format stream-json --verbose --include-partial-messages)
+else
+  claude_args+=(--output-format "$output_format")
 fi
 
 # Run the worker from inside its worktree. NOTE: this sets the working directory
@@ -196,4 +225,36 @@ if [[ -n "$worktree" ]]; then
   cd "$worktree" || fail "could not enter worktree: $worktree"
 fi
 
-exec claude "${claude_args[@]}"
+# Fast path: no progress log requested — hand the process over to claude.
+[[ -n "$progress_log" ]] || exec claude "${claude_args[@]}"
+
+# Progress path: distill each stream-json event into a one-line entry appended
+# to the progress log the moment it happens (mirrored to stderr), so a manager
+# can poll the log and judge the worker by idle time instead of killing a
+# long-but-healthy session. The raw stream is kept beside it for forensics.
+raw_stream="$progress_log.ndjson"
+: > "$progress_log"
+: > "$raw_stream"
+
+set +e
+claude "${claude_args[@]}" \
+  | tee "$raw_stream" \
+  | jq -nRr --unbuffered -f "$PROGRESS_FILTER" \
+  | tee -a "$progress_log" >&2
+worker_status="${PIPESTATUS[0]}"
+set -e
+
+printf '%s [exit] worker exited code=%s\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$worker_status" >> "$progress_log"
+
+# Re-emit the final result on stdout in the caller's requested format,
+# tolerating a truncated last line if the worker died mid-write.
+if [[ "$output_format" == "json" ]]; then
+  jq -nRc '[inputs | fromjson? // empty | select(type == "object" and .type == "result")] | last // empty' \
+    "$raw_stream"
+else
+  jq -nRr '[inputs | fromjson? // empty | select(type == "object" and .type == "result")] | last | .result // empty' \
+    "$raw_stream"
+fi
+
+exit "$worker_status"

--- a/scripts/test-claude-deepseek-agent.sh
+++ b/scripts/test-claude-deepseek-agent.sh
@@ -31,9 +31,21 @@ assert_not_contains() {
 }
 
 mkdir -p "$TEMP_DIR/bin"
+
+# Fake claude: echoes args/env/stdin (plain modes), or emits a canned
+# stream-json event stream when invoked with --output-format stream-json so
+# the --progress-log path can be tested without a real endpoint.
 cat > "$TEMP_DIR/bin/claude" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ " $* " == *" stream-json "* ]]; then
+  cat >/dev/null
+  printf '%s\n' '{"type":"system","subtype":"init","model":"fake-model"}'
+  printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"Reading context files"}]}}'
+  printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"npm run build"}}]}}'
+  printf '%s\n' '{"type":"result","subtype":"success","result":"STATUS: complete","num_turns":3,"duration_ms":4200}'
+  exit "${FAKE_CLAUDE_EXIT:-0}"
+fi
 printf 'args:\n'
 printf '<%s>\n' "$@"
 printf 'model=<%s>\n' "$ANTHROPIC_MODEL"
@@ -48,35 +60,76 @@ DEEPSEEK_API_KEY=test-secret
 DEEPSEEK_PRO_MODEL="test-pro-model"
 DEEPSEEK_FLASH_MODEL='test-flash-model'
 DEEPSEEK_EFFORT_LEVEL=high
-DEEPSEEK_MAX_BUDGET_USD=0.50
 EOF
+# The launcher refuses group/other-readable credential files.
+chmod 600 "$TEMP_DIR/agent.env"
 
-review_output="$(printf 'first line\nsecond line\n' | PATH="$TEMP_DIR/bin:$PATH" DEEPSEEK_AGENT_ENV_FILE="$TEMP_DIR/agent.env" "$LAUNCHER" --mode review)"
+# A minimal real git repo so --worktree validation passes in implement mode.
+git init -q "$TEMP_DIR/wt"
+
+run_launcher() {
+  PATH="$TEMP_DIR/bin:$PATH" DEEPSEEK_AGENT_ENV_FILE="$TEMP_DIR/agent.env" "$LAUNCHER" "$@"
+}
+
+# ---- review mode: plan permissions, model/endpoint env, prompt passthrough ----
+review_output="$(printf 'first line\nsecond line\n' | run_launcher --mode review)"
 assert_contains "$review_output" '<--permission-mode>'
 assert_contains "$review_output" '<plan>'
 assert_not_contains "$review_output" 'bypassPermissions'
-assert_contains "$review_output" '<--max-budget-usd>'
-assert_contains "$review_output" '<0.50>'
 assert_contains "$review_output" 'model=<test-pro-model>'
 assert_contains "$review_output" 'endpoint=<https://api.deepseek.com/anthropic>'
 assert_contains "$review_output" 'first line'
 assert_contains "$review_output" 'second line'
 assert_not_contains "$review_output" 'test-secret'
 
-if implement_error="$(printf 'implement task\n' | PATH="$TEMP_DIR/bin:$PATH" DEEPSEEK_AGENT_ENV_FILE="$TEMP_DIR/agent.env" "$LAUNCHER" --mode implement 2>&1)"; then
+# ---- implement mode guards ----
+if implement_error="$(printf 'implement task\n' | run_launcher --mode implement 2>&1)"; then
   fail 'implementation mode unexpectedly ran without --allow-bypass'
 fi
 assert_contains "$implement_error" '--mode implement requires --allow-bypass'
 
-implement_output="$(printf 'implement task\n' | PATH="$TEMP_DIR/bin:$PATH" DEEPSEEK_AGENT_ENV_FILE="$TEMP_DIR/agent.env" "$LAUNCHER" --mode implement --allow-bypass --max-budget-usd 0.25 --output-format json)"
+if no_worktree_error="$(printf 'implement task\n' | run_launcher --mode implement --allow-bypass 2>&1)"; then
+  fail 'implementation mode unexpectedly ran without --worktree'
+fi
+assert_contains "$no_worktree_error" '--mode implement requires --worktree'
+
+implement_output="$(printf 'implement task\n' | run_launcher --mode implement --allow-bypass --worktree "$TEMP_DIR/wt" --output-format json)"
 assert_contains "$implement_output" '<bypassPermissions>'
-assert_contains "$implement_output" '<0.25>'
 assert_contains "$implement_output" '<json>'
 
+# ---- missing credentials ----
 if missing_config_error="$(printf 'review\n' | PATH="$TEMP_DIR/bin:$PATH" DEEPSEEK_AGENT_ENV_FILE="$TEMP_DIR/missing.env" "$LAUNCHER" --mode review 2>&1)"; then
   fail 'launcher unexpectedly ran without credentials'
 fi
 assert_contains "$missing_config_error" 'DEEPSEEK_API_KEY is not configured'
 assert_not_contains "$missing_config_error" 'test-secret'
+
+# ---- progress log: distilled entries stream to the log; stdout stays final-text ----
+progress_log="$TEMP_DIR/slice.progress.log"
+progress_stdout="$(printf 'task\n' | run_launcher --mode review --progress-log "$progress_log" 2>"$TEMP_DIR/progress.stderr")"
+[[ "$progress_stdout" == "STATUS: complete" ]] \
+  || fail "expected stdout to be the final result text, got: $progress_stdout"
+[[ -f "$progress_log" ]] || fail 'progress log was not created'
+progress_content="$(cat "$progress_log")"
+assert_contains "$progress_content" '[init] model=fake-model'
+assert_contains "$progress_content" '[note] Reading context files'
+assert_contains "$progress_content" '[tool] Bash npm run build'
+assert_contains "$progress_content" '[done] success turns=3'
+assert_contains "$progress_content" '[exit] worker exited code=0'
+[[ -f "$progress_log.ndjson" ]] || fail 'raw event stream (.ndjson) was not kept'
+# Progress lines are mirrored to stderr for foreground callers.
+assert_contains "$(cat "$TEMP_DIR/progress.stderr")" '[tool] Bash npm run build'
+
+# ---- progress log + json format: stdout carries the final result event ----
+progress_json="$(printf 'task\n' | run_launcher --mode review --progress-log "$TEMP_DIR/json.progress.log" --output-format json 2>/dev/null)"
+assert_contains "$progress_json" '"type":"result"'
+assert_contains "$progress_json" '"result":"STATUS: complete"'
+
+# ---- progress log: worker exit code propagates through the pipeline ----
+if FAKE_CLAUDE_EXIT=7 run_launcher --mode review --progress-log "$TEMP_DIR/fail.progress.log" \
+     < <(printf 'task\n') >/dev/null 2>&1; then
+  fail 'launcher unexpectedly exited zero when the worker failed'
+fi
+assert_contains "$(cat "$TEMP_DIR/fail.progress.log")" '[exit] worker exited code=7'
 
 printf 'test-claude-deepseek-agent: passed\n'

--- a/scripts/worker-progress-filter.jq
+++ b/scripts/worker-progress-filter.jq
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# worker-progress-filter.jq — distill `claude --output-format stream-json`
+# events (one JSON object per line on stdin) into short, timestamped,
+# one-line progress entries for the dispatch progress log.
+#
+# Used by run-claude-deepseek-agent.sh --progress-log; kept as a standalone
+# file so it can be tested and tuned without touching the launcher.
+#
+# Invoke as: jq -nRr --unbuffered -f worker-progress-filter.jq
+#
+# Line vocabulary (worker-status.sh and the manager skill key off these tags):
+#   [init]  session started, resolved model
+#   [note]  assistant text — the worker narrating what it is doing
+#   [think] extended-thinking excerpt (reasoning models)
+#   [tool]  a tool call observed by the harness — the reliable liveness signal
+#   [gen]   heartbeat during a long uninterrupted generation turn
+#   [done]  final result event (subtype, turn count, duration)
+
+def ts: now | todate;
+def clip: tostring | gsub("\\s+"; " ") | .[0:160];
+
+foreach (inputs | fromjson? // empty | select(type == "object")) as $e (
+  0;
+  # State: consecutive stream_event chunks since the last full event, so a
+  # long generation turn with no tool calls still heartbeats periodically.
+  if $e.type == "stream_event" then . + 1 else 0 end;
+  . as $chunks
+  | (if $e.type == "system" and $e.subtype == "init" then
+       "[init] model=\($e.model // "?")"
+     elif $e.type == "assistant" then
+       (($e.message.content // [])[]
+        | if .type == "tool_use" then
+            "[tool] \(.name) \((.input.file_path // .input.command // .input.pattern // .input.description // "") | clip)"
+          elif .type == "text" and ((.text // "") | length) > 0 then
+            "[note] \(.text | clip)"
+          elif .type == "thinking" and ((.thinking // "") | length) > 0 then
+            "[think] \(.thinking | clip)"
+          else
+            empty
+          end)
+     elif $e.type == "result" then
+       "[done] \($e.subtype // "?") turns=\($e.num_turns // "?") duration=\((($e.duration_ms // 0) / 1000) | floor)s"
+     elif $e.type == "stream_event" and ($chunks % 250 == 0) then
+       "[gen] model is generating (long turn in progress)"
+     else
+       empty
+     end)
+  | "\(ts) \(.)"
+)

--- a/scripts/worker-status.sh
+++ b/scripts/worker-status.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+# worker-status.sh — cheap, bounded status probe for a dispatched slice.
+# Reads the progress log written by dispatch-task.sh / run-claude-deepseek-agent.sh
+# and reports the worker's state plus its recent activity. Designed for a manager
+# to poll every 30-60s instead of blocking on (or killing) a long dispatch:
+# judge the worker by idle time since its last progress entry, never by total
+# wall-clock runtime — a healthy slice can run 10+ minutes.
+
+set -euo pipefail
+
+WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-/Users/frankp/Projects/worktrees/purecutcnc}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/worker-status.sh --slug SLUG [options]
+       scripts/worker-status.sh --log FILE [options]
+
+Report the state of a dispatched worker from its progress log:
+  state=waiting     log not created yet (dispatch still setting up)
+  state=running     worker active; idle= shows seconds since the last entry
+  state=stale       no progress for --stale-after seconds — inspect the log
+                    tail and worktree before deciding anything; do not kill
+                    on this signal alone
+  state=verifying   worker exited; independent build gate in progress
+  state=done        dispatch finished; read the dispatch report
+
+Options:
+  --slug SLUG         Locate the log at $PURECUT_WORKTREE_BASE/SLUG.progress.log.
+  --log FILE          Explicit progress log path (overrides --slug).
+  --stale-after SECS  Idle threshold before reporting stale (default 300).
+  --lines N           Recent progress lines to echo (default 8).
+  --help              Show this help.
+EOF
+}
+
+fail() { printf 'worker-status: %s\n' "$*" >&2; exit 1; }
+
+slug=""
+log=""
+stale_after=300
+lines=8
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --slug)        [[ $# -ge 2 ]] || fail "--slug requires a value"; slug="$2"; shift 2 ;;
+    --log)         [[ $# -ge 2 ]] || fail "--log requires a file path"; log="$2"; shift 2 ;;
+    --stale-after) [[ $# -ge 2 ]] || fail "--stale-after requires seconds"; stale_after="$2"; shift 2 ;;
+    --lines)       [[ $# -ge 2 ]] || fail "--lines requires a number"; lines="$2"; shift 2 ;;
+    --help|-h)     usage; exit 0 ;;
+    *)             fail "unknown option: $1" ;;
+  esac
+done
+
+[[ -n "$log" || -n "$slug" ]] || fail "--slug SLUG or --log FILE is required"
+[[ "$stale_after" =~ ^[0-9]+$ ]] || fail "--stale-after must be a number of seconds"
+[[ "$lines" =~ ^[0-9]+$ ]] || fail "--lines must be a number"
+[[ -n "$log" ]] || log="$WORKTREE_BASE/$slug.progress.log"
+
+if [[ ! -f "$log" ]]; then
+  printf 'state=waiting log=%s (not created yet)\n' "$log"
+  exit 0
+fi
+
+mtime="$(stat -f '%m' "$log" 2>/dev/null || stat -c '%Y' "$log" 2>/dev/null)" \
+  || fail "cannot stat progress log: $log"
+idle=$(( $(date +%s) - mtime ))
+
+# Lifecycle markers, newest wins: [dispatch] done > [exit] > activity.
+if grep -q '\[dispatch\] done' "$log"; then
+  state="done"
+elif grep -q '\[exit\]' "$log"; then
+  state="verifying"
+elif (( idle > stale_after )); then
+  state="stale"
+else
+  state="running"
+fi
+
+printf 'state=%s idle=%ss log=%s\n' "$state" "$idle" "$log"
+if [[ "$state" == "stale" ]]; then
+  printf 'no progress for %ss — inspect the log tail and worktree before acting; do not kill on this alone\n' "$idle"
+fi
+printf -- '--- last %s entries ---\n' "$lines"
+tail -n "$lines" "$log"


### PR DESCRIPTION
## Problem

The dispatched DeepSeek worker ran `claude --print` in `text` mode, which emits nothing until the session ends. A manager (Codex) watching the pipe saw minutes of silence on long slices, got nervous, and would kill an otherwise-healthy worker before it finished.

## Fix: stream progress so the manager polls instead of kills

The worker now streams its activity into a per-slice log; the manager judges liveness by **idle time since the last entry**, never by total wall-clock runtime.

### `run-claude-deepseek-agent.sh`
- New `--progress-log FILE` runs `claude` in `stream-json` mode internally and distills each event into one-line timestamped entries — `[init]` / `[note]` / `[think]` / `[tool]` / `[gen]` / `[done]` — appended live to `FILE` (mirrored to stderr) via `scripts/worker-progress-filter.jq`.
- **stdout is unchanged**: it still carries only the final result in the requested `--output-format` (`text`/`json`), so anything parsing the completion block keeps working.
- The raw event stream is kept at `FILE.ndjson` for forensics; a trailing `[exit]` line records the worker exit code, which propagates through the pipeline.

### `dispatch-task.sh`
- Implement mode wires a per-slice progress log at `$PURECUT_WORKTREE_BASE/SLUG.progress.log` automatically, echoes the path at dispatch, and appends `[gate]` / `[dispatch] done` lifecycle markers so the whole dispatch (worker + build gate) is observable from one file.

### `worker-status.sh` (new)
- Instant, bounded probe reporting `waiting` / `running` / `stale` / `verifying` / `done` plus idle seconds and the log tail. Safe to poll every 30–60s.

### Docs — `manager-delegate` skill + `AGENTS.md`
- Document the background-dispatch + poll flow and the **patience rule**: never kill on total runtime; `stale` (5+ min silent) means *inspect the log tail and worktree first*, not *kill*. `[tool]` lines are harness-observed, so they're the reliable liveness signal even if the model forgets to narrate.

### `finish-task.sh`
- Removes the slice's progress-log artifacts at teardown.

## Testing

`scripts/test-claude-deepseek-agent.sh` passes. This PR also repairs the test's stale baseline (it still asserted the removed `--max-budget-usd` flag and used a non-`chmod 600` credential fixture, so it failed on `main` before this change) and adds coverage for the progress path: distilled log entries, stderr mirroring, `text` and `json` stdout contracts, raw `.ndjson` retention, and worker exit-code propagation. `worker-status.sh` was exercised through all five states; the jq filter was verified on heartbeats, thinking blocks, and malformed-line tolerance.

## Caveat

The first real dispatch exercises `--include-partial-messages` against DeepSeek's Anthropic-compatible shim. If that shim doesn't stream partial messages, you simply lose `[gen]` heartbeats during long uninterrupted generation turns — every other progress line (driven by full events and tool calls) still works.
