### PR TITLE
Select overlapping sketch features

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -41,7 +41,7 @@ Current smoke targets:
 - `creationTargets.smoke.spec.ts` — dedicated Line creation target wiring, active drawing badge, and landscape-tablet availability.
 - `gcodeExport.smoke.spec.ts` — Export G-code dialog operation checklist: per-operation entry point, default set, none-selected disabled state.
 - `importGeometry.smoke.spec.ts` — real-user import flow: dialog open/close, button state, file upload via hidden input, SVG/DXF mode selection with classification summary verification (Auto/Paths/Solid regions), real Import button, project-role verification through existing `getProject` seam, and landscape tablet layout. Synthetic inline fixtures only.
-- `overlapFeatureSelection.smoke.spec.ts` — overlapping sketch feature picker wiring, non-topmost selection, and landscape-tablet availability.
+- `overlapFeatureSelection.smoke.spec.ts` — overlapping sketch feature picker wiring, non-topmost selection, boxed scroll behavior, next-action dismissal, and landscape-tablet availability.
 
 ## Adding a test
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -41,6 +41,7 @@ Current smoke targets:
 - `creationTargets.smoke.spec.ts` — dedicated Line creation target wiring, active drawing badge, and landscape-tablet availability.
 - `gcodeExport.smoke.spec.ts` — Export G-code dialog operation checklist: per-operation entry point, default set, none-selected disabled state.
 - `importGeometry.smoke.spec.ts` — real-user import flow: dialog open/close, button state, file upload via hidden input, SVG/DXF mode selection with classification summary verification (Auto/Paths/Solid regions), real Import button, project-role verification through existing `getProject` seam, and landscape tablet layout. Synthetic inline fixtures only.
+- `overlapFeatureSelection.smoke.spec.ts` — overlapping sketch feature picker wiring, non-topmost selection, and landscape-tablet availability.
 
 ## Adding a test
 

--- a/e2e/overlapFeatureSelection.helpers.ts
+++ b/e2e/overlapFeatureSelection.helpers.ts
@@ -57,7 +57,7 @@ function feature(id: string, name: string, definitionId: string) {
   }
 }
 
-function buildOverlapFeatureProjectJson(): string {
+function buildOverlapFeatureProjectJson(featureCount: number): string {
   const now = '2026-07-13T00:00:00.000Z'
   const stockWidth = 120
   const stockHeight = 90
@@ -100,14 +100,17 @@ function buildOverlapFeatureProjectJson(): string {
     dimensions: {},
     annotations: [],
     modelAssets: {},
-    featureDefinitions: {
-      'def-overlap-bottom': definition('def-overlap-bottom', stockWidth, stockHeight),
-      'def-overlap-top': definition('def-overlap-top', stockWidth, stockHeight),
-    },
-    features: [
-      feature('f-overlap-bottom', 'Bottom overlap', 'def-overlap-bottom'),
-      feature('f-overlap-top', 'Top overlap', 'def-overlap-top'),
-    ],
+    featureDefinitions: Object.fromEntries(Array.from({ length: featureCount }, (_, index) => {
+      const id = `overlap-${index + 1}`
+      return [`def-${id}`, definition(`def-${id}`, stockWidth, stockHeight)]
+    })),
+    features: Array.from({ length: featureCount }, (_, index) => {
+      const name = featureCount === 2
+        ? (index === 0 ? 'Bottom overlap' : 'Top overlap')
+        : `Overlap feature ${index + 1}`
+      const id = `overlap-${index + 1}`
+      return feature(`f-${id}`, name, `def-${id}`)
+    }),
     featureFolders: [],
     featureTree: [],
     global_constraints: [],
@@ -119,10 +122,8 @@ function buildOverlapFeatureProjectJson(): string {
   })
 }
 
-const OVERLAP_FEATURE_PROJECT_JSON = buildOverlapFeatureProjectJson()
-
-export async function seedOverlapFeatureProject(page: Page): Promise<void> {
-  await seedProject(page, OVERLAP_FEATURE_PROJECT_JSON)
+export async function seedOverlapFeatureProject(page: Page, featureCount = 2): Promise<void> {
+  await seedProject(page, buildOverlapFeatureProjectJson(featureCount))
 }
 
 export async function clickCanvasCenter(canvas: Locator): Promise<void> {

--- a/e2e/overlapFeatureSelection.helpers.ts
+++ b/e2e/overlapFeatureSelection.helpers.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Locator, Page } from '@playwright/test'
+import { seedProject } from './helpers'
+
+function rectProfile(x: number, y: number, width: number, height: number) {
+  return {
+    start: { x, y },
+    segments: [
+      { type: 'line' as const, to: { x: x + width, y } },
+      { type: 'line' as const, to: { x: x + width, y: y + height } },
+      { type: 'line' as const, to: { x, y: y + height } },
+      { type: 'line' as const, to: { x, y } },
+    ],
+    closed: true,
+  }
+}
+
+function definition(id: string, width: number, height: number) {
+  return {
+    id,
+    kind: 'rect' as const,
+    profile: rectProfile(0, 0, width, height),
+    dimensions: [] as unknown[],
+    text: null,
+    stl: null,
+    operation: 'add' as const,
+  }
+}
+
+function feature(id: string, name: string, definitionId: string) {
+  return {
+    id,
+    name,
+    definitionId,
+    transform: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+    constraints: [] as unknown[],
+    folderId: null,
+    z_top: 5,
+    z_bottom: 0,
+    visible: true,
+    locked: false,
+  }
+}
+
+function buildOverlapFeatureProjectJson(): string {
+  const now = '2026-07-13T00:00:00.000Z'
+  const stockWidth = 120
+  const stockHeight = 90
+
+  return JSON.stringify({
+    version: '3.0',
+    meta: {
+      name: 'Overlap selection E2E fixture',
+      created: now,
+      modified: now,
+      units: 'inch',
+      showFeatureInfo: true,
+      showDimensions: true,
+      copyMode: 'reference',
+      maxTravelZ: 2,
+      operationClearanceZ: 0.2,
+      clampClearanceXY: 0.5,
+      clampClearanceZ: 0.2,
+      machineDefinitions: [],
+      selectedMachineId: null,
+    },
+    grid: {
+      extent: 200,
+      majorSpacing: 1,
+      minorSpacing: 0.25,
+      snapEnabled: false,
+      snapIncrement: 0.25,
+      visible: true,
+    },
+    stock: {
+      profile: rectProfile(0, 0, stockWidth, stockHeight),
+      thickness: 2,
+      material: 'aluminum_6061',
+      color: '#b9a83c',
+      visible: true,
+      origin: { x: 0, y: 0 },
+    },
+    origin: { name: 'Origin', x: stockWidth / 2, y: stockHeight / 2, z: 2, visible: true },
+    backdrop: null,
+    dimensions: {},
+    annotations: [],
+    modelAssets: {},
+    featureDefinitions: {
+      'def-overlap-bottom': definition('def-overlap-bottom', stockWidth, stockHeight),
+      'def-overlap-top': definition('def-overlap-top', stockWidth, stockHeight),
+    },
+    features: [
+      feature('f-overlap-bottom', 'Bottom overlap', 'def-overlap-bottom'),
+      feature('f-overlap-top', 'Top overlap', 'def-overlap-top'),
+    ],
+    featureFolders: [],
+    featureTree: [],
+    global_constraints: [],
+    tools: [],
+    operations: [],
+    tabs: [],
+    clamps: [],
+    ai_history: [],
+  })
+}
+
+const OVERLAP_FEATURE_PROJECT_JSON = buildOverlapFeatureProjectJson()
+
+export async function seedOverlapFeatureProject(page: Page): Promise<void> {
+  await seedProject(page, OVERLAP_FEATURE_PROJECT_JSON)
+}
+
+export async function clickCanvasCenter(canvas: Locator): Promise<void> {
+  const box = await canvas.boundingBox()
+  if (!box) throw new Error('sketch canvas did not have a bounding box')
+
+  await canvas.click({ position: { x: box.width / 2, y: box.height / 2 } })
+}

--- a/e2e/overlapFeatureSelection.smoke.spec.ts
+++ b/e2e/overlapFeatureSelection.smoke.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures'
+import { clickCanvasCenter, seedOverlapFeatureProject } from './overlapFeatureSelection.helpers'
+
+test.describe('Overlap feature selection browser smoke', () => {
+  test('shows overlapping candidates and lets the user select a non-topmost feature', async ({ app, ui }) => {
+    await seedOverlapFeatureProject(app.page)
+
+    await clickCanvasCenter(ui.canvas.sketch(app.page))
+
+    const picker = ui.overlapFeaturePicker.root(app.page)
+    await expect(picker).toBeVisible()
+    await expect(ui.overlapFeaturePicker.candidates(app.page)).toHaveCount(2)
+    await expect(ui.overlapFeaturePicker.candidate(app.page, 'Top overlap')).toBeVisible()
+    await expect(ui.overlapFeaturePicker.candidate(app.page, 'Bottom overlap')).toBeVisible()
+
+    await ui.overlapFeaturePicker.candidate(app.page, 'Bottom overlap').click()
+
+    await expect(picker).not.toBeVisible()
+    await expect(ui.tree.rowByName(app.page, 'Bottom overlap')).toHaveClass(/tree-row--selected/)
+    await expect(ui.tree.rowByName(app.page, 'Top overlap')).not.toHaveClass(/tree-row--selected/)
+  })
+
+  test('picker is usable in the landscape-tablet layout and Escape cancels it', async ({ app, ui }) => {
+    await app.page.setViewportSize({ width: 1024, height: 768 })
+    await seedOverlapFeatureProject(app.page)
+
+    await clickCanvasCenter(ui.canvas.sketch(app.page))
+
+    const picker = ui.overlapFeaturePicker.root(app.page)
+    await expect(picker).toBeVisible()
+    await expect(ui.overlapFeaturePicker.candidate(app.page, 'Bottom overlap')).toBeVisible()
+
+    await app.page.keyboard.press('Escape')
+
+    await expect(picker).not.toBeVisible()
+    await expect(ui.tree.selectedRows(app.page)).toHaveCount(0)
+  })
+})

--- a/e2e/overlapFeatureSelection.smoke.spec.ts
+++ b/e2e/overlapFeatureSelection.smoke.spec.ts
@@ -51,4 +51,40 @@ test.describe('Overlap feature selection browser smoke', () => {
     await expect(picker).not.toBeVisible()
     await expect(ui.tree.selectedRows(app.page)).toHaveCount(0)
   })
+
+  test('boxes and scrolls a long candidate list', async ({ app, ui }) => {
+    await seedOverlapFeatureProject(app.page, 17)
+
+    await clickCanvasCenter(ui.canvas.sketch(app.page))
+
+    const list = ui.overlapFeaturePicker.list(app.page)
+    await expect(list).toBeVisible()
+    await expect(ui.overlapFeaturePicker.candidates(app.page)).toHaveCount(17)
+    await expect(list).toHaveCSS('overflow-y', 'auto')
+
+    const dimensions = await list.evaluate((element) => ({
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+    }))
+    expect(dimensions.scrollHeight, 'long candidate list should scroll within its boxed viewport')
+      .toBeGreaterThan(dimensions.clientHeight)
+
+    await list.evaluate((element) => { element.scrollTop = element.scrollHeight })
+    expect(await list.evaluate((element) => element.scrollTop), 'candidate list should accept scrolling')
+      .toBeGreaterThan(0)
+  })
+
+  test('dismisses when the user starts a different action', async ({ app, ui }) => {
+    await seedOverlapFeatureProject(app.page)
+
+    await clickCanvasCenter(ui.canvas.sketch(app.page))
+
+    const picker = ui.overlapFeaturePicker.root(app.page)
+    await expect(picker).toBeVisible()
+
+    await ui.tree.rowByName(app.page, 'Bottom overlap').click()
+
+    await expect(picker).not.toBeVisible()
+    await expect(ui.tree.rowByName(app.page, 'Bottom overlap')).toHaveClass(/tree-row--selected/)
+  })
 })

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -180,6 +180,15 @@ export const canvas = {
   any: (page: Page) => page.locator('canvas').first(),
 }
 
+// ── Overlap feature picker ─────────────────────────────────────────
+
+export const overlapFeaturePicker = {
+  root: (page: Page) => page.getByRole('dialog', { name: 'Select feature' }),
+  candidates: (page: Page) => overlapFeaturePicker.root(page).locator('.overlap-feature-picker__candidate'),
+  candidate: (page: Page, name: string) => overlapFeaturePicker.root(page).getByRole('button', { name: new RegExp(`Select ${name}`) }),
+  cancelButton: (page: Page) => overlapFeaturePicker.root(page).getByRole('button', { name: 'Cancel', exact: true }),
+}
+
 // ── Toolbar ─────────────────────────────────────────────────────────
 
 export const toolbar = {

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -184,6 +184,7 @@ export const canvas = {
 
 export const overlapFeaturePicker = {
   root: (page: Page) => page.getByRole('dialog', { name: 'Select feature' }),
+  list: (page: Page) => overlapFeaturePicker.root(page).locator('.overlap-feature-picker__list'),
   candidates: (page: Page) => overlapFeaturePicker.root(page).locator('.overlap-feature-picker__candidate'),
   candidate: (page: Page, name: string) => overlapFeaturePicker.root(page).getByRole('button', { name: new RegExp(`Select ${name}`) }),
   cancelButton: (page: Page) => overlapFeaturePicker.root(page).getByRole('button', { name: 'Cancel', exact: true }),

--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -16,7 +16,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 
 ## Subfolders (by area)
 - `common/` — shared cross-panel UI primitives. `DisclosureSection` is the reusable collapsible "Advanced" section (progressive disclosure); its open/collapsed state persists via the pure helpers in `common/disclosureState.ts`.
-- `canvas/` — 2D sketch canvas: drawing, snapping, panning/zoom, pointer handling, and creation workflow panels including gear/parameter reference diagrams. `previewPrimitives.ts` keeps Line/Construction geometry stroke-only; `previewPrimitives.test.ts` covers that rendering-role policy. Dimension annotations + tape measure render via `canvas/dimensionRendering.ts` (pure geometry in `sketch/dimensions.ts`); `canvas/operationSnapshot.ts` renders static operation booklet images.
+- `canvas/` — 2D sketch canvas: drawing, snapping, panning/zoom, pointer handling, creation workflow panels, and overlap disambiguation through `useOverlapFeaturePicker` / `OverlapFeaturePicker`. `previewPrimitives.ts` keeps Line/Construction geometry stroke-only; `previewPrimitives.test.ts` covers that rendering-role policy. Dimension annotations + tape measure render via `canvas/dimensionRendering.ts` (pure geometry in `sketch/dimensions.ts`); `canvas/operationSnapshot.ts` renders static operation booklet images.
 - `viewport3d/` — Three.js 3D preview of the CSG-derived model, including toolpath overlay helpers
 - `simulation/` — voxel toolpath simulation viewport and playback controls
 - `cam/` — CAM panels (tools, operations, parameters); per-parameter reference icons via `OperationParameterReference`

--- a/src/components/canvas/OverlapFeaturePicker.tsx
+++ b/src/components/canvas/OverlapFeaturePicker.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { FeatureKind } from '../../types/project'
+import { CanvasWorkflowPanel } from './CanvasWorkflowPanel'
+import type { OverlapFeaturePickerController } from './useOverlapFeaturePicker'
+
+interface OverlapFeaturePickerProps {
+  picker: OverlapFeaturePickerController
+}
+
+const FEATURE_KIND_LABELS: Record<FeatureKind, string> = {
+  rect: 'Rectangle',
+  circle: 'Circle',
+  ellipse: 'Ellipse',
+  polygon: 'Polygon',
+  spline: 'Spline',
+  composite: 'Composite path',
+  text: 'Text',
+  stl: 'STL model',
+}
+
+export function OverlapFeaturePicker({ picker }: OverlapFeaturePickerProps) {
+  if (!picker.isOpen) return null
+
+  const candidateCount = picker.candidates.length
+
+  return (
+    <div className="overlap-feature-picker" role="dialog" aria-label="Select feature" aria-modal="false">
+      <CanvasWorkflowPanel
+        title="Select feature"
+        step={`${candidateCount} features overlap here. Choose one to select.`}
+        position={picker.workflowPanel.position}
+        panelRef={picker.workflowPanel.panelRef}
+        handleProps={picker.workflowPanel.handleProps}
+        actionRowProps={picker.workflowPanel.actionRowProps}
+        className="overlap-feature-picker__panel"
+        moveLabel="Move feature selection controls"
+        actions={(
+          <button
+            type="button"
+            className="tablet-cmd-btn tablet-cmd-btn--cancel"
+            onClick={picker.cancel}
+          >Cancel</button>
+        )}
+      >
+        <div className="overlap-feature-picker__list" aria-label="Overlapping features">
+          {picker.candidates.map((candidate) => {
+            const kindLabel = FEATURE_KIND_LABELS[candidate.kind]
+            return (
+              <button
+                key={candidate.id}
+                type="button"
+                className="overlap-feature-picker__candidate"
+                aria-label={`Select ${candidate.name}, ${kindLabel}`}
+                onClick={() => picker.selectCandidate(candidate.id)}
+              >
+                <span className="overlap-feature-picker__candidate-name">{candidate.name}</span>
+                <span className="overlap-feature-picker__candidate-kind">{kindLabel}</span>
+              </button>
+            )
+          })}
+        </div>
+      </CanvasWorkflowPanel>
+    </div>
+  )
+}

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -140,7 +140,9 @@ import { useStableEvent } from '../../hooks/useStableEvent'
 import { useRafScheduler } from '../../hooks/useRafScheduler'
 import { useShellMode, isTabletMode } from '../layout/useShellMode'
 import { CanvasWorkflowPanel } from './CanvasWorkflowPanel'
+import { OverlapFeaturePicker } from './OverlapFeaturePicker'
 import { useCanvasWorkflowPanel } from './useCanvasWorkflowPanel'
+import { useOverlapFeaturePicker } from './useOverlapFeaturePicker'
 import {
   buildPlacedClipboardFeatures,
   FEATURE_CLIPBOARD_PLACEMENT_EVENT,
@@ -2518,6 +2520,13 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     })
   }
 
+  const overlapFeaturePicker = useOverlapFeaturePicker({
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+    selectFeature,
+  })
+
   const keyboard = useCanvasKeyboard({
     projectRef,
     selectionRef,
@@ -2544,6 +2553,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     originPreviewPointRef,
     hoveredEditControlRef,
     canvasRef,
+    overlapFeaturePickerOpen: overlapFeaturePicker.isOpen,
     dimEdit,
     constraint,
     move,
@@ -2566,6 +2576,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     confirmCutCutters,
     cancelPendingShapeAction,
     cancelPendingSketchEdit,
+    cancelOverlapFeaturePicker: overlapFeaturePicker.cancel,
     completePendingMove,
     completePendingShapeAction,
     beginHistoryTransaction,
@@ -2668,6 +2679,8 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     isDraggingNodeRef,
     zoomWindowActive,
     multiSelectMode,
+    clearOverlapFeaturePicker: overlapFeaturePicker.dismiss,
+    openOverlapFeaturePicker: overlapFeaturePicker.open,
     selectionRef,
     projectRef,
     pendingAddRef,
@@ -2813,6 +2826,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         onContextMenu={contextMenu.handleContextMenu}
         tabIndex={0}
       />
+      <OverlapFeaturePicker picker={overlapFeaturePicker} />
       <CreationTargetBadge />
       {!depthLegendCollapsed ? <DepthLegend onToggleDepthLegend={onToggleDepthLegend} /> : null}
       {(toolpaths && toolpaths.some((tp) => tp.moves.length > 0)) && toolpathVisibility && onToolpathVisibilityChange && (

--- a/src/components/canvas/hitTest.test.ts
+++ b/src/components/canvas/hitTest.test.ts
@@ -27,7 +27,7 @@ import { rectProfile } from '../../types/project'
 import { newProject, type Matrix2D, type Project, type SketchFeature } from '../../types/project'
 import { resolvedProjectFeatures } from '../../store/helpers/resolveFeatures'
 import { projectWithFeatures } from '../../test/projectFixtures'
-import { findHitFeatureId, featureFullyInsideRect } from './hitTest'
+import { findHitFeatureId, findHitFeatureIds, featureFullyInsideRect } from './hitTest'
 import type { ViewTransform } from './viewTransform'
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -114,13 +114,19 @@ function makeProject(
   assert(raw.definitionId === 'f0001', 'feature should have definitionId')
   assert(raw.transform?.e === 100 && raw.transform?.f === 50, 'feature should have translate transform')
 
+  const resolvedFeatures = resolvedProjectFeatures(project)
+
   // Point at world position (105, 53) — inside the transformed profile.
-  const hitWorld = findHitFeatureId({ x: 105, y: 53 }, resolvedProjectFeatures(project), vt)
+  const hitWorld = findHitFeatureId({ x: 105, y: 53 }, resolvedFeatures, vt)
   assert(hitWorld === 'f0001', 'point inside transformed world profile should hit')
+  assert(
+    findHitFeatureIds({ x: 105, y: 53 }, resolvedFeatures, vt).join(',') === 'f0001',
+    'candidate hits should use the transformed world profile',
+  )
 
   // Point at definition-local position (5, 3) — should NOT hit because the
   // world-space profile is at (100,50)-(110,56), and (5,3) is outside it.
-  const hitLocal = findHitFeatureId({ x: 5, y: 3 }, resolvedProjectFeatures(project), vt)
+  const hitLocal = findHitFeatureId({ x: 5, y: 3 }, resolvedFeatures, vt)
   assert(hitLocal === null, 'point at definition-local position should NOT hit transformed feature')
 
   console.log('   ✓ transformed feature hit test correct')
@@ -193,6 +199,28 @@ function makeProject(
   assert(resolvedList[0].instanceId === 'f0001', 'resolved instanceId = feature id')
 
   console.log('   ✓ instance IDs preserved')
+}
+
+// Overlapping feature picks retain topmost-first order and ignore hidden features.
+{
+  console.log('6. Overlap hit candidates...')
+
+  const bottom = makeFeature('bottom')
+  const hidden = makeFeature('hidden', undefined, { visible: false })
+  const top = makeFeature('top')
+  const project = makeProject([bottom, hidden, top])
+  const features = resolvedProjectFeatures(project)
+
+  const hitIds = findHitFeatureIds({ x: 5, y: 3 }, features, vt)
+  assert(hitIds.join(',') === 'top,bottom', `expected top,bottom candidates, got ${hitIds.join(',')}`)
+  assert(findHitFeatureId({ x: 5, y: 3 }, features, vt) === 'top', 'single-hit helper should keep returning topmost candidate')
+
+  // Closed-profile edge tolerance is part of ordinary selection and must apply
+  // to the full candidate list as well.
+  const edgeHitIds = findHitFeatureIds({ x: 14, y: 3 }, features, vt)
+  assert(edgeHitIds.join(',') === 'top,bottom', `expected edge candidates, got ${edgeHitIds.join(',')}`)
+
+  console.log('   ✓ overlap candidates retain hit-test semantics')
 }
 
 console.log('\nall hitTest.test.ts assertions passed')

--- a/src/components/canvas/hitTest.ts
+++ b/src/components/canvas/hitTest.ts
@@ -248,14 +248,32 @@ export function segmentHitTest(
   return best
 }
 
+function featureContainsPoint(feature: FeatureLike, worldPoint: Point, vt: ViewTransform): boolean {
+  return pointInProfile(worldPoint.x, worldPoint.y, feature.sketch.profile)
+    || pointNearProfile(worldPoint, feature.sketch.profile, vt)
+}
+
+/**
+ * Returns every visible feature at a point in topmost-first draw order.
+ *
+ * The selection UI uses this to disambiguate overlaps. Callers that only need
+ * the topmost feature should keep using {@link findHitFeatureId}.
+ */
+export function findHitFeatureIds(worldPoint: Point, features: readonly FeatureLike[], vt: ViewTransform): string[] {
+  const hitIds: string[] = []
+  for (let index = features.length - 1; index >= 0; index -= 1) {
+    const feature = features[index]
+    if (!feature.visible) continue
+    if (featureContainsPoint(feature, worldPoint, vt)) hitIds.push(feature.id)
+  }
+  return hitIds
+}
+
 export function findHitFeatureId(worldPoint: Point, features: readonly FeatureLike[], vt: ViewTransform): string | null {
   for (let index = features.length - 1; index >= 0; index -= 1) {
     const feature = features[index]
     if (!feature.visible) continue
-    if (
-      pointInProfile(worldPoint.x, worldPoint.y, feature.sketch.profile)
-      || pointNearProfile(worldPoint, feature.sketch.profile, vt)
-    ) {
+    if (featureContainsPoint(feature, worldPoint, vt)) {
       return feature.id
     }
   }

--- a/src/components/canvas/useCanvasKeyboard.ts
+++ b/src/components/canvas/useCanvasKeyboard.ts
@@ -93,6 +93,7 @@ export interface CanvasKeyboardCtx {
   originPreviewPointRef: MutableRefObject<PendingPreviewPoint | null>
   hoveredEditControlRef: MutableRefObject<SketchControlRef | null>
   canvasRef: RefObject<HTMLCanvasElement | null>
+  overlapFeaturePickerOpen: boolean
 
   dimEdit: DimensionEditWorkflow
   constraint: ConstraintWorkflow
@@ -117,6 +118,7 @@ export interface CanvasKeyboardCtx {
   confirmCutCutters: () => void
   cancelPendingShapeAction: () => void
   cancelPendingSketchEdit: () => void
+  cancelOverlapFeaturePicker: () => void
   completePendingMove: (toPoint: Point, copyCount?: number) => void
   completePendingShapeAction: () => void
   beginHistoryTransaction: () => void
@@ -166,6 +168,7 @@ export function useCanvasKeyboard(ctx: CanvasKeyboardCtx): {
     originPreviewPointRef,
     hoveredEditControlRef,
     canvasRef,
+    overlapFeaturePickerOpen,
     dimEdit,
     constraint,
     move,
@@ -188,6 +191,7 @@ export function useCanvasKeyboard(ctx: CanvasKeyboardCtx): {
     confirmCutCutters,
     cancelPendingShapeAction,
     cancelPendingSketchEdit,
+    cancelOverlapFeaturePicker,
     completePendingMove,
     completePendingShapeAction,
     beginHistoryTransaction,
@@ -216,6 +220,12 @@ export function useCanvasKeyboard(ctx: CanvasKeyboardCtx): {
     const pendingOffset = pendingOffsetRef.current
     const pendingShapeAction = pendingShapeActionRef.current
     const viewState = viewStateRef.current
+
+    if (event.key === 'Escape' && overlapFeaturePickerOpen) {
+      event.preventDefault()
+      cancelOverlapFeaturePicker()
+      return
+    }
 
     // ── Measure & dimension tools ──
     if (event.key === 'Escape' && tapeMeasureRef.current) {

--- a/src/components/canvas/useClickPlacement.ts
+++ b/src/components/canvas/useClickPlacement.ts
@@ -49,6 +49,7 @@ import {
 import {
   findHitClampId,
   findHitFeatureId,
+  findHitFeatureIds,
   findHitTabId,
   segmentHitTest,
 } from './hitTest'
@@ -67,6 +68,7 @@ import type { MoveWorkflow } from './useMoveWorkflow'
 import type { TransformExactWorkflow } from './useTransformExactWorkflow'
 import type { FilletWorkflow } from './useFilletWorkflow'
 import type { UseSnapPreviewReturn } from './useSnapPreview'
+import type { OverlapFeatureCandidate } from './useOverlapFeaturePicker'
 
 const POLYGON_CLOSE_RADIUS = 12
 
@@ -102,6 +104,8 @@ export interface ClickPlacementCtx {
   isDraggingNodeRef: MutableRefObject<boolean>
   zoomWindowActive: boolean
   multiSelectMode: boolean
+  clearOverlapFeaturePicker: () => void
+  openOverlapFeaturePicker: (candidates: readonly OverlapFeatureCandidate[], additive: boolean) => void
   selectionRef: MutableRefObject<SelectionState>
   projectRef: MutableRefObject<Project>
   pendingAddRef: MutableRefObject<PendingAddTool | null>
@@ -235,6 +239,8 @@ export function useClickPlacement(ctx: ClickPlacementCtx): UseClickPlacementRetu
     isDraggingNodeRef,
     zoomWindowActive,
     multiSelectMode,
+    clearOverlapFeaturePicker,
+    openOverlapFeaturePicker,
     selectionRef,
     projectRef,
     pendingAddRef,
@@ -352,6 +358,8 @@ export function useClickPlacement(ctx: ClickPlacementCtx): UseClickPlacementRetu
     const point = canvasCoordinates(event)
     const canvas = canvasRef.current
     if (!canvas) return
+
+    clearOverlapFeaturePicker()
 
     const vt = computeViewTransform(project.stock, canvas.width, canvas.height, viewState)
     const world = canvasToWorld(point.cx, point.cy, vt)
@@ -917,10 +925,20 @@ export function useClickPlacement(ctx: ClickPlacementCtx): UseClickPlacementRetu
       return
     }
 
-    const hitId = findHitFeatureId(world, resolvedProjectFeatures(project), vt)
+    const resolvedFeatures = resolvedProjectFeatures(project)
+    const featuresById = new Map(resolvedFeatures.map((feature) => [feature.id, feature]))
+    const hitCandidates: OverlapFeatureCandidate[] = []
+    for (const id of findHitFeatureIds(world, resolvedFeatures, vt)) {
+      const feature = featuresById.get(id)
+      if (feature) {
+        hitCandidates.push({ id: feature.id, name: feature.name, kind: feature.kind })
+      }
+    }
     const additive = event.metaKey || event.ctrlKey || event.shiftKey || multiSelectMode || !!pendingShapeAction
-    if (hitId) {
-      selectFeature(hitId, additive)
+    if (hitCandidates.length > 1) {
+      openOverlapFeaturePicker(hitCandidates, additive)
+    } else if (hitCandidates.length === 1) {
+      selectFeature(hitCandidates[0].id, additive)
     } else if (project.backdrop?.visible && hitBackdrop(world, project.backdrop)) {
       selectBackdrop()
     } else if (!additive) {

--- a/src/components/canvas/useOverlapFeaturePicker.ts
+++ b/src/components/canvas/useOverlapFeaturePicker.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react'
+import type { RefObject } from 'react'
+import type { FeatureKind } from '../../types/project'
+import { useCanvasWorkflowPanel } from './useCanvasWorkflowPanel'
+
+export interface OverlapFeatureCandidate {
+  id: string
+  name: string
+  kind: FeatureKind
+}
+
+interface PendingOverlapFeatureSelection {
+  candidates: readonly OverlapFeatureCandidate[]
+  additive: boolean
+}
+
+interface UseOverlapFeaturePickerOptions {
+  containerRef: RefObject<HTMLDivElement | null>
+  canvasRef: RefObject<HTMLCanvasElement | null>
+  clearTransientCanvasState: () => void
+  selectFeature: (id: string | null, additive?: boolean) => void
+}
+
+export interface OverlapFeaturePickerController {
+  isOpen: boolean
+  candidates: readonly OverlapFeatureCandidate[]
+  workflowPanel: ReturnType<typeof useCanvasWorkflowPanel>
+  open: (candidates: readonly OverlapFeatureCandidate[], additive: boolean) => void
+  dismiss: () => void
+  cancel: () => void
+  selectCandidate: (id: string) => void
+}
+
+/**
+ * Keeps the temporary UI state for choosing one feature among overlapping
+ * canvas hits. It does not own project selection; that stays in the store.
+ */
+export function useOverlapFeaturePicker({
+  containerRef,
+  canvasRef,
+  clearTransientCanvasState,
+  selectFeature,
+}: UseOverlapFeaturePickerOptions): OverlapFeaturePickerController {
+  const [pendingSelection, setPendingSelection] = useState<PendingOverlapFeatureSelection | null>(null)
+  const workflowPanel = useCanvasWorkflowPanel({
+    open: pendingSelection !== null,
+    phaseKey: pendingSelection?.candidates.map((candidate) => candidate.id).join(',') ?? null,
+    containerRef,
+    canvasRef,
+    clearTransientCanvasState,
+  })
+
+  function open(candidates: readonly OverlapFeatureCandidate[], additive: boolean) {
+    if (candidates.length < 2) return
+    setPendingSelection({ candidates, additive })
+  }
+
+  function dismiss() {
+    setPendingSelection(null)
+  }
+
+  function selectCandidate(id: string) {
+    if (!pendingSelection?.candidates.some((candidate) => candidate.id === id)) return
+    selectFeature(id, pendingSelection.additive)
+    dismiss()
+  }
+
+  return {
+    isOpen: pendingSelection !== null,
+    candidates: pendingSelection?.candidates ?? [],
+    workflowPanel,
+    open,
+    dismiss,
+    cancel: dismiss,
+    selectCandidate,
+  }
+}

--- a/src/components/canvas/useOverlapFeaturePicker.ts
+++ b/src/components/canvas/useOverlapFeaturePicker.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { RefObject } from 'react'
 import type { FeatureKind } from '../../types/project'
 import { useCanvasWorkflowPanel } from './useCanvasWorkflowPanel'
@@ -65,6 +65,23 @@ export function useOverlapFeaturePicker({
     canvasRef,
     clearTransientCanvasState,
   })
+
+  useEffect(() => {
+    if (!pendingSelection) return undefined
+
+    function dismissForOutsideAction(event: PointerEvent) {
+      const target = event.target
+      if (target instanceof Node && !workflowPanel.panelRef.current?.contains(target)) {
+        setPendingSelection(null)
+      }
+    }
+
+    document.addEventListener('pointerdown', dismissForOutsideAction, true)
+    return () => document.removeEventListener('pointerdown', dismissForOutsideAction, true)
+    // useCanvasWorkflowPanel keeps its panel ref stable, while its return object
+    // is intentionally recreated each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingSelection])
 
   function open(candidates: readonly OverlapFeatureCandidate[], additive: boolean) {
     if (candidates.length < 2) return

--- a/src/styles/canvas-workflow.css
+++ b/src/styles/canvas-workflow.css
@@ -207,15 +207,28 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
+  container-type: size;
 }
 
 .overlap-feature-picker__panel {
   width: min(360px, calc(100% - 24px));
+  max-height: calc(100% - 24px);
 }
 
 .overlap-feature-picker__list {
   display: grid;
   gap: 6px;
+  max-height: min(26rem, calc(100cqh - 164px));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: rgba(200, 156, 98, 0.68) rgba(7, 12, 17, 0.42);
+  scrollbar-gutter: stable;
+  touch-action: pan-y;
+  border: 1px solid rgba(200, 156, 98, 0.38);
+  border-radius: 8px;
+  background: rgba(7, 12, 17, 0.4);
+  box-shadow: inset 0 1px 0 rgba(229, 235, 238, 0.04);
+  padding: 6px;
 }
 
 .overlap-feature-picker__candidate {

--- a/src/styles/canvas-workflow.css
+++ b/src/styles/canvas-workflow.css
@@ -202,3 +202,57 @@
   padding: 0 10px;
   font-size: 12px;
 }
+
+.overlap-feature-picker {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.overlap-feature-picker__panel {
+  width: min(360px, calc(100% - 24px));
+}
+
+.overlap-feature-picker__list {
+  display: grid;
+  gap: 6px;
+}
+
+.overlap-feature-picker__candidate {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 44px;
+  border: 1px solid rgba(200, 156, 98, 0.24);
+  border-radius: 6px;
+  background: rgba(7, 12, 17, 0.54);
+  color: var(--text);
+  padding: 0 10px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.overlap-feature-picker__candidate:hover,
+.overlap-feature-picker__candidate:focus-visible {
+  border-color: var(--accent);
+  background: rgba(220, 165, 106, 0.14);
+  outline: none;
+}
+
+.overlap-feature-picker__candidate-name {
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.overlap-feature-picker__candidate-kind {
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
## Summary
- Present a topmost-first picker when a normal canvas click hits multiple visible sketch features.
- Keep modifier and tablet multi-selection intent when a candidate is chosen; Cancel and Escape leave selection unchanged.
- Place candidate buttons in a bordered, height-capped, touch-scrollable viewport while keeping the header, instruction, and Cancel action visible.
- Dismiss the picker before any outside pointer action proceeds, including canvas, tree, and toolbar interactions.
- Add structural coverage for transformed/hidden/edge hits and browser smoke coverage for non-topmost selection, scrolling, next-action dismissal, and landscape tablet behavior.

## Verification
- `npm run build`
- `npm run test:e2e -- e2e/overlapFeatureSelection.smoke.spec.ts` (4 passed)

Closes #289