### PR TITLE
Restore desktop tree reordering

### DIFF
--- a/e2e/camOperations.smoke.spec.ts
+++ b/e2e/camOperations.smoke.spec.ts
@@ -33,6 +33,33 @@ interface OperationSnapshot {
 }
 
 test.describe('CAM operation browser smoke', () => {
+  test('HTML5 drag reorders CAM operations', async ({ app, ui }) => {
+    await seedCamQuickOperationProject(app.page)
+
+    const edgeMenu = await openRowContextMenu(app.page, rowByName(app.page, 'Machinable Add'))
+    await ui.contextMenu.item(edgeMenu, 'Create operation').hover()
+    await clickMenuItem(ui.contextMenu.submenu(app.page), 'Create Outside Route')
+    await expect(ui.operations.rowByName(app.page, 'Edge route outside Rough')).toBeVisible()
+
+    const carveMenu = await openRowContextMenu(app.page, rowByName(app.page, 'Carve Target'))
+    await ui.contextMenu.item(carveMenu, 'Create operation').hover()
+    await clickMenuItem(ui.contextMenu.submenu(app.page), 'Create V-Carve (medial)')
+    await expect(ui.operations.rows(app.page)).toHaveCount(2)
+
+    await ui.operations.rowByName(app.page, 'V-Carve medial')
+      .dragTo(ui.operations.rowByName(app.page, 'Edge route outside Rough'))
+
+    await expect(ui.operations.rows(app.page).nth(0)).toContainText('V-Carve medial')
+    await expect(ui.operations.rows(app.page).nth(1)).toContainText('Edge route outside Rough')
+
+    const project = await getProject(app.page)
+    const operations = project.operations as Array<{ name?: unknown }>
+    expect(operations.map((operation) => operation.name)).toEqual([
+      'V-Carve medial',
+      'Edge route outside Rough',
+    ])
+  })
+
   test('feature-row quick operation creates a CAM operation', async ({ app, ui }) => {
     await seedCamQuickOperationProject(app.page)
 

--- a/e2e/featureReferences.smoke.spec.ts
+++ b/e2e/featureReferences.smoke.spec.ts
@@ -48,6 +48,23 @@ test.describe('Feature references browser smoke', () => {
     await expect(ui.tree.rows(app.page).first()).toBeAttached()
   })
 
+  test('HTML5 drag reorders project features and folders', async ({ app, ui }) => {
+    await seedLinkedProject(app.page)
+
+    await rowByName(app.page, 'Linked B').dragTo(rowByName(app.page, 'Linked A'))
+    await expect(ui.tree.featureRows(app.page).nth(0)).toContainText('Linked B')
+    await expect(ui.tree.featureRows(app.page).nth(1)).toContainText('Linked A')
+
+    await ui.tree.addFolderButton(app.page).click()
+    await ui.tree.addFolderButton(app.page).click()
+    await expect(ui.tree.folderRows(app.page)).toHaveCount(2)
+
+    await ui.tree.folderRowByName(app.page, 'Folder 2')
+      .dragTo(ui.tree.folderRowByName(app.page, 'Folder 1'))
+    await expect(ui.tree.folderRows(app.page).nth(0)).toContainText('Folder 2')
+    await expect(ui.tree.folderRows(app.page).nth(1)).toContainText('Folder 1')
+  })
+
   // ── 2. Linked badge renders on the right rows ──────────────────
 
   test('linked badge visible on linked rows, absent on independent/unique', async ({ app, ui }) => {

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -75,9 +75,19 @@ export const tree = {
   /** Feature rows only (excludes folders, section headers, etc.). */
   featureRows: (page: Page) => page.locator('.tree-row.tree-row--feature'),
 
+  /** Feature-folder rows only. */
+  folderRows: (page: Page) => page.locator('.tree-row.tree-row--folder'),
+
   /** A specific feature row by its label text. */
   rowByName: (page: Page, name: string) =>
     page.locator('.tree-row--feature').filter({ hasText: name }),
+
+  /** A specific feature-folder row by its label text. */
+  folderRowByName: (page: Page, name: string) =>
+    page.locator('.tree-row--folder').filter({ hasText: name }),
+
+  /** Adds a folder to the machining-features section. */
+  addFolderButton: (page: Page) => page.getByRole('button', { name: 'Add folder', exact: true }),
 
   /** Rows that are currently selected. */
   selectedRows: (page: Page) => page.locator('.tree-row--selected'),

--- a/planning/DESKTOP_DESIGN.md
+++ b/planning/DESKTOP_DESIGN.md
@@ -1,7 +1,7 @@
 ---
 status: current
 authoritative-for: desktop shell and platform-abstraction design
-last-verified: 2026-07-15
+last-verified: 2026-07-16
 ---
 
 # Desktop Design
@@ -56,6 +56,10 @@ Those remain in the shared TypeScript application.
   and browser e2e tests.
 - Native paths and filesystem capabilities are never serialized into portable
   project data unless the schema explicitly defines them.
+- The main window keeps Tauri native drag/drop disabled so the shared frontend
+  HTML5 drag interaction remains available for Project-tree and CAM-operation
+  reordering. Finder-to-window `.camj` dropping is intentionally unsupported;
+  projects open through File > Open or macOS file association instead.
 
 ## Security and distribution
 
@@ -71,5 +75,6 @@ Desktop/platform changes should cover:
 - focused platform or store tests;
 - `npm run build`;
 - browser fallback boot and the relevant `npm run test:e2e` smoke;
+- Project-tree feature/folder and CAM-operation reordering;
 - native file/close/menu testing on the affected desktop platform;
 - tablet impact when shared commands or dialogs change.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
         "width": 1280,
         "height": 800,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/src/platform/useDesktopIntegration.ts
+++ b/src/platform/useDesktopIntegration.ts
@@ -16,7 +16,6 @@
 
 import { useEffect, useRef } from 'react'
 import type { MutableRefObject } from 'react'
-import { readTextFile } from '@tauri-apps/plugin-fs'
 import { useProjectStore } from '../store/projectStore'
 import { platform } from './index'
 import { checkDesktopUpdate, loadChannel, saveChannel } from '../utils/updateCheck'
@@ -140,7 +139,6 @@ function runFeatureClipboardCommand(
  *  - document.title + Tauri window title updated with file name + dirty indicator
  *  - window close prompt when there are unsaved changes
  *  - native app menu event routing
- *  - drag-and-drop .camj open
  *
  * Safe to call in the browser — all Tauri-specific listeners are guarded by
  * `platform.isDesktop` and loaded lazily so the web bundle is not affected.
@@ -210,7 +208,7 @@ export function useDesktopIntegration({ onExportGcode, onPrintDesign, onShowAbou
   }, [])
 
   // -------------------------------------------------------------------------
-  // Desktop-only: window close prompt, menu events, drag-and-drop
+  // Desktop-only: window close prompt and menu events
   //
   // Runs ONCE on mount. Uses:
   //  - isCancelled flag — prevents late-resolving async setup from
@@ -380,36 +378,6 @@ export function useDesktopIntegration({ onExportGcode, onPrintDesign, onShowAbou
       // The native menu defaults to "snapshot"; reflect a previously saved
       // choice so the checkmark is correct from launch.
       invoke('set_update_channel', { channel: loadChannel() }).catch(() => {})
-
-      // -- Drag-and-drop .camj open ------------------------------------------
-      const unlistenDrop = await win.onDragDropEvent(async (event) => {
-        if (event.payload.type !== 'drop') return
-        const camjPath = event.payload.paths.find((p) =>
-          p.toLowerCase().endsWith('.camj')
-        )
-        if (!camjPath) return
-
-        const { dirty: currentDirty } = useProjectStore.getState()
-        if (currentDirty) {
-          const ok = await platform.confirmDiscardChanges()
-          if (!ok) return
-        }
-
-        try {
-          const content = await readTextFile(camjPath)
-          useProjectStore.setState({ projectLoading: true })
-          await new Promise<void>((resolve) =>
-            requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
-          )
-          useProjectStore.getState().openProjectFromText(content, camjPath)
-        } catch {
-          alert('Failed to open dropped file.')
-        } finally {
-          useProjectStore.setState({ projectLoading: false })
-        }
-      })
-      if (isCancelled) { unlistenDrop(); return }
-      cleanups.push(unlistenDrop)
     }
 
     setup()


### PR DESCRIPTION
## Summary

- Disable Tauri native window drag/drop so the shared HTML5 drag path can reorder Project-tree features/folders and CAM operations on desktop.
- Remove Finder-to-window `.camj` opening while preserving File > Open and macOS file-association opening.
- Document the desktop drag/drop contract and add browser coverage for all three reorder surfaces.

## Root cause

Tauri/WKWebView native file-drop handling intercepted the frontend drag/drop events used by both tree implementations. The native listener existed only for Finder-to-window `.camj` opening, so this deliberately prioritizes in-app ordering as planned in issue #303.

## Verification

- `npm run build`
- `npm run test:e2e` — 47 passed
- `src-tauri/tauri.conf.json` parses as JSON and `dragDropEnabled` is present in the installed Tauri config schema

## Native follow-up

- Confirm Project-tree and CAM-operation mouse reordering in the packaged macOS app.
- Confirm File > Open and `.camj` file-association opening still work.
- Confirm Finder-to-window `.camj` dropping is intentionally unsupported.

Closes #303
