### PR TITLE
Join closed features that share a line segment

### DIFF
--- a/src/store/INDEX.md
+++ b/src/store/INDEX.md
@@ -29,7 +29,7 @@ Zustand store. The single source of truth for the current `.camj` project. **All
   - `constraintsSlice.ts` — persistent fixed-distance constraint placement, value updates, cancellation, and deletion
   - `treeVisibilitySlice.ts` — feature-tree visibility toggles for all regions/construction, folders, region/construction folders, and folder selection
 - `helpers/` — pure helpers used by the store
-  - `clipping.ts` — clipper-lib wrappers (handles the integer scaling factor): profile↔Clipper-path conversion, boolean/offset execution, and overlap predicates. Arc/curve reconstruction of Clipper output lives in `engine/toolpaths/arcReconstruction.ts`.
+  - `clipping.ts` — clipper-lib wrappers (handles the integer scaling factor): profile↔Clipper-path conversion, boolean/offset execution, and overlap predicates. Join connectivity counts area overlap or a positive-length shared boundary segment (issue #271); corner-only contact does not connect. Arc/curve reconstruction of Clipper output lives in `engine/toolpaths/arcReconstruction.ts`.
   - `derivedFeatures.ts` — computes derived snapshot features from the feature tree; also previewOffsetFeatures, joinOpenProfiles, and clearStaleConstraints
   - `featureDefinitions.ts` — definition creation, orphan collection, instance rebaking, and make-unique support for feature references
   - `gearFeature.ts` — grouped gear+bore feature insertion helper used by the gear creation action
@@ -63,7 +63,9 @@ Zustand store. The single source of truth for the current `.camj` project. **All
 - `featureReferencesMigration.test.ts` — legacy project migration into definitions and instances
 - `featureResolver.test.ts` — matrix resolution and definition lookup behavior
 - `geometryFidelity.test.ts` — per-FeatureKind × transform-class resolveProfile fidelity, edit round-trip, duplicate-as-reference, per-kind store transforms
+- `helpers/clipping.test.ts` — join-connectivity predicates (issue #271): shared-edge, corner-contact, disjoint, overlap, and hole-forming union cases for featuresOverlap and the grouping helpers
 - `instanceTransforms.test.ts` — instance transform matrix composition
+- `joinSharedEdge.test.ts` — store-level join of edge-adjacent closed features (issue #271): grouping, session click-to-add, merge result, keepOriginals
 - `linkedConstraintResolve.test.ts` — linked constraint re-solve after definition edit propagates to sibling instances; direct-edit regression; no-drift idempotency
 - `openProfileJoin.test.ts` — open-profile joining behavior
 - `polygonSplit.test.ts` — polygon splitting

--- a/src/store/helpers/clipping.test.ts
+++ b/src/store/helpers/clipping.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the join-connectivity predicates in clipping.ts (issue #271):
+ * features sharing a positive-length boundary segment are joinable, while
+ * corner-only contact and disjoint features remain unjoinable.
+ *
+ * Run with: npx tsx src/store/helpers/clipping.test.ts
+ */
+
+import {
+  polygonProfile,
+  rectProfile,
+  type SketchFeature,
+  type SketchProfile,
+} from '../../types/project'
+import {
+  featuresFormConnectedOverlapGroup,
+  featuresOverlap,
+  largestConnectedOverlapGroup,
+} from './clipping'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+let passed = 0
+let failed = 0
+
+function test(name: string, fn: () => void): void {
+  try {
+    fn()
+    passed += 1
+    console.log(`   ✓ ${name}`)
+  } catch (err: unknown) {
+    failed += 1
+    const msg = err instanceof Error ? err.message : String(err)
+    console.log(`   ✗ ${name}: ${msg}`)
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function featureFromProfile(id: string, profile: SketchProfile): SketchFeature {
+  return {
+    id,
+    name: id,
+    kind: 'rect' as const,
+    folderId: null,
+    sketch: {
+      profile,
+      origin: { x: 0, y: 0 },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+    operation: 'add' as const,
+    z_top: 5,
+    z_bottom: 0,
+    visible: true,
+    locked: false,
+  } as SketchFeature
+}
+
+function rectFeature(id: string, x: number, y: number, w: number, h: number): SketchFeature {
+  return featureFromProfile(id, rectProfile(x, y, w, h))
+}
+
+// ────────────────────────────────────────────────────────────────────
+
+console.log('\nClipping — join connectivity (featuresOverlap)')
+
+test('full shared edge connects two rects', () => {
+  const a = rectFeature('a', 0, 0, 10, 10)
+  const b = rectFeature('b', 10, 0, 10, 10)
+  assert(featuresOverlap(a, b), 'rects sharing a full edge must overlap for join')
+  assert(featuresOverlap(b, a), 'predicate must be symmetric')
+})
+
+test('partial shared edge connects two rects', () => {
+  const a = rectFeature('a', 0, 0, 10, 10)
+  const b = rectFeature('b', 10, 4, 10, 10)
+  assert(featuresOverlap(a, b), 'rects sharing a partial edge must overlap for join')
+})
+
+test('corner-only contact does not connect', () => {
+  const a = rectFeature('a', 0, 0, 10, 10)
+  const b = rectFeature('b', 10, 10, 10, 10)
+  assert(!featuresOverlap(a, b), 'corner-touching rects must not count as joinable')
+})
+
+test('disjoint rects do not connect', () => {
+  const a = rectFeature('a', 0, 0, 10, 10)
+  const b = rectFeature('b', 30, 0, 10, 10)
+  assert(!featuresOverlap(a, b), 'disjoint rects must not overlap')
+})
+
+test('area overlap still connects (regression)', () => {
+  const a = rectFeature('a', 0, 0, 10, 10)
+  const b = rectFeature('b', 5, 0, 10, 10)
+  assert(featuresOverlap(a, b), 'area-overlapping rects must keep overlapping')
+})
+
+test('open profile never connects', () => {
+  const a = rectFeature('a', 0, 0, 10, 10)
+  const openProfile = { ...rectProfile(10, 0, 10, 10), closed: false }
+  const b = featureFromProfile('b', openProfile)
+  assert(!featuresOverlap(a, b), 'open profiles are not joinable')
+})
+
+test('shared edges forming an enclosed hole still connect', () => {
+  // U-shape opening upward; the bar caps it across the top, sharing the
+  // tops of both prongs. Their union is an outer contour plus a hole, so
+  // the predicate must not assume a single-path union result.
+  const u = featureFromProfile('u', polygonProfile([
+    { x: 0, y: 0 },
+    { x: 30, y: 0 },
+    { x: 30, y: 30 },
+    { x: 20, y: 30 },
+    { x: 20, y: 10 },
+    { x: 10, y: 10 },
+    { x: 10, y: 30 },
+    { x: 0, y: 30 },
+  ]))
+  const bar = rectFeature('bar', 0, 30, 30, 10)
+  assert(featuresOverlap(u, bar), 'hole-forming shared-edge union must connect')
+})
+
+console.log('\nClipping — connectivity grouping')
+
+test('largestConnectedOverlapGroup chains shared edges', () => {
+  const a = rectFeature('a', 0, 0, 10, 10)
+  const b = rectFeature('b', 10, 0, 10, 10)
+  const c = rectFeature('c', 20, 0, 10, 10)
+  const d = rectFeature('d', 50, 50, 10, 10)
+  const group = largestConnectedOverlapGroup([a, b, c, d])
+  const ids = group.map((feature) => feature.id).sort()
+  assert(ids.join(',') === 'a,b,c', `expected a,b,c got ${ids.join(',')}`)
+})
+
+test('largestConnectedOverlapGroup excludes corner-touching feature', () => {
+  const a = rectFeature('a', 0, 0, 10, 10)
+  const b = rectFeature('b', 10, 0, 10, 10)
+  const corner = rectFeature('corner', 20, 10, 10, 10)
+  const group = largestConnectedOverlapGroup([a, b, corner])
+  const ids = group.map((feature) => feature.id).sort()
+  assert(ids.join(',') === 'a,b', `expected a,b got ${ids.join(',')}`)
+})
+
+test('featuresFormConnectedOverlapGroup accepts shared-edge pair', () => {
+  const a = rectFeature('a', 0, 0, 10, 10)
+  const b = rectFeature('b', 10, 0, 10, 10)
+  assert(featuresFormConnectedOverlapGroup([a, b]), 'shared-edge pair must form a group')
+})
+
+test('featuresFormConnectedOverlapGroup rejects corner-touching pair', () => {
+  const a = rectFeature('a', 0, 0, 10, 10)
+  const b = rectFeature('b', 10, 10, 10, 10)
+  assert(!featuresFormConnectedOverlapGroup([a, b]), 'corner-touching pair must not form a group')
+})
+
+// ── Results ─────────────────────────────────────────────────────────
+
+console.log(`\n${passed} passed, ${failed} failed${failed > 0 ? ' ❌' : ' ✓'}\n`)
+
+if (failed > 0) throw new Error(`${failed} test(s) failed`)

--- a/src/store/helpers/clipping.ts
+++ b/src/store/helpers/clipping.ts
@@ -115,6 +115,39 @@ function rangesOverlap(minA: number, maxA: number, minB: number, maxB: number): 
   return maxA >= minB && maxB >= minA
 }
 
+function pathPerimeter(path: ReturnType<typeof flattenFeatureToClipperPath>): number {
+  let perimeter = 0
+  for (let index = 0; index < path.length; index += 1) {
+    const from = path[index]
+    const to = path[(index + 1) % path.length]
+    perimeter += Math.hypot(to.X - from.X, to.Y - from.Y)
+  }
+  return perimeter
+}
+
+// Unioning two features that share a positive-length stretch of boundary
+// dissolves that stretch from both outlines, shortening the combined
+// perimeter by twice the shared length. Point contact keeps the sum exact,
+// so corner-touching features stay unjoinable (a join would produce a
+// degenerate bow-tie profile). Threshold is in Clipper integer units
+// (1e-4 mm at DEFAULT_CLIPPER_SCALE).
+const SHARED_BOUNDARY_MIN_PERIMETER_DROP = 2
+
+function pathsShareBoundarySegment(
+  pathA: ReturnType<typeof flattenFeatureToClipperPath>,
+  pathB: ReturnType<typeof flattenFeatureToClipperPath>,
+): boolean {
+  const union = executeClipPaths([pathA], [pathB], ClipperLib.ClipType.ctUnion)
+  if (union.length === 0) {
+    return false
+  }
+  const unionPerimeter = union.reduce((sum, path) => sum + pathPerimeter(path), 0)
+  return unionPerimeter < pathPerimeter(pathA) + pathPerimeter(pathB) - SHARED_BOUNDARY_MIN_PERIMETER_DROP
+}
+
+// Join-connectivity predicate (issue #271): closed features count as
+// connected when they overlap in area or share a positive-length boundary
+// segment. Corner-only contact does not connect them.
 export function featuresOverlap(a: SketchFeature, b: SketchFeature): boolean {
   if (!a.sketch.profile.closed || !b.sketch.profile.closed) {
     return false
@@ -129,13 +162,14 @@ export function featuresOverlap(a: SketchFeature, b: SketchFeature): boolean {
     return false
   }
 
-  const intersections = executeClipPaths(
-    [flattenFeatureToClipperPath(a)],
-    [flattenFeatureToClipperPath(b)],
-    0,
-  )
+  const pathA = flattenFeatureToClipperPath(a)
+  const pathB = flattenFeatureToClipperPath(b)
+  const intersections = executeClipPaths([pathA], [pathB], ClipperLib.ClipType.ctIntersection)
+  if (intersections.length > 0) {
+    return true
+  }
 
-  return intersections.length > 0
+  return pathsShareBoundarySegment(pathA, pathB)
 }
 
 // Overlap test used to validate cut-mode target selection. Unlike

--- a/src/store/joinSharedEdge.test.ts
+++ b/src/store/joinSharedEdge.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Store-level tests for joining closed features that share a line segment
+ * (issue #271): the join workflow must group edge-adjacent features, admit
+ * them to an active join session, and merge them into a single feature.
+ *
+ * Run with: npx tsx src/store/joinSharedEdge.test.ts
+ */
+
+import {
+  getProfileBounds,
+  newProject,
+  rectProfile,
+  type FeatureDefinition,
+  type Project,
+  type SketchFeature,
+} from '../types/project'
+import { useProjectStore } from './projectStore'
+import type { ProjectStore } from './types'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+let passed = 0
+let failed = 0
+
+function test(name: string, fn: () => void): void {
+  try {
+    fn()
+    passed += 1
+    console.log(`   ✓ ${name}`)
+  } catch (err: unknown) {
+    failed += 1
+    const msg = err instanceof Error ? err.message : String(err)
+    console.log(`   ✗ ${name}: ${msg}`)
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/** Setup store with a fresh project. */
+function resetStore(): void {
+  useProjectStore.setState({
+    project: newProject(),
+    selection: { selectedFeatureIds: [] },
+    pendingShapeAction: null,
+    history: { past: [], future: [], transactionStart: null },
+  } as unknown as Partial<ProjectStore>)
+}
+
+/** Add a rect feature with a definition to the project via direct state mutation. */
+function addRectFeature(id: string, name: string, x: number, y: number, w: number, h: number): SketchFeature {
+  const profile = rectProfile(x, y, w, h)
+  const definition: FeatureDefinition = {
+    id: `def-${id}`,
+    kind: 'rect',
+    profile,
+    dimensions: [],
+    text: null,
+    stl: null,
+    operation: 'add',
+  }
+  const feature = {
+    id,
+    name,
+    kind: 'rect' as const,
+    folderId: null,
+    sketch: {
+      profile,
+      origin: { x: 0, y: 0 },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+    operation: 'add' as const,
+    z_top: 5,
+    z_bottom: 0,
+    visible: true,
+    locked: false,
+    definitionId: `def-${id}`,
+  } as SketchFeature
+
+  const state = useProjectStore.getState()
+  useProjectStore.setState({
+    project: {
+      ...state.project,
+      features: [...state.project.features, feature],
+      featureDefinitions: {
+        ...state.project.featureDefinitions,
+        [`def-${id}`]: definition,
+      },
+    },
+  } as unknown as Partial<ProjectStore>)
+
+  return feature
+}
+
+/** Set the selected feature IDs in the store. */
+function selectFeatures(ids: string[]): void {
+  useProjectStore.setState({
+    selection: {
+      ...useProjectStore.getState().selection,
+      selectedFeatureIds: ids,
+      selectedFeatureId: ids.length > 0 ? ids[ids.length - 1] : null,
+      selectedNode: ids.length > 0 ? { type: 'feature', featureId: ids[ids.length - 1] } : null,
+      mode: 'feature',
+      activeControl: null,
+    },
+  } as unknown as Partial<ProjectStore>)
+}
+
+function getProject(): Project {
+  return useProjectStore.getState().project
+}
+
+function joinEntityIds(): string[] {
+  const pending = useProjectStore.getState().pendingShapeAction
+  return pending?.kind === 'join' ? pending.entityIds : []
+}
+
+// ────────────────────────────────────────────────────────────────────
+
+console.log('\nJoin — closed features sharing a line segment (issue #271)')
+
+test('startJoinSelectedFeatures groups edge-adjacent rects', () => {
+  resetStore()
+  addRectFeature('a', 'Left', 0, 0, 10, 10)
+  addRectFeature('b', 'Right', 10, 0, 10, 10)
+  selectFeatures(['a', 'b'])
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  const ids = [...joinEntityIds()].sort()
+  assert(ids.join(',') === 'a,b', `both edge-adjacent rects must enter the join group, got ${ids.join(',')}`)
+})
+
+test('completePendingShapeAction merges edge-adjacent rects into one feature', () => {
+  resetStore()
+  addRectFeature('a', 'Left', 0, 0, 10, 10)
+  addRectFeature('b', 'Right', 10, 0, 10, 10)
+  selectFeatures(['a', 'b'])
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+  const createdIds = useProjectStore.getState().completePendingShapeAction()
+
+  assert(createdIds.length === 1, `join must create exactly one feature, got ${createdIds.length}`)
+  const project = getProject()
+  assert(!project.features.find((feature) => feature.id === 'a'), 'original a must be consumed')
+  assert(!project.features.find((feature) => feature.id === 'b'), 'original b must be consumed')
+
+  const merged = project.features.find((feature) => feature.id === createdIds[0])
+  assert(merged, 'merged feature must exist in the project')
+  assert(merged.sketch.profile.closed, 'merged profile must be closed')
+  const bounds = getProfileBounds(merged.sketch.profile)
+  assert(
+    bounds.minX === 0 && bounds.minY === 0 && bounds.maxX === 20 && bounds.maxY === 10,
+    `merged outline must span the combined rect, got ${JSON.stringify(bounds)}`,
+  )
+})
+
+test('startJoinSelectedFeatures still excludes corner-touching rects', () => {
+  resetStore()
+  addRectFeature('a', 'Left', 0, 0, 10, 10)
+  addRectFeature('c', 'Corner', 10, 10, 10, 10)
+  selectFeatures(['a', 'c'])
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  assert(joinEntityIds().length === 1, 'corner-touching rects must not group for join')
+})
+
+test('active join session admits an edge-adjacent feature via selectFeature', () => {
+  resetStore()
+  addRectFeature('a', 'Left', 0, 0, 10, 10)
+  addRectFeature('b', 'Right', 10, 0, 10, 10)
+  addRectFeature('c', 'Corner', 20, 10, 10, 10)
+  selectFeatures(['a'])
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+  assert(joinEntityIds().join(',') === 'a', 'join session must start with the selected rect')
+
+  useProjectStore.getState().selectFeature('b', true)
+  const afterAdjacent = [...joinEntityIds()].sort()
+  assert(afterAdjacent.join(',') === 'a,b', `edge-adjacent rect must be admitted, got ${afterAdjacent.join(',')}`)
+
+  useProjectStore.getState().selectFeature('c', true)
+  const afterCorner = [...joinEntityIds()].sort()
+  assert(afterCorner.join(',') === 'a,b', `corner-touching rect must be rejected, got ${afterCorner.join(',')}`)
+})
+
+test('keepOriginals join preserves the source features', () => {
+  resetStore()
+  addRectFeature('a', 'Left', 0, 0, 10, 10)
+  addRectFeature('b', 'Right', 10, 0, 10, 10)
+  selectFeatures(['a', 'b'])
+
+  const createdIds = useProjectStore.getState().mergeSelectedFeatures(true)
+
+  assert(createdIds.length === 1, `join must create exactly one feature, got ${createdIds.length}`)
+  const project = getProject()
+  assert(project.features.find((feature) => feature.id === 'a'), 'original a must remain with keepOriginals')
+  assert(project.features.find((feature) => feature.id === 'b'), 'original b must remain with keepOriginals')
+})
+
+// ── Results ─────────────────────────────────────────────────────────
+
+console.log(`\n${passed} passed, ${failed} failed${failed > 0 ? ' ❌' : ' ✓'}\n`)
+
+if (failed > 0) throw new Error(`${failed} test(s) failed`)


### PR DESCRIPTION
Closes #271

Implements the approved plan on the issue: closed features that share a positive-length boundary segment can now be joined; corner-only contact and disjoint features remain unjoinable.

## What changed

- `src/store/helpers/clipping.ts` — `featuresOverlap` (the single predicate behind join grouping and join-session selection) gets a shared-boundary fallback when the area intersection is empty: union the two paths and compare perimeters. A shared segment dissolves in the union and shortens the combined perimeter by twice its length; point contact keeps the sum exact, so corner-touching features stay rejected. Threshold is 2 Clipper integer units (0.2 µm at `DEFAULT_CLIPPER_SCALE`). `featuresOverlapForCut` is intentionally untouched.
- `src/store/helpers/clipping.test.ts` (new) — predicate + grouping tests: full/partial shared edge, corner contact, disjoint, area-overlap regression, open profiles, and a hole-forming union (U-shape capped by a bar).
- `src/store/joinSharedEdge.test.ts` (new) — store-level workflow tests: `startJoinSelectedFeatures` grouping, join-session click-to-add (admits edge-adjacent, rejects corner-touch), merge producing a single feature with the combined outline, `keepOriginals`.
- `src/store/INDEX.md` — updated for the predicate semantics and the two new test files.

## Plan refinement (issue updated)

The plan proposed requiring the union to collapse to exactly one path in addition to the perimeter drop. Implementation drops the single-path requirement: a legitimate shared-edge union can produce two paths (outer contour + enclosed hole, e.g. a U-shape capped by a bar), and the perimeter test alone already rejects disjoint and corner-touching cases. Covered by a dedicated test.

## Verification

- `npm run build` green (lint + tsc + structural suite + vite); all 95 test files pass including the two new ones.
- No e2e addition: the change is store/engine-level with no new DOM, menu, or dialog behavior — the join panel and command wiring are unchanged. The store-level tests drive the same actions the UI buttons call (`startJoinSelectedFeatures` → `selectFeature` → `completePendingShapeAction`), so structural coverage is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
