### PR TITLE
Restore construction features in the project tree

### DIFF
--- a/e2e/creationTargets.smoke.spec.ts
+++ b/e2e/creationTargets.smoke.spec.ts
@@ -15,6 +15,31 @@
  */
 
 import { test, expect } from './fixtures'
+import type { Page } from '@playwright/test'
+import { seedOverlapFeatureProject } from './overlapFeatureSelection.helpers'
+
+async function convertFolderedFeatureToConstruction(page: Page): Promise<void> {
+  await seedOverlapFeatureProject(page, 1)
+  await page.locator('.tree-row--features').getByRole('button', { name: 'Add folder' }).click()
+
+  let feature = page.locator('.tree-row--feature').filter({ hasText: 'Overlap feature 1' })
+  await feature.click()
+  await page.locator('.properties-panel').getByRole('button', { name: 'Instance', exact: true }).click()
+  const folderField = page.locator('.properties-panel .properties-field').filter({ hasText: 'Folder' })
+  await folderField.locator('.ui-select__trigger').click()
+  await folderField.getByRole('option', { name: 'Folder 1' }).click()
+
+  feature = page.locator('.tree-row--feature').filter({ hasText: 'Overlap feature 1' })
+  await feature.locator('.tree-action-btn--operation').click()
+  await page.locator('.tree-operation-menu__item').filter({ hasText: 'Construction' }).click()
+}
+
+async function expectConvertedFeatureInConstruction(page: Page): Promise<void> {
+  const constructionChildren = page.locator('.tree-row--constructions + .tree-children')
+  const converted = constructionChildren.locator('.tree-row--feature').filter({ hasText: 'Overlap feature 1' })
+  await expect(converted).toHaveCount(1)
+  await expect(converted).toHaveClass(/tree-row--construction/)
+}
 
 test('dedicated Line creation target is visible and active on desktop', async ({ app }) => {
   const button = app.page.getByRole('button', { name: 'Create lines', exact: true })
@@ -32,4 +57,15 @@ test('dedicated Line creation target remains available on landscape tablet', asy
   await button.click()
   await expect(button).toHaveAttribute('aria-pressed', 'true')
   await expect(app.page.getByRole('status', { name: 'Drawing lines', exact: true })).toBeVisible()
+})
+
+test('foldered feature appears under Construction immediately after conversion', async ({ app }) => {
+  await convertFolderedFeatureToConstruction(app.page)
+  await expectConvertedFeatureInConstruction(app.page)
+})
+
+test('foldered construction conversion updates the landscape-tablet tree immediately', async ({ app }) => {
+  await app.page.setViewportSize({ width: 1024, height: 768 })
+  await convertFolderedFeatureToConstruction(app.page)
+  await expectConvertedFeatureInConstruction(app.page)
 })

--- a/src/store/constructionWorkflows.test.ts
+++ b/src/store/constructionWorkflows.test.ts
@@ -157,6 +157,32 @@ function testSectionIntegrity(): void {
   assert(getFeature(constructionId).visible, 'setAllFeaturesVisible leaves construction alone')
 }
 
+function testRoleConversionRestoresRootTreeEntry(): void {
+  console.log('Testing role conversion restores root tree entries...')
+  freshStore()
+  useProjectStore.getState().addRectFeature('Foldered feature', 0, 0, 10, 10, 5)
+  const featureId = lastFeature().id
+  const folderId = useProjectStore.getState().addFeatureFolder('features')
+  useProjectStore.getState().assignFeaturesToFolder([featureId], folderId)
+
+  assert(
+    !useProjectStore.getState().project.featureTree.some(
+      (entry) => entry.type === 'feature' && entry.featureId === featureId,
+    ),
+    'foldered feature has no root tree entry',
+  )
+
+  useProjectStore.getState().updateFeature(featureId, { operation: 'construction' })
+
+  assert(getFeature(featureId).folderId === null, 'conversion clears the incompatible folder')
+  assert(
+    useProjectStore.getState().project.featureTree.some(
+      (entry) => entry.type === 'feature' && entry.featureId === featureId,
+    ),
+    'conversion restores the feature at its new section root',
+  )
+}
+
 // ── Grouping stays within one section ────────────────────────────
 
 function testGrouping(): void {
@@ -422,6 +448,7 @@ function testSaveVersionStamping(): void {
 testConstructionCreation()
 testConversions()
 testSectionIntegrity()
+testRoleConversionRestoresRootTreeEntry()
 testGrouping()
 testCopyIntoGroup()
 testFirstSolidRule()

--- a/src/store/slices/featureSlice.ts
+++ b/src/store/slices/featureSlice.ts
@@ -597,6 +597,7 @@ export function createFeatureSlice(
           featureDefinitions: updated.featureDefinitions,
           meta: { ...s.project.meta, modified: new Date().toISOString() },
         }
+        nextProject = syncFeatureTreeProject(nextProject)
         nextProject = syncFeatureBasedStock(nextProject)
         if (projectsEqual(nextProject, s.project)) {
           return {}
@@ -627,6 +628,7 @@ export function createFeatureSlice(
           featureDefinitions: updated.featureDefinitions,
           meta: { ...s.project.meta, modified: new Date().toISOString() },
         }
+        nextProject = syncFeatureTreeProject(nextProject)
         nextProject = syncFeatureBasedStock(nextProject)
         if (projectsEqual(nextProject, s.project)) {
           return {}


### PR DESCRIPTION
## Summary

- reconcile persisted feature-tree root entries after single or multi-feature role updates
- restore foldered features under Construction immediately when their operation changes
- add focused store coverage plus desktop and landscape-tablet browser regressions

## Root cause

Assigning a feature to a folder removes its root-level tree entry. Changing that feature to Construction correctly cleared the incompatible folder, but the shared update paths did not run the existing feature-tree reconciler to restore a destination-section root entry. The feature therefore remained absent until a later action synchronized the tree.

## User impact

Converted construction geometry now appears in the Construction section immediately, without requiring another creation or unrelated action.

## Verification

- `npx tsx src/store/constructionWorkflows.test.ts`
- `npx playwright test e2e/creationTargets.smoke.spec.ts`
- `npm run build`
- `npm run test:e2e` (49 passed)

Closes #307
