### PR TITLE
Scroll feature tree to selection made outside the tree

### DIFF
--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { DragEvent, MouseEvent as ReactMouseEvent } from 'react'
 import type { FeatureOperation, RegionMaskMode } from '../../types/project'
 import { useProjectStore } from '../../store/projectStore'
@@ -86,6 +86,57 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
   const [tabsCollapsed, setTabsCollapsed] = useState(false)
   const [clampsCollapsed, setClampsCollapsed] = useState(false)
   const dragOverTarget = useRef<{ kind: 'features' | 'folder' | 'feature'; id?: string } | null>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const pendingScrollFeatureId = useRef<string | null>(null)
+
+  // #276: selection can originate outside the tree (sketch canvas click, sketch-edit
+  // entry) — bring the primary selected row into view. Keyed on selectedNode's object
+  // identity, not the feature id: every selection action builds a fresh selectedNode
+  // (hover does not), so re-selecting the same feature — or another member of a
+  // grouped folder, which keeps the same primary id — still scrolls. block:'nearest'
+  // keeps clicks on an already-visible row from scrolling. If the row is hidden
+  // inside a collapsed folder or section, expand it (revealFeatureFolder skips undo
+  // history) and let the follow-up effect below scroll once the row is rendered.
+  const selectedNode = selection.selectedNode
+  useEffect(() => {
+    pendingScrollFeatureId.current = null
+    if (selectedNode?.type !== 'feature') return
+    const row = panelRef.current?.querySelector(`[data-feature-id="${CSS.escape(selectedNode.featureId)}"]`)
+    if (row) {
+      row.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      return
+    }
+    const { project: currentProject, revealFeatureFolder } = useProjectStore.getState()
+    const feature = currentProject.features.find((f) => f.id === selectedNode.featureId)
+    if (!feature) return
+    pendingScrollFeatureId.current = feature.id
+    const section = sectionForOperation(feature.operation)
+    // Intentional setState-in-effect: the effect reacts to an external event
+    // (store selection change) and must expand the hidden row's section before
+    // the deferred scroll below can find it. Fires only on the collapsed path.
+    if (section === 'regions') {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setRegionsCollapsed(false)
+    } else if (section === 'construction') {
+      setConstructionCollapsed(false)
+    } else {
+      setFeaturesCollapsed(false)
+    }
+    if (feature.folderId) {
+      revealFeatureFolder(feature.folderId)
+    }
+  }, [selectedNode])
+
+  // Deferred half of the reveal-then-scroll: runs after every commit and scrolls
+  // once the newly expanded row is actually in the DOM.
+  useEffect(() => {
+    const id = pendingScrollFeatureId.current
+    if (!id) return
+    const row = panelRef.current?.querySelector(`[data-feature-id="${CSS.escape(id)}"]`)
+    if (!row) return
+    pendingScrollFeatureId.current = null
+    row.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+  })
 
   function handleFeatureDragStart(id: string) {
     setDragItem({ kind: 'feature', id })
@@ -308,6 +359,7 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
           selection.selectedFeatureIds.includes(feature.id)
         }
         isDragging={dragItem?.kind === 'feature' && dragItem.id === feature.id}
+        dataFeatureId={feature.id}
         visible={feature.visible}
         operation={feature.operation}
         profileClosed={feature.sketch.profile.closed}
@@ -348,7 +400,7 @@ export function FeatureTree({ onFeatureContextMenu, onTabContextMenu, onClampCon
   }
 
   return (
-    <div className="feature-tree-panel">
+    <div className="feature-tree-panel" ref={panelRef}>
       <div className="tree-list">
         <TreeRow
           label="Project"
@@ -785,6 +837,7 @@ interface TreeRowProps {
   depth?: number
   isSelected: boolean
   isDragging: boolean
+  dataFeatureId?: string
   visible?: boolean
   operation?: FeatureOperation
   profileClosed?: boolean
@@ -825,6 +878,7 @@ function TreeRow({
   depth = 0,
   isSelected,
   isDragging,
+  dataFeatureId,
   visible,
   operation,
   profileClosed = true,
@@ -883,6 +937,7 @@ function TreeRow({
         kind === 'feature' && operation === 'region' ? 'tree-row--region' : '',
         kind === 'feature' && operation === 'construction' ? 'tree-row--construction' : '',
       ].join(' ')}
+      data-feature-id={dataFeatureId}
       onClick={onClick}
       onMouseDown={(event) => {
         if (event.shiftKey) {

--- a/src/store/revealFeatureFolder.test.ts
+++ b/src/store/revealFeatureFolder.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * revealFeatureFolder (#276) — expands a collapsed folder without recording
+ * undo history, so selection-driven reveals never pollute Cmd+Z.
+ *
+ * Run with: npx tsx src/store/revealFeatureFolder.test.ts
+ */
+
+import { newProject, type Project } from '../types/project'
+import { useProjectStore } from './projectStore'
+import type { ProjectStore } from './types'
+
+// ── Assertion helpers ──────────────────────────────────────────────
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+// ── Store helpers ──────────────────────────────────────────────────
+
+function resetStore(project?: Project): void {
+  useProjectStore.setState({
+    project: project ?? newProject(),
+    selection: {
+      selectedFeatureIds: [],
+      selectedFeatureId: null,
+      selectedNode: null,
+      mode: 'feature' as const,
+      sketchEditTool: null,
+      activeControl: null,
+      hoveredFeatureId: null,
+    },
+    history: { past: [], future: [], transactionStart: null },
+    sketchEditSession: null,
+    pendingConstraint: null,
+    pendingTransform: null,
+    pendingOffset: null,
+  } as unknown as Partial<ProjectStore>)
+}
+
+// ── Test runner ────────────────────────────────────────────────────
+
+let passed = 0
+let failed = 0
+
+function test(name: string, fn: () => void): void {
+  try {
+    fn()
+    passed += 1
+    console.log(`   ✓ ${name}`)
+  } catch (err: unknown) {
+    failed += 1
+    const msg = err instanceof Error ? err.message : String(err)
+    console.log(`   ✗ ${name}: ${msg}`)
+  }
+}
+
+console.log('\nrevealFeatureFolder — expands without undo history')
+
+test('expands a collapsed folder', () => {
+  resetStore()
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().updateFeatureFolder(folderId, { collapsed: true })
+
+  useProjectStore.getState().revealFeatureFolder(folderId)
+  const folder = useProjectStore.getState().project.featureFolders.find((f) => f.id === folderId)
+  assert(folder !== undefined, 'folder should exist')
+  assert(folder.collapsed === false, `expected collapsed === false, got ${folder.collapsed}`)
+})
+
+test('does not push an undo history entry', () => {
+  resetStore()
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().updateFeatureFolder(folderId, { collapsed: true })
+  const pastLengthBefore = useProjectStore.getState().history.past.length
+
+  useProjectStore.getState().revealFeatureFolder(folderId)
+  const { history } = useProjectStore.getState()
+  assert(
+    history.past.length === pastLengthBefore,
+    `expected history.past to stay at ${pastLengthBefore}, got ${history.past.length}`,
+  )
+})
+
+test('no-op when the folder is already expanded', () => {
+  resetStore()
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  const projectBefore = useProjectStore.getState().project
+
+  useProjectStore.getState().revealFeatureFolder(folderId)
+  assert(
+    useProjectStore.getState().project === projectBefore,
+    'project reference should be unchanged for an already-expanded folder',
+  )
+})
+
+test('no-op for an unknown folder id', () => {
+  resetStore()
+  const projectBefore = useProjectStore.getState().project
+
+  useProjectStore.getState().revealFeatureFolder('fd-does-not-exist')
+  assert(
+    useProjectStore.getState().project === projectBefore,
+    'project reference should be unchanged for an unknown folder id',
+  )
+})
+
+// ============================================================================
+// Summary
+// ============================================================================
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  process.exitCode = 1
+}

--- a/src/store/slices/treeVisibilitySlice.ts
+++ b/src/store/slices/treeVisibilitySlice.ts
@@ -28,6 +28,7 @@ export type TreeVisibilitySlice = Pick<
   | 'toggleConstructionFolderVisible'
   | 'selectFolderFeatures'
   | 'toggleFolderGrouped'
+  | 'revealFeatureFolder'
 >
 
 export function createTreeVisibilitySlice(
@@ -226,6 +227,26 @@ export function createTreeVisibilitySlice(
       return selectionChanged
         ? { ...base, selection: { ...s.selection, groupFolderId: nextGroupFolderId } }
         : base
+    }),
+
+  // Selection-driven reveal (#276): expands a collapsed folder WITHOUT pushing
+  // undo history — Cmd+Z after clicking a feature in the sketch must undo a
+  // real edit, not this UI-state change.
+  revealFeatureFolder: (folderId) =>
+    set((s) => {
+      const folder = s.project.featureFolders.find((f) => f.id === folderId)
+      if (!folder || !folder.collapsed) {
+        return {}
+      }
+      return {
+        project: {
+          ...s.project,
+          featureFolders: s.project.featureFolders.map((f) =>
+            f.id === folderId ? { ...f, collapsed: false } : f
+          ),
+          meta: { ...s.project.meta, modified: new Date().toISOString() },
+        },
+      }
     }),
 
   }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -359,6 +359,7 @@ export interface ProjectStore {
   toggleConstructionFolderVisible: (folderId: string) => void
   selectFolderFeatures: (folderId: string) => void
   toggleFolderGrouped: (folderId: string) => void
+  revealFeatureFolder: (folderId: string) => void
   groupSelectedFeaturesIntoNewFolder: () => string
   addFeature: (feature: SketchFeature) => void
   importShapes: (input: { fileName: string; sourceType: ImportSourceType; shapes: ImportedShape[] }) => string[]


### PR DESCRIPTION
## Summary

Closes #276.

When a feature is selected from outside the feature tree — a sketch-canvas click, a marquee selection, or entering sketch-edit — the tree now scrolls so the selected row is visible. Previously the selection highlighted a row that could be scrolled out of view.

## Behavior

- **Visible row:** scrolls into view with `block: 'nearest'`, so clicks originating *inside* the tree (already-visible row) never cause a jump.
- **Row hidden in a collapsed folder or section:** the blocking folder and/or section (Features / Regions / Construction) is expanded first, then a deferred effect scrolls once the row is actually rendered — riding React's commit cycle rather than timers.
- **Grouped folders / repeated selections:** the effect is keyed on `selection.selectedNode`'s object identity (a fresh object per selection action, but not on hover), so re-selecting the same feature or another member of a grouped folder still scrolls.

## Implementation

- `revealFeatureFolder` — new store action that expands a collapsed folder **without pushing an undo-history entry**, so `Cmd+Z` after clicking a shape in the sketch still undoes the last real edit, not the folder expand.
- `FeatureTree.tsx` — feature rows carry `data-feature-id`; a selection effect finds the row (or expands its section/folder), and a follow-up effect completes the scroll after the expansion re-render commits.

## Tests

New `src/store/revealFeatureFolder.test.ts` covers: expands a collapsed folder, leaves undo history untouched, and no-ops for already-expanded or unknown folders.

Verified with `npm run build` (lint, typecheck, full test suite, bundle) — all green.