### PR TITLE
Add light and system appearance themes

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -36,6 +36,7 @@ browser-free while PRs still exercise the browser smoke.
 
 Current smoke targets:
 
+- `appearance.smoke.spec.ts` — Dark/Light/System switching, persistence, system-media response, project-state isolation, and tablet touch targets.
 - `featureReferences.smoke.spec.ts` — linked-feature tree badges, context menu wiring, properties grouping, and load round-trip.
 - `camOperations.smoke.spec.ts` — feature-row quick operation wiring into CAM operation state.
 - `creationTargets.smoke.spec.ts` — dedicated Line creation target wiring, active drawing badge, and landscape-tablet availability.

--- a/e2e/appearance.smoke.spec.ts
+++ b/e2e/appearance.smoke.spec.ts
@@ -87,6 +87,23 @@ test('keeps New Project template hover states within the light palette', async (
   await expect(imperialTemplate).toHaveCSS('color', 'rgb(37, 48, 57)')
 })
 
+test('keeps shared positive workflow actions legible in the light theme', async ({ app, ui }) => {
+  await ui.appearance.trigger(app.page).click()
+  await ui.appearance.option(app.page, 'Light').click()
+
+  await app.page.evaluate(() => {
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.className = 'tablet-cmd-btn tablet-cmd-btn--confirm'
+    button.textContent = 'Positive action contrast probe'
+    document.body.appendChild(button)
+  })
+
+  const positiveAction = ui.appearance.positiveActionProbe(app.page)
+  await expect(positiveAction).toHaveCSS('color', 'rgb(57, 121, 77)')
+  await expect(positiveAction).toHaveCSS('font-weight', '650')
+})
+
 test.describe('tablet appearance', () => {
   test.use({ viewport: { width: 1024, height: 768 }, hasTouch: true })
 

--- a/e2e/appearance.smoke.spec.ts
+++ b/e2e/appearance.smoke.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures'
+import { getProject } from './helpers'
+
+const STORAGE_KEY = 'purecutcnc.appearance.theme'
+
+function withoutModified(snapshot: Record<string, unknown>): Record<string, unknown> {
+  const meta = snapshot.meta as Record<string, unknown>
+  const { modified: _modified, ...stableMeta } = meta
+  return { ...snapshot, meta: stableMeta }
+}
+
+test('switches and restores appearance without changing the project', async ({ app, ui }) => {
+  const before = await getProject(app.page)
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme', 'dark')
+
+  await ui.appearance.trigger(app.page).click()
+  await ui.appearance.option(app.page, 'Light').click()
+
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme', 'light')
+  await expect(ui.appearance.trigger(app.page)).toHaveAttribute('aria-label', 'Appearance: Light')
+  expect(await app.page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY)).toBe('light')
+  expect(withoutModified(await getProject(app.page))).toEqual(withoutModified(before))
+
+  await app.page.reload()
+  await app.page.waitForSelector('canvas', { timeout: 15000 })
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme', 'light')
+  await expect(ui.appearance.trigger(app.page)).toHaveAttribute('aria-label', 'Appearance: Light')
+})
+
+test('system appearance follows prefers-color-scheme changes', async ({ app, ui }) => {
+  await app.page.emulateMedia({ colorScheme: 'dark' })
+  await ui.appearance.trigger(app.page).click()
+  await ui.appearance.option(app.page, 'System').click()
+
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-preference', 'system')
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme', 'dark')
+
+  await app.page.emulateMedia({ colorScheme: 'light' })
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme', 'light')
+  expect(await app.page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY)).toBe('system')
+})
+
+test.describe('tablet appearance', () => {
+  test.use({ viewport: { width: 1024, height: 768 }, hasTouch: true })
+
+  test('keeps the selector and choices touch-sized', async ({ app, ui }) => {
+    const trigger = ui.appearance.trigger(app.page)
+    await expect(trigger).toBeVisible()
+    const triggerBox = await trigger.boundingBox()
+    expect(triggerBox).not.toBeNull()
+    expect(triggerBox!.height).toBeGreaterThanOrEqual(44)
+    expect(triggerBox!.width).toBeGreaterThanOrEqual(44)
+
+    await trigger.click()
+    const lightOption = ui.appearance.option(app.page, 'Light')
+    await expect(lightOption).toBeVisible()
+    const optionBox = await lightOption.boundingBox()
+    expect(optionBox).not.toBeNull()
+    expect(optionBox!.height).toBeGreaterThanOrEqual(44)
+
+    await lightOption.click()
+    await expect(app.page.locator('html')).toHaveAttribute('data-theme', 'light')
+  })
+})

--- a/e2e/appearance.smoke.spec.ts
+++ b/e2e/appearance.smoke.spec.ts
@@ -104,6 +104,18 @@ test('keeps shared positive workflow actions legible in the light theme', async 
   await expect(positiveAction).toHaveCSS('font-weight', '650')
 })
 
+test('keeps the operation add menu opaque and its guidance legible in the light theme', async ({ app, ui }) => {
+  await ui.appearance.trigger(app.page).click()
+  await ui.appearance.option(app.page, 'Light').click()
+
+  await ui.operations.headerAddButton(app.page).click()
+
+  await expect(ui.operations.addMenu(app.page)).toBeVisible()
+  await expect(ui.operations.addMenu(app.page)).toHaveCSS('background-color', 'rgb(248, 244, 236)')
+  await expect(ui.operations.addMenuHint(app.page)).toHaveCSS('color', 'rgb(139, 76, 23)')
+  await expect(ui.operations.addMenuHint(app.page)).toHaveCSS('font-weight', '500')
+})
+
 test.describe('tablet appearance', () => {
   test.use({ viewport: { width: 1024, height: 768 }, hasTouch: true })
 

--- a/e2e/appearance.smoke.spec.ts
+++ b/e2e/appearance.smoke.spec.ts
@@ -56,6 +56,37 @@ test('system appearance follows prefers-color-scheme changes', async ({ app, ui 
   expect(await app.page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY)).toBe('system')
 })
 
+test('keeps status and dialog text legible in both themes', async ({ app, ui }) => {
+  await expect(ui.statusBar.root(app.page)).toHaveCSS('color', 'rgb(216, 228, 239)')
+
+  await ui.statusBar.toggle(app.page, 'Grid').click()
+  await expect(ui.statusBar.toggle(app.page, 'Grid')).toHaveAttribute('aria-pressed', 'false')
+  await app.page.mouse.move(0, 0)
+  await expect(ui.statusBar.toggle(app.page, 'Grid')).toHaveCSS('color', 'rgb(174, 191, 205)')
+
+  await ui.appearance.trigger(app.page).click()
+  await ui.appearance.option(app.page, 'Light').click()
+
+  await expect(ui.statusBar.root(app.page)).toHaveCSS('color', 'rgb(37, 48, 57)')
+  await expect(ui.statusBar.toggle(app.page, 'Grid')).toHaveCSS('color', 'rgb(79, 90, 97)')
+
+  await ui.statusBar.about(app.page).click()
+  await expect(ui.aboutDialog.title(app.page)).toHaveCSS('color', 'rgb(37, 48, 57)')
+  await expect(ui.aboutDialog.productName(app.page)).toHaveCSS('color', 'rgb(37, 48, 57)')
+})
+
+test('keeps New Project template hover states within the light palette', async ({ app, ui }) => {
+  await ui.appearance.trigger(app.page).click()
+  await ui.appearance.option(app.page, 'Light').click()
+
+  await ui.toolbar.newProjectButton(app.page).click()
+  const imperialTemplate = ui.newProjectDialog.template(app.page, 'Blank Imperial')
+  await imperialTemplate.hover()
+
+  await expect(imperialTemplate).toHaveCSS('background-color', 'rgba(88, 70, 46, 0.08)')
+  await expect(imperialTemplate).toHaveCSS('color', 'rgb(37, 48, 57)')
+})
+
 test.describe('tablet appearance', () => {
   test.use({ viewport: { width: 1024, height: 768 }, hasTouch: true })
 

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -33,6 +33,8 @@ export const appearance = {
   menu: (page: Page) => page.getByRole('menu', { name: 'Appearance theme' }),
   option: (page: Page, label: 'Dark' | 'Light' | 'System') =>
     appearance.menu(page).getByRole('menuitemradio', { name: new RegExp(`^${label}`) }),
+  positiveActionProbe: (page: Page) =>
+    page.getByRole('button', { name: 'Positive action contrast probe' }),
 }
 
 // ── Status bar and About dialog ────────────────────────────────────

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -35,6 +35,29 @@ export const appearance = {
     appearance.menu(page).getByRole('menuitemradio', { name: new RegExp(`^${label}`) }),
 }
 
+// ── Status bar and About dialog ────────────────────────────────────
+
+export const statusBar = {
+  root: (page: Page) => page.locator('.app-statusbar'),
+  toggle: (page: Page, label: string) =>
+    statusBar.root(page).getByRole('button', { name: label, exact: true }),
+  about: (page: Page) => statusBar.root(page).locator('.statusbar-about'),
+}
+
+export const aboutDialog = {
+  root: (page: Page) => page.getByRole('dialog', { name: 'About PureCutCNC' }),
+  title: (page: Page) => aboutDialog.root(page).locator('.dialog-title'),
+  productName: (page: Page) => aboutDialog.root(page).locator('.about-name'),
+}
+
+// ── New Project dialog ─────────────────────────────────────────────
+
+export const newProjectDialog = {
+  root: (page: Page) => page.locator('.dialog--new-project'),
+  template: (page: Page, label: string) =>
+    newProjectDialog.root(page).getByRole('button', { name: new RegExp(`^${label}`) }),
+}
+
 // ── Feature tree ────────────────────────────────────────────────────
 
 export const tree = {
@@ -207,4 +230,7 @@ export const toolbar = {
 
   /** Add-point button (visible during sketch edit). */
   addPointButton: (page: Page) => page.locator('button[aria-label="Add point"]'),
+
+  /** Opens the New Project dialog. */
+  newProjectButton: (page: Page) => page.getByRole('button', { name: 'New project' }),
 }

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -167,6 +167,12 @@ export const operations = {
   headerExportButton: (page: Page) =>
     page.locator('.cam-panel .cam-section-toolbar').getByRole('button', { name: 'Export', exact: true }),
 
+  /** The "Add" button and menu in the Operations panel header. */
+  headerAddButton: (page: Page) =>
+    page.locator('.cam-panel .cam-section-toolbar').getByRole('button', { name: 'Add', exact: true }),
+  addMenu: (page: Page) => page.locator('.cam-add-menu--vertical'),
+  addMenuHint: (page: Page) => page.locator('.cam-add-menu--vertical .cam-operation-hint').first(),
+
   /** The Properties-header "Export G-code" action for the selected operation. */
   propertiesExportButton: (page: Page, name: string) =>
     page

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -26,6 +26,15 @@
 
 import type { Locator, Page } from '@playwright/test'
 
+// ── Appearance ─────────────────────────────────────────────────────
+
+export const appearance = {
+  trigger: (page: Page) => page.getByRole('button', { name: /^Appearance:/ }),
+  menu: (page: Page) => page.getByRole('menu', { name: 'Appearance theme' }),
+  option: (page: Page, label: 'Dark' | 'Light' | 'System') =>
+    appearance.menu(page).getByRole('menuitemradio', { name: new RegExp(`^${label}`) }),
+}
+
 // ── Feature tree ────────────────────────────────────────────────────
 
 export const tree = {

--- a/public/icons.svg
+++ b/public/icons.svg
@@ -35,6 +35,17 @@
     <path d="M 8 12 L 16 12" />
     <path d="M 5 17 L 19 17" />
   </symbol>
+  <symbol id="appearance" viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="3.5" />
+    <path d="M12 2.75v2" />
+    <path d="M12 19.25v2" />
+    <path d="M2.75 12h2" />
+    <path d="M19.25 12h2" />
+    <path d="m5.46 5.46 1.42 1.42" />
+    <path d="m17.12 17.12 1.42 1.42" />
+    <path d="m18.54 5.46-1.42 1.42" />
+    <path d="m6.88 17.12-1.42 1.42" />
+  </symbol>
   <symbol id="chamfer" viewBox="0 0 24 24">
     <path d="M 20 5 L 11 5" />
     <path d="M 11 5 L 5 11" />

--- a/src/INDEX.md
+++ b/src/INDEX.md
@@ -16,6 +16,7 @@ Application source. React + TypeScript + Zustand. Tauri-wrapped for desktop.
 - [text/](text/) — text-to-geometry (font → machinable paths); `index.ts` is the public API, `fontData.ts` the typed font-parse seam, and `outlineContours.ts` removes self-intersection slivers before profiles reach downstream consumers
 - [sketch/](sketch/) — sketch geometry helpers (segment math, profile ops, visible-scene bounds in `sceneBounds.ts`, gear profile generation)
 - [hooks/](hooks/INDEX.md) — shared cross-cutting React hooks (`useStableEvent`, `useWindowEvent`/`useEventListener`)
+- [theme/](theme/INDEX.md) — app-local Dark/Light/System appearance state plus typed canvas and Three.js palettes
 - [commands/](commands/INDEX.md) — shared desktop/tablet command descriptors and store-backed command predicates
 - [types/](types/) — core data model. `project.ts` is the canonical `.camj` schema
 - [utils/](utils/) — units, analytics, icons, version, misc helpers

--- a/src/assets/icons/appearance.svg
+++ b/src/assets/icons/appearance.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="3.5" />
+  <path d="M12 2.75v2" />
+  <path d="M12 19.25v2" />
+  <path d="M2.75 12h2" />
+  <path d="M19.25 12h2" />
+  <path d="m5.46 5.46 1.42 1.42" />
+  <path d="m17.12 17.12 1.42 1.42" />
+  <path d="m18.54 5.46-1.42 1.42" />
+  <path d="m6.88 17.12-1.42 1.42" />
+</svg>

--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -21,7 +21,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 - `simulation/` — voxel toolpath simulation viewport and playback controls
 - `cam/` — CAM panels (tools, operations, parameters); per-parameter reference icons via `OperationParameterReference`
 - `feature-tree/` — sketch feature tree UI (reordering, visibility, grouping) plus the extracted feature/tab/clamp context menu
-- `layout/` — app shell (toolbars, sidebars, mode switching); toolbar internals are documented in `layout/toolbar/INDEX.md`
+- `layout/` — app shell (toolbars, sidebars, mode switching), including the shared `AppearanceControl`; toolbar internals are documented in `layout/toolbar/INDEX.md`
 - `project/` — project-level UI (new/open/save, stock, machine, units), including `UnitConversionDialog` for the explicit convert-vs-reinterpret units decision. Import dialog is `ImportGeometryDialog` with analysis delegated to `useImportGeometryAnalysis` (parse/classify caching hook), `ImportGeometryModeSection` (mode select + summary), and `importModelFile` (3D model import utility).
 - `export/` — export dialogs: G-code (`ExportDialog`, with a per-operation checklist backed by the pure helpers in `exportOperationSelection.ts`), the Export Model dialog (`ModelExportDialog`, STL mesh + 2D design SVG via `src/engine/modelExport/`), and the Print Design dialog (`PrintDesignDialog`, backed by `src/engine/designPrint/`)
 - `machine/` — machine definition editor (focused form + raw JSON + Zod validation)

--- a/src/components/about/about.css
+++ b/src/components/about/about.css
@@ -31,7 +31,7 @@
 .about-name {
   font-size: 20px;
   font-weight: 700;
-  color: #fff;
+  color: var(--text);
 }
 
 .about-version {

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -150,6 +150,8 @@ import {
   type FeatureClipboardPayload,
 } from '../../platform/featureClipboard'
 import { resolveFeatureInstance, resolveFeatureInstances, resolveFeatureRow, resolvedProjectFeatures } from '../../store/helpers/resolveFeatures'
+import { useTheme } from '../../theme/themeContext'
+import { THEME_PALETTES } from '../../theme/palette'
 
 export type { SketchCanvasHandle }
 
@@ -173,6 +175,8 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   },
   ref
 ) {
+  const { resolvedTheme } = useTheme()
+  const canvasPalette = THEME_PALETTES[resolvedTheme].canvas
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const isDraggingNodeRef = useRef(false)
@@ -797,7 +801,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
   useEffect(() => {
     scheduleDraw()
-  }, [scheduleDraw, project, selection, pendingAdd, pendingMove, pendingTransform, pendingOffset, pendingClipboardPlacement, viewState, backdropImage, stlImageRevision, toolpaths, selectedOperationId, collidingClampIds, snapSettings, copyCountDraft, dimEdit.dimensionEdit, toolpathVisibility, operationHighlightKind])
+  }, [scheduleDraw, project, selection, pendingAdd, pendingMove, pendingTransform, pendingOffset, pendingClipboardPlacement, viewState, backdropImage, stlImageRevision, toolpaths, selectedOperationId, collidingClampIds, snapSettings, copyCountDraft, dimEdit.dimensionEdit, toolpathVisibility, operationHighlightKind, resolvedTheme])
 
   useEffect(() => {
     sketchEditPreviewRef.current = null
@@ -889,10 +893,10 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     const collidingClampIdSet = new Set(collidingClampIds)
 
     ctx.clearRect(0, 0, width, height)
-    ctx.fillStyle = '#0f151d'
+    ctx.fillStyle = canvasPalette.background
     ctx.fillRect(0, 0, width, height)
 
-    drawGrid(ctx, vt, width, height, project.stock, project.grid)
+    drawGrid(ctx, vt, width, height, project.stock, project.grid, canvasPalette)
 
     if (project.backdrop?.visible && backdropImage) {
       drawBackdropImage(
@@ -901,6 +905,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         backdropImage,
         vt,
         selection.selectedNode?.type === 'backdrop',
+        canvasPalette,
         project.backdrop.name,
       )
     }
@@ -912,11 +917,11 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           && feature.kind !== 'text'
           && profileExceedsStock(feature.sketch.profile, project.stock),
       )
-      drawStockOutline(ctx, project.stock, vt, project.meta.units, anyFeatureExceedsStock, stockLabelRectsRef.current)
+      drawStockOutline(ctx, project.stock, vt, project.meta.units, anyFeatureExceedsStock, canvasPalette, stockLabelRectsRef.current)
     }
 
     if (project.origin.visible) {
-      drawOriginMarker(ctx, project.origin, vt)
+      drawOriginMarker(ctx, project.origin, vt, canvasPalette)
     }
 
     const batchedLineFeatures: SketchFeature[] = []
@@ -952,7 +957,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           ctx.shadowBlur = 8
           ctx.stroke()
         } else if (feature.sketch.profile.closed) {
-          ctx.fillStyle = 'rgba(8, 12, 18, 0.5)'
+          ctx.fillStyle = canvasPalette.veil
           ctx.fill()
         }
         ctx.restore()
@@ -973,7 +978,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           isDraggingNodeRef.current
             ? selection.activeControl
             : (dimEdit.dimensionEditControlRef.current ?? selection.activeControl ?? hoveredEditControl)
-        drawSketchControls(ctx, feature.sketch.profile, vt, editControl)
+        drawSketchControls(ctx, feature.sketch.profile, vt, editControl, canvasPalette)
         if (editControl && (isDraggingNodeRef.current || dimEdit.dimensionEditControlRef.current || hoveredEditControl)) {
           drawActiveEditMeasurements(ctx, feature.sketch.profile, vt, project.meta.units, editControl)
         }
@@ -1067,7 +1072,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
         const isInvalid = !!c.is_invalid
         const lineColor = isInvalid ? 'rgba(220, 60, 60, 0.85)' : 'rgba(91, 165, 216, 0.8)'
         const dotColor = isInvalid ? 'rgba(220, 60, 60, 0.9)' : 'rgba(91, 165, 216, 0.9)'
-        const labelColor = isInvalid ? 'rgba(255, 180, 180, 0.95)' : 'rgba(200, 220, 240, 0.95)'
+        const labelColor = isInvalid ? 'rgba(255, 180, 180, 0.95)' : canvasPalette.labelText
         const aC = worldToCanvas(c.anchor_point, vt)
         const rC = worldToCanvas(c.reference_point, vt)
         ctx.save()
@@ -1098,7 +1103,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           const padY = 2
           const halfW = metrics.width / 2 + padX
           const halfH = 7 + padY
-          ctx.fillStyle = isInvalid ? 'rgba(80, 20, 20, 0.9)' : 'rgba(18, 26, 36, 0.85)'
+          ctx.fillStyle = isInvalid ? 'rgba(80, 20, 20, 0.9)' : canvasPalette.labelBackground
           ctx.fillRect(midX - halfW, midY - halfH, halfW * 2, halfH * 2)
           ctx.fillStyle = labelColor
           ctx.textAlign = 'center'
@@ -1123,7 +1128,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       const selected = selection.selectedNode?.type === 'clamp' && selection.selectedNode.clampId === clamp.id
       drawClampFootprint(ctx, clamp, vt, selected, collidingClampIdSet.has(clamp.id))
       if (selection.mode === 'sketch_edit' && selection.selectedNode?.type === 'clamp' && selection.selectedNode.clampId === clamp.id) {
-        drawSketchControls(ctx, rectProfile(clamp.x, clamp.y, clamp.w, clamp.h), vt, selection.activeControl)
+        drawSketchControls(ctx, rectProfile(clamp.x, clamp.y, clamp.w, clamp.h), vt, selection.activeControl, canvasPalette)
       }
     }
 
@@ -1132,7 +1137,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       const selected = selection.selectedNode?.type === 'tab' && selection.selectedNode.tabId === tab.id
       drawTabFootprint(ctx, tab, vt, selected)
       if (selection.mode === 'sketch_edit' && selection.selectedNode?.type === 'tab' && selection.selectedNode.tabId === tab.id) {
-        drawSketchControls(ctx, rectProfile(tab.x, tab.y, tab.w, tab.h), vt, selection.activeControl)
+        drawSketchControls(ctx, rectProfile(tab.x, tab.y, tab.w, tab.h), vt, selection.activeControl, canvasPalette)
       }
     }
 
@@ -1343,6 +1348,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
             backdropImage,
             vt,
             true,
+            canvasPalette,
             'Move preview',
           )
         } else if (currentMovePreviewPoint) {
@@ -1536,6 +1542,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
               backdropImage,
               vt,
               true,
+              canvasPalette,
               pendingTransform.mode === 'resize' ? 'Resize preview' : 'Rotate preview',
             )
           }

--- a/src/components/canvas/scenePrimitives.ts
+++ b/src/components/canvas/scenePrimitives.ts
@@ -23,6 +23,7 @@ import { hexToRgba } from './previewPrimitives'
 import { arcControlPoint, anchorPointForIndex, traceProfilePath } from './profilePrimitives'
 import { worldToCanvas } from './viewTransform'
 import type { ViewTransform } from './viewTransform'
+import type { CanvasThemePalette } from '../../theme/palette'
 
 const NODE_RADIUS = 5
 const HANDLE_RADIUS = 4
@@ -46,6 +47,7 @@ export function drawSketchControls(
   profile: SketchProfile,
   vt: ViewTransform,
   activeControl: SketchControlRef | null,
+  palette: CanvasThemePalette,
 ): void {
   const vertices = profileVertices(profile)
 
@@ -116,7 +118,7 @@ export function drawSketchControls(
     ctx.beginPath()
     ctx.arc(center.cx, center.cy, radius, startAngle, endAngle, seg.clockwise)
     ctx.setLineDash([5, 5])
-    ctx.strokeStyle = 'rgba(210, 221, 230, 0.3)'
+    ctx.strokeStyle = palette.mutedGeometry
     ctx.lineWidth = 1
     ctx.stroke()
     ctx.setLineDash([])
@@ -129,7 +131,7 @@ export function drawSketchControls(
     ctx.lineTo(center.cx + crossSize, center.cy)
     ctx.moveTo(center.cx, center.cy - crossSize)
     ctx.lineTo(center.cx, center.cy + crossSize)
-    ctx.strokeStyle = active ? '#f2b95c' : '#d2dde6'
+    ctx.strokeStyle = active ? '#f2b95c' : palette.mutedGeometry
     ctx.lineWidth = active ? 2 : 1.2
     ctx.stroke()
   }
@@ -141,7 +143,7 @@ export function drawSketchControls(
 
     ctx.beginPath()
     ctx.arc(cx, cy, active ? NODE_RADIUS + 2 : NODE_RADIUS, 0, Math.PI * 2)
-    ctx.fillStyle = active ? '#f2b95c' : '#d2dde6'
+    ctx.fillStyle = active ? '#f2b95c' : palette.mutedGeometry
     ctx.fill()
     ctx.strokeStyle = active ? '#f7d394' : '#3f708f'
     ctx.lineWidth = 2
@@ -221,6 +223,7 @@ export function drawGrid(
   canvasH: number,
   stock: Stock,
   grid: GridSettings,
+  palette: CanvasThemePalette,
 ): void {
   if (!grid.visible) return
 
@@ -248,7 +251,7 @@ export function drawGrid(
     ctx.beginPath()
     ctx.moveTo(p0.cx, 0)
     ctx.lineTo(p1.cx, canvasH)
-    ctx.strokeStyle = isMajor ? 'rgba(104, 132, 154, 0.34)' : 'rgba(88, 112, 130, 0.18)'
+    ctx.strokeStyle = isMajor ? palette.gridMajor : palette.gridMinor
     ctx.lineWidth = isMajor ? 1.2 : 1
     ctx.stroke()
   }
@@ -261,7 +264,7 @@ export function drawGrid(
     ctx.beginPath()
     ctx.moveTo(0, p0.cy)
     ctx.lineTo(canvasW, p1.cy)
-    ctx.strokeStyle = isMajor ? 'rgba(104, 132, 154, 0.34)' : 'rgba(88, 112, 130, 0.18)'
+    ctx.strokeStyle = isMajor ? palette.gridMajor : palette.gridMinor
     ctx.lineWidth = isMajor ? 1.2 : 1
     ctx.stroke()
   }
@@ -284,14 +287,15 @@ function drawStockDimensionLabel(
   text: string,
   cx: number,
   cy: number,
+  palette: CanvasThemePalette,
 ): void {
   ctx.font = '11px sans-serif'
   const metrics = ctx.measureText(text)
   const halfW = metrics.width / 2 + 4
   const halfH = 9
-  ctx.fillStyle = 'rgba(18, 26, 36, 0.85)'
+  ctx.fillStyle = palette.labelBackground
   ctx.fillRect(cx - halfW, cy - halfH, halfW * 2, halfH * 2)
-  ctx.fillStyle = 'rgba(200, 220, 240, 0.95)'
+  ctx.fillStyle = palette.labelText
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   ctx.fillText(text, cx, cy)
@@ -303,6 +307,7 @@ export function drawStockOutline(
   vt: ViewTransform,
   units: Units,
   exceeded: boolean,
+  palette: CanvasThemePalette,
   stockLabelRects?: StockLabelRect[],
 ): void {
   traceProfilePath(ctx, stock.profile, vt)
@@ -341,6 +346,7 @@ export function drawStockOutline(
     widthLabelText,
     widthCx,
     widthCy,
+    palette,
   )
   const heightCx = maxCx + 8 + ctx.measureText(heightLabelText).width / 2
   const heightCy = (minCy + maxCy) / 2
@@ -349,6 +355,7 @@ export function drawStockOutline(
     heightLabelText,
     heightCx,
     heightCy,
+    palette,
   )
   ctx.restore()
 
@@ -418,6 +425,7 @@ export function drawOriginMarker(
   ctx: CanvasRenderingContext2D,
   origin: { x: number; y: number; name: string },
   vt: ViewTransform,
+  palette: CanvasThemePalette,
 ): void {
   const anchor = worldToCanvas({ x: origin.x, y: origin.y }, vt)
   const axisLength = 20
@@ -459,7 +467,7 @@ export function drawOriginMarker(
   ctx.arc(anchor.cx, anchor.cy, 4, 0, Math.PI * 2)
   ctx.fillStyle = '#5b90e3'
   ctx.fill()
-  ctx.strokeStyle = 'rgba(230, 237, 245, 0.95)'
+  ctx.strokeStyle = palette.labelText
   ctx.lineWidth = 1.5
   ctx.stroke()
 
@@ -469,7 +477,7 @@ export function drawOriginMarker(
   ctx.fillStyle = '#63c07a'
   ctx.fillText('Y', anchor.cx - 3, anchor.cy - axisLength - 4)
 
-  ctx.fillStyle = 'rgba(230, 237, 245, 0.95)'
+  ctx.fillStyle = palette.labelText
   ctx.fillText(origin.name, anchor.cx + 10, anchor.cy - 8)
   ctx.restore()
 }
@@ -484,6 +492,7 @@ export function drawBackdropImage(
   image: HTMLImageElement,
   vt: ViewTransform,
   selected: boolean,
+  palette: CanvasThemePalette,
   label = 'Backdrop',
 ): void {
   const center = worldToCanvas(backdrop.center, vt)
@@ -513,9 +522,9 @@ export function drawBackdropImage(
     ctx.fill()
     ctx.restore()
 
-    ctx.fillStyle = 'rgba(18, 22, 29, 0.8)'
+    ctx.fillStyle = palette.labelBackground
     ctx.fillRect(center.cx - 38, center.cy - 14, 76, 18)
-    ctx.fillStyle = '#d8e4f0'
+    ctx.fillStyle = palette.labelText
     ctx.font = '11px monospace'
     ctx.textAlign = 'center'
     ctx.fillText(label, center.cx, center.cy - 1)

--- a/src/components/layout/AppearanceControl.tsx
+++ b/src/components/layout/AppearanceControl.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useId, useRef, useState } from 'react'
+import { useOutsideDismiss } from '../../hooks/useOutsideDismiss'
+import { THEME_PREFERENCES, type ThemePreference } from '../../theme/theme'
+import { useTheme } from '../../theme/themeContext'
+import { Icon } from '../Icon'
+
+const THEME_LABELS: Record<ThemePreference, { label: string; detail: string }> = {
+  dark: { label: 'Dark', detail: 'Low-light workshop' },
+  light: { label: 'Light', detail: 'Drafting paper' },
+  system: { label: 'System', detail: 'Match this device' },
+}
+
+export function AppearanceControl() {
+  const { preference, resolvedTheme, setPreference } = useTheme()
+  const [open, setOpen] = useState(false)
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const menuId = useId()
+
+  useOutsideDismiss({ open, refs: hostRef, onDismiss: () => setOpen(false) })
+
+  const currentLabel = THEME_LABELS[preference].label
+
+  const chooseTheme = (nextPreference: ThemePreference) => {
+    setPreference(nextPreference)
+    setOpen(false)
+    triggerRef.current?.focus({ preventScroll: true })
+  }
+
+  return (
+    <div className="appearance-control" ref={hostRef}>
+      <div className="toolbar-action">
+        <button
+          ref={triggerRef}
+          className="toolbar-icon-btn appearance-control__trigger"
+          type="button"
+          aria-label={`Appearance: ${currentLabel}`}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-controls={open ? menuId : undefined}
+          data-resolved-theme={resolvedTheme}
+          onClick={() => setOpen((previous) => !previous)}
+        >
+          <Icon id="appearance" />
+        </button>
+        {!open && (
+          <span className="toolbar-tooltip toolbar-tooltip--bottom" role="tooltip">
+            Appearance
+          </span>
+        )}
+      </div>
+
+      {open && (
+        <div className="appearance-menu" id={menuId} role="menu" aria-label="Appearance theme">
+          <div className="appearance-menu__heading">Appearance</div>
+          <div className="appearance-menu__options">
+            {THEME_PREFERENCES.map((option) => {
+              const selected = preference === option
+              const copy = THEME_LABELS[option]
+              return (
+                <button
+                  key={option}
+                  className={`appearance-menu__option ${selected ? 'appearance-menu__option--selected' : ''}`}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={selected}
+                  onClick={() => chooseTheme(option)}
+                >
+                  <span className={`appearance-menu__swatch appearance-menu__swatch--${option}`} aria-hidden="true" />
+                  <span className="appearance-menu__copy">
+                    <span className="appearance-menu__label">{copy.label}</span>
+                    <span className="appearance-menu__detail">{copy.detail}</span>
+                  </span>
+                  <span className="appearance-menu__check" aria-hidden="true">{selected ? '✓' : ''}</span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/layout/TopCommandBar.tsx
+++ b/src/components/layout/TopCommandBar.tsx
@@ -23,6 +23,7 @@ import type { SnapMode, SnapSettings } from '../../sketch/snapping'
 import { SnapPopover } from './SnapPopover'
 import { DimensionPopover } from './DimensionPopover'
 import { useFileCommands } from '../../commands/fileCommands'
+import { AppearanceControl } from './AppearanceControl'
 
 interface TopCommandBarProps {
   centerTab: 'sketch' | 'preview3d' | 'simulation'
@@ -224,6 +225,7 @@ export function TopCommandBar({
             onToggleSnapMode={onToggleSnapMode}
           />
           <DimensionPopover />
+          <AppearanceControl />
           <button
             className="top-cmd-btn top-cmd-btn--operations"
             type="button"

--- a/src/components/layout/toolbar/GlobalToolbar.tsx
+++ b/src/components/layout/toolbar/GlobalToolbar.tsx
@@ -22,6 +22,7 @@ import { SnapActions } from './SnapActions'
 import { ToolbarDialog } from './ToolbarDialog'
 import { useToolbarState } from './useToolbarState'
 import type { SnapToolbarProps, ToolbarProps } from './shared'
+import { AppearanceControl } from '../AppearanceControl'
 
 export function GlobalToolbar({
   onZoomToModel,
@@ -82,6 +83,9 @@ export function GlobalToolbar({
           onDeleteDimension={toolbar.sketchCommands.dimension.deleteDimension.onActivate}
           onToggleShowDimensions={toolbar.sketchCommands.dimension.showDimensions.onActivate}
         />
+        <div className="toolbar-group toolbar-group--appearance">
+          <AppearanceControl />
+        </div>
       </div>
       <ToolbarDialog
         showNewProjectDialog={toolbar.showNewProjectDialog}

--- a/src/components/layout/toolbar/INDEX.md
+++ b/src/components/layout/toolbar/INDEX.md
@@ -20,3 +20,4 @@ Toolbar internals split out from `src/components/layout/Toolbar.tsx`. The parent
 - `SnapActions.tsx` — snapping mode action group.
 - `MeasureActions.tsx` — tape measure and dimension action group.
 - `GlobalToolbar.tsx`, `CreationToolbar.tsx`, `Toolbar.tsx`, `SnapToolbar.tsx` — assembly components exported by the public barrel.
+- `../AppearanceControl.tsx` — shared Dark/Light/System selector rendered by desktop and tablet command bars.

--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -28,6 +28,8 @@ import type { PlaybackPose } from '../../engine/simulation/playback'
 import type { SimulationGrid, SimulationResult } from '../../engine/simulation'
 import type { ToolpathMove } from '../../engine/toolpaths/types'
 import type { Clamp, MachineOrigin, Operation, ToolType } from '../../types/project'
+import { useTheme } from '../../theme/themeContext'
+import { THEME_PALETTES } from '../../theme/palette'
 
 const EMPTY_PLAYBACK_POSE: PlaybackPose = { x: 0, y: 0, z: 0, moveKind: null, feedScale: undefined }
 
@@ -575,6 +577,9 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   isActive = true,
   projectKey,
 }, ref) {
+  const { resolvedTheme } = useTheme()
+  const threePalette = THEME_PALETTES[resolvedTheme].three
+  const initialThreePaletteRef = useRef(threePalette)
   const playbackUnits = playbackInput?.units ?? 'mm'
   const fallbackFeed = playbackUnits === 'in' ? PLAYBACK_FALLBACK_FEED_IN : PLAYBACK_FALLBACK_FEED_MM
   // Anchor the playback speed multiplier to the operation's feed (units/sec). If the
@@ -776,7 +781,7 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
     }
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
     renderer.setSize(mount.clientWidth, mount.clientHeight)
-    renderer.setClearColor(0x141820, 1)
+    renderer.setClearColor(initialThreePaletteRef.current.background, 1)
     renderer.domElement.style.display = 'block'
     renderer.domElement.style.touchAction = 'none'
     mount.appendChild(renderer.domElement)
@@ -859,6 +864,11 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
       mount.removeChild(renderer.domElement)
     }
   }, [disposeClampMeshes, disposeCurrentMesh])
+
+  useEffect(() => {
+    rendererRef.current?.setClearColor(threePalette.background, 1)
+    needsRenderRef.current = true
+  }, [threePalette])
 
   useEffect(() => {
     const scene = sceneRef.current

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -27,6 +27,8 @@ import { applyClampHighlight, applyTabHighlight, buildOriginTriad, buildScene } 
 import { getStockBounds, rectProfile } from '../../types/project'
 import { getFeatureGeometryProfiles } from '../../text'
 import { buildToolpathLinePositionChunks, toolpathPointToWorldTuple } from './toolpathOverlay'
+import { useTheme } from '../../theme/themeContext'
+import { THEME_PALETTES } from '../../theme/palette'
 
 function configureGridMaterial(material: THREE.Material | THREE.Material[]) {
   const materials = Array.isArray(material) ? material : [material]
@@ -669,6 +671,9 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
   toolpathVisibility,
   onToolpathVisibilityChange,
 }, ref) {
+  const { resolvedTheme } = useTheme()
+  const threePalette = THEME_PALETTES[resolvedTheme].three
+  const threePaletteRef = useRef(threePalette)
   const mountRef = useRef<HTMLDivElement>(null)
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null)
   const sceneRef = useRef<THREE.Scene | null>(null)
@@ -694,9 +699,10 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
   // pointer handlers (which read them outside render). Write after commit, not
   // during render, so we don't touch refs while rendering.
   useLayoutEffect(() => {
+    threePaletteRef.current = threePalette
     zoomWindowActiveRef.current = zoomWindowActive
     zoomWindowBoxRef.current = zoomWindowBox
-  }, [zoomWindowActive, zoomWindowBox])
+  }, [threePalette, zoomWindowActive, zoomWindowBox])
 
   // Reset the zoom-window box during render when the tool deactivates (React-
   // recommended adjust-state-during-render; the ref mirror above nulls
@@ -739,7 +745,7 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
     })
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
     renderer.setSize(mount.clientWidth, mount.clientHeight)
-    renderer.setClearColor(0x141820, 1)
+    renderer.setClearColor(threePaletteRef.current.background, 1)
     renderer.domElement.style.display = 'block'
     renderer.domElement.style.touchAction = 'none'
     mount.appendChild(renderer.domElement)
@@ -839,8 +845,9 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
     const minorDivisions = Math.max(1, Math.round(extent / project.grid.minorSpacing))
     const majorDivisions = Math.max(1, Math.round(extent / project.grid.majorSpacing))
 
-    const minorGrid = new THREE.GridHelper(extent, minorDivisions, 0x223344, 0x223344)
-    const majorGrid = new THREE.GridHelper(extent, majorDivisions, 0x334455, 0x51657a)
+    const palette = threePaletteRef.current
+    const minorGrid = new THREE.GridHelper(extent, minorDivisions, palette.gridMinorCenter, palette.gridMinor)
+    const majorGrid = new THREE.GridHelper(extent, majorDivisions, palette.gridMajorCenter, palette.gridMajor)
     configureGridMaterial(minorGrid.material)
     configureGridMaterial(majorGrid.material)
     majorGrid.position.y = 0.001
@@ -848,6 +855,11 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
     gridGroup.add(minorGrid)
     gridGroup.add(majorGrid)
   }, [disposeObjectMaterial, project.grid.extent, project.grid.majorSpacing, project.grid.minorSpacing, project.grid.visible, project.stock, syncGridVisibility])
+
+  useEffect(() => {
+    rendererRef.current?.setClearColor(threePalette.background, 1)
+    rebuildGridHelpers()
+  }, [rebuildGridHelpers, threePalette])
 
   const clearRenderedObjects = useCallback((scene: THREE.Scene) => {
     for (const object of objectsRef.current) {

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,7 @@
 @import './styles/tablet.css';
 
 :root {
+  color-scheme: dark;
   --bg: #0a1016;
   --bg-elev-1: #101821;
   --bg-elev-2: #16222d;
@@ -31,14 +32,79 @@
   --accent-strong: #eab982;
   --add: #6abb81;
   --cut: #5a8fcc;
+  --surface-app: #0a1016;
+  --surface-canvas: #0f151d;
+  --surface-panel: #0f1820;
+  --surface-subtle: #0d141c;
+  --surface-raised: rgba(16, 24, 33, 0.94);
+  --surface-popover: rgba(12, 18, 26, 0.96);
+  --surface-translucent: rgba(10, 18, 27, 0.85);
+  --surface-input: rgba(7, 12, 17, 0.72);
+  --surface-hover: rgba(255, 255, 255, 0.06);
+  --surface-control-top: #2a3a4c;
+  --surface-control-bottom: #17232f;
+  --surface-button-top: #24374a;
+  --surface-button-bottom: #13202c;
+  --surface-sheen: rgba(255, 255, 255, 0.04);
+  --surface-sheen-soft: rgba(255, 255, 255, 0.03);
+  --surface-sheen-mid: rgba(255, 255, 255, 0.05);
+  --surface-sheen-strong: rgba(255, 255, 255, 0.08);
+  --surface-inset: rgba(0, 0, 0, 0.28);
+  --shadow: rgba(0, 0, 0, 0.35);
+  --shadow-strong: rgba(0, 0, 0, 0.45);
+  --accent-soft: rgba(220, 165, 106, 0.12);
+  --surface-active-top: #3d4f61;
+  --surface-active-bottom: #202d3a;
+  --on-accent: #fff;
+  --danger-text: #f0bbb6;
 
   font-family: 'Avenir Next', 'IBM Plex Sans', 'Segoe UI', sans-serif;
   color: var(--text);
-  background: radial-gradient(circle at 18% -10%, #1c2a37, #0a1016 58%);
+  background: radial-gradient(circle at 18% -10%, var(--bg-elev-2), var(--surface-app) 58%);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+:root[data-theme='light'] {
+  color-scheme: light;
+  --bg: #eee8dd;
+  --bg-elev-1: #f8f4ec;
+  --bg-elev-2: #e5ddcf;
+  --line: #c9bdab;
+  --line-strong: #a99a84;
+  --text: #253039;
+  --text-dim: #657078;
+  --accent: #a66126;
+  --accent-strong: #874717;
+  --add: #39794d;
+  --cut: #356f9d;
+  --surface-app: #eee8dd;
+  --surface-canvas: #f6f1e7;
+  --surface-panel: #f9f5ed;
+  --surface-subtle: #e9e1d4;
+  --surface-raised: rgba(252, 249, 242, 0.97);
+  --surface-popover: rgba(252, 249, 242, 0.98);
+  --surface-translucent: rgba(247, 243, 235, 0.94);
+  --surface-input: rgba(255, 252, 247, 0.94);
+  --surface-hover: rgba(88, 70, 46, 0.08);
+  --surface-control-top: #fdfaf4;
+  --surface-control-bottom: #e5dccd;
+  --surface-button-top: #f8f3e9;
+  --surface-button-bottom: #ddd3c3;
+  --surface-sheen: rgba(255, 255, 255, 0.54);
+  --surface-sheen-soft: rgba(255, 255, 255, 0.34);
+  --surface-sheen-mid: rgba(255, 255, 255, 0.46);
+  --surface-sheen-strong: rgba(255, 255, 255, 0.72);
+  --surface-inset: rgba(69, 54, 36, 0.13);
+  --shadow: rgba(55, 43, 28, 0.18);
+  --shadow-strong: rgba(55, 43, 28, 0.24);
+  --accent-soft: rgba(166, 97, 38, 0.12);
+  --surface-active-top: #ead6bf;
+  --surface-active-bottom: #cbb293;
+  --on-accent: #fffaf3;
+  --danger-text: #91443e;
 }
 
 * {
@@ -73,6 +139,7 @@ body,
 
 body {
   min-height: 100svh;
+  background: var(--surface-app);
 }
 
 button,
@@ -88,7 +155,7 @@ input {
   padding: 1.5rem;
   background:
     radial-gradient(circle at top, rgba(90, 143, 204, 0.22), transparent 36%),
-    linear-gradient(180deg, #091018 0%, #0a1016 100%);
+    linear-gradient(180deg, var(--surface-subtle) 0%, var(--surface-app) 100%);
 }
 
 .unsupported-mobile-card {
@@ -96,8 +163,8 @@ input {
   padding: 1.5rem;
   border: 1px solid var(--line);
   border-radius: 1rem;
-  background: rgba(16, 24, 33, 0.94);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+  background: var(--surface-raised);
+  box-shadow: 0 24px 60px var(--shadow);
 }
 
 .unsupported-mobile-eyebrow {
@@ -155,7 +222,7 @@ input {
   padding: 1.5rem;
   background:
     radial-gradient(circle at top, rgba(204, 90, 90, 0.16), transparent 36%),
-    linear-gradient(180deg, #091018 0%, #0a1016 100%);
+    linear-gradient(180deg, var(--surface-subtle) 0%, var(--surface-app) 100%);
 }
 
 .app-error-card {
@@ -163,8 +230,8 @@ input {
   padding: 1.75rem;
   border: 1px solid var(--line);
   border-radius: 1rem;
-  background: rgba(16, 24, 33, 0.94);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+  background: var(--surface-raised);
+  box-shadow: 0 24px 60px var(--shadow);
 }
 
 .app-error-eyebrow {
@@ -207,7 +274,7 @@ input {
   padding: 0.75rem;
   border: 1px solid var(--line);
   border-radius: 0.6rem;
-  background: rgba(9, 14, 20, 0.7);
+  background: var(--surface-input);
   color: var(--text-dim);
   font-size: 0.78rem;
   line-height: 1.5;

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,8 @@
   --line-strong: #3c5265;
   --text: #d8e4ef;
   --text-dim: #94aabc;
+  --status-text: #d8e4ef;
+  --status-text-muted: #aebfcd;
   --accent: #dca56a;
   --accent-strong: #eab982;
   --add: #6abb81;
@@ -57,6 +59,13 @@
   --surface-active-bottom: #202d3a;
   --on-accent: #fff;
   --danger-text: #f0bbb6;
+  --warning-text: #f7b86a;
+  --role-line: #5a8fcc;
+  --role-line-text: #8fb6f4;
+  --role-region: #9966cc;
+  --role-region-text: #c4a6e0;
+  --role-construction: #8a9aab;
+  --role-construction-text: #a9b6c4;
 
   font-family: 'Avenir Next', 'IBM Plex Sans', 'Segoe UI', sans-serif;
   color: var(--text);
@@ -76,6 +85,8 @@
   --line-strong: #a99a84;
   --text: #253039;
   --text-dim: #657078;
+  --status-text: #253039;
+  --status-text-muted: #4f5a61;
   --accent: #a66126;
   --accent-strong: #874717;
   --add: #39794d;
@@ -105,6 +116,13 @@
   --surface-active-bottom: #cbb293;
   --on-accent: #fffaf3;
   --danger-text: #91443e;
+  --warning-text: #8b4c17;
+  --role-line: #356f9d;
+  --role-line-text: #285d87;
+  --role-region: #7947a5;
+  --role-region-text: #673b8c;
+  --role-construction: #60778b;
+  --role-construction-text: #4e6477;
 }
 
 * {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,6 +24,10 @@ import { UnsupportedMobileScreen } from './components/UnsupportedMobileScreen'
 import { isDesktop } from './platform'
 import { installAnalytics } from './utils/analytics'
 import { applyVersionToTitle } from './utils/version'
+import { ThemeProvider } from './theme/ThemeProvider'
+import { bootstrapTheme } from './theme/theme'
+
+bootstrapTheme()
 
 // Swap #root for a static error card if something throws before React mounts.
 // Once React is alive, AppErrorBoundary takes over — this flag prevents the
@@ -69,12 +73,18 @@ const isIconGalleryRoute =
   window.location.hash === '#icons'
 
 function rootElement() {
-  if (isPhoneSizedTouchDevice()) return <UnsupportedMobileScreen />
-  if (isIconGalleryRoute) return <IconGalleryRoute />
   return (
-    <AppErrorBoundary>
-      <App />
-    </AppErrorBoundary>
+    <ThemeProvider>
+      {isPhoneSizedTouchDevice()
+        ? <UnsupportedMobileScreen />
+        : isIconGalleryRoute
+          ? <IconGalleryRoute />
+          : (
+              <AppErrorBoundary>
+                <App />
+              </AppErrorBoundary>
+            )}
+    </ThemeProvider>
   )
 }
 

--- a/src/styles/canvas-workflow.css
+++ b/src/styles/canvas-workflow.css
@@ -18,11 +18,10 @@
   position: absolute;
   z-index: 26;
   width: min(340px, calc(100% - 24px));
-  border: 1px solid rgba(200, 156, 98, 0.7);
+  border: 1px solid color-mix(in oklab, var(--accent) 62%, var(--line-strong));
   border-radius: 8px;
-  background:
-    linear-gradient(180deg, rgba(29, 35, 38, 0.96), rgba(15, 21, 27, 0.94));
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.38);
+  background: linear-gradient(180deg, var(--surface-popover), var(--surface-raised));
+  box-shadow: 0 18px 44px var(--shadow-strong);
   color: var(--text);
   overflow: hidden;
   pointer-events: auto;
@@ -35,7 +34,7 @@
   gap: 8px;
   min-height: 40px;
   padding: 0 12px;
-  border-bottom: 1px solid rgba(200, 156, 98, 0.24);
+  border-bottom: 1px solid color-mix(in oklab, var(--accent) 25%, var(--line));
   cursor: grab;
   touch-action: none;
   user-select: none;
@@ -93,7 +92,7 @@
   align-items: center;
   gap: 8px;
   min-height: 32px;
-  color: var(--text-muted);
+  color: var(--text-dim);
   font-size: 12px;
 }
 
@@ -104,7 +103,7 @@
   gap: 10px;
   width: 100%;
   min-height: 32px;
-  color: var(--text-muted);
+  color: var(--text-dim);
   font-size: 12px;
 }
 
@@ -132,7 +131,7 @@
 .canvas-workflow-panel__parameter-reference {
   width: 50px;
   height: 34px;
-  border: 1px solid rgba(200, 156, 98, 0.22);
+  border: 1px solid color-mix(in oklab, var(--accent) 24%, var(--line));
   border-radius: 6px;
   background: var(--surface-input);
 }
@@ -147,12 +146,12 @@
 }
 
 .gear-reference__outline {
-  stroke: rgba(229, 235, 238, 0.68);
+  stroke: var(--text-dim);
   stroke-width: 1.7;
 }
 
 .gear-reference__guide {
-  stroke: rgba(148, 163, 172, 0.48);
+  stroke: color-mix(in oklab, var(--text-dim) 58%, transparent);
   stroke-width: 1.1;
 }
 
@@ -221,13 +220,13 @@
   max-height: min(26rem, calc(100cqh - 164px));
   overflow-y: auto;
   overscroll-behavior: contain;
-  scrollbar-color: rgba(200, 156, 98, 0.68) rgba(7, 12, 17, 0.42);
+  scrollbar-color: color-mix(in oklab, var(--accent) 70%, var(--line-strong)) var(--surface-input);
   scrollbar-gutter: stable;
   touch-action: pan-y;
-  border: 1px solid rgba(200, 156, 98, 0.38);
+  border: 1px solid color-mix(in oklab, var(--accent) 38%, var(--line));
   border-radius: 8px;
   background: var(--surface-input);
-  box-shadow: inset 0 1px 0 rgba(229, 235, 238, 0.04);
+  box-shadow: inset 0 1px 0 var(--surface-sheen);
   padding: 6px;
 }
 
@@ -238,7 +237,7 @@
   gap: 12px;
   width: 100%;
   min-height: 44px;
-  border: 1px solid rgba(200, 156, 98, 0.24);
+  border: 1px solid color-mix(in oklab, var(--accent) 24%, var(--line));
   border-radius: 6px;
   background: var(--surface-input);
   color: var(--text);
@@ -250,7 +249,7 @@
 .overlap-feature-picker__candidate:hover,
 .overlap-feature-picker__candidate:focus-visible {
   border-color: var(--accent);
-  background: rgba(220, 165, 106, 0.14);
+  background: var(--accent-soft);
   outline: none;
 }
 

--- a/src/styles/canvas-workflow.css
+++ b/src/styles/canvas-workflow.css
@@ -134,7 +134,7 @@
   height: 34px;
   border: 1px solid rgba(200, 156, 98, 0.22);
   border-radius: 6px;
-  background: rgba(7, 12, 17, 0.72);
+  background: var(--surface-input);
 }
 
 .gear-reference__outline,
@@ -177,7 +177,7 @@
   height: 32px;
   border: 1px solid var(--line-strong);
   border-radius: 6px;
-  background: #0f1820;
+  background: var(--surface-panel);
   color: var(--text);
   padding: 0 8px;
   outline: none;
@@ -226,7 +226,7 @@
   touch-action: pan-y;
   border: 1px solid rgba(200, 156, 98, 0.38);
   border-radius: 8px;
-  background: rgba(7, 12, 17, 0.4);
+  background: var(--surface-input);
   box-shadow: inset 0 1px 0 rgba(229, 235, 238, 0.04);
   padding: 6px;
 }
@@ -240,7 +240,7 @@
   min-height: 44px;
   border: 1px solid rgba(200, 156, 98, 0.24);
   border-radius: 6px;
-  background: rgba(7, 12, 17, 0.54);
+  background: var(--surface-input);
   color: var(--text);
   padding: 0 10px;
   text-align: left;

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -130,7 +130,7 @@
   border: 1px solid var(--line-strong);
   border-radius: 8px;
   background: var(--surface-subtle);
-  color: var(--on-accent);
+  color: var(--text);
   font-family: var(--font-mono);
   font-size: 14px;
   font-weight: 700;
@@ -195,7 +195,7 @@
 
 .unit-conversion-option--recommended {
   border-color: color-mix(in oklab, var(--accent) 62%, var(--line-strong));
-  background: linear-gradient(120deg, rgba(220, 165, 106, 0.13), rgba(8, 14, 20, 0.76) 62%);
+  background: linear-gradient(120deg, var(--accent-soft), var(--surface-translucent) 62%);
 }
 
 .unit-conversion-option--reinterpret:hover {
@@ -210,7 +210,7 @@
 }
 
 .unit-conversion-option__heading strong {
-  color: var(--on-accent);
+  color: var(--text);
   font-size: 14px;
   font-weight: 650;
 }
@@ -231,8 +231,8 @@
   padding: 3px 7px;
   border: 1px solid var(--surface-sheen-strong);
   border-radius: 5px;
-  background: rgba(0, 0, 0, 0.24);
-  color: #d8e2ea;
+  background: var(--surface-input);
+  color: var(--text);
   font-family: var(--font-mono);
   font-size: 11px;
 }
@@ -264,7 +264,7 @@
 .dialog-title {
   font-size: 18px;
   font-weight: 600;
-  color: var(--on-accent);
+  color: var(--text);
 }
 
 .dialog-close {
@@ -281,7 +281,7 @@
 
 .dialog-close:hover {
   background: var(--surface-sheen-mid);
-  color: var(--on-accent);
+  color: var(--text);
 }
 
 .dialog-body {
@@ -311,7 +311,7 @@
   display: flex;
   justify-content: flex-end;
   gap: 12px;
-  background: rgba(0, 0, 0, 0.15);
+  background: var(--surface-subtle);
 }
 
 .dialog-section {
@@ -348,7 +348,7 @@
   padding: 12px;
   font-family: var(--font-mono);
   font-size: 12px;
-  color: #a5b4c0;
+  color: var(--text-dim);
   white-space: pre;
   overflow: auto;
   user-select: text;
@@ -460,7 +460,7 @@
   padding: 10px 12px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: rgba(0, 0, 0, 0.15);
+  background: var(--surface-subtle);
 }
 
 .export-option--disabled {
@@ -492,7 +492,7 @@
   background: rgba(255, 130, 30, 0.08);
   border: 1px solid rgba(255, 160, 60, 0.4);
   border-radius: 8px;
-  color: #f7b86a;
+  color: var(--warning-text);
   font-size: 12px;
   line-height: 1.45;
 }
@@ -517,12 +517,12 @@
 
 .project-template-card:hover {
   border-color: var(--line-bright);
-  background: rgba(24, 31, 43, 0.9);
+  background: var(--surface-hover);
 }
 
 .project-template-card--active {
   border-color: var(--accent);
-  background: rgba(74, 53, 27, 0.26);
+  background: var(--accent-soft);
 }
 
 .project-template-card__title {
@@ -546,7 +546,7 @@
 }
 
 .project-template-preview__title {
-  color: var(--on-accent);
+  color: var(--text);
   font-size: 14px;
   font-weight: 600;
 }
@@ -619,13 +619,13 @@
 
 .import-dialog__field-note {
   margin-top: -2px;
-  color: color-mix(in oklab, var(--text-dim) 88%, #d6e2f0 12%);
+  color: var(--text-dim);
   font-size: 12px;
   line-height: 1.45;
 }
 
 .import-dialog__field-note--warn {
-  color: #f7b86a;
+  color: var(--warning-text);
 }
 
 .import-progress-container {
@@ -764,10 +764,10 @@
   gap: 1px;
   max-height: 180px;
   overflow-y: auto;
-  border: 1px solid var(--border, rgba(255,255,255,0.08));
+  border: 1px solid var(--line);
   border-radius: 6px;
   padding: 4px 0;
-  background: var(--surface-raised, rgba(0,0,0,0.15));
+  background: var(--surface-raised);
 }
 
 /* When layers are in their own column, let the list fill all available height */
@@ -787,7 +787,7 @@
 }
 
 .import-dialog__layer-row:hover {
-  background: rgba(255,255,255,0.05);
+  background: var(--surface-hover);
 }
 
 .import-dialog__layer-row input[type="checkbox"] {
@@ -1255,7 +1255,7 @@
   background: rgba(255, 80, 60, 0.08);
   border: 1px solid rgba(255, 100, 80, 0.4);
   border-radius: 7px;
-  color: #f7726a;
+  color: var(--danger-text);
   font-size: 12px;
   line-height: 1.45;
 }
@@ -1372,7 +1372,7 @@
 .machine-manager-detail-name {
   font-size: 16px;
   font-weight: 600;
-  color: var(--on-accent);
+  color: var(--text);
   margin: 0;
 }
 
@@ -1400,7 +1400,7 @@
 
 .machine-manager-badge--builtin {
   background: rgba(100, 160, 220, 0.12);
-  color: #7eb8e0;
+  color: var(--cut);
 }
 
 /* Meta */
@@ -1452,7 +1452,7 @@
   align-self: flex-start;
   background: transparent;
   border: none;
-  color: #f7726a;
+  color: var(--danger-text);
   cursor: pointer;
   font: inherit;
   font-size: 12px;

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -29,10 +29,10 @@
   width: 100%;
   max-width: 800px;
   max-height: 90vh;
-  background: #121a24;
+  background: var(--bg-elev-1);
   border: 1px solid var(--line-strong);
   border-radius: 14px;
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 24px 48px var(--shadow-strong);
   display: grid;
   grid-template-rows: auto 1fr auto;
   overflow: hidden;
@@ -129,8 +129,8 @@
   height: 38px;
   border: 1px solid var(--line-strong);
   border-radius: 8px;
-  background: #0b1219;
-  color: #fff;
+  background: var(--surface-subtle);
+  color: var(--on-accent);
   font-family: var(--font-mono);
   font-size: 14px;
   font-weight: 700;
@@ -172,7 +172,7 @@
   padding: 14px 16px;
   border: 1px solid var(--line-strong);
   border-radius: 10px;
-  background: rgba(8, 14, 20, 0.62);
+  background: var(--surface-translucent);
   color: var(--text-dim);
   cursor: pointer;
   font: inherit;
@@ -184,7 +184,7 @@
 
 .unit-conversion-option:hover {
   border-color: var(--line-bright);
-  background: rgba(17, 25, 34, 0.9);
+  background: var(--surface-raised);
   transform: translateY(-1px);
 }
 
@@ -210,7 +210,7 @@
 }
 
 .unit-conversion-option__heading strong {
-  color: #fff;
+  color: var(--on-accent);
   font-size: 14px;
   font-weight: 650;
 }
@@ -229,7 +229,7 @@
 .unit-conversion-option code {
   justify-self: start;
   padding: 3px 7px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--surface-sheen-strong);
   border-radius: 5px;
   background: rgba(0, 0, 0, 0.24);
   color: #d8e2ea;
@@ -264,7 +264,7 @@
 .dialog-title {
   font-size: 18px;
   font-weight: 600;
-  color: #fff;
+  color: var(--on-accent);
 }
 
 .dialog-close {
@@ -280,8 +280,8 @@
 }
 
 .dialog-close:hover {
-  background: rgba(255, 255, 255, 0.05);
-  color: #fff;
+  background: var(--surface-sheen-mid);
+  color: var(--on-accent);
 }
 
 .dialog-body {
@@ -342,7 +342,7 @@
 }
 
 .dialog-preview {
-  background: #090f16;
+  background: var(--surface-subtle);
   border: 1px solid var(--line-strong);
   border-radius: 10px;
   padding: 12px;
@@ -509,7 +509,7 @@
   padding: 12px 14px;
   border: 1px solid var(--line-strong);
   border-radius: 10px;
-  background: rgba(18, 24, 33, 0.82);
+  background: var(--surface-translucent);
   color: var(--text);
   text-align: left;
   cursor: pointer;
@@ -546,7 +546,7 @@
 }
 
 .project-template-preview__title {
-  color: #fff;
+  color: var(--on-accent);
   font-size: 14px;
   font-weight: 600;
 }
@@ -601,7 +601,7 @@
 .import-dialog__info-row input[type="number"] {
   width: 130px;
   flex-shrink: 0;
-  background: #0f1820;
+  background: var(--surface-panel);
   border: 1px solid var(--line-strong);
   border-radius: 7px;
   color: var(--text);
@@ -643,7 +643,7 @@
 .import-progress-track {
   width: 100%;
   height: 6px;
-  background: #090f16;
+  background: var(--surface-subtle);
   border-radius: 3px;
   overflow: hidden;
   border: 1px solid var(--line);
@@ -663,7 +663,7 @@
 .import-dialog__analysis {
   margin-top: 8px;
   padding: 12px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-sheen-soft);
   border: 1px solid var(--line);
   border-radius: 8px;
   display: grid;
@@ -720,7 +720,7 @@
   margin: 0;
   flex: 0 0 auto;
   accent-color: var(--accent);
-  background: #0f1820;
+  background: var(--surface-panel);
   border: 1px solid var(--line-strong);
   border-radius: 4px;
   cursor: pointer;
@@ -839,7 +839,7 @@
 
 .btn-secondary:hover {
   border-color: var(--line-bright);
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-sheen-soft);
 }
 
 /* ── Print Design dialog ──────────────────── */
@@ -853,7 +853,7 @@
 }
 
 .print-preview {
-  background: #0b1119;
+  background: var(--surface-subtle);
   border: 1px solid var(--line-strong);
   border-radius: 10px;
   padding: 18px;
@@ -870,7 +870,7 @@
   max-height: 56vh;
   height: auto;
   width: 100%;
-  background: #fff;
+  background: var(--on-accent);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
 }
 
@@ -907,7 +907,7 @@
 .print-dialog__row input[type="number"] {
   width: 84px;
   flex-shrink: 0;
-  background: #0f1820;
+  background: var(--surface-panel);
   border: 1px solid var(--line-strong);
   border-radius: 7px;
   color: var(--text);
@@ -943,7 +943,7 @@
 
 .print-dialog__scale-input {
   width: 96px;
-  background: #0f1820;
+  background: var(--surface-panel);
   border: 1px solid var(--line-strong);
   border-radius: 7px;
   color: var(--text);
@@ -1189,7 +1189,7 @@
 }
 
 .machine-editor-input {
-  background: #0f1820;
+  background: var(--surface-panel);
   border: 1px solid var(--line-strong);
   border-radius: 7px;
   color: var(--text);
@@ -1207,7 +1207,7 @@
 }
 
 .machine-editor-textarea {
-  background: #0f1820;
+  background: var(--surface-panel);
   border: 1px solid var(--line-strong);
   border-radius: 7px;
   color: var(--text);
@@ -1228,7 +1228,7 @@
 }
 
 .machine-editor-json {
-  background: #090f16;
+  background: var(--surface-subtle);
   border: 1px solid var(--line-strong);
   border-radius: 7px;
   color: var(--text);
@@ -1334,11 +1334,11 @@
 }
 
 .machine-manager-item:hover {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-sheen);
 }
 
 .machine-manager-item--selected {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-hover);
 }
 
 .machine-manager-item--active .machine-manager-item-name {
@@ -1372,7 +1372,7 @@
 .machine-manager-detail-name {
   font-size: 16px;
   font-weight: 600;
-  color: #fff;
+  color: var(--on-accent);
   margin: 0;
 }
 
@@ -1394,7 +1394,7 @@
 }
 
 .machine-manager-badge--custom {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-hover);
   color: var(--text-dim);
 }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -143,22 +143,22 @@
 }
 
 .toolbar-target-btn--active {
-  color: var(--on-accent);
+  color: var(--accent-strong);
 }
 
 .toolbar-target-btn--line.toolbar-target-btn--active {
-  border-color: rgba(91, 144, 227, 0.9);
-  box-shadow: inset 0 0 0 1px rgba(91, 144, 227, 0.42);
+  border-color: color-mix(in oklab, var(--role-line) 88%, var(--line-strong));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--role-line) 42%, transparent);
 }
 
 .toolbar-target-btn--region.toolbar-target-btn--active {
-  border-color: rgba(153, 102, 204, 0.9);
-  box-shadow: inset 0 0 0 1px rgba(153, 102, 204, 0.42);
+  border-color: color-mix(in oklab, var(--role-region) 88%, var(--line-strong));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--role-region) 42%, transparent);
 }
 
 .toolbar-target-btn--construction.toolbar-target-btn--active {
-  border-color: rgba(138, 154, 171, 0.9);
-  box-shadow: inset 0 0 0 1px rgba(138, 154, 171, 0.42);
+  border-color: color-mix(in oklab, var(--role-construction) 88%, var(--line-strong));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--role-construction) 42%, transparent);
 }
 
 .toolbar--creation.toolbar--vertical .toolbar-group {
@@ -378,7 +378,8 @@
 .toolbar-project-name:hover,
 .toolbar-icon-btn:hover {
   border-color: var(--accent);
-  color: var(--on-accent);
+  background: var(--surface-hover);
+  color: var(--accent-strong);
 }
 
 .toolbar-icon-btn:disabled {
@@ -395,13 +396,13 @@
 
 .toolbar-btn--active {
   border-color: var(--accent);
-  color: var(--on-accent);
+  color: var(--accent-strong);
   box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--accent) 35%, transparent);
 }
 
 .toolbar-icon-btn--active {
   border-color: var(--accent);
-  color: var(--on-accent);
+  color: var(--accent-strong);
   background: linear-gradient(180deg, var(--surface-active-top), var(--surface-active-bottom));
   box-shadow:
     inset 0 0 0 1px color-mix(in oklab, var(--accent) 42%, transparent),
@@ -409,12 +410,12 @@
 }
 
 .toolbar-icon-btn--live {
-  border-color: #7bc7f6;
-  color: #dff5ff;
+  border-color: var(--cut);
+  color: var(--cut);
   box-shadow:
-    inset 0 0 0 1px rgba(123, 199, 246, 0.48),
-    0 0 0 1px rgba(123, 199, 246, 0.12),
-    0 0 12px rgba(123, 199, 246, 0.12);
+    inset 0 0 0 1px color-mix(in oklab, var(--cut) 48%, transparent),
+    0 0 0 1px color-mix(in oklab, var(--cut) 12%, transparent),
+    0 0 12px color-mix(in oklab, var(--cut) 12%, transparent);
 }
 
 .toolbar-tooltip {
@@ -899,8 +900,8 @@
 .simulation-viewport__spinner {
   width: 32px;
   height: 32px;
-  border: 3px solid rgba(255, 255, 255, 0.15);
-  border-top-color: rgba(255, 255, 255, 0.7);
+  border: 3px solid color-mix(in oklab, var(--text-dim) 22%, transparent);
+  border-top-color: var(--text-dim);
   border-radius: 50%;
   animation: sim-spin 0.7s linear infinite;
 }
@@ -923,10 +924,10 @@
 .simulation-viewport__webgl-message {
   max-width: 360px;
   padding: 16px 20px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--line-strong);
   border-radius: 8px;
-  background: var(--surface-raised);
-  color: rgba(255, 255, 255, 0.85);
+  background: var(--surface-popover);
+  color: var(--text);
   font-size: 13px;
   text-align: center;
 }
@@ -940,7 +941,7 @@
 .simulation-viewport__webgl-message p {
   margin: 0;
   line-height: 1.5;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-dim);
 }
 
 .simulation-detail-control {
@@ -1387,10 +1388,10 @@
   align-items: center;
   gap: 6px;
   padding: 3px 9px 3px 7px;
-  border: 1px solid rgba(91, 117, 138, 0.55);
+  border: 1px solid color-mix(in oklab, var(--accent) 62%, var(--line-strong));
   border-radius: 999px;
-  background: var(--surface-translucent);
-  color: rgba(203, 216, 227, 0.85);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.02em;
@@ -1404,21 +1405,21 @@
 }
 
 .creation-target-badge--line {
-  border-color: rgba(91, 144, 227, 0.65);
-  background: rgba(25, 39, 61, 0.85);
-  color: #8fb6f4;
+  border-color: color-mix(in oklab, var(--role-line) 70%, var(--line-strong));
+  background: color-mix(in oklab, var(--role-line) 16%, var(--surface-translucent));
+  color: var(--role-line-text);
 }
 
 .creation-target-badge--region {
-  border-color: rgba(153, 102, 204, 0.65);
-  background: rgba(41, 28, 56, 0.85);
-  color: #c4a6e0;
+  border-color: color-mix(in oklab, var(--role-region) 70%, var(--line-strong));
+  background: color-mix(in oklab, var(--role-region) 16%, var(--surface-translucent));
+  color: var(--role-region-text);
 }
 
 .creation-target-badge--construction {
-  border-color: rgba(138, 154, 171, 0.65);
-  background: rgba(31, 38, 46, 0.85);
-  color: #a9b6c4;
+  border-color: color-mix(in oklab, var(--role-construction) 70%, var(--line-strong));
+  background: color-mix(in oklab, var(--role-construction) 16%, var(--surface-translucent));
+  color: var(--role-construction-text);
 }
 
 .axis-lock-chip {
@@ -1468,7 +1469,7 @@
   justify-content: space-between;
   gap: 10px;
   margin-bottom: 8px;
-  color: rgba(230, 238, 245, 0.94);
+  color: var(--text);
   font-size: 11px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -1484,6 +1485,10 @@
   transition: border-color 0.18s ease, color 0.18s ease, background 0.18s ease;
 }
 
+.statusbar-depth-legend {
+  color: var(--status-text-muted);
+}
+
 .sketch-depth-legend__toggle {
   width: 20px;
   height: 20px;
@@ -1496,7 +1501,7 @@
 .sketch-depth-legend__toggle:hover,
 .statusbar-depth-legend:hover {
   border-color: var(--accent);
-  color: var(--text);
+  color: var(--status-text);
 }
 
 .sketch-depth-legend__items {
@@ -1508,7 +1513,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: rgba(206, 220, 231, 0.95);
+  color: var(--text-dim);
   font-size: 11px;
 }
 
@@ -1668,7 +1673,7 @@
 }
 
 .tree-row--selected .tree-label {
-  color: var(--on-accent);
+  color: var(--text);
 }
 
 .tree-row--group-selected {
@@ -1712,13 +1717,13 @@
 }
 
 .tree-row--regions .tree-branch {
-  border-color: rgba(153, 102, 204, 0.75);
-  background: rgba(153, 102, 204, 0.13);
+  border-color: color-mix(in oklab, var(--role-region) 76%, var(--line));
+  background: color-mix(in oklab, var(--role-region) 13%, transparent);
 }
 
 .tree-row--constructions .tree-branch {
-  border-color: rgba(138, 154, 171, 0.75);
-  background: rgba(138, 154, 171, 0.13);
+  border-color: color-mix(in oklab, var(--role-construction) 76%, var(--line));
+  background: color-mix(in oklab, var(--role-construction) 13%, transparent);
 }
 
 .tree-row--folder .tree-branch {
@@ -1751,11 +1756,11 @@
 }
 
 .tree-row--regions .tree-branch::before {
-  background: #b98add;
+  background: var(--role-region);
 }
 
 .tree-row--constructions .tree-branch::before {
-  background: #9dadbe;
+  background: var(--role-construction);
 }
 
 .tree-branch--folder::before {
@@ -1895,7 +1900,7 @@
 }
 
 .tree-action-btn--grouped {
-  color: var(--on-accent);
+  color: var(--accent-strong);
   border-color: rgba(220, 165, 106, 0.65);
   background: rgba(220, 165, 106, 0.28);
   box-shadow: inset 0 0 0 1px rgba(220, 165, 106, 0.25);
@@ -2223,7 +2228,8 @@
 
 .properties-actions button:hover {
   border-color: var(--accent);
-  color: var(--on-accent);
+  background: var(--surface-hover);
+  color: var(--accent-strong);
 }
 
 .properties-actions button:disabled {
@@ -2318,7 +2324,7 @@
 }
 
 .feat-btn:hover {
-  color: var(--on-accent);
+  color: var(--accent-strong);
   border-color: var(--accent);
   background: linear-gradient(180deg, var(--surface-control-top) 0%, var(--surface-control-bottom) 100%);
   box-shadow:
@@ -2341,10 +2347,11 @@
 .feat-btn--primary:hover {
   border-color: #e3b374;
   background: linear-gradient(180deg, #8b6742 0%, #573f2d 100%);
+  color: #fff3de;
 }
 
 .feat-btn--active {
-  color: var(--on-accent);
+  color: var(--accent-strong);
   border-color: var(--accent);
   background: rgba(37, 82, 136, 0.24);
 }
@@ -2666,7 +2673,7 @@
 
 .app-statusbar {
   border-top: 1px solid var(--line);
-  color: var(--text-dim);
+  color: var(--status-text);
   font-size: 12px;
   display: flex;
   flex-wrap: nowrap;
@@ -2687,7 +2694,7 @@
   flex: 0 0 auto;
   background: transparent;
   border: none;
-  color: var(--text-dim);
+  color: var(--status-text);
   font: inherit;
   font-size: 12px;
   cursor: pointer;
@@ -2718,10 +2725,11 @@
   border: 1px solid transparent;
   border-radius: 6px;
   background: transparent;
-  color: color-mix(in oklab, var(--text-dim) 72%, transparent);
+  color: var(--status-text-muted);
   cursor: pointer;
   font: inherit;
   font-size: 11px;
+  font-weight: 600;
   line-height: 1;
 }
 
@@ -2747,7 +2755,7 @@
 }
 
 .statusbar-toggle--active {
-  color: var(--text);
+  color: var(--status-text);
 }
 
 .statusbar-toggle--active::before {
@@ -3061,9 +3069,9 @@
   gap: 6px;
   padding: 6px 10px;
   border-radius: 8px;
-  border: 1px dashed rgba(153, 102, 204, 0.5);
-  background: rgba(153, 102, 204, 0.1);
-  color: #c4a6e0;
+  border: 1px dashed color-mix(in oklab, var(--role-region) 58%, transparent);
+  background: color-mix(in oklab, var(--role-region) 10%, transparent);
+  color: var(--role-region-text);
   font-size: 11px;
   line-height: 1.35;
   text-transform: none;
@@ -3076,8 +3084,8 @@
   height: 14px;
   line-height: 14px;
   border-radius: 3px;
-  border: 1px dashed rgba(153, 102, 204, 0.7);
-  background: rgba(153, 102, 204, 0.16);
+  border: 1px dashed color-mix(in oklab, var(--role-region) 72%, transparent);
+  background: color-mix(in oklab, var(--role-region) 16%, transparent);
   font-size: 9px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -3158,7 +3166,7 @@
 }
 
 .cam-operation-tree .tree-row--selected .tree-label {
-  color: var(--on-accent);
+  color: var(--text);
 }
 
 .cam-operation-tree .tree-row:not(.tree-row--selected) .tree-label {
@@ -3250,7 +3258,7 @@
 }
 
 .cam-tool-tree .tree-row--selected .cam-tool-label__name {
-  color: var(--on-accent);
+  color: var(--text);
 }
 
 .cam-tool-tree .tree-label {
@@ -3447,20 +3455,20 @@
 }
 
 .tree-action-btn--region {
-  color: #9966cc;
-  border-color: rgba(153, 102, 204, 0.45);
+  color: var(--role-region);
+  border-color: color-mix(in oklab, var(--role-region) 48%, var(--line));
 }
 
 /* ── Region rows read as filters/masks, not machinable geometry ─── */
 
 .tree-row--region {
   /* Dashed accent so a region reads as a non-solid filter, not a cut target. */
-  box-shadow: inset 2px 0 0 0 rgba(153, 102, 204, 0.55);
+  box-shadow: inset 2px 0 0 0 color-mix(in oklab, var(--role-region) 62%, transparent);
 }
 
 .tree-row--region .tree-label {
   font-style: italic;
-  color: #c4a6e0;
+  color: var(--role-region-text);
 }
 
 .tree-region-badge {
@@ -3470,9 +3478,9 @@
   height: 14px;
   line-height: 14px;
   border-radius: 3px;
-  border: 1px dashed rgba(153, 102, 204, 0.7);
-  background: rgba(153, 102, 204, 0.12);
-  color: #c4a6e0;
+  border: 1px dashed color-mix(in oklab, var(--role-region) 72%, transparent);
+  background: color-mix(in oklab, var(--role-region) 12%, transparent);
+  color: var(--role-region-text);
   font-size: 9px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -3482,25 +3490,25 @@
 
 .tree-region-badge--exclude {
   border-style: solid;
-  background: rgba(153, 102, 204, 0.08);
-  color: #d2b8ee;
+  background: color-mix(in oklab, var(--role-region) 8%, transparent);
+  color: var(--role-region-text);
 }
 
 /* ── Construction rows read as sketch reference geometry (issue #199) ─── */
 
 .tree-action-btn--construction {
-  color: #8a9aab;
-  border-color: rgba(138, 154, 171, 0.45);
+  color: var(--role-construction);
+  border-color: color-mix(in oklab, var(--role-construction) 48%, var(--line));
 }
 
 .tree-row--construction {
   /* Muted accent so construction reads as reference marks, not material. */
-  box-shadow: inset 2px 0 0 0 rgba(138, 154, 171, 0.55);
+  box-shadow: inset 2px 0 0 0 color-mix(in oklab, var(--role-construction) 62%, transparent);
 }
 
 .tree-row--construction .tree-label {
   font-style: italic;
-  color: #a9b6c4;
+  color: var(--role-construction-text);
 }
 
 .tree-construction-badge {
@@ -3510,9 +3518,9 @@
   height: 14px;
   line-height: 14px;
   border-radius: 3px;
-  border: 1px dashed rgba(138, 154, 171, 0.7);
-  background: rgba(138, 154, 171, 0.12);
-  color: #a9b6c4;
+  border: 1px dashed color-mix(in oklab, var(--role-construction) 72%, transparent);
+  background: color-mix(in oklab, var(--role-construction) 12%, transparent);
+  color: var(--role-construction-text);
   font-size: 9px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -3607,7 +3615,7 @@
 }
 
 .tree-operation-menu__icon--region {
-  color: #b98add;
+  color: var(--role-region);
 }
 
 .tree-operation-icon {
@@ -3624,9 +3632,9 @@
   margin: 2px 0 4px;
   padding: 6px 8px;
   border-radius: 6px;
-  border: 1px dashed rgba(153, 102, 204, 0.5);
-  background: rgba(153, 102, 204, 0.1);
-  color: #c4a6e0;
+  border: 1px dashed color-mix(in oklab, var(--role-region) 58%, transparent);
+  background: color-mix(in oklab, var(--role-region) 10%, transparent);
+  color: var(--role-region-text);
   font-size: 11px;
   line-height: 1.35;
 }
@@ -3637,8 +3645,8 @@
   height: 14px;
   line-height: 14px;
   border-radius: 3px;
-  border: 1px dashed rgba(153, 102, 204, 0.7);
-  background: rgba(153, 102, 204, 0.16);
+  border: 1px dashed color-mix(in oklab, var(--role-region) 72%, transparent);
+  background: color-mix(in oklab, var(--role-region) 16%, transparent);
   font-size: 9px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -3652,9 +3660,9 @@
   margin: 2px 0 4px;
   padding: 6px 8px;
   border-radius: 6px;
-  border: 1px dashed rgba(138, 154, 171, 0.5);
-  background: rgba(138, 154, 171, 0.1);
-  color: #a9b6c4;
+  border: 1px dashed color-mix(in oklab, var(--role-construction) 58%, transparent);
+  background: color-mix(in oklab, var(--role-construction) 10%, transparent);
+  color: var(--role-construction-text);
   font-size: 11px;
   line-height: 1.35;
 }
@@ -3665,8 +3673,8 @@
   height: 14px;
   line-height: 14px;
   border-radius: 3px;
-  border: 1px dashed rgba(138, 154, 171, 0.7);
-  background: rgba(138, 154, 171, 0.16);
+  border: 1px dashed color-mix(in oklab, var(--role-construction) 72%, transparent);
+  background: color-mix(in oklab, var(--role-construction) 16%, transparent);
   font-size: 9px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -3688,7 +3696,7 @@
   padding: 7px 2px;
   border: none;
   background: none;
-  color: var(--text-muted, #9bb0c0);
+  color: var(--text-dim);
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.03em;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -41,7 +41,7 @@
   gap: 10px;
   border-bottom: 1px solid var(--line);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0)),
+    linear-gradient(180deg, var(--surface-sheen-soft), rgba(255, 255, 255, 0)),
     color-mix(in oklab, var(--bg-elev-2) 94%, black);
   padding: 8px 10px;
 }
@@ -143,7 +143,7 @@
 }
 
 .toolbar-target-btn--active {
-  color: #fff;
+  color: var(--on-accent);
 }
 
 .toolbar-target-btn--line.toolbar-target-btn--active {
@@ -231,7 +231,7 @@
   padding: 6px;
   border-radius: 8px;
   border: 1px solid rgba(104, 129, 151, 0.6);
-  background: linear-gradient(180deg, #1e2c3b, #111923);
+  background: linear-gradient(180deg, var(--surface-control-top), var(--surface-control-bottom));
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.42);
 }
 
@@ -284,15 +284,15 @@
 .toolbar-project-name,
 .toolbar-btn {
   border: 1px solid rgba(104, 129, 151, 0.48);
-  background: linear-gradient(180deg, #26384a, #182430);
+  background: linear-gradient(180deg, var(--surface-control-top), var(--surface-control-bottom));
   color: var(--text);
   border-radius: 8px;
   min-height: var(--control-hit-target);
   padding: 0 12px;
   cursor: pointer;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.04),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.28);
+    inset 0 1px 0 var(--surface-sheen),
+    inset 0 -1px 0 var(--surface-inset);
 }
 
 .toolbar-project-name {
@@ -333,14 +333,14 @@
   align-items: center;
   justify-content: center;
   border: 1px solid rgba(104, 129, 151, 0.44);
-  background: linear-gradient(180deg, #2a3a4c, #17232f);
+  background: linear-gradient(180deg, var(--surface-control-top), var(--surface-control-bottom));
   color: var(--text);
   border-radius: 0;
   cursor: pointer;
   padding: 0;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.04),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.28);
+    inset 0 1px 0 var(--surface-sheen),
+    inset 0 -1px 0 var(--surface-inset);
 }
 
 .toolbar-group .toolbar-action:first-child .toolbar-icon-btn {
@@ -378,7 +378,7 @@
 .toolbar-project-name:hover,
 .toolbar-icon-btn:hover {
   border-color: var(--accent);
-  color: #fff;
+  color: var(--on-accent);
 }
 
 .toolbar-icon-btn:disabled {
@@ -395,17 +395,17 @@
 
 .toolbar-btn--active {
   border-color: var(--accent);
-  color: #fff;
+  color: var(--on-accent);
   box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--accent) 35%, transparent);
 }
 
 .toolbar-icon-btn--active {
   border-color: var(--accent);
-  color: #fff;
-  background: linear-gradient(180deg, #3d4f61, #202d3a);
+  color: var(--on-accent);
+  background: linear-gradient(180deg, var(--surface-active-top), var(--surface-active-bottom));
   box-shadow:
     inset 0 0 0 1px color-mix(in oklab, var(--accent) 42%, transparent),
-    0 0 0 1px rgba(220, 165, 106, 0.12);
+    0 0 0 1px var(--accent-soft);
 }
 
 .toolbar-icon-btn--live {
@@ -426,7 +426,7 @@
   padding: 6px 8px;
   border-radius: 7px;
   border: 1px solid rgba(94, 121, 142, 0.72);
-  background: rgba(13, 21, 29, 0.96);
+  background: var(--surface-popover);
   color: var(--text);
   font-size: 11px;
   line-height: 1;
@@ -452,6 +452,128 @@
   top: 50%;
   bottom: auto;
   transform: translate(4px, -50%);
+}
+
+/* ── Appearance selector ─────────────────────────────────────────── */
+
+.appearance-control {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  z-index: 70;
+}
+
+.appearance-control__trigger {
+  position: relative;
+  border-radius: 6px;
+}
+
+.appearance-control__trigger::after {
+  content: '';
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  border-top: 4px solid currentColor;
+  border-left: 4px solid transparent;
+  opacity: 0.68;
+}
+
+.appearance-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 100;
+  width: 248px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface-popover);
+  box-shadow: 0 18px 48px var(--shadow-strong);
+  backdrop-filter: blur(18px);
+}
+
+.appearance-menu__heading {
+  padding: 4px 6px 9px;
+  color: var(--text-dim);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.appearance-menu__options {
+  display: grid;
+  gap: 4px;
+}
+
+.appearance-menu__option {
+  display: grid;
+  grid-template-columns: 38px 1fr 20px;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 52px;
+  padding: 6px 8px;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.appearance-menu__option:hover,
+.appearance-menu__option:focus-visible {
+  border-color: var(--line);
+  background: var(--surface-hover);
+  outline: none;
+}
+
+.appearance-menu__option--selected {
+  border-color: color-mix(in oklab, var(--accent) 55%, var(--line));
+  background: var(--accent-soft);
+}
+
+.appearance-menu__swatch {
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 3px var(--surface-raised);
+}
+
+.appearance-menu__swatch--dark {
+  background: linear-gradient(135deg, #101922 0 48%, #dca56a 49% 57%, #2a3a49 58% 100%);
+}
+
+.appearance-menu__swatch--light {
+  background: linear-gradient(135deg, #f6f1e7 0 48%, #a66126 49% 57%, #d8cdbc 58% 100%);
+}
+
+.appearance-menu__swatch--system {
+  background: linear-gradient(135deg, #101922 0 45%, #dca56a 46% 53%, #f6f1e7 54% 100%);
+}
+
+.appearance-menu__copy {
+  display: grid;
+  gap: 2px;
+}
+
+.appearance-menu__label {
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.appearance-menu__detail {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.appearance-menu__check {
+  color: var(--accent-strong);
+  font-size: 16px;
+  font-weight: 800;
+  text-align: center;
 }
 
 .toolbar-action:hover .toolbar-tooltip,
@@ -481,7 +603,7 @@
 
 .toolbar-name-input,
 .toolbar-field input {
-  background: #0f1820;
+  background: var(--surface-panel);
   border: 1px solid var(--line-strong);
   color: var(--text);
   border-radius: 7px;
@@ -591,7 +713,7 @@
 .panel {
   border: 1px solid var(--line);
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0));
+  background: linear-gradient(180deg, var(--surface-sheen-soft), rgba(255, 255, 255, 0));
   display: grid;
   grid-template-rows: auto 1fr;
   min-height: 0;
@@ -652,7 +774,7 @@
 .centre-stage {
   position: relative;
   min-height: 0;
-  background: #0d141c;
+  background: var(--surface-subtle);
 }
 
 .centre-view {
@@ -676,7 +798,7 @@
   background:
     radial-gradient(circle at top left, rgba(120, 170, 255, 0.08), transparent 34%),
     radial-gradient(circle at bottom right, rgba(255, 196, 120, 0.06), transparent 30%),
-    #0d141c;
+    var(--surface-subtle);
 }
 
 .simulation-viewport__canvas {
@@ -693,7 +815,7 @@
   padding: 12px 14px;
   border: 1px solid var(--line-strong);
   border-radius: 10px;
-  background: rgba(11, 18, 27, 0.88);
+  background: var(--surface-raised);
   backdrop-filter: blur(8px);
   box-shadow: 0 16px 32px rgba(0, 0, 0, 0.18);
   overflow: auto;
@@ -711,7 +833,7 @@
   padding: 0 8px;
   border: 1px solid var(--line-strong);
   border-radius: 6px;
-  background: rgba(10, 18, 27, 0.85);
+  background: var(--surface-translucent);
   color: var(--text-dim);
   font-size: 11px;
   cursor: pointer;
@@ -769,7 +891,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(13, 20, 28, 0.45);
+  background: var(--surface-translucent);
   pointer-events: none;
   z-index: 5;
 }
@@ -793,7 +915,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(13, 20, 28, 0.72);
+  background: var(--surface-translucent);
   pointer-events: none;
   z-index: 6;
 }
@@ -803,7 +925,7 @@
   padding: 16px 20px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 8px;
-  background: rgba(20, 28, 38, 0.95);
+  background: var(--surface-raised);
   color: rgba(255, 255, 255, 0.85);
   font-size: 13px;
   text-align: center;
@@ -832,7 +954,7 @@
   min-height: var(--control-hit-target);
   border: 1px solid var(--line-strong);
   border-radius: 7px;
-  background: rgba(10, 18, 27, 0.85);
+  background: var(--surface-translucent);
   color: var(--text);
 }
 
@@ -863,7 +985,7 @@
   height: var(--control-hit-target);
   border: 1px solid var(--line-strong);
   border-radius: 8px;
-  background: rgba(10, 18, 27, 0.85);
+  background: var(--surface-translucent);
 }
 
 .simulation-mode-toggle__btn {
@@ -880,7 +1002,7 @@
 }
 
 .simulation-mode-toggle__btn--active {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-hover);
   color: var(--text);
 }
 
@@ -892,7 +1014,7 @@
   padding: 0 12px;
   border: 1px solid var(--line-strong);
   border-radius: 7px;
-  background: rgba(10, 18, 27, 0.85);
+  background: var(--surface-translucent);
   color: var(--text-dim);
   font-size: 12px;
   cursor: pointer;
@@ -914,10 +1036,10 @@
   padding: 8px 14px;
   border: 1px solid var(--line-strong);
   border-radius: 10px;
-  background: rgba(10, 18, 27, 0.92);
+  background: var(--surface-raised);
   color: var(--text);
   font-size: 12px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 8px 24px var(--shadow);
   min-width: 460px;
   pointer-events: auto;
 }
@@ -932,7 +1054,7 @@
   height: 28px;
   border: 1px solid var(--line-strong);
   border-radius: 6px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-sheen-soft);
   color: var(--text);
   cursor: pointer;
   font-size: 12px;
@@ -942,13 +1064,13 @@
 }
 
 .simulation-playback-bar__btn:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--surface-sheen-strong);
 }
 
 .simulation-playback-bar__btn--primary {
   background: var(--accent, #3b82f6);
   border-color: var(--accent, #3b82f6);
-  color: #fff;
+  color: var(--on-accent);
 }
 
 .simulation-playback-bar__btn--primary:hover {
@@ -995,7 +1117,7 @@
   padding: 0 6px;
   border: 1px solid var(--line-strong);
   border-radius: 6px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-sheen-soft);
   color: var(--text);
   font-size: 11px;
 }
@@ -1105,7 +1227,7 @@
   border: 1px solid var(--line);
   border-bottom-color: transparent;
   border-radius: 10px 10px 0 0;
-  background: rgba(18, 25, 34, 0.72);
+  background: var(--surface-translucent);
   color: var(--text-dim);
   min-height: var(--control-hit-target);
   padding: 0 14px;
@@ -1118,14 +1240,14 @@
   color: var(--text);
   border-color: var(--line-strong);
   border-bottom-color: transparent;
-  background: rgba(23, 31, 42, 0.86);
+  background: var(--surface-translucent);
 }
 
 .panel-tab--active {
   color: var(--text);
   border-color: rgba(220, 165, 106, 0.75);
-  border-bottom-color: rgba(15, 22, 31, 0.96);
-  background: rgba(15, 22, 31, 0.96);
+  border-bottom-color: var(--surface-popover);
+  background: var(--surface-popover);
   min-height: 0;
   position: relative;
   z-index: 1;
@@ -1147,7 +1269,7 @@
   justify-content: center;
   border: 1px solid var(--line-strong);
   border-radius: 0;
-  background: rgba(18, 25, 34, 0.72);
+  background: var(--surface-translucent);
   color: var(--text-dim);
   cursor: pointer;
   padding: 0;
@@ -1161,7 +1283,7 @@
 .workspace-layout-btn--active {
   color: var(--text);
   border-color: rgba(220, 165, 106, 0.75);
-  background: rgba(15, 22, 31, 0.96);
+  background: var(--surface-popover);
 }
 
 .workspace-layout-controls .workspace-layout-btn:first-child {
@@ -1267,7 +1389,7 @@
   padding: 3px 9px 3px 7px;
   border: 1px solid rgba(91, 117, 138, 0.55);
   border-radius: 999px;
-  background: rgba(16, 22, 30, 0.82);
+  background: var(--surface-translucent);
   color: rgba(203, 216, 227, 0.85);
   font-size: 11px;
   font-weight: 600;
@@ -1307,7 +1429,7 @@
   padding: 2px 10px;
   border: 1px solid;
   border-radius: 4px;
-  background: rgba(15, 21, 27, 0.85);
+  background: var(--surface-translucent);
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
@@ -1334,10 +1456,10 @@
   padding: 10px 10px 9px;
   border: 1px solid rgba(91, 117, 138, 0.78);
   border-radius: 10px;
-  background: rgba(16, 22, 30, 0.92);
+  background: var(--surface-raised);
   box-shadow:
     0 10px 24px rgba(0, 0, 0, 0.22),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    inset 0 1px 0 var(--surface-sheen);
 }
 
 .sketch-depth-legend__header {
@@ -1356,7 +1478,7 @@
 .statusbar-depth-legend {
   border: 1px solid var(--line-strong);
   border-radius: 7px;
-  background: rgba(13, 19, 27, 0.88);
+  background: var(--surface-translucent);
   color: var(--text-dim);
   cursor: pointer;
   transition: border-color 0.18s ease, color 0.18s ease, background 0.18s ease;
@@ -1428,7 +1550,7 @@
   font: 11px "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
   text-align: center;
   color: rgba(245, 216, 183, 0.96);
-  background: rgba(15, 21, 29, 0.92);
+  background: var(--surface-popover);
   border: 1px solid rgba(239, 188, 122, 0.65);
   border-radius: 5px;
   outline: none;
@@ -1542,11 +1664,11 @@
 }
 
 .tree-row--selected {
-  background: rgba(220, 165, 106, 0.12);
+  background: var(--accent-soft);
 }
 
 .tree-row--selected .tree-label {
-  color: #fff;
+  color: var(--on-accent);
 }
 
 .tree-row--group-selected {
@@ -1567,7 +1689,7 @@
   border-radius: 999px;
   border: 1px solid var(--line-strong);
   color: var(--text-dim);
-  background: rgba(19, 32, 44, 0.85);
+  background: var(--bg-elev-2);
   font-size: 0;
 }
 
@@ -1728,7 +1850,7 @@
   justify-content: center;
   border-radius: 6px;
   border: 1px solid rgba(92, 118, 138, 0.55);
-  background: rgba(19, 32, 44, 0.78);
+  background: var(--bg-elev-2);
   color: var(--text-dim);
   cursor: pointer;
   padding: 0;
@@ -1773,7 +1895,7 @@
 }
 
 .tree-action-btn--grouped {
-  color: #fff;
+  color: var(--on-accent);
   border-color: rgba(220, 165, 106, 0.65);
   background: rgba(220, 165, 106, 0.28);
   box-shadow: inset 0 0 0 1px rgba(220, 165, 106, 0.25);
@@ -1851,7 +1973,7 @@
 .properties-field select,
 .properties-field textarea,
 .properties-field button:not(.tree-action-btn):not(.feat-btn) {
-  background-color: #0f1820;
+  background-color: var(--surface-panel);
   border: 1px solid var(--line-strong);
   color: var(--text);
   border-radius: 7px;
@@ -1925,7 +2047,7 @@
   width: 100%;
   height: 32px;
   padding: 0 8px;
-  background-color: #0f1820;
+  background-color: var(--surface-panel);
   border: 1px solid var(--line-strong);
   border-radius: 7px;
   color: var(--text);
@@ -1981,10 +2103,10 @@
   left: 0;
   right: 0;
   z-index: 200;
-  background: #16222d;
+  background: var(--bg-elev-2);
   border: 1px solid var(--line-strong);
   border-radius: 7px;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 6px 18px var(--shadow-strong);
   overflow: hidden;
   padding: 3px;
 }
@@ -2001,7 +2123,7 @@
 }
 
 .ui-select__option:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-hover);
 }
 
 .ui-select__option--selected {
@@ -2046,7 +2168,7 @@
   height: 34px;
   border: 1px solid rgba(200, 156, 98, 0.22);
   border-radius: 6px;
-  background: rgba(7, 12, 17, 0.72);
+  background: var(--surface-input);
   pointer-events: none;
 }
 
@@ -2088,20 +2210,20 @@
   padding: 0 10px;
   border: 1px solid var(--line-strong);
   border-radius: 7px;
-  background: linear-gradient(180deg, #2a3a4c, #17232f);
+  background: linear-gradient(180deg, var(--surface-control-top), var(--surface-control-bottom));
   color: var(--text);
   font-size: 12px;
   font-weight: 500;
   line-height: 1;
   cursor: pointer;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.04),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.28);
+    inset 0 1px 0 var(--surface-sheen),
+    inset 0 -1px 0 var(--surface-inset);
 }
 
 .properties-actions button:hover {
   border-color: var(--accent);
-  color: #fff;
+  color: var(--on-accent);
 }
 
 .properties-actions button:disabled {
@@ -2178,15 +2300,15 @@
 .feat-btn {
   border: 1px solid var(--line-strong);
   border-radius: 6px;
-  background: linear-gradient(180deg, #24374a 0%, #13202c 100%);
+  background: linear-gradient(180deg, var(--surface-button-top) 0%, var(--surface-button-bottom) 100%);
   color: var(--text);
   font-size: 11px;
   font-weight: 600;
   height: 28px;
   padding: 0 10px;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.06),
-    0 1px 0 rgba(0, 0, 0, 0.28);
+    inset 0 1px 0 var(--surface-hover),
+    0 1px 0 var(--surface-inset);
   cursor: pointer;
   transition:
     transform 80ms ease,
@@ -2196,18 +2318,18 @@
 }
 
 .feat-btn:hover {
-  color: #fff;
+  color: var(--on-accent);
   border-color: var(--accent);
-  background: linear-gradient(180deg, #2d4358 0%, #172635 100%);
+  background: linear-gradient(180deg, var(--surface-control-top) 0%, var(--surface-control-bottom) 100%);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    inset 0 1px 0 var(--surface-sheen-strong),
     0 2px 4px rgba(0, 0, 0, 0.22);
 }
 
 .feat-btn:active {
   transform: translateY(1px);
-  background: linear-gradient(180deg, #13202c 0%, #1d3040 100%);
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.35);
+  background: linear-gradient(180deg, var(--surface-button-bottom) 0%, var(--surface-control-top) 100%);
+  box-shadow: inset 0 1px 3px var(--shadow);
 }
 
 .feat-btn--primary {
@@ -2222,7 +2344,7 @@
 }
 
 .feat-btn--active {
-  color: #fff;
+  color: var(--on-accent);
   border-color: var(--accent);
   background: rgba(37, 82, 136, 0.24);
 }
@@ -2273,7 +2395,7 @@
   box-sizing: border-box;
   border: 1px solid var(--line-strong);
   border-radius: 7px;
-  background: rgba(10, 18, 27, 0.85);
+  background: var(--surface-translucent);
   color: var(--text);
   min-width: var(--control-hit-target);
   height: var(--control-hit-target);
@@ -2338,7 +2460,7 @@
   padding: 5px 7px;
   border-radius: 8px;
   border: 1px solid var(--line-strong);
-  background: rgba(10, 18, 27, 0.85);
+  background: var(--surface-translucent);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
   font-size: 12px;
@@ -2367,7 +2489,7 @@
 }
 
 .viewport-toolpath-vis__label:hover {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-sheen);
   color: var(--text);
 }
 
@@ -2420,7 +2542,7 @@
 }
 
 .viewport-toolpath-vis__item:hover {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-sheen);
   color: var(--text);
 }
 
@@ -2466,10 +2588,10 @@
   padding: 4px;
   border-radius: 10px;
   border: 1px solid rgba(94, 121, 142, 0.72);
-  background: rgba(12, 18, 26, 0.96);
+  background: var(--surface-popover);
   box-shadow:
-    0 12px 26px rgba(0, 0, 0, 0.35),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    0 12px 26px var(--shadow),
+    inset 0 1px 0 var(--surface-sheen);
   display: grid;
   gap: 1px;
   box-sizing: border-box;
@@ -2522,7 +2644,7 @@
 
 .feature-context-menu__item:hover {
   border-color: var(--line-strong);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-sheen);
 }
 
 .feature-context-menu__item:disabled {
@@ -2552,7 +2674,7 @@
   align-items: center;
   height: 35px;
   padding: 8px 14px;
-  background: rgba(16, 24, 33, 0.9);
+  background: var(--surface-raised);
   overflow-x: auto;
   overflow-y: hidden;
   white-space: nowrap;
@@ -2575,7 +2697,7 @@
 
 .statusbar-about:hover {
   color: var(--text);
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface-sheen-mid);
 }
 
 .statusbar-visibility {
@@ -2620,7 +2742,7 @@
 
 .statusbar-toggle:hover:not(:disabled) {
   border-color: rgba(94, 121, 142, 0.48);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-sheen);
   color: var(--text);
 }
 
@@ -2683,7 +2805,7 @@
   padding: 0 12px;
   border: 1px solid var(--line-strong);
   border-radius: 8px;
-  background: rgba(22, 29, 39, 0.86);
+  background: var(--bg-elev-2);
   color: var(--muted);
   font-size: 12px;
   cursor: pointer;
@@ -2806,7 +2928,7 @@
   min-height: 0;
   border: 1px solid var(--line);
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0));
+  background: linear-gradient(180deg, var(--surface-sheen-soft), rgba(255, 255, 255, 0));
   overflow: visible;
 }
 
@@ -2835,7 +2957,7 @@
   padding: 0 10px;
   border-radius: 7px;
   border: 1px solid var(--line-strong);
-  background: rgba(18, 25, 34, 0.86);
+  background: var(--surface-translucent);
   color: var(--text);
   cursor: pointer;
   text-transform: none;
@@ -2853,7 +2975,7 @@
 }
 
 .cam-header-action--danger {
-  color: #f0bbb6;
+  color: var(--danger-text);
   border-color: rgba(170, 92, 84, 0.6);
   background: rgba(61, 27, 24, 0.42);
 }
@@ -2870,8 +2992,8 @@
   right: 0;
   z-index: 10;
   border: 1px solid var(--line-strong);
-  background: rgba(14, 20, 28, 0.98);
-  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
+  background: var(--surface-popover);
+  box-shadow: 0 14px 28px var(--shadow);
 }
 
 .cam-add-menu--horizontal {
@@ -2908,7 +3030,7 @@
 }
 
 .cam-field-message {
-  color: #f0bbb6;
+  color: var(--danger-text);
   font-size: 11px;
   line-height: 1.35;
   text-transform: none;
@@ -2925,7 +3047,7 @@
   border-radius: 8px;
   border: 1px solid rgba(170, 92, 84, 0.45);
   background: rgba(61, 27, 24, 0.24);
-  color: #f0bbb6;
+  color: var(--danger-text);
   font-size: 11px;
   line-height: 1.35;
   text-transform: none;
@@ -3025,18 +3147,18 @@
 }
 
 .cam-operation-tree .tree-row:focus-visible {
-  background: rgba(220, 165, 106, 0.12);
+  background: var(--accent-soft);
 }
 
 .cam-operation-tree .tree-row--selected,
 .cam-operation-tree .tree-row--selected:hover,
 .cam-operation-tree .tree-row--selected:focus-visible,
 .cam-operation-tree .tree-row--selected:active {
-  background: rgba(220, 165, 106, 0.12);
+  background: var(--accent-soft);
 }
 
 .cam-operation-tree .tree-row--selected .tree-label {
-  color: #fff;
+  color: var(--on-accent);
 }
 
 .cam-operation-tree .tree-row:not(.tree-row--selected) .tree-label {
@@ -3117,18 +3239,18 @@
 }
 
 .cam-tool-tree .tree-row:focus-visible {
-  background: rgba(220, 165, 106, 0.12);
+  background: var(--accent-soft);
 }
 
 .cam-tool-tree .tree-row--selected,
 .cam-tool-tree .tree-row--selected:hover,
 .cam-tool-tree .tree-row--selected:focus-visible,
 .cam-tool-tree .tree-row--selected:active {
-  background: rgba(220, 165, 106, 0.12);
+  background: var(--accent-soft);
 }
 
 .cam-tool-tree .tree-row--selected .cam-tool-label__name {
-  color: #fff;
+  color: var(--on-accent);
 }
 
 .cam-tool-tree .tree-label {
@@ -3166,12 +3288,12 @@
 .tree-action-btn--delete:hover:not(:disabled) {
   border-color: rgba(170, 92, 84, 0.6);
   background: rgba(61, 27, 24, 0.42);
-  color: #f0bbb6;
+  color: var(--danger-text);
 }
 
 .cam-header-action--active {
   border-color: var(--line-bright);
-  background: rgba(220, 165, 106, 0.12);
+  background: var(--accent-soft);
 }
 
 .cam-library-browser {
@@ -3179,7 +3301,7 @@
   gap: 0;
   border-top: 1px solid var(--line-strong);
   border-bottom: 1px solid var(--line-strong);
-  background: rgba(12, 18, 26, 0.6);
+  background: var(--surface-translucent);
 }
 
 .cam-library-browser__filters {
@@ -3196,7 +3318,7 @@
   padding: 0 6px;
   border-radius: 6px;
   border: 1px solid var(--line-strong);
-  background: rgba(18, 25, 34, 0.86);
+  background: var(--surface-translucent);
   color: var(--text);
   font: inherit;
   font-size: 12px;
@@ -3434,10 +3556,10 @@
   padding: 4px;
   border-radius: 10px;
   border: 1px solid rgba(94, 121, 142, 0.72);
-  background: rgba(12, 18, 26, 0.96);
+  background: var(--surface-popover);
   box-shadow:
-    0 12px 26px rgba(0, 0, 0, 0.35),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    0 12px 26px var(--shadow),
+    inset 0 1px 0 var(--surface-sheen);
   display: grid;
   gap: 1px;
 }
@@ -3460,12 +3582,12 @@
 
 .tree-operation-menu__item:hover {
   border-color: var(--line-strong);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-sheen);
 }
 
 .tree-operation-menu__item--active {
   border-color: rgba(94, 121, 142, 0.5);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-hover);
 }
 
 .tree-operation-menu__item--disabled {
@@ -3604,7 +3726,7 @@
   padding: 4px 8px;
   border-radius: 6px;
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-sheen-soft);
   color: var(--text);
   font-size: 13px;
   min-height: 28px;
@@ -3652,7 +3774,7 @@
 
 /* Field inputs styled identically to .properties-field input */
 .z-range-slider__field {
-  background-color: #0f1820;
+  background-color: var(--surface-panel);
   border: 1px solid var(--line-strong);
   color: var(--text);
   border-radius: 7px;
@@ -3704,7 +3826,7 @@
   height: 16px;
   background: var(--accent);
   border-radius: 50%;
-  border: 2.5px solid #0f1820;
+  border: 2.5px solid var(--surface-panel);
   cursor: ns-resize;
   z-index: 1;
   touch-action: none;
@@ -3812,7 +3934,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(8, 16, 24, 0.55);
+  background: var(--surface-input);
   pointer-events: none;
   animation: toolpath-overlay-in 0.15s ease-out;
 }
@@ -3828,7 +3950,7 @@
   gap: 12px;
   padding: 12px 22px;
   border-radius: 12px;
-  background: rgba(19, 32, 44, 0.92);
+  background: var(--bg-elev-2);
   border: 1px solid rgba(220, 165, 106, 0.25);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
 }
@@ -3886,7 +4008,7 @@
 }
 
 .cam-operation-item--expanded {
-  background-color: rgba(255, 255, 255, 0.03);
+  background-color: var(--surface-sheen-soft);
 }
 
 .cam-operation-row {
@@ -4008,7 +4130,7 @@
   height: 160px;
   border-radius: 6px;
   overflow: hidden;
-  background-color: rgba(255, 255, 255, 0.03);
+  background-color: var(--surface-sheen-soft);
   border: 1px solid var(--line);
   display: flex;
   align-items: center;
@@ -4039,7 +4161,7 @@
 .cam-operation-details__image-fallback code {
   font-size: 10px;
   color: var(--text-dim);
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface-sheen-mid);
   padding: 2px 6px;
   border-radius: 3px;
 }
@@ -4139,7 +4261,7 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(8, 12, 18, 0.55);
+  background: var(--surface-input);
   backdrop-filter: blur(2px);
   overflow-y: auto;
 }
@@ -4151,8 +4273,8 @@
   padding: 24px;
   border-radius: 14px;
   border: 1px solid rgba(94, 121, 142, 0.6);
-  background: rgba(14, 20, 28, 0.97);
-  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+  background: var(--surface-popover);
+  box-shadow: 0 18px 48px var(--shadow-strong);
   box-sizing: border-box;
 }
 
@@ -4192,7 +4314,7 @@
 
 .empty-state-action:hover {
   border-color: var(--accent);
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface-sheen-mid);
 }
 
 .empty-state-action__title {
@@ -4240,7 +4362,7 @@
 
 .example-project-card:hover:not(:disabled) {
   border-color: var(--accent);
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface-sheen-mid);
 }
 
 .example-project-card:disabled {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -3032,8 +3032,9 @@
 
 /* P5: success confirmation colour */
 .cam-field-message--success {
-  color: #7ddf7d;
+  color: var(--add);
   font-size: 11px;
+  font-weight: 600;
   line-height: 1.35;
 }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -3000,7 +3000,7 @@
   right: 0;
   z-index: 10;
   border: 1px solid var(--line-strong);
-  background: var(--surface-popover);
+  background: var(--bg-elev-1);
   box-shadow: 0 14px 28px var(--shadow);
 }
 
@@ -4013,7 +4013,7 @@
 }
 
 .cam-operation-item:hover {
-  background-color: rgba(255, 255, 255, 0.02);
+  background-color: var(--surface-hover);
 }
 
 .cam-operation-item--expanded {
@@ -4045,10 +4045,11 @@
   margin: 0 10px 6px;
   padding: 4px 8px;
   border-radius: 6px;
-  border-left: 2px solid rgba(214, 165, 92, 0.6);
-  background: rgba(214, 165, 92, 0.1);
-  color: #e0c08a;
-  font-size: 10.5px;
+  border-left: 2px solid color-mix(in oklab, var(--warning-text) 62%, var(--line-strong));
+  background: color-mix(in oklab, var(--warning-text) 9%, var(--bg-elev-1));
+  color: var(--warning-text);
+  font-size: 11px;
+  font-weight: 500;
   line-height: 1.3;
 }
 
@@ -4117,7 +4118,7 @@
   gap: 10px;
   padding: 10px 10px;
   margin: 0;
-  background-color: rgba(255, 255, 255, 0.02);
+  background-color: var(--surface-subtle);
   border-top: 1px solid var(--line);
   border-bottom: 1px solid var(--line);
   animation: cam-operation-expand 0.2s ease-out;
@@ -4252,12 +4253,12 @@
 }
 
 .cam-add-menu--vertical::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.1);
+  background: color-mix(in oklab, var(--text-dim) 28%, transparent);
   border-radius: 3px;
 }
 
 .cam-add-menu--vertical::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.2);
+  background: color-mix(in oklab, var(--text-dim) 42%, transparent);
 }
 
 /* ── Empty-state onboarding overlay ─────────────────────────────── */

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -37,6 +37,14 @@
   }
 }
 
+[data-shell-mode="tablet"] .appearance-control__trigger,
+[data-shell-mode="tablet-compact"] .appearance-control__trigger {
+  width: var(--touch-target, 44px);
+  height: var(--touch-target, 44px);
+  min-width: var(--touch-target, 44px);
+  min-height: var(--touch-target, 44px);
+}
+
 /* ── Tablet layout: right panel becomes a slide-in drawer ─── */
 
 @media (pointer: coarse), (max-width: 960px) {
@@ -52,7 +60,7 @@
     flex-direction: column;
     background: var(--bg-elev-1);
     border-left: 1px solid var(--line);
-    box-shadow: -8px 0 32px rgba(0, 0, 0, 0.45);
+    box-shadow: -8px 0 32px var(--shadow-strong);
     transform: translateX(100%);
     transition: transform 0.22s ease;
     /* Override the grid-area assignment from the narrow desktop breakpoint */
@@ -70,7 +78,7 @@
     position: fixed;
     inset: 0;
     z-index: 49;
-    background: rgba(0, 0, 0, 0.45);
+    background: var(--shadow-strong);
   }
 
   /* The main body no longer needs to reserve a column for the right panel */
@@ -282,7 +290,7 @@
   flex-direction: column;
   background: var(--bg-elev-1);
   border-left: 1px solid var(--line);
-  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.45);
+  box-shadow: -8px 0 32px var(--shadow-strong);
   transform: translateX(100%);
   transition: transform 0.22s ease;
   pointer-events: none;
@@ -400,7 +408,7 @@
   gap: 6px;
   padding: 6px;
   border-radius: 10px;
-  background: rgba(16, 24, 33, 0.88);
+  background: var(--surface-raised);
   border: 1px solid var(--line);
   backdrop-filter: blur(8px);
   pointer-events: auto;
@@ -428,7 +436,7 @@
 }
 
 .tablet-cmd-btn:active {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--surface-sheen-strong);
 }
 
 .tablet-cmd-btn--active {
@@ -500,7 +508,7 @@
 }
 
 .top-command-bar__name:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-hover);
 }
 
 .top-command-bar__save-state {
@@ -538,7 +546,7 @@
 }
 
 .top-cmd-group--tabs {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-sheen);
   border-radius: 8px;
   padding: 2px;
 }
@@ -557,7 +565,7 @@
 }
 
 .top-cmd-btn:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-hover);
   color: var(--text);
 }
 
@@ -674,7 +682,7 @@
   align-items: center;
   gap: 2px;
   padding-bottom: 4px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid var(--surface-hover);
   width: 100%;
 }
 
@@ -704,7 +712,7 @@
 }
 
 .tool-rail__btn:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-hover);
   color: var(--text);
 }
 
@@ -756,7 +764,7 @@
   gap: 2px;
   padding: 2px;
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-sheen);
 }
 
 .tool-rail__target-btn {
@@ -840,7 +848,7 @@
 }
 
 .tool-rail__popover button:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-hover);
   color: var(--text);
 }
 
@@ -946,7 +954,7 @@
 }
 
 .snap-popover-item:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-hover);
   color: var(--text);
 }
 
@@ -987,7 +995,7 @@
   flex-direction: column;
   background: var(--bg-elev-1);
   border-right: 1px solid var(--line);
-  box-shadow: 8px 0 32px rgba(0, 0, 0, 0.45);
+  box-shadow: 8px 0 32px var(--shadow-strong);
   transform: translateX(-100%);
   transition: transform 0.22s ease;
   pointer-events: none;
@@ -1135,7 +1143,7 @@
 }
 
 .statusbar-expand-btn:active {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--surface-sheen-strong);
 }
 
 .statusbar-visibility--hidden {
@@ -1283,7 +1291,7 @@
     position: fixed;
     inset: 0;
     z-index: 99999;
-    background: #0b1219;
+    background: var(--surface-subtle);
     color: var(--text-dim);
     font-size: 18px;
     text-align: center;

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -1136,7 +1136,7 @@
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: var(--text-dim);
+  color: var(--status-text);
   cursor: pointer;
   font-size: 10px;
   flex-shrink: 0;

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -446,9 +446,16 @@
 }
 
 .tablet-cmd-btn--confirm {
-  background: rgba(60, 180, 60, 0.15);
-  border-color: rgba(60, 180, 60, 0.4);
-  color: #7ddf7d;
+  background: color-mix(in oklab, var(--add) 18%, var(--surface-raised));
+  border-color: color-mix(in oklab, var(--add) 72%, var(--line-strong));
+  color: var(--add);
+  font-weight: 650;
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--add) 12%, transparent);
+}
+
+.tablet-cmd-btn--confirm:hover {
+  background: color-mix(in oklab, var(--add) 24%, var(--surface-raised));
+  border-color: var(--add);
 }
 
 .tablet-cmd-btn--cancel {
@@ -926,9 +933,9 @@
 }
 
 .snap-popover-enable-btn--active {
-  background: rgba(60, 180, 60, 0.12);
-  border-color: rgba(60, 180, 60, 0.4);
-  color: #7ddf7d;
+  background: color-mix(in oklab, var(--add) 14%, var(--surface-raised));
+  border-color: color-mix(in oklab, var(--add) 62%, var(--line-strong));
+  color: var(--add);
 }
 
 .snap-popover-grid {

--- a/src/theme/INDEX.md
+++ b/src/theme/INDEX.md
@@ -1,0 +1,9 @@
+# INDEX — src/theme/
+
+Application-local appearance preferences. Theme state is deliberately separate from the `.camj` project store, so changing appearance never dirties a project or changes saved files.
+
+- `theme.ts` — theme preference types, persistence codec, system resolution, and pre-React root bootstrap.
+- `ThemeProvider.tsx` — React context, localStorage persistence, and the conditional system-theme listener.
+- `themeContext.ts` — context contract and `useTheme()` consumer hook, separated for Fast Refresh.
+- `palette.ts` — typed 2D canvas and Three.js colors keyed by resolved theme.
+- `theme.test.ts` — pure preference, bootstrap-root, codec, and palette coverage.

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useLayoutEffect, useMemo, useState, type ReactNode } from 'react'
+import { useLocalStorageState } from '../hooks/useLocalStorageState'
+import {
+  applyThemeToRoot,
+  getSystemPrefersDark,
+  resolveThemePreference,
+  THEME_STORAGE_KEY,
+  themePreferenceCodec,
+  type ThemePreference,
+} from './theme'
+import { ThemeContext, type ThemeContextValue } from './themeContext'
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [preference, setPreference] = useLocalStorageState<ThemePreference>(
+    THEME_STORAGE_KEY,
+    'dark',
+    { codec: themePreferenceCodec },
+  )
+  const [systemPrefersDark, setSystemPrefersDark] = useState(getSystemPrefersDark)
+  const resolvedTheme = resolveThemePreference(preference, systemPrefersDark)
+
+  useLayoutEffect(() => {
+    applyThemeToRoot(document.documentElement, preference, resolvedTheme)
+  }, [preference, resolvedTheme])
+
+  useEffect(() => {
+    if (preference !== 'system' || typeof window.matchMedia !== 'function') return
+
+    const query = window.matchMedia('(prefers-color-scheme: dark)')
+    const syncSystemTheme = () => setSystemPrefersDark(query.matches)
+    syncSystemTheme()
+    query.addEventListener('change', syncSystemTheme)
+    return () => query.removeEventListener('change', syncSystemTheme)
+  }, [preference])
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ preference, resolvedTheme, setPreference }),
+    [preference, resolvedTheme, setPreference],
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ResolvedTheme } from './theme'
+
+export interface CanvasThemePalette {
+  background: string
+  gridMajor: string
+  gridMinor: string
+  labelBackground: string
+  labelText: string
+  mutedGeometry: string
+  veil: string
+}
+
+export interface ThreeThemePalette {
+  background: number
+  gridMinorCenter: number
+  gridMinor: number
+  gridMajorCenter: number
+  gridMajor: number
+}
+
+export interface ThemePalette {
+  canvas: CanvasThemePalette
+  three: ThreeThemePalette
+}
+
+export const THEME_PALETTES: Record<ResolvedTheme, ThemePalette> = {
+  dark: {
+    canvas: {
+      background: '#0f151d',
+      gridMajor: 'rgba(104, 132, 154, 0.34)',
+      gridMinor: 'rgba(88, 112, 130, 0.18)',
+      labelBackground: 'rgba(18, 26, 36, 0.88)',
+      labelText: 'rgba(218, 232, 244, 0.96)',
+      mutedGeometry: 'rgba(210, 221, 230, 0.62)',
+      veil: 'rgba(8, 12, 18, 0.5)',
+    },
+    three: {
+      background: 0x141820,
+      gridMinorCenter: 0x223344,
+      gridMinor: 0x223344,
+      gridMajorCenter: 0x334455,
+      gridMajor: 0x51657a,
+    },
+  },
+  light: {
+    canvas: {
+      background: '#f6f1e7',
+      gridMajor: 'rgba(92, 105, 110, 0.32)',
+      gridMinor: 'rgba(112, 119, 116, 0.16)',
+      labelBackground: 'rgba(255, 252, 246, 0.94)',
+      labelText: 'rgba(36, 45, 51, 0.96)',
+      mutedGeometry: 'rgba(65, 79, 88, 0.68)',
+      veil: 'rgba(246, 241, 231, 0.66)',
+    },
+    three: {
+      background: 0xece7dd,
+      gridMinorCenter: 0xb7b1a7,
+      gridMinor: 0xc9c3b8,
+      gridMajorCenter: 0x827c73,
+      gridMajor: 0xaaa399,
+    },
+  },
+}

--- a/src/theme/theme.test.ts
+++ b/src/theme/theme.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  applyThemeToRoot,
+  readThemePreference,
+  resolveThemePreference,
+  THEME_STORAGE_KEY,
+  themePreferenceCodec,
+} from './theme'
+import { THEME_PALETTES } from './palette'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+assert(resolveThemePreference('dark', false) === 'dark', 'dark stays dark')
+assert(resolveThemePreference('light', true) === 'light', 'light stays light')
+assert(resolveThemePreference('system', true) === 'dark', 'system follows dark media')
+assert(resolveThemePreference('system', false) === 'light', 'system follows light media')
+
+const storage = {
+  getItem: (key: string) => key === THEME_STORAGE_KEY ? 'system' : null,
+}
+assert(readThemePreference(storage) === 'system', 'stored system preference is restored')
+assert(readThemePreference({ getItem: () => 'unknown' }) === 'dark', 'invalid preference falls back')
+assert(readThemePreference({ getItem: () => { throw new Error('disabled') } }) === 'dark', 'storage errors fall back')
+assert(themePreferenceCodec.deserialize(themePreferenceCodec.serialize('light')) === 'light', 'codec round-trips')
+
+const root: {
+  dataset: { theme?: string; themePreference?: string }
+  style: { colorScheme: string }
+} = { dataset: {}, style: { colorScheme: '' } }
+applyThemeToRoot(root, 'system', 'light')
+assert(root.dataset.theme === 'light', 'resolved theme is written to data-theme')
+assert(root.dataset.themePreference === 'system', 'preference is exposed for diagnostics')
+assert(root.style.colorScheme === 'light', 'native controls receive the resolved color scheme')
+
+assert(THEME_PALETTES.dark.canvas.background !== THEME_PALETTES.light.canvas.background, 'canvas palettes differ')
+assert(THEME_PALETTES.dark.three.background !== THEME_PALETTES.light.three.background, 'Three palettes differ')
+
+console.log('theme tests passed')

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { StorageCodec } from '../hooks/useLocalStorageState'
+
+export const THEME_STORAGE_KEY = 'purecutcnc.appearance.theme'
+export const THEME_PREFERENCES = ['dark', 'light', 'system'] as const
+
+export type ThemePreference = (typeof THEME_PREFERENCES)[number]
+export type ResolvedTheme = Exclude<ThemePreference, 'system'>
+
+export const themePreferenceCodec: StorageCodec<ThemePreference> = {
+  serialize: (value) => value,
+  deserialize: (raw) => {
+    if (isThemePreference(raw)) return raw
+    throw new Error(`Unsupported theme preference: ${raw}`)
+  },
+}
+
+export function isThemePreference(value: string): value is ThemePreference {
+  return THEME_PREFERENCES.some((preference) => preference === value)
+}
+
+export function resolveThemePreference(
+  preference: ThemePreference,
+  systemPrefersDark: boolean,
+): ResolvedTheme {
+  if (preference === 'system') return systemPrefersDark ? 'dark' : 'light'
+  return preference
+}
+
+interface ThemeRoot {
+  dataset: {
+    theme?: string
+    themePreference?: string
+  }
+  style: {
+    colorScheme: string
+  }
+}
+
+export function readThemePreference(
+  storage: Pick<Storage, 'getItem'> | null,
+): ThemePreference {
+  if (!storage) return 'dark'
+  try {
+    const stored = storage.getItem(THEME_STORAGE_KEY)
+    return stored && isThemePreference(stored) ? stored : 'dark'
+  } catch {
+    return 'dark'
+  }
+}
+
+export function applyThemeToRoot(
+  root: ThemeRoot,
+  preference: ThemePreference,
+  resolvedTheme: ResolvedTheme,
+): void {
+  root.dataset.theme = resolvedTheme
+  root.dataset.themePreference = preference
+  root.style.colorScheme = resolvedTheme
+}
+
+export function getSystemPrefersDark(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+/** Applies the stored preference before React renders, preventing a theme flash. */
+export function bootstrapTheme(): ThemePreference {
+  if (typeof document === 'undefined') return 'dark'
+
+  const storage = typeof window === 'undefined' ? null : window.localStorage
+  const preference = readThemePreference(storage)
+  const resolvedTheme = resolveThemePreference(preference, getSystemPrefersDark())
+  applyThemeToRoot(document.documentElement, preference, resolvedTheme)
+  return preference
+}

--- a/src/theme/themeContext.ts
+++ b/src/theme/themeContext.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useContext, type Dispatch, type SetStateAction } from 'react'
+import type { ResolvedTheme, ThemePreference } from './theme'
+
+export interface ThemeContextValue {
+  preference: ThemePreference
+  resolvedTheme: ResolvedTheme
+  setPreference: Dispatch<SetStateAction<ThemePreference>>
+}
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+export function useTheme(): ThemeContextValue {
+  const value = useContext(ThemeContext)
+  if (!value) throw new Error('useTheme must be used inside ThemeProvider')
+  return value
+}


### PR DESCRIPTION
## Summary
- add an app-local Dark, Light, and System appearance preference with pre-render bootstrap and persistence
- introduce semantic CSS, canvas, 3D viewport, and simulation palettes while keeping project data unchanged
- add the shared appearance control to desktop and tablet toolbars with accessible, touch-sized choices
- cover persistence, system preference changes, project isolation, and tablet sizing in browser smoke tests

## Verification
- `npm run build`
- `npm run test:e2e`
- `npx playwright test e2e/appearance.smoke.spec.ts`
- desktop and tablet visual trace review in dark and light themes

Closes #302