### PR TITLE
Improve overlapping feature selection clarity

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -29,7 +29,7 @@ browser-free while PRs still exercise the browser smoke.
 |------|------|
 | `fixtures.ts` | Playwright `test` extension. Every spec imports `test` / `expect` from **here**, not `@playwright/test`. Provides `app` (booted page + error guard) and `ui` (selector module). |
 | `selectors.ts` | **Single source of truth** for DOM selectors. Logical name → `Locator`. When the UI moves a class, update it **here** — every spec picks it up. |
-| `helpers.ts` | Generic primitives: `seedProject`, `getProject`, `getPendingMove`, `completePendingMove`, `openRowContextMenu`, `clickMenuItem`, `rowByName`, `featureRowCount`, `assertNoConsoleErrors`. Domain-agnostic. |
+| `helpers.ts` | Generic primitives: `seedProject`, `getProject`, `getHoveredFeatureId`, `getPendingMove`, `completePendingMove`, `openRowContextMenu`, `clickMenuItem`, `rowByName`, `featureRowCount`, `assertNoConsoleErrors`. Domain-agnostic. |
 | `featureReferences.helpers.ts` | FR-specific helpers (e.g. `seedLinkedProject`). Built on the generic primitives. A new feature area gets its own `<area>.helpers.ts`. |
 | `camOperations.helpers.ts` | CAM-specific fixture helpers for operation workflow smoke tests. |
 | `gcodeExport.helpers.ts` | Export-dialog fixture: tool + two toolpath-producing operations + bundled GRBL machine selected. |
@@ -41,7 +41,7 @@ Current smoke targets:
 - `creationTargets.smoke.spec.ts` — dedicated Line creation target wiring, active drawing badge, and landscape-tablet availability.
 - `gcodeExport.smoke.spec.ts` — Export G-code dialog operation checklist: per-operation entry point, default set, none-selected disabled state.
 - `importGeometry.smoke.spec.ts` — real-user import flow: dialog open/close, button state, file upload via hidden input, SVG/DXF mode selection with classification summary verification (Auto/Paths/Solid regions), real Import button, project-role verification through existing `getProject` seam, and landscape tablet layout. Synthetic inline fixtures only.
-- `overlapFeatureSelection.smoke.spec.ts` — overlapping sketch feature picker wiring, non-topmost selection, boxed scroll behavior, next-action dismissal, and landscape-tablet availability.
+- `overlapFeatureSelection.smoke.spec.ts` — direct selection for clear outline clicks, ambiguous-overlap picker wiring, candidate hover/focus previews, non-topmost selection, boxed scroll behavior, next-action dismissal, and landscape-tablet availability.
 
 ## Adding a test
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -44,6 +44,14 @@ export async function getProject(page: Page): Promise<Record<string, unknown>> {
   })
 }
 
+/** Return the feature currently preview-highlighted by the live store. */
+export async function getHoveredFeatureId(page: Page): Promise<string | null> {
+  return page.evaluate(async () => {
+    const w = window as unknown as { __pcTest: { getHoveredFeatureId: () => Promise<string | null> } }
+    return w.__pcTest.getHoveredFeatureId()
+  })
+}
+
 /** Get the current pending move state (null if idle). */
 export async function getPendingMove(
   page: Page,

--- a/e2e/overlapFeatureSelection.helpers.ts
+++ b/e2e/overlapFeatureSelection.helpers.ts
@@ -42,12 +42,17 @@ function definition(id: string, width: number, height: number) {
   }
 }
 
-function feature(id: string, name: string, definitionId: string) {
+function feature(
+  id: string,
+  name: string,
+  definitionId: string,
+  transform = { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+) {
   return {
     id,
     name,
     definitionId,
-    transform: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+    transform,
     constraints: [] as unknown[],
     folderId: null,
     z_top: 5,
@@ -57,7 +62,7 @@ function feature(id: string, name: string, definitionId: string) {
   }
 }
 
-function buildOverlapFeatureProjectJson(featureCount: number): string {
+function buildOverlapFeatureProjectJson(featureCount: number, obviousOutline = false): string {
   const now = '2026-07-13T00:00:00.000Z'
   const stockWidth = 120
   const stockHeight = 90
@@ -102,14 +107,23 @@ function buildOverlapFeatureProjectJson(featureCount: number): string {
     modelAssets: {},
     featureDefinitions: Object.fromEntries(Array.from({ length: featureCount }, (_, index) => {
       const id = `overlap-${index + 1}`
-      return [`def-${id}`, definition(`def-${id}`, stockWidth, stockHeight)]
+      const isObviousTop = obviousOutline && featureCount === 2 && index === 1
+      return [`def-${id}`, definition(`def-${id}`, isObviousTop ? 50 : stockWidth, isObviousTop ? 30 : stockHeight)]
     })),
     features: Array.from({ length: featureCount }, (_, index) => {
       const name = featureCount === 2
         ? (index === 0 ? 'Bottom overlap' : 'Top overlap')
         : `Overlap feature ${index + 1}`
       const id = `overlap-${index + 1}`
-      return feature(`f-${id}`, name, `def-${id}`)
+      const isObviousTop = obviousOutline && featureCount === 2 && index === 1
+      return feature(
+        `f-${id}`,
+        name,
+        `def-${id}`,
+        isObviousTop
+          ? { a: 1, b: 0, c: 0, d: 1, e: 10, f: 30 }
+          : undefined,
+      )
     }),
     featureFolders: [],
     featureTree: [],
@@ -124,6 +138,10 @@ function buildOverlapFeatureProjectJson(featureCount: number): string {
 
 export async function seedOverlapFeatureProject(page: Page, featureCount = 2): Promise<void> {
   await seedProject(page, buildOverlapFeatureProjectJson(featureCount))
+}
+
+export async function seedObviousOverlapFeatureProject(page: Page): Promise<void> {
+  await seedProject(page, buildOverlapFeatureProjectJson(2, true))
 }
 
 export async function clickCanvasCenter(canvas: Locator): Promise<void> {

--- a/e2e/overlapFeatureSelection.smoke.spec.ts
+++ b/e2e/overlapFeatureSelection.smoke.spec.ts
@@ -15,9 +15,24 @@
  */
 
 import { test, expect } from './fixtures'
-import { clickCanvasCenter, seedOverlapFeatureProject } from './overlapFeatureSelection.helpers'
+import { getHoveredFeatureId } from './helpers'
+import {
+  clickCanvasCenter,
+  seedObviousOverlapFeatureProject,
+  seedOverlapFeatureProject,
+} from './overlapFeatureSelection.helpers'
 
 test.describe('Overlap feature selection browser smoke', () => {
+  test('selects a uniquely indicated outline without opening the picker', async ({ app, ui }) => {
+    await seedObviousOverlapFeatureProject(app.page)
+
+    await clickCanvasCenter(ui.canvas.sketch(app.page))
+
+    await expect(ui.overlapFeaturePicker.root(app.page)).not.toBeVisible()
+    await expect(ui.tree.rowByName(app.page, 'Top overlap')).toHaveClass(/tree-row--selected/)
+    await expect(ui.tree.rowByName(app.page, 'Bottom overlap')).not.toHaveClass(/tree-row--selected/)
+  })
+
   test('shows overlapping candidates and lets the user select a non-topmost feature', async ({ app, ui }) => {
     await seedOverlapFeatureProject(app.page)
 
@@ -34,6 +49,29 @@ test.describe('Overlap feature selection browser smoke', () => {
     await expect(picker).not.toBeVisible()
     await expect(ui.tree.rowByName(app.page, 'Bottom overlap')).toHaveClass(/tree-row--selected/)
     await expect(ui.tree.rowByName(app.page, 'Top overlap')).not.toHaveClass(/tree-row--selected/)
+  })
+
+  test('previews a hovered or focused candidate without selecting it', async ({ app, ui }) => {
+    await seedOverlapFeatureProject(app.page)
+    await clickCanvasCenter(ui.canvas.sketch(app.page))
+
+    const bottomCandidate = ui.overlapFeaturePicker.candidate(app.page, 'Bottom overlap')
+    const topCandidate = ui.overlapFeaturePicker.candidate(app.page, 'Top overlap')
+    const cancelButton = ui.overlapFeaturePicker.cancelButton(app.page)
+
+    await bottomCandidate.hover()
+    await expect.poll(() => getHoveredFeatureId(app.page)).toBe('f-overlap-1')
+    await expect(ui.tree.selectedRows(app.page)).toHaveCount(0)
+
+    await cancelButton.hover()
+    await expect.poll(() => getHoveredFeatureId(app.page)).toBeNull()
+
+    await topCandidate.focus()
+    await expect.poll(() => getHoveredFeatureId(app.page)).toBe('f-overlap-2')
+    await expect(ui.tree.selectedRows(app.page)).toHaveCount(0)
+
+    await cancelButton.focus()
+    await expect.poll(() => getHoveredFeatureId(app.page)).toBeNull()
   })
 
   test('picker is usable in the landscape-tablet layout and Escape cancels it', async ({ app, ui }) => {

--- a/src/components/canvas/OverlapFeaturePicker.tsx
+++ b/src/components/canvas/OverlapFeaturePicker.tsx
@@ -67,6 +67,18 @@ export function OverlapFeaturePicker({ picker }: OverlapFeaturePickerProps) {
                 className="overlap-feature-picker__candidate"
                 aria-label={`Select ${candidate.name}, ${kindLabel}`}
                 onClick={() => picker.selectCandidate(candidate.id)}
+                onPointerEnter={() => picker.previewCandidate(candidate.id)}
+                onPointerLeave={(event) => {
+                  if (document.activeElement !== event.currentTarget) {
+                    picker.previewCandidate(null)
+                  }
+                }}
+                onFocus={() => picker.previewCandidate(candidate.id)}
+                onBlur={(event) => {
+                  if (!event.currentTarget.matches(':hover')) {
+                    picker.previewCandidate(null)
+                  }
+                }}
               >
                 <span className="overlap-feature-picker__candidate-name">{candidate.name}</span>
                 <span className="overlap-feature-picker__candidate-kind">{kindLabel}</span>

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -2525,6 +2525,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     canvasRef,
     clearTransientCanvasState,
     selectFeature,
+    hoverFeature,
   })
 
   const keyboard = useCanvasKeyboard({

--- a/src/components/canvas/hitTest.test.ts
+++ b/src/components/canvas/hitTest.test.ts
@@ -27,7 +27,12 @@ import { rectProfile } from '../../types/project'
 import { newProject, type Matrix2D, type Project, type SketchFeature } from '../../types/project'
 import { resolvedProjectFeatures } from '../../store/helpers/resolveFeatures'
 import { projectWithFeatures } from '../../test/projectFixtures'
-import { findHitFeatureId, findHitFeatureIds, featureFullyInsideRect } from './hitTest'
+import {
+  findHitFeatureId,
+  findHitFeatureIds,
+  featureFullyInsideRect,
+  resolveFeatureSelectionHit,
+} from './hitTest'
 import type { ViewTransform } from './viewTransform'
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -36,6 +41,7 @@ function assert(condition: unknown, message: string): asserts condition {
 
 // Simple view transform: scale=1, no offset → world coords = screen coords.
 const vt: ViewTransform = { scale: 1, offsetX: 0, offsetY: 0 }
+const preciseVt: ViewTransform = { scale: 10, offsetX: 0, offsetY: 0 }
 
 // ── Helpers ────────────────────────────────────────────────────────
 
@@ -221,6 +227,69 @@ function makeProject(
   assert(edgeHitIds.join(',') === 'top,bottom', `expected edge candidates, got ${edgeHitIds.join(',')}`)
 
   console.log('   ✓ overlap candidates retain hit-test semantics')
+}
+
+// A unique nearby outline wins over other containing profiles.
+{
+  console.log('7. Clear outline selection...')
+
+  const outlined = makeFeature('outlined', rectProfile(0, 0, 10, 10))
+  const containingTop = makeFeature('containing-top', rectProfile(-5, -5, 20, 20))
+  const features = resolvedProjectFeatures(makeProject([outlined, containingTop]))
+  const result = resolveFeatureSelectionHit({ x: 0.2, y: 5 }, features, preciseVt)
+
+  assert(result.kind === 'direct', `expected direct hit, got ${result.kind}`)
+  assert(result.featureId === 'outlined', `expected outlined feature, got ${result.featureId}`)
+  assert(
+    result.candidateIds.join(',') === 'containing-top,outlined',
+    `expected all candidates in topmost order, got ${result.candidateIds.join(',')}`,
+  )
+
+  console.log('   ✓ unique nearby outline resolves directly')
+}
+
+// Coincident outlines remain ambiguous.
+{
+  console.log('8. Coincident outline ambiguity...')
+
+  const bottom = makeFeature('bottom', rectProfile(0, 0, 20, 20))
+  const top = makeFeature('top', rectProfile(0, 0, 20, 20))
+  const features = resolvedProjectFeatures(makeProject([bottom, top]))
+  const result = resolveFeatureSelectionHit({ x: 0.2, y: 10 }, features, preciseVt)
+
+  assert(result.kind === 'ambiguous', `expected ambiguous coincident outlines, got ${result.kind}`)
+  assert(result.candidateIds.join(',') === 'top,bottom', 'coincident candidates should remain topmost-first')
+
+  console.log('   ✓ coincident outlines remain ambiguous')
+}
+
+// Shared interiors with no nearby outline remain ambiguous.
+{
+  console.log('9. Shared interior ambiguity...')
+
+  const bottom = makeFeature('bottom', rectProfile(0, 0, 20, 20))
+  const top = makeFeature('top', rectProfile(0, 0, 20, 20))
+  const features = resolvedProjectFeatures(makeProject([bottom, top]))
+  const result = resolveFeatureSelectionHit({ x: 10, y: 10 }, features, preciseVt)
+
+  assert(result.kind === 'ambiguous', `expected ambiguous shared interior, got ${result.kind}`)
+  assert(result.candidateIds.join(',') === 'top,bottom', 'interior candidates should remain topmost-first')
+
+  console.log('   ✓ shared interiors remain ambiguous')
+}
+
+// A lone hit keeps ordinary direct-selection behavior.
+{
+  console.log('10. Single candidate selection...')
+
+  const feature = makeFeature('only', rectProfile(0, 0, 20, 20))
+  const features = resolvedProjectFeatures(makeProject([feature]))
+  const result = resolveFeatureSelectionHit({ x: 10, y: 10 }, features, preciseVt)
+
+  assert(result.kind === 'direct', `expected single candidate to resolve directly, got ${result.kind}`)
+  assert(result.featureId === 'only', `expected only candidate, got ${result.featureId}`)
+
+  console.log('   ✓ single candidate still resolves directly')
 }
 
 console.log('\nall hitTest.test.ts assertions passed')

--- a/src/components/canvas/hitTest.ts
+++ b/src/components/canvas/hitTest.ts
@@ -27,6 +27,11 @@ export interface FeatureLike {
   sketch: { profile: SketchProfile }
 }
 
+export type FeatureSelectionHit =
+  | { kind: 'none'; candidateIds: [] }
+  | { kind: 'direct'; featureId: string; candidateIds: string[] }
+  | { kind: 'ambiguous'; candidateIds: string[] }
+
 export interface SegmentHitResult {
   featureId: string
   segmentIndex: number
@@ -267,6 +272,44 @@ export function findHitFeatureIds(worldPoint: Point, features: readonly FeatureL
     if (featureContainsPoint(feature, worldPoint, vt)) hitIds.push(feature.id)
   }
   return hitIds
+}
+
+/**
+ * Resolves ordinary feature selection without interrupting a clear outline
+ * click. Interior-only and coincident-outline hits remain ambiguous so the
+ * overlap picker can expose every candidate.
+ */
+export function resolveFeatureSelectionHit(
+  worldPoint: Point,
+  features: readonly FeatureLike[],
+  vt: ViewTransform,
+): FeatureSelectionHit {
+  const candidateIds: string[] = []
+  const nearbyOutlineIds: string[] = []
+
+  for (let index = features.length - 1; index >= 0; index -= 1) {
+    const feature = features[index]
+    if (!feature.visible) continue
+
+    const nearOutline = pointNearProfile(worldPoint, feature.sketch.profile, vt)
+    if (!nearOutline && !pointInProfile(worldPoint.x, worldPoint.y, feature.sketch.profile)) {
+      continue
+    }
+
+    candidateIds.push(feature.id)
+    if (nearOutline) nearbyOutlineIds.push(feature.id)
+  }
+
+  if (candidateIds.length === 0) {
+    return { kind: 'none', candidateIds: [] }
+  }
+  if (candidateIds.length === 1) {
+    return { kind: 'direct', featureId: candidateIds[0], candidateIds }
+  }
+  if (nearbyOutlineIds.length === 1) {
+    return { kind: 'direct', featureId: nearbyOutlineIds[0], candidateIds }
+  }
+  return { kind: 'ambiguous', candidateIds }
 }
 
 export function findHitFeatureId(worldPoint: Point, features: readonly FeatureLike[], vt: ViewTransform): string | null {

--- a/src/components/canvas/useClickPlacement.ts
+++ b/src/components/canvas/useClickPlacement.ts
@@ -49,8 +49,8 @@ import {
 import {
   findHitClampId,
   findHitFeatureId,
-  findHitFeatureIds,
   findHitTabId,
+  resolveFeatureSelectionHit,
   segmentHitTest,
 } from './hitTest'
 import { hitBackdrop } from './scenePrimitives'
@@ -926,19 +926,21 @@ export function useClickPlacement(ctx: ClickPlacementCtx): UseClickPlacementRetu
     }
 
     const resolvedFeatures = resolvedProjectFeatures(project)
-    const featuresById = new Map(resolvedFeatures.map((feature) => [feature.id, feature]))
-    const hitCandidates: OverlapFeatureCandidate[] = []
-    for (const id of findHitFeatureIds(world, resolvedFeatures, vt)) {
-      const feature = featuresById.get(id)
-      if (feature) {
-        hitCandidates.push({ id: feature.id, name: feature.name, kind: feature.kind })
-      }
-    }
+    const featureHit = resolveFeatureSelectionHit(world, resolvedFeatures, vt)
     const additive = event.metaKey || event.ctrlKey || event.shiftKey || multiSelectMode || !!pendingShapeAction
-    if (hitCandidates.length > 1) {
+
+    if (featureHit.kind === 'direct') {
+      selectFeature(featureHit.featureId, additive)
+    } else if (featureHit.kind === 'ambiguous') {
+      const featuresById = new Map(resolvedFeatures.map((feature) => [feature.id, feature]))
+      const hitCandidates: OverlapFeatureCandidate[] = []
+      for (const id of featureHit.candidateIds) {
+        const feature = featuresById.get(id)
+        if (feature) {
+          hitCandidates.push({ id: feature.id, name: feature.name, kind: feature.kind })
+        }
+      }
       openOverlapFeaturePicker(hitCandidates, additive)
-    } else if (hitCandidates.length === 1) {
-      selectFeature(hitCandidates[0].id, additive)
     } else if (project.backdrop?.visible && hitBackdrop(world, project.backdrop)) {
       selectBackdrop()
     } else if (!additive) {

--- a/src/components/canvas/useOverlapFeaturePicker.ts
+++ b/src/components/canvas/useOverlapFeaturePicker.ts
@@ -35,6 +35,7 @@ interface UseOverlapFeaturePickerOptions {
   canvasRef: RefObject<HTMLCanvasElement | null>
   clearTransientCanvasState: () => void
   selectFeature: (id: string | null, additive?: boolean) => void
+  hoverFeature: (id: string | null) => void
 }
 
 export interface OverlapFeaturePickerController {
@@ -45,6 +46,7 @@ export interface OverlapFeaturePickerController {
   dismiss: () => void
   cancel: () => void
   selectCandidate: (id: string) => void
+  previewCandidate: (id: string | null) => void
 }
 
 /**
@@ -56,6 +58,7 @@ export function useOverlapFeaturePicker({
   canvasRef,
   clearTransientCanvasState,
   selectFeature,
+  hoverFeature,
 }: UseOverlapFeaturePickerOptions): OverlapFeaturePickerController {
   const [pendingSelection, setPendingSelection] = useState<PendingOverlapFeatureSelection | null>(null)
   const workflowPanel = useCanvasWorkflowPanel({
@@ -72,16 +75,20 @@ export function useOverlapFeaturePicker({
     function dismissForOutsideAction(event: PointerEvent) {
       const target = event.target
       if (target instanceof Node && !workflowPanel.panelRef.current?.contains(target)) {
+        hoverFeature(null)
         setPendingSelection(null)
       }
     }
 
     document.addEventListener('pointerdown', dismissForOutsideAction, true)
-    return () => document.removeEventListener('pointerdown', dismissForOutsideAction, true)
+    return () => {
+      document.removeEventListener('pointerdown', dismissForOutsideAction, true)
+      hoverFeature(null)
+    }
     // useCanvasWorkflowPanel keeps its panel ref stable, while its return object
     // is intentionally recreated each render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingSelection])
+  }, [hoverFeature, pendingSelection])
 
   function open(candidates: readonly OverlapFeatureCandidate[], additive: boolean) {
     if (candidates.length < 2) return
@@ -89,6 +96,7 @@ export function useOverlapFeaturePicker({
   }
 
   function dismiss() {
+    hoverFeature(null)
     setPendingSelection(null)
   }
 
@@ -96,6 +104,11 @@ export function useOverlapFeaturePicker({
     if (!pendingSelection?.candidates.some((candidate) => candidate.id === id)) return
     selectFeature(id, pendingSelection.additive)
     dismiss()
+  }
+
+  function previewCandidate(id: string | null) {
+    if (id !== null && !pendingSelection?.candidates.some((candidate) => candidate.id === id)) return
+    hoverFeature(id)
   }
 
   return {
@@ -106,5 +119,6 @@ export function useOverlapFeaturePicker({
     dismiss,
     cancel: dismiss,
     selectCandidate,
+    previewCandidate,
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -95,6 +95,10 @@ if (import.meta.env.DEV) {
       const { useProjectStore } = await _pcTestStore()
       return JSON.parse(useProjectStore.getState().saveProject())
     },
+    getHoveredFeatureId: async () => {
+      const { useProjectStore } = await _pcTestStore()
+      return useProjectStore.getState().selection.hoveredFeatureId
+    },
     loadProject: async (json: string) => {
       const { useProjectStore } = await _pcTestStore()
       useProjectStore.getState().openProjectFromText(json, null)
@@ -134,6 +138,7 @@ declare global {
     __pcBootWatchdog?: number
     __pcTest?: {
       getProject: () => Promise<Record<string, unknown>>
+      getHoveredFeatureId: () => Promise<string | null>
       loadProject: (json: string) => Promise<void>
       getPendingMove: () => Promise<{ mode: string; entityType: string; entityIds: string[] } | null>
       completePendingMove: (x: number, y: number) => Promise<void>


### PR DESCRIPTION
## Summary
- Select a clear feature outline immediately when it is the only nearby outline, even when other closed features contain the click
- Keep the overlap picker for shared interiors and coincident/nearby outlines
- Preview picker candidates in the sketch on pointer hover and keyboard focus, with cleanup across every picker exit path
- Add focused structural coverage and browser smoke coverage, including landscape tablet behavior

## Verification
- `npx tsx src/components/canvas/hitTest.test.ts`
- `npm run build`
- `npm run test:e2e -- e2e/overlapFeatureSelection.smoke.spec.ts`
- `npm run test:e2e`

Closes #294