### PR TITLE
Add theme manager and guided custom-theme editor

### DIFF
--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -33,8 +33,75 @@ export const appearance = {
   menu: (page: Page) => page.getByRole('menu', { name: 'Appearance theme' }),
   option: (page: Page, label: 'Dark' | 'Light' | 'System') =>
     appearance.menu(page).getByRole('menuitemradio', { name: new RegExp(`^${label}`) }),
+  customOption: (page: Page, name: string) =>
+    appearance.menu(page).getByRole('menuitemradio').filter({ has: page.getByText(name, { exact: true }) }),
+  manageEntry: (page: Page) =>
+    appearance.menu(page).getByRole('menuitem', { name: /^Manage themes/ }),
   positiveActionProbe: (page: Page) =>
     page.getByRole('button', { name: 'Positive action contrast probe' }),
+}
+
+// ── Theme manager & editor ─────────────────────────────────────────
+
+export const themeManager = {
+  dialog: (page: Page) => page.getByRole('dialog', { name: 'Manage themes' }),
+  themeItem: (page: Page, name: string) =>
+    themeManager.dialog(page).getByRole('option')
+      .filter({ has: page.getByText(name, { exact: true }) }),
+  detailName: (page: Page) =>
+    themeManager.dialog(page).locator('.machine-manager-detail-name'),
+  useButton: (page: Page) =>
+    themeManager.dialog(page).getByRole('button', { name: 'Use this theme' }),
+  duplicateButton: (page: Page) =>
+    themeManager.dialog(page).getByRole('button', { name: /^Duplicate/ }),
+  editButton: (page: Page) =>
+    themeManager.dialog(page).getByRole('button', { name: 'Edit', exact: true }),
+  renameButton: (page: Page) =>
+    themeManager.dialog(page).getByRole('button', { name: 'Rename' }),
+  renameInput: (page: Page) =>
+    themeManager.dialog(page).getByRole('textbox', { name: 'Theme name' }),
+  saveNameButton: (page: Page) =>
+    themeManager.dialog(page).getByRole('button', { name: 'Save name' }),
+  resetButton: (page: Page) =>
+    themeManager.dialog(page).getByRole('button', { name: 'Reset to base' }),
+  importButton: (page: Page) =>
+    themeManager.dialog(page).getByRole('button', { name: 'Import theme' }),
+  exportButton: (page: Page) =>
+    themeManager.dialog(page).getByRole('button', { name: 'Export theme' }),
+  deleteButton: (page: Page) =>
+    themeManager.dialog(page).getByRole('button', { name: 'Delete theme' }),
+  notice: (page: Page) =>
+    themeManager.dialog(page).locator('.theme-manager-notice'),
+  fixedModeRadio: (page: Page) =>
+    themeManager.dialog(page).getByRole('radio', { name: 'Fixed theme' }),
+  systemModeRadio: (page: Page) =>
+    themeManager.dialog(page).getByRole('radio', { name: 'Follow system light/dark' }),
+  systemLightSelect: (page: Page) =>
+    themeManager.dialog(page).getByLabel('Light theme'),
+  systemDarkSelect: (page: Page) =>
+    themeManager.dialog(page).getByLabel('Dark theme'),
+  doneButton: (page: Page) =>
+    themeManager.dialog(page).getByRole('button', { name: 'Done' }),
+}
+
+export const themeEditor = {
+  dialog: (page: Page) => page.getByRole('dialog', { name: /^Edit theme/ }),
+  nameInput: (page: Page) =>
+    themeEditor.dialog(page).getByLabel('Theme name'),
+  colorText: (page: Page, label: string) =>
+    themeEditor.dialog(page).getByLabel(label, { exact: true }),
+  resetField: (page: Page, label: string) =>
+    themeEditor.dialog(page).getByRole('button', { name: `Reset ${label} to base value` }),
+  restoreButton: (page: Page) =>
+    themeEditor.dialog(page).getByRole('button', { name: 'Restore saved colors' }),
+  applyButton: (page: Page) =>
+    themeEditor.dialog(page).getByRole('button', { name: 'Apply theme' }),
+  cancelButton: (page: Page) =>
+    themeEditor.dialog(page).getByRole('button', { name: 'Cancel' }),
+  blockers: (page: Page) =>
+    themeEditor.dialog(page).locator('.theme-editor-contrast__item--block'),
+  contrastOk: (page: Page) =>
+    themeEditor.dialog(page).locator('.theme-editor-contrast__ok'),
 }
 
 // ── Status bar and About dialog ────────────────────────────────────

--- a/e2e/themeManager.smoke.spec.ts
+++ b/e2e/themeManager.smoke.spec.ts
@@ -1,0 +1,347 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Theme manager + guided editor smoke (issue #305): duplicate/edit/apply,
+ * preview cancel vs. apply, reload persistence, import/export round-trip,
+ * invalid import rejection, contrast blocking with recovery, custom System
+ * pairing, and the no-project-changes guarantee.
+ */
+
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { getProject } from './helpers'
+
+const SELECTION_KEY = 'purecutcnc.appearance.themeSelection'
+const CUSTOM_THEMES_KEY = 'purecutcnc.appearance.customThemes'
+const LEGACY_KEY = 'purecutcnc.appearance.theme'
+
+function withoutModified(snapshot: Record<string, unknown>): Record<string, unknown> {
+  const meta = snapshot.meta as Record<string, unknown>
+  const { modified: _modified, ...stableMeta } = meta
+  return { ...snapshot, meta: stableMeta }
+}
+
+async function inlineToken(page: Page, token: string): Promise<string> {
+  return page.evaluate(
+    (name) => document.documentElement.style.getPropertyValue(name),
+    token,
+  )
+}
+
+async function readStorage(page: Page, key: string): Promise<string | null> {
+  return page.evaluate((storageKey) => window.localStorage.getItem(storageKey), key)
+}
+
+/** Open Appearance → Manage themes. */
+async function openManager(page: Page, ui: typeof import('./selectors')): Promise<void> {
+  await ui.appearance.trigger(page).click()
+  await ui.appearance.manageEntry(page).click()
+  await expect(ui.themeManager.dialog(page)).toBeVisible()
+}
+
+/** Duplicate the currently selected theme; the editor opens on the copy. */
+async function duplicateToEditor(page: Page, ui: typeof import('./selectors')): Promise<void> {
+  await ui.themeManager.duplicateButton(page).click()
+  await expect(ui.themeEditor.dialog(page)).toBeVisible()
+}
+
+test('duplicates a built-in, edits with live preview, applies, and persists', async ({ app, ui }) => {
+  const before = await getProject(app.page)
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', 'dark')
+
+  await openManager(app.page, ui)
+  await duplicateToEditor(app.page, ui)
+
+  await expect(ui.themeEditor.nameInput(app.page)).toHaveValue('Dark copy')
+  await expect(ui.themeEditor.contrastOk(app.page)).toBeVisible()
+
+  // Live preview: the edit lands on the root immediately, without persistence.
+  await ui.themeEditor.colorText(app.page, 'Accent / focus').fill('#ff8800')
+  await expect.poll(() => inlineToken(app.page, '--accent')).toBe('#ff8800')
+  expect(await readStorage(app.page, CUSTOM_THEMES_KEY) ?? '[]').not.toContain('#ff8800')
+
+  await ui.themeEditor.applyButton(app.page).click()
+  await expect(ui.themeEditor.dialog(app.page)).toBeHidden()
+
+  // Applied: the copy is active, saved, and the override still applied.
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', /^custom-/)
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme', 'dark')
+  expect(await inlineToken(app.page, '--accent')).toBe('#ff8800')
+  expect(await readStorage(app.page, CUSTOM_THEMES_KEY)).toContain('#ff8800')
+  expect(await readStorage(app.page, LEGACY_KEY)).toBe('dark')
+
+  await ui.themeManager.doneButton(app.page).click()
+  await expect(ui.appearance.trigger(app.page)).toHaveAttribute('aria-label', 'Appearance: Dark copy')
+
+  // Theme work never touches the project.
+  expect(withoutModified(await getProject(app.page))).toEqual(withoutModified(before))
+
+  // Persists across reload (bootstrap applies it before React renders).
+  await app.page.reload()
+  await app.page.waitForSelector('canvas', { timeout: 15000 })
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', /^custom-/)
+  expect(await inlineToken(app.page, '--accent')).toBe('#ff8800')
+  await expect(ui.appearance.trigger(app.page)).toHaveAttribute('aria-label', 'Appearance: Dark copy')
+})
+
+test('cancelling the editor restores the active theme without persisting', async ({ app, ui }) => {
+  await openManager(app.page, ui)
+  await duplicateToEditor(app.page, ui)
+
+  await ui.themeEditor.colorText(app.page, 'Accent / focus').fill('#00ff00')
+  await expect.poll(() => inlineToken(app.page, '--accent')).toBe('#00ff00')
+
+  await ui.themeEditor.cancelButton(app.page).click()
+  await expect(ui.themeEditor.dialog(app.page)).toBeHidden()
+  await expect(ui.themeManager.dialog(app.page)).toBeVisible()
+
+  // Preview fully reverted; the duplicate exists but carries no override.
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', 'dark')
+  await expect.poll(() => inlineToken(app.page, '--accent')).toBe('')
+  expect(await readStorage(app.page, CUSTOM_THEMES_KEY)).not.toContain('#00ff00')
+
+  // Escape also cancels: reopen the editor, edit, and press Escape.
+  await ui.themeManager.editButton(app.page).click()
+  await ui.themeEditor.colorText(app.page, 'Accent / focus').fill('#00ff00')
+  await expect.poll(() => inlineToken(app.page, '--accent')).toBe('#00ff00')
+  await app.page.keyboard.press('Escape')
+  await expect(ui.themeEditor.dialog(app.page)).toBeHidden()
+  await expect(ui.themeManager.dialog(app.page)).toBeVisible()
+  await expect.poll(() => inlineToken(app.page, '--accent')).toBe('')
+})
+
+test('blocks applying an unreadable theme and recovers via the safety action', async ({ app, ui }) => {
+  await openManager(app.page, ui)
+  await duplicateToEditor(app.page, ui)
+
+  // Make primary text nearly invisible on panels.
+  await ui.themeEditor.colorText(app.page, 'Primary text').fill('#101821')
+
+  await expect(ui.themeEditor.blockers(app.page).first()).toBeVisible()
+  await expect(ui.themeEditor.blockers(app.page).first()).toContainText('Primary text on panels')
+  await expect(ui.themeEditor.applyButton(app.page)).toBeDisabled()
+
+  // The always-readable recovery action restores the saved colors.
+  await ui.themeEditor.restoreButton(app.page).click()
+  await expect(ui.themeEditor.blockers(app.page)).toHaveCount(0)
+  await expect(ui.themeEditor.applyButton(app.page)).toBeEnabled()
+  await expect(ui.themeEditor.contrastOk(app.page)).toBeVisible()
+  await expect.poll(() => inlineToken(app.page, '--text')).toBe('')
+
+  await ui.themeEditor.cancelButton(app.page).click()
+})
+
+test('exports a custom theme and re-imports it after deletion', async ({ app, ui }) => {
+  await openManager(app.page, ui)
+  await duplicateToEditor(app.page, ui)
+  await ui.themeEditor.colorText(app.page, 'Accent / focus').fill('#ff8800')
+  await ui.themeEditor.applyButton(app.page).click()
+
+  // Capture the exported JSON by stubbing the save picker.
+  await app.page.evaluate(() => {
+    const w = window as unknown as Record<string, unknown>
+    w.__exportedTheme = null
+    w.showSaveFilePicker = async () => ({
+      name: 'theme.json',
+      createWritable: async () => ({
+        write: async (content: string) => { w.__exportedTheme = content },
+        close: async () => {},
+      }),
+    })
+  })
+  await ui.themeManager.exportButton(app.page).click()
+  const exported = await app.page.evaluate(() => (window as unknown as Record<string, unknown>).__exportedTheme as string | null)
+  expect(exported).not.toBeNull()
+  const envelope = JSON.parse(exported!) as { format: string; schemaVersion: number; theme: { name: string } }
+  expect(envelope.format).toBe('purecutcnc-theme')
+  expect(envelope.schemaVersion).toBe(1)
+  expect(envelope.theme.name).toBe('Dark copy')
+
+  // Delete the active custom theme — it falls back to its base explicitly.
+  await ui.themeManager.deleteButton(app.page).click()
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', 'dark')
+  expect(await inlineToken(app.page, '--accent')).toBe('')
+  await expect(ui.themeManager.detailName(app.page)).toHaveText('Dark')
+
+  // Round-trip: import the exported file back and activate it.
+  const chooser = app.page.waitForEvent('filechooser')
+  await ui.themeManager.importButton(app.page).click()
+  await (await chooser).setFiles({
+    name: 'Dark copy.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(exported!, 'utf8'),
+  })
+  await expect(ui.themeManager.notice(app.page)).toContainText('Imported')
+  await expect(ui.themeManager.detailName(app.page)).toHaveText('Dark copy')
+  await ui.themeManager.useButton(app.page).click()
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', /^custom-/)
+  expect(await inlineToken(app.page, '--accent')).toBe('#ff8800')
+})
+
+test('rejects invalid theme imports with a readable error', async ({ app, ui }) => {
+  await openManager(app.page, ui)
+
+  const notJson = app.page.waitForEvent('filechooser')
+  await ui.themeManager.importButton(app.page).click()
+  await (await notJson).setFiles({
+    name: 'broken.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from('this is not json', 'utf8'),
+  })
+  await expect(ui.themeManager.notice(app.page)).toContainText('Import failed: Not a valid JSON file.')
+
+  const badToken = app.page.waitForEvent('filechooser')
+  await ui.themeManager.importButton(app.page).click()
+  await (await badToken).setFiles({
+    name: 'sneaky.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(JSON.stringify({
+      format: 'purecutcnc-theme',
+      schemaVersion: 1,
+      theme: {
+        schemaVersion: 1,
+        id: 'custom-sneaky',
+        name: 'Sneaky',
+        family: 'dark',
+        baseThemeId: 'dark',
+        overrides: { accent: 'url(javascript:alert(1))' },
+      },
+    }), 'utf8'),
+  })
+  await expect(ui.themeManager.notice(app.page)).toContainText('invalid color value')
+
+  const wrongVersion = app.page.waitForEvent('filechooser')
+  await ui.themeManager.importButton(app.page).click()
+  await (await wrongVersion).setFiles({
+    name: 'future.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(JSON.stringify({ format: 'purecutcnc-theme', schemaVersion: 99, theme: {} }), 'utf8'),
+  })
+  await expect(ui.themeManager.notice(app.page)).toContainText('Unsupported theme schema version')
+})
+
+test('renames, resets, and lists custom themes in the appearance menu', async ({ app, ui }) => {
+  await openManager(app.page, ui)
+  await duplicateToEditor(app.page, ui)
+  await ui.themeEditor.colorText(app.page, 'Accent / focus').fill('#ff8800')
+  await ui.themeEditor.applyButton(app.page).click()
+
+  await ui.themeManager.renameButton(app.page).click()
+  await ui.themeManager.renameInput(app.page).fill('Workshop Amber')
+  await ui.themeManager.saveNameButton(app.page).click()
+  await expect(ui.themeManager.detailName(app.page)).toHaveText('Workshop Amber')
+
+  await ui.themeManager.resetButton(app.page).click()
+  await expect.poll(() => inlineToken(app.page, '--accent')).toBe('')
+  await expect(ui.themeManager.notice(app.page)).toContainText('Reset')
+
+  await ui.themeManager.doneButton(app.page).click()
+
+  // The custom theme is selectable from the quick appearance menu.
+  await ui.appearance.trigger(app.page).click()
+  await expect(ui.appearance.customOption(app.page, 'Workshop Amber')).toHaveAttribute('aria-checked', 'true')
+  await ui.appearance.option(app.page, 'Dark').click()
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', 'dark')
+  await ui.appearance.trigger(app.page).click()
+  await ui.appearance.customOption(app.page, 'Workshop Amber').click()
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', /^custom-/)
+})
+
+test('supports a custom theme in the System pair and follows the OS scheme', async ({ app, ui }) => {
+  await app.page.emulateMedia({ colorScheme: 'dark' })
+  await openManager(app.page, ui)
+  await duplicateToEditor(app.page, ui)
+  await ui.themeEditor.colorText(app.page, 'Accent / focus').fill('#ff8800')
+  await ui.themeEditor.applyButton(app.page).click()
+
+  await ui.themeManager.systemModeRadio(app.page).check()
+  await ui.themeManager.systemDarkSelect(app.page).selectOption({ label: 'Dark copy' })
+
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-preference', 'system')
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', /^custom-/)
+  expect(await inlineToken(app.page, '--accent')).toBe('#ff8800')
+
+  // Following the OS to light uses the light slot (built-in Light).
+  await app.page.emulateMedia({ colorScheme: 'light' })
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', 'light')
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme', 'light')
+  expect(await inlineToken(app.page, '--accent')).toBe('')
+
+  // And back to dark re-activates the custom member of the pair.
+  await app.page.emulateMedia({ colorScheme: 'dark' })
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', /^custom-/)
+
+  await ui.themeManager.doneButton(app.page).click()
+
+  // The pair persists across reload.
+  await app.page.reload()
+  await app.page.waitForSelector('canvas', { timeout: 15000 })
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-preference', 'system')
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', /^custom-/)
+  expect(await readStorage(app.page, LEGACY_KEY)).toBe('system')
+})
+
+test('migrates a legacy light preference into the selection model', async ({ app }) => {
+  await app.page.evaluate(([legacyKey, selectionKey]) => {
+    window.localStorage.clear()
+    window.localStorage.setItem(legacyKey, 'light')
+    window.localStorage.removeItem(selectionKey)
+  }, [LEGACY_KEY, SELECTION_KEY])
+
+  await app.page.reload()
+  await app.page.waitForSelector('canvas', { timeout: 15000 })
+
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme', 'light')
+  await expect(app.page.locator('html')).toHaveAttribute('data-theme-id', 'light')
+  const migrated = JSON.parse((await readStorage(app.page, SELECTION_KEY))!) as { mode: string; fixedThemeId: string }
+  expect(migrated.mode).toBe('fixed')
+  expect(migrated.fixedThemeId).toBe('light')
+})
+
+test.describe('tablet theme management', () => {
+  test.use({ viewport: { width: 1024, height: 768 }, hasTouch: true })
+
+  test('keeps the manager and editor touch-sized', async ({ app, ui }) => {
+    await ui.appearance.trigger(app.page).click()
+    const manageEntry = ui.appearance.manageEntry(app.page)
+    await expect(manageEntry).toBeVisible()
+    const manageBox = await manageEntry.boundingBox()
+    expect(manageBox).not.toBeNull()
+    expect(manageBox!.height).toBeGreaterThanOrEqual(44)
+
+    await manageEntry.click()
+    await expect(ui.themeManager.dialog(app.page)).toBeVisible()
+
+    const item = ui.themeManager.themeItem(app.page, 'Dark')
+    const itemBox = await item.boundingBox()
+    expect(itemBox).not.toBeNull()
+    expect(itemBox!.height).toBeGreaterThanOrEqual(44)
+
+    const duplicate = ui.themeManager.duplicateButton(app.page)
+    const duplicateBox = await duplicate.boundingBox()
+    expect(duplicateBox).not.toBeNull()
+    expect(duplicateBox!.height).toBeGreaterThanOrEqual(44)
+
+    await duplicate.click()
+    await expect(ui.themeEditor.dialog(app.page)).toBeVisible()
+    const picker = ui.themeEditor.dialog(app.page).getByLabel('Accent / focus color picker')
+    await picker.scrollIntoViewIfNeeded()
+    const pickerBox = await picker.boundingBox()
+    expect(pickerBox).not.toBeNull()
+    expect(pickerBox!.width).toBeGreaterThanOrEqual(40)
+  })
+})

--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -25,6 +25,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 - `project/` — project-level UI (new/open/save, stock, machine, units), including `UnitConversionDialog` for the explicit convert-vs-reinterpret units decision. Import dialog is `ImportGeometryDialog` with analysis delegated to `useImportGeometryAnalysis` (parse/classify caching hook), `ImportGeometryModeSection` (mode select + summary), and `importModelFile` (3D model import utility).
 - `export/` — export dialogs: G-code (`ExportDialog`, with a per-operation checklist backed by the pure helpers in `exportOperationSelection.ts`), the Export Model dialog (`ModelExportDialog`, STL mesh + 2D design SVG via `src/engine/modelExport/`), and the Print Design dialog (`PrintDesignDialog`, backed by `src/engine/designPrint/`)
 - `machine/` — machine definition editor (focused form + raw JSON + Zod validation)
+- `theme/` — theme manager + guided custom-theme editor dialogs (see `theme/INDEX.md`); backed by the registry/selection model in `src/theme/`
 - `about/` — About dialog (web only; version info + links). Desktop uses the native About menu.
 - `ai/` — MCP / agent-facing UI (placeholder — MCP not yet implemented)
 - `onboarding/` — first-run / empty-state UI (`EmptyStateOverlay` shown over the center viewport when the project has no features)

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -151,7 +151,6 @@ import {
 } from '../../platform/featureClipboard'
 import { resolveFeatureInstance, resolveFeatureInstances, resolveFeatureRow, resolvedProjectFeatures } from '../../store/helpers/resolveFeatures'
 import { useTheme } from '../../theme/themeContext'
-import { THEME_PALETTES } from '../../theme/palette'
 
 export type { SketchCanvasHandle }
 
@@ -175,8 +174,8 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   },
   ref
 ) {
-  const { resolvedTheme } = useTheme()
-  const canvasPalette = THEME_PALETTES[resolvedTheme].canvas
+  const { palette } = useTheme()
+  const canvasPalette = palette.canvas
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const isDraggingNodeRef = useRef(false)
@@ -801,7 +800,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
   useEffect(() => {
     scheduleDraw()
-  }, [scheduleDraw, project, selection, pendingAdd, pendingMove, pendingTransform, pendingOffset, pendingClipboardPlacement, viewState, backdropImage, stlImageRevision, toolpaths, selectedOperationId, collidingClampIds, snapSettings, copyCountDraft, dimEdit.dimensionEdit, toolpathVisibility, operationHighlightKind, resolvedTheme])
+  }, [scheduleDraw, project, selection, pendingAdd, pendingMove, pendingTransform, pendingOffset, pendingClipboardPlacement, viewState, backdropImage, stlImageRevision, toolpaths, selectedOperationId, collidingClampIds, snapSettings, copyCountDraft, dimEdit.dimensionEdit, toolpathVisibility, operationHighlightKind, canvasPalette])
 
   useEffect(() => {
     sketchEditPreviewRef.current = null

--- a/src/components/layout/AppearanceControl.tsx
+++ b/src/components/layout/AppearanceControl.tsx
@@ -16,8 +16,11 @@
 
 import { useId, useRef, useState } from 'react'
 import { useOutsideDismiss } from '../../hooks/useOutsideDismiss'
+import { resolveCustomTheme } from '../../theme/registry'
 import { THEME_PREFERENCES, type ThemePreference } from '../../theme/theme'
 import { useTheme } from '../../theme/themeContext'
+import { ThemeManagerDialog } from '../theme/ThemeManagerDialog'
+import { ThemeSwatch } from '../theme/ThemeSwatch'
 import { Icon } from '../Icon'
 
 const THEME_LABELS: Record<ThemePreference, { label: string; detail: string }> = {
@@ -27,18 +30,28 @@ const THEME_LABELS: Record<ThemePreference, { label: string; detail: string }> =
 }
 
 export function AppearanceControl() {
-  const { preference, resolvedTheme, setPreference } = useTheme()
+  const { resolvedTheme, selection, customThemes, activeTheme, setPreference, activateTheme } = useTheme()
   const [open, setOpen] = useState(false)
+  const [managerOpen, setManagerOpen] = useState(false)
   const hostRef = useRef<HTMLDivElement | null>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
   const menuId = useId()
 
   useOutsideDismiss({ open, refs: hostRef, onDismiss: () => setOpen(false) })
 
-  const currentLabel = THEME_LABELS[preference].label
+  const currentLabel = selection.mode === 'system'
+    ? THEME_LABELS.system.label
+    : activeTheme.builtin
+      ? THEME_LABELS[activeTheme.family].label
+      : activeTheme.name
 
-  const chooseTheme = (nextPreference: ThemePreference) => {
-    setPreference(nextPreference)
+  const isQuickOptionSelected = (option: ThemePreference): boolean => {
+    if (option === 'system') return selection.mode === 'system'
+    return selection.mode === 'fixed' && selection.fixedThemeId === option
+  }
+
+  const chooseTheme = (apply: () => void) => {
+    apply()
     setOpen(false)
     triggerRef.current?.focus({ preventScroll: true })
   }
@@ -71,7 +84,7 @@ export function AppearanceControl() {
           <div className="appearance-menu__heading">Appearance</div>
           <div className="appearance-menu__options">
             {THEME_PREFERENCES.map((option) => {
-              const selected = preference === option
+              const selected = isQuickOptionSelected(option)
               const copy = THEME_LABELS[option]
               return (
                 <button
@@ -80,7 +93,7 @@ export function AppearanceControl() {
                   type="button"
                   role="menuitemradio"
                   aria-checked={selected}
-                  onClick={() => chooseTheme(option)}
+                  onClick={() => chooseTheme(() => setPreference(option))}
                 >
                   <span className={`appearance-menu__swatch appearance-menu__swatch--${option}`} aria-hidden="true" />
                   <span className="appearance-menu__copy">
@@ -91,9 +104,55 @@ export function AppearanceControl() {
                 </button>
               )
             })}
+
+            {customThemes.length > 0 && (
+              <>
+                <div className="appearance-menu__heading appearance-menu__heading--section">Custom themes</div>
+                {customThemes.map((custom) => {
+                  const selected = selection.mode === 'fixed' && selection.fixedThemeId === custom.id
+                  const resolved = resolveCustomTheme(custom)
+                  return (
+                    <button
+                      key={custom.id}
+                      className={`appearance-menu__option ${selected ? 'appearance-menu__option--selected' : ''}`}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={selected}
+                      onClick={() => chooseTheme(() => activateTheme(custom.id))}
+                    >
+                      <ThemeSwatch values={resolved.values} />
+                      <span className="appearance-menu__copy">
+                        <span className="appearance-menu__label">{custom.name}</span>
+                        <span className="appearance-menu__detail">
+                          {custom.family === 'dark' ? 'Dark family' : 'Light family'}
+                        </span>
+                      </span>
+                      <span className="appearance-menu__check" aria-hidden="true">{selected ? '✓' : ''}</span>
+                    </button>
+                  )
+                })}
+              </>
+            )}
+
+            <button
+              className="appearance-menu__option appearance-menu__option--manage"
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false)
+                setManagerOpen(true)
+              }}
+            >
+              <span className="appearance-menu__copy">
+                <span className="appearance-menu__label">Manage themes…</span>
+                <span className="appearance-menu__detail">Create, edit, import, export</span>
+              </span>
+            </button>
           </div>
         </div>
       )}
+
+      {managerOpen && <ThemeManagerDialog onClose={() => setManagerOpen(false)} />}
     </div>
   )
 }

--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -29,7 +29,6 @@ import type { SimulationGrid, SimulationResult } from '../../engine/simulation'
 import type { ToolpathMove } from '../../engine/toolpaths/types'
 import type { Clamp, MachineOrigin, Operation, ToolType } from '../../types/project'
 import { useTheme } from '../../theme/themeContext'
-import { THEME_PALETTES } from '../../theme/palette'
 
 const EMPTY_PLAYBACK_POSE: PlaybackPose = { x: 0, y: 0, z: 0, moveKind: null, feedScale: undefined }
 
@@ -577,8 +576,8 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   isActive = true,
   projectKey,
 }, ref) {
-  const { resolvedTheme } = useTheme()
-  const threePalette = THEME_PALETTES[resolvedTheme].three
+  const { palette } = useTheme()
+  const threePalette = palette.three
   const initialThreePaletteRef = useRef(threePalette)
   const playbackUnits = playbackInput?.units ?? 'mm'
   const fallbackFeed = playbackUnits === 'in' ? PLAYBACK_FALLBACK_FEED_IN : PLAYBACK_FALLBACK_FEED_MM

--- a/src/components/theme/INDEX.md
+++ b/src/components/theme/INDEX.md
@@ -1,0 +1,9 @@
+# INDEX — src/components/theme/
+
+Theme management UI: the manager dialog reached from the Appearance menu and the guided custom-theme editor. All state flows through `useTheme()` (see `src/theme/`); nothing here touches project data.
+
+- `ThemeManagerDialog.tsx` — built-in + custom theme list with swatch previews; activate, duplicate, rename, edit, delete, reset-to-base, import, and export actions; System light/dark pairing controls.
+- `ThemeEditorDialog.tsx` — guided editor: semantic color groups, live root preview (never persisted until Apply), contrast gate that blocks Apply on unreadable critical pairs, and a hardcoded-palette recovery bar that stays readable under any preview.
+- `ThemeColorRow.tsx` — one editor field: native color input (alpha-preserving), normalized text value, base-value comparison chip, per-field reset.
+- `ThemePreviewSamples.tsx` — representative preview states (panel text, controls, selection/focus, status messages, sketch-canvas annotations and semantic role colors).
+- `ThemeSwatch.tsx` — small color strip rendered from a theme's own resolved values, used in lists and menus.

--- a/src/components/theme/ThemeColorRow.tsx
+++ b/src/components/theme/ThemeColorRow.tsx
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useId, useState } from 'react'
+import { formatColor, normalizeColorValue, opaqueHex, parseColor } from '../../theme/color'
+
+export interface ThemeColorRowProps {
+  label: string
+  /** Current effective value (base or override). */
+  value: string
+  /** The base theme's value, shown for comparison. */
+  baseValue: string
+  /** True when the current value differs from the base. */
+  overridden: boolean
+  onChange: (nextValue: string) => void
+  onReset: () => void
+}
+
+/**
+ * One guided-editor color field: a native color input, a normalized text
+ * value, a base-value comparison chip, and a per-field reset. Valid edits
+ * propagate immediately (live preview); invalid text is held locally and
+ * flagged without touching the theme.
+ */
+export function ThemeColorRow({ label, value, baseValue, overridden, onChange, onReset }: ThemeColorRowProps) {
+  const inputId = useId()
+  const [draft, setDraft] = useState(value)
+  const [invalid, setInvalid] = useState(false)
+
+  // Adopt external changes (reset, restore, picker edits) into the text field
+  // via render-time state adjustment (the React-endorsed alternative to a
+  // setState-in-effect for derived-from-props state). A change that merely
+  // echoes the draft's own normalized form back (live typing) keeps the
+  // user's text as typed instead of clobbering it mid-edit.
+  const [adoptedValue, setAdoptedValue] = useState(value)
+  if (adoptedValue !== value) {
+    setAdoptedValue(value)
+    if (normalizeColorValue(draft) !== normalizeColorValue(value)) {
+      setDraft(value)
+      setInvalid(false)
+    }
+  }
+
+  const parsed = parseColor(value)
+
+  const commitText = (raw: string) => {
+    setDraft(raw)
+    const normalized = normalizeColorValue(raw)
+    if (normalized === null) {
+      setInvalid(true)
+      return
+    }
+    setInvalid(false)
+    if (normalized !== normalizeColorValue(value)) onChange(normalized)
+  }
+
+  const pickColor = (pickedHex: string) => {
+    const picked = parseColor(pickedHex)
+    if (!picked) return
+    // The native input cannot express alpha — keep the token's current alpha.
+    onChange(formatColor({ ...picked, a: parsed?.a ?? 1 }))
+  }
+
+  return (
+    <div className={`theme-editor-row ${overridden ? 'theme-editor-row--overridden' : ''}`}>
+      <label className="theme-editor-row__label" htmlFor={inputId}>{label}</label>
+      <input
+        className="theme-editor-row__picker"
+        type="color"
+        aria-label={`${label} color picker`}
+        value={parsed ? opaqueHex(parsed) : '#000000'}
+        onChange={(event) => pickColor(event.target.value)}
+      />
+      <input
+        id={inputId}
+        className={`theme-editor-row__value ${invalid ? 'theme-editor-row__value--invalid' : ''}`}
+        type="text"
+        spellCheck={false}
+        autoComplete="off"
+        value={draft}
+        aria-invalid={invalid}
+        onChange={(event) => commitText(event.target.value)}
+        onBlur={() => {
+          if (invalid) {
+            setDraft(value)
+            setInvalid(false)
+          }
+        }}
+      />
+      <span
+        className="theme-editor-row__base"
+        title={`Base value: ${baseValue}`}
+        style={{ background: baseValue }}
+        aria-hidden="true"
+      />
+      <button
+        className="theme-editor-row__reset"
+        type="button"
+        aria-label={`Reset ${label} to base value`}
+        title={`Reset to base (${baseValue})`}
+        disabled={!overridden}
+        onClick={onReset}
+      >
+        ↺
+      </button>
+    </div>
+  )
+}

--- a/src/components/theme/ThemeEditorDialog.tsx
+++ b/src/components/theme/ThemeEditorDialog.tsx
@@ -1,0 +1,267 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useWindowEvent } from '../../hooks/useEventListener'
+import { evaluateThemeContrast } from '../../theme/contrast'
+import {
+  builtinTheme,
+  resolveCustomTheme,
+  THEME_NAME_MAX_LENGTH,
+  type CustomThemeData,
+} from '../../theme/registry'
+import { useTheme } from '../../theme/themeContext'
+import { THEME_TOKEN_GROUPS, THEME_TOKENS, type ThemeTokenKey } from '../../theme/tokens'
+import { ThemeColorRow } from './ThemeColorRow'
+import { ThemePreviewSamples } from './ThemePreviewSamples'
+
+export interface ThemeEditorDialogProps {
+  theme: CustomThemeData
+  /** Called with the edited theme when Apply passes validation. */
+  onApply: (theme: CustomThemeData) => void
+  /** Cancel/Escape/close — the provider preview is cleared on unmount. */
+  onClose: () => void
+}
+
+/**
+ * The always-readable recovery styles: hardcoded so a garbage preview can
+ * never make the escape hatch itself unreadable.
+ */
+const RECOVERY_BAR_STYLE: React.CSSProperties = {
+  background: '#f6f1e7',
+  color: '#253039',
+  border: '1px solid #a99a84',
+}
+
+const RECOVERY_BUTTON_STYLE: React.CSSProperties = {
+  background: '#253039',
+  color: '#f6f1e7',
+  border: '1px solid #253039',
+  borderRadius: 7,
+  padding: '6px 12px',
+  font: 'inherit',
+  fontSize: 13,
+  fontWeight: 650,
+  cursor: 'pointer',
+}
+
+/**
+ * Guided custom-theme editor: semantic color groups with live preview,
+ * base comparison and per-field reset, representative preview states, and a
+ * contrast gate that blocks Apply while critical combinations are unreadable.
+ * Nothing is persisted until Apply — Cancel, Escape, or closing restores the
+ * previously active theme.
+ */
+export function ThemeEditorDialog({ theme, onApply, onClose }: ThemeEditorDialogProps) {
+  const { setPreview } = useTheme()
+  const [name, setName] = useState(theme.name)
+  const [overrides, setOverrides] = useState(theme.overrides)
+
+  const base = builtinTheme(theme.baseThemeId)
+
+  const working = useMemo<CustomThemeData>(
+    () => ({ ...theme, name: name.trim() === '' ? theme.name : name.trim(), overrides }),
+    [theme, name, overrides],
+  )
+  const resolved = useMemo(() => resolveCustomTheme(working), [working])
+  const contrast = useMemo(() => evaluateThemeContrast(resolved.values), [resolved])
+
+  // Live preview: presentation-only, never written to storage. Every close
+  // path clears the preview in the same commit (so the saved theme is back
+  // on screen the moment the dialog goes), and the unmount cleanup is the
+  // safety net for any unexpected teardown.
+  useEffect(() => {
+    setPreview(resolved)
+  }, [resolved, setPreview])
+  useEffect(() => () => setPreview(null), [setPreview])
+
+  const handleClose = () => {
+    setPreview(null)
+    onClose()
+  }
+
+  useWindowEvent('keydown', (event) => {
+    if (event.key === 'Escape') handleClose()
+  })
+
+  const changeToken = (key: ThemeTokenKey, nextValue: string) => {
+    setOverrides((previous) => {
+      const next = { ...previous }
+      if (nextValue === base.values[key]) {
+        delete next[key]
+      } else {
+        next[key] = nextValue
+      }
+      return next
+    })
+  }
+
+  const resetToken = (key: ThemeTokenKey) => {
+    setOverrides((previous) => {
+      if (previous[key] === undefined) return previous
+      const next = { ...previous }
+      delete next[key]
+      return next
+    })
+  }
+
+  const restoreSaved = () => {
+    setName(theme.name)
+    setOverrides(theme.overrides)
+  }
+
+  const nameInvalid = name.trim() === ''
+  const blocked = contrast.blockers.length > 0
+  const dirty = name.trim() !== theme.name
+    || JSON.stringify(overrides) !== JSON.stringify(theme.overrides)
+
+  const handleApply = () => {
+    if (blocked || nameInvalid) return
+    onApply(working)
+  }
+
+  return createPortal(
+    <div className="dialog-backdrop" onClick={handleClose}>
+      <div
+        className="dialog dialog--theme-editor"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Edit theme ${theme.name}`}
+      >
+        <div className="dialog-header">
+          <h2 className="dialog-title">Edit Theme</h2>
+          <button className="dialog-close" onClick={handleClose} aria-label="Close" type="button">
+            ✕
+          </button>
+        </div>
+
+        <div className="theme-editor-recovery" style={RECOVERY_BAR_STYLE}>
+          <span>
+            Previewing your edits live.
+            {dirty ? ' Colors look wrong?' : ''}
+          </span>
+          <button
+            type="button"
+            style={RECOVERY_BUTTON_STYLE}
+            onClick={restoreSaved}
+            disabled={!dirty}
+          >
+            Restore saved colors
+          </button>
+        </div>
+
+        <div className="dialog-body dialog-body--theme-editor">
+          <div className="theme-editor-fields">
+            <div className="theme-editor-name">
+              <label className="theme-editor-name__label" htmlFor="theme-editor-name-input">
+                Theme name
+              </label>
+              <input
+                id="theme-editor-name-input"
+                className={`theme-editor-name__input ${nameInvalid ? 'theme-editor-row__value--invalid' : ''}`}
+                type="text"
+                value={name}
+                maxLength={THEME_NAME_MAX_LENGTH}
+                onChange={(event) => setName(event.target.value)}
+              />
+              <span className="theme-editor-name__base">
+                Based on {base.name} · {resolved.overriddenKeys.length} color{resolved.overriddenKeys.length === 1 ? '' : 's'} changed
+              </span>
+            </div>
+
+            {THEME_TOKEN_GROUPS.map((group) => {
+              const tokens = THEME_TOKENS.filter((token) => token.group === group.id)
+              return (
+                <section key={group.id} className="theme-editor-group">
+                  <h3 className="theme-editor-group__title">{group.label}</h3>
+                  <p className="theme-editor-group__hint">{group.description}</p>
+                  {tokens.map((token) => (
+                    <ThemeColorRow
+                      key={token.key}
+                      label={token.label}
+                      value={resolved.values[token.key]}
+                      baseValue={base.values[token.key]}
+                      overridden={overrides[token.key] !== undefined}
+                      onChange={(nextValue) => changeToken(token.key, nextValue)}
+                      onReset={() => resetToken(token.key)}
+                    />
+                  ))}
+                </section>
+              )
+            })}
+          </div>
+
+          <aside className="theme-editor-side">
+            <ThemePreviewSamples values={resolved.values} />
+
+            <section className="theme-editor-contrast" aria-label="Contrast checks">
+              <h4 className="theme-editor-contrast__title">Readability checks</h4>
+              {contrast.blockers.length === 0 && contrast.warnings.length === 0 ? (
+                <p className="theme-editor-contrast__ok">
+                  All {contrast.findings.length} checks pass.
+                </p>
+              ) : null}
+              {contrast.blockers.map((finding) => (
+                <p key={finding.id} className="theme-editor-contrast__item theme-editor-contrast__item--block">
+                  <strong>Blocked:</strong> {finding.label} — {finding.kind === 'ratio'
+                    ? `${finding.measured}:1, needs ${finding.required}:1`
+                    : `ΔE ${finding.measured}, needs ${finding.required}`}
+                </p>
+              ))}
+              {contrast.warnings.map((finding) => (
+                <p key={finding.id} className="theme-editor-contrast__item theme-editor-contrast__item--warn">
+                  <strong>Warning:</strong> {finding.label} — {finding.kind === 'ratio'
+                    ? `${finding.measured}:1, recommended ${finding.required}:1`
+                    : `ΔE ${finding.measured}, recommended ${finding.required}`}
+                </p>
+              ))}
+              <p className="theme-editor-contrast__note">
+                Automated spot checks of representative states — not full WCAG coverage.
+              </p>
+            </section>
+          </aside>
+        </div>
+
+        <div className="dialog-footer">
+          {blocked ? (
+            <span className="theme-editor-footer-blocked" role="status">
+              {contrast.blockers.length} readability check{contrast.blockers.length === 1 ? '' : 's'} failing
+            </span>
+          ) : null}
+          <button className="btn-secondary" type="button" onClick={handleClose}>
+            Cancel
+          </button>
+          <button
+            className="btn-primary"
+            type="button"
+            onClick={handleApply}
+            disabled={blocked || nameInvalid}
+            title={blocked
+              ? 'Fix the blocked readability checks before applying'
+              : nameInvalid
+                ? 'Give the theme a name'
+                : undefined}
+          >
+            Apply theme
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/components/theme/ThemeManagerDialog.tsx
+++ b/src/components/theme/ThemeManagerDialog.tsx
@@ -1,0 +1,380 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useWindowEvent } from '../../hooks/useEventListener'
+import { platform } from '../../platform'
+import {
+  BUILTIN_THEMES,
+  duplicateThemeAsCustom,
+  duplicateThemeName,
+  parseThemeImport,
+  resolveBuiltinTheme,
+  resolveCustomTheme,
+  serializeThemeExport,
+  THEME_NAME_MAX_LENGTH,
+  type CustomThemeData,
+  type ResolvedThemeDefinition,
+} from '../../theme/registry'
+import { useTheme } from '../../theme/themeContext'
+import { ThemeEditorDialog } from './ThemeEditorDialog'
+import { ThemeSwatch } from './ThemeSwatch'
+
+export interface ThemeManagerDialogProps {
+  onClose: () => void
+}
+
+/**
+ * Theme manager: built-in and custom themes with representative previews,
+ * activate/duplicate/rename/edit/delete/reset/export/import actions, and the
+ * System light/dark pairing. Custom themes are application-local preferences;
+ * nothing here touches project data.
+ */
+export function ThemeManagerDialog({ onClose }: ThemeManagerDialogProps) {
+  const {
+    selection,
+    setSelection,
+    customThemes,
+    activeTheme,
+    activateTheme,
+    saveCustomTheme,
+    deleteCustomTheme,
+    systemPrefersDark,
+  } = useTheme()
+
+  const allThemes = useMemo<ResolvedThemeDefinition[]>(
+    () => [
+      ...BUILTIN_THEMES.map((definition) => resolveBuiltinTheme(definition.id)),
+      ...customThemes.map((custom) => resolveCustomTheme(custom)),
+    ],
+    [customThemes],
+  )
+
+  const [selectedId, setSelectedId] = useState(activeTheme.id)
+  const [editingTheme, setEditingTheme] = useState<CustomThemeData | null>(null)
+  const [renameDraft, setRenameDraft] = useState<string | null>(null)
+  const [notice, setNotice] = useState<{ kind: 'error' | 'info'; text: string } | null>(null)
+
+  const selected = allThemes.find((theme) => theme.id === selectedId) ?? allThemes[0]
+  const selectedCustom = customThemes.find((theme) => theme.id === selected.id) ?? null
+  const existingNames = useMemo(() => allThemes.map((theme) => theme.name), [allThemes])
+
+  // Escape closes the manager, unless the nested editor owns the key press.
+  useWindowEvent('keydown', (event) => {
+    if (event.key !== 'Escape' || editingTheme) return
+    onClose()
+  })
+
+  const openEditor = (custom: CustomThemeData) => {
+    setNotice(null)
+    setRenameDraft(null)
+    setEditingTheme(custom)
+  }
+
+  const handleDuplicate = (edit: boolean) => {
+    const duplicated = duplicateThemeAsCustom(selected, existingNames)
+    saveCustomTheme(duplicated)
+    setSelectedId(duplicated.id)
+    if (edit) openEditor(duplicated)
+  }
+
+  const handleDelete = () => {
+    if (!selectedCustom) return
+    deleteCustomTheme(selectedCustom.id)
+    setSelectedId(selectedCustom.baseThemeId)
+    setNotice(null)
+  }
+
+  const handleResetOverrides = () => {
+    if (!selectedCustom) return
+    saveCustomTheme({ ...selectedCustom, overrides: {} })
+    setNotice({ kind: 'info', text: `Reset “${selectedCustom.name}” to its ${selectedCustom.baseThemeId} base colors.` })
+  }
+
+  const handleExport = () => {
+    if (!selectedCustom) return
+    void platform.saveTextFile(
+      `${selectedCustom.name}.json`,
+      serializeThemeExport(selectedCustom),
+      'json',
+    )
+  }
+
+  const handleImport = async () => {
+    const content = await platform.pickJsonFile()
+    if (content === null) return
+    const result = parseThemeImport(content)
+    if (result.error !== undefined) {
+      setNotice({ kind: 'error', text: `Import failed: ${result.error}` })
+      return
+    }
+    const imported = existingNames.some((name) => name.toLowerCase() === result.ok.name.toLowerCase())
+      ? { ...result.ok, name: duplicateThemeName(result.ok.name, existingNames) }
+      : result.ok
+    saveCustomTheme(imported)
+    setSelectedId(imported.id)
+    setNotice({ kind: 'info', text: `Imported “${imported.name}”.` })
+  }
+
+  const commitRename = () => {
+    if (!selectedCustom || renameDraft === null) return
+    const trimmed = renameDraft.trim()
+    if (trimmed !== '' && trimmed !== selectedCustom.name) {
+      saveCustomTheme({ ...selectedCustom, name: trimmed })
+    }
+    setRenameDraft(null)
+  }
+
+  const handleEditorApply = (edited: CustomThemeData) => {
+    saveCustomTheme(edited)
+    activateTheme(edited.id)
+    setSelectedId(edited.id)
+    setEditingTheme(null)
+  }
+
+  const isActive = selected.id === activeTheme.id && selection.mode === 'fixed'
+  const lightFamilyThemes = allThemes.filter((theme) => theme.family === 'light')
+  const darkFamilyThemes = allThemes.filter((theme) => theme.family === 'dark')
+  const systemActiveNow = systemPrefersDark ? 'dark' : 'light'
+
+  return createPortal(
+    <div className="dialog-backdrop" onClick={onClose}>
+      <div
+        className="dialog dialog--theme-manager"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Manage themes"
+      >
+        <div className="dialog-header">
+          <h2 className="dialog-title">Manage Themes</h2>
+          <button className="dialog-close" onClick={onClose} aria-label="Close" type="button">
+            ✕
+          </button>
+        </div>
+
+        <div className="dialog-body dialog-body--theme-manager">
+          {/* Left: theme list */}
+          <div className="theme-manager-list" role="listbox" aria-label="Themes">
+            {allThemes.map((theme) => (
+              <button
+                key={theme.id}
+                type="button"
+                role="option"
+                aria-selected={theme.id === selected.id}
+                className={[
+                  'theme-manager-item',
+                  theme.id === selected.id ? 'theme-manager-item--selected' : '',
+                  theme.id === activeTheme.id ? 'theme-manager-item--active' : '',
+                ].join(' ').trim()}
+                onClick={() => {
+                  setSelectedId(theme.id)
+                  setRenameDraft(null)
+                  setNotice(null)
+                }}
+              >
+                <ThemeSwatch values={theme.values} />
+                <span className="theme-manager-item-name">{theme.name}</span>
+                <span className={theme.builtin ? 'machine-manager-badge machine-manager-badge--builtin' : 'machine-manager-badge machine-manager-badge--custom'}>
+                  {theme.builtin ? 'Built-in' : 'Custom'}
+                </span>
+              </button>
+            ))}
+          </div>
+
+          {/* Right: detail + actions */}
+          <div className="theme-manager-detail">
+            <div className="machine-manager-detail-header">
+              {renameDraft !== null && selectedCustom ? (
+                <span className="theme-manager-rename">
+                  <input
+                    className="theme-manager-rename__input"
+                    type="text"
+                    value={renameDraft}
+                    maxLength={THEME_NAME_MAX_LENGTH}
+                    autoFocus
+                    aria-label="Theme name"
+                    onChange={(event) => setRenameDraft(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') commitRename()
+                      if (event.key === 'Escape') {
+                        event.stopPropagation()
+                        setRenameDraft(null)
+                      }
+                    }}
+                  />
+                  <button className="btn-secondary" type="button" onClick={commitRename}>Save name</button>
+                </span>
+              ) : (
+                <h3 className="machine-manager-detail-name">{selected.name}</h3>
+              )}
+              {selected.id === activeTheme.id ? (
+                <span className="machine-manager-badge machine-manager-badge--active">Active</span>
+              ) : null}
+              <span className={selected.builtin ? 'machine-manager-badge machine-manager-badge--builtin' : 'machine-manager-badge machine-manager-badge--custom'}>
+                {selected.builtin ? 'Built-in' : 'Custom'}
+              </span>
+            </div>
+
+            <dl className="machine-manager-meta">
+              <dt>Family</dt>
+              <dd>{selected.family === 'dark' ? 'Dark' : 'Light'}</dd>
+              {!selected.builtin ? (
+                <>
+                  <dt>Based on</dt>
+                  <dd>{resolveBuiltinTheme(selected.baseThemeId).name}</dd>
+                  <dt>Changed colors</dt>
+                  <dd>{selected.overriddenKeys.length}</dd>
+                </>
+              ) : null}
+              {selected.builtin ? (
+                <dd className="machine-manager-hint">
+                  Built-in themes are read-only. Duplicate to create an editable copy.
+                </dd>
+              ) : null}
+            </dl>
+
+            {notice ? (
+              <p
+                className={`theme-manager-notice theme-manager-notice--${notice.kind}`}
+                role={notice.kind === 'error' ? 'alert' : 'status'}
+              >
+                {notice.text}
+              </p>
+            ) : null}
+
+            <div className="machine-manager-actions">
+              {!isActive ? (
+                <button className="btn-primary" type="button" onClick={() => activateTheme(selected.id)}>
+                  Use this theme
+                </button>
+              ) : null}
+
+              <div className="machine-manager-actions-row">
+                {selectedCustom ? (
+                  <button className="btn-secondary" type="button" onClick={() => openEditor(selectedCustom)}>
+                    Edit
+                  </button>
+                ) : null}
+                <button className="btn-secondary" type="button" onClick={() => handleDuplicate(true)}>
+                  {selected.builtin ? 'Duplicate to edit' : 'Duplicate'}
+                </button>
+                {selectedCustom ? (
+                  <button
+                    className="btn-secondary"
+                    type="button"
+                    onClick={() => setRenameDraft(selectedCustom.name)}
+                  >
+                    Rename
+                  </button>
+                ) : null}
+                {selectedCustom && selected.overriddenKeys.length > 0 ? (
+                  <button className="btn-secondary" type="button" onClick={handleResetOverrides}>
+                    Reset to base
+                  </button>
+                ) : null}
+                <button className="btn-secondary" type="button" onClick={() => { void handleImport() }}>
+                  Import theme
+                </button>
+                {selectedCustom ? (
+                  <button className="btn-secondary" type="button" onClick={handleExport}>
+                    Export theme
+                  </button>
+                ) : null}
+              </div>
+
+              {selectedCustom ? (
+                <button className="machine-manager-action--remove" type="button" onClick={handleDelete}>
+                  Delete theme
+                </button>
+              ) : null}
+            </div>
+
+            <section className="theme-manager-system" aria-label="System mode pairing">
+              <h4 className="theme-manager-system__title">Mode</h4>
+              <label className="theme-manager-system__mode">
+                <input
+                  type="radio"
+                  name="theme-selection-mode"
+                  checked={selection.mode === 'fixed'}
+                  onChange={() => setSelection((previous) => ({ ...previous, mode: 'fixed' }))}
+                />
+                Fixed theme
+              </label>
+              <label className="theme-manager-system__mode">
+                <input
+                  type="radio"
+                  name="theme-selection-mode"
+                  checked={selection.mode === 'system'}
+                  onChange={() => setSelection((previous) => ({ ...previous, mode: 'system' }))}
+                />
+                Follow system light/dark
+              </label>
+
+              {selection.mode === 'system' ? (
+                <div className="theme-manager-system__pair">
+                  <label className="theme-manager-system__slot">
+                    Light theme
+                    <select
+                      value={selection.systemLightThemeId}
+                      onChange={(event) =>
+                        setSelection((previous) => ({ ...previous, systemLightThemeId: event.target.value }))}
+                    >
+                      {lightFamilyThemes.map((theme) => (
+                        <option key={theme.id} value={theme.id}>{theme.name}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="theme-manager-system__slot">
+                    Dark theme
+                    <select
+                      value={selection.systemDarkThemeId}
+                      onChange={(event) =>
+                        setSelection((previous) => ({ ...previous, systemDarkThemeId: event.target.value }))}
+                    >
+                      {darkFamilyThemes.map((theme) => (
+                        <option key={theme.id} value={theme.id}>{theme.name}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <p className="theme-manager-system__hint">
+                    This device currently prefers {systemActiveNow}.
+                  </p>
+                </div>
+              ) : null}
+            </section>
+          </div>
+        </div>
+
+        <div className="dialog-footer">
+          <button className="btn-primary" type="button" onClick={onClose}>
+            Done
+          </button>
+        </div>
+      </div>
+
+      {editingTheme ? (
+        <ThemeEditorDialog
+          theme={editingTheme}
+          onApply={handleEditorApply}
+          onClose={() => setEditingTheme(null)}
+        />
+      ) : null}
+    </div>,
+    document.body,
+  )
+}

--- a/src/components/theme/ThemePreviewSamples.tsx
+++ b/src/components/theme/ThemePreviewSamples.tsx
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ThemeValues } from '../../theme/registry'
+
+/**
+ * Representative preview states for the guided editor. UI samples read the
+ * live CSS custom properties (the edited theme is previewed on the document
+ * root), while sketch-canvas samples use the working values directly because
+ * canvas colors are not CSS variables.
+ */
+export function ThemePreviewSamples({ values }: { values: ThemeValues }) {
+  return (
+    <div className="theme-preview-samples">
+      <section className="theme-preview-samples__panel">
+        <h4 className="theme-preview-samples__title">Panel & text</h4>
+        <p className="theme-preview-samples__text">Primary text on a panel surface.</p>
+        <p className="theme-preview-samples__text-dim">Muted guidance text for hints.</p>
+      </section>
+
+      <section className="theme-preview-samples__panel">
+        <h4 className="theme-preview-samples__title">Controls</h4>
+        <div className="theme-preview-samples__row">
+          <button type="button" className="btn-primary" tabIndex={-1}>Primary</button>
+          <button type="button" className="btn-secondary" tabIndex={-1}>Secondary</button>
+          <button type="button" className="btn-secondary" tabIndex={-1} disabled>Disabled</button>
+        </div>
+        <div className="theme-preview-samples__row">
+          <span className="theme-preview-samples__selected">Selected item</span>
+          <span className="theme-preview-samples__focus">Focused control</span>
+        </div>
+      </section>
+
+      <section className="theme-preview-samples__panel">
+        <h4 className="theme-preview-samples__title">Messages</h4>
+        <p className="theme-preview-samples__positive">Positive: toolpath generated.</p>
+        <p className="theme-preview-samples__warning">Warning: shallow pass depth.</p>
+        <p className="theme-preview-samples__danger">Danger: clamp collision detected.</p>
+      </section>
+
+      <section className="theme-preview-samples__panel">
+        <h4 className="theme-preview-samples__title">Sketch canvas</h4>
+        <div className="theme-preview-samples__canvas" style={{ background: values['canvas.background'] }}>
+          <svg viewBox="0 0 220 84" className="theme-preview-samples__canvas-svg" aria-hidden="true">
+            <line x1="0" y1="42" x2="220" y2="42" stroke={values['canvas.gridMajor']} strokeWidth="1" />
+            <line x1="110" y1="0" x2="110" y2="84" stroke={values['canvas.gridMinor']} strokeWidth="1" />
+            <path d="M14 66 L66 22" stroke={values['role-line']} strokeWidth="2.5" fill="none" />
+            <rect x="84" y="18" width="44" height="30" stroke={values['role-region']} strokeWidth="2.5" fill="none" />
+            <path d="M146 64 L200 64" stroke={values['role-construction']} strokeWidth="2" strokeDasharray="6 4" fill="none" />
+            <path d="M150 20 C 168 42, 186 42, 204 20" stroke={values['canvas.mutedGeometry']} strokeWidth="1.5" fill="none" />
+          </svg>
+          <span
+            className="theme-preview-samples__canvas-label"
+            style={{ background: values['canvas.labelBackground'], color: values['canvas.labelText'] }}
+          >
+            42.5 mm
+          </span>
+        </div>
+        <div className="theme-preview-samples__row theme-preview-samples__row--legend">
+          {([
+            ['Line', values['role-line']],
+            ['Region', values['role-region']],
+            ['Constr.', values['role-construction']],
+            ['Add', values.add],
+            ['Cut', values.cut],
+          ] as const).map(([label, color]) => (
+            <span key={label} className="theme-preview-samples__chip">
+              <span className="theme-preview-samples__chip-dot" style={{ background: color }} />
+              {label}
+            </span>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/theme/ThemeSwatch.tsx
+++ b/src/components/theme/ThemeSwatch.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ThemeValues } from '../../theme/registry'
+
+/**
+ * Small representative color strip for a theme: app surface, panel, text,
+ * accent, and cut colors. Rendered from the theme's own resolved values so a
+ * list of themes previews correctly regardless of the active theme.
+ */
+export function ThemeSwatch({ values }: { values: ThemeValues }) {
+  const chips = [
+    values['surface-app'],
+    values['surface-panel'],
+    values.text,
+    values.accent,
+    values.cut,
+  ]
+  return (
+    <span className="theme-swatch" aria-hidden="true">
+      {chips.map((color, index) => (
+        <span key={index} className="theme-swatch__chip" style={{ background: color }} />
+      ))}
+    </span>
+  )
+}

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -28,7 +28,6 @@ import { getStockBounds, rectProfile } from '../../types/project'
 import { getFeatureGeometryProfiles } from '../../text'
 import { buildToolpathLinePositionChunks, toolpathPointToWorldTuple } from './toolpathOverlay'
 import { useTheme } from '../../theme/themeContext'
-import { THEME_PALETTES } from '../../theme/palette'
 
 function configureGridMaterial(material: THREE.Material | THREE.Material[]) {
   const materials = Array.isArray(material) ? material : [material]
@@ -671,8 +670,8 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
   toolpathVisibility,
   onToolpathVisibilityChange,
 }, ref) {
-  const { resolvedTheme } = useTheme()
-  const threePalette = THEME_PALETTES[resolvedTheme].three
+  const { palette } = useTheme()
+  const threePalette = palette.three
   const threePaletteRef = useRef(threePalette)
   const mountRef = useRef<HTMLDivElement>(null)
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,7 +25,7 @@ import { isDesktop } from './platform'
 import { installAnalytics } from './utils/analytics'
 import { applyVersionToTitle } from './utils/version'
 import { ThemeProvider } from './theme/ThemeProvider'
-import { bootstrapTheme } from './theme/theme'
+import { bootstrapTheme } from './theme/bootstrap'
 
 bootstrapTheme()
 

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -1569,3 +1569,584 @@
   min-height: 44px;
   font-size: 15px;
 }
+
+/* ── Theme Manager ──────────────────── */
+
+.dialog--theme-manager {
+  max-width: 780px;
+}
+
+.dialog-body--theme-manager {
+  grid-template-columns: 264px 1fr;
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.theme-manager-list {
+  border-right: 1px solid var(--line);
+  overflow-y: auto;
+  max-height: 60vh;
+}
+
+.theme-manager-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 10px 14px;
+  border: none;
+  border-bottom: 1px solid var(--line);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  gap: 10px;
+}
+
+.theme-manager-item:hover {
+  background: var(--surface-sheen);
+}
+
+.theme-manager-item--selected {
+  background: var(--surface-hover);
+}
+
+.theme-manager-item--active .theme-manager-item-name {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.theme-manager-item-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.theme-swatch {
+  display: inline-flex;
+  flex: 0 0 auto;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.theme-swatch__chip {
+  width: 8px;
+  height: 22px;
+}
+
+.theme-manager-detail {
+  padding: 16px 20px;
+  overflow-y: auto;
+  max-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.theme-manager-rename {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.theme-manager-rename__input {
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: var(--surface-input);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+}
+
+.theme-manager-notice {
+  margin: 0;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+.theme-manager-notice--error {
+  border: 1px solid color-mix(in oklab, var(--danger-text) 45%, transparent);
+  background: color-mix(in oklab, var(--danger-text) 12%, transparent);
+  color: var(--danger-text);
+}
+
+.theme-manager-notice--info {
+  border: 1px solid var(--line);
+  background: var(--surface-hover);
+  color: var(--text-dim);
+}
+
+.theme-manager-system {
+  border-top: 1px solid var(--line);
+  padding-top: 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.theme-manager-system__title {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.theme-manager-system__mode {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.theme-manager-system__pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  padding-left: 24px;
+}
+
+.theme-manager-system__slot {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.theme-manager-system__slot select {
+  height: 34px;
+  padding: 0 8px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: var(--surface-input);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+}
+
+.theme-manager-system__hint {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 12px;
+  font-style: italic;
+}
+
+/* ── Theme Editor ──────────────────── */
+
+.dialog--theme-editor {
+  max-width: 880px;
+  grid-template-rows: auto auto 1fr auto;
+}
+
+.theme-editor-recovery {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 20px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.theme-editor-recovery button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.dialog-body--theme-editor {
+  grid-template-columns: minmax(0, 1.2fr) minmax(240px, 1fr);
+  gap: 20px;
+  overflow: hidden;
+  padding: 16px 20px;
+}
+
+.theme-editor-fields {
+  overflow-y: auto;
+  padding-right: 6px;
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+.theme-editor-side {
+  overflow-y: auto;
+  display: grid;
+  gap: 14px;
+  align-content: start;
+}
+
+.theme-editor-name {
+  display: grid;
+  gap: 4px;
+}
+
+.theme-editor-name__label {
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.theme-editor-name__input {
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: var(--surface-input);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+}
+
+.theme-editor-name__base {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.theme-editor-group {
+  display: grid;
+  gap: 6px;
+}
+
+.theme-editor-group__title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.theme-editor-group__hint {
+  margin: 0 0 2px;
+  color: var(--text-dim);
+  font-size: 11.5px;
+}
+
+.theme-editor-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 34px minmax(96px, 132px) 18px 26px;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+}
+
+.theme-editor-row--overridden .theme-editor-row__label {
+  color: var(--accent-strong);
+  font-weight: 650;
+}
+
+.theme-editor-row__label {
+  font-size: 12.5px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.theme-editor-row__picker {
+  width: 34px;
+  height: 26px;
+  padding: 1px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: var(--surface-input);
+  cursor: pointer;
+}
+
+.theme-editor-row__value {
+  height: 28px;
+  padding: 0 8px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: var(--surface-input);
+  color: var(--text);
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  font-size: 11.5px;
+  min-width: 0;
+}
+
+.theme-editor-row__value--invalid {
+  border-color: var(--danger-text);
+  color: var(--danger-text);
+}
+
+.theme-editor-row__base {
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+}
+
+.theme-editor-row__reset {
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.theme-editor-row__reset:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.theme-editor-row__reset:not(:disabled):hover {
+  background: var(--surface-hover);
+}
+
+/* Preview samples */
+
+.theme-preview-samples {
+  display: grid;
+  gap: 10px;
+}
+
+.theme-preview-samples__panel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface-panel);
+  padding: 10px 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.theme-preview-samples__title {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.theme-preview-samples__text {
+  margin: 0;
+  color: var(--text);
+  font-size: 13px;
+}
+
+.theme-preview-samples__text-dim {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 12.5px;
+}
+
+.theme-preview-samples__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.theme-preview-samples__row .btn-primary,
+.theme-preview-samples__row .btn-secondary {
+  height: 30px;
+  padding: 0 12px;
+  font-size: 12.5px;
+  pointer-events: none;
+}
+
+.theme-preview-samples__selected {
+  padding: 4px 10px;
+  border: 1px solid color-mix(in oklab, var(--accent) 55%, var(--line));
+  border-radius: 7px;
+  background: var(--accent-soft);
+  color: var(--text);
+  font-size: 12.5px;
+}
+
+.theme-preview-samples__focus {
+  padding: 4px 10px;
+  border-radius: 7px;
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  background: var(--surface-input);
+  color: var(--text);
+  font-size: 12.5px;
+}
+
+.theme-preview-samples__positive {
+  margin: 0;
+  color: var(--add);
+  font-size: 12.5px;
+  font-weight: 650;
+}
+
+.theme-preview-samples__warning {
+  margin: 0;
+  color: var(--warning-text);
+  font-size: 12.5px;
+  font-weight: 650;
+}
+
+.theme-preview-samples__danger {
+  margin: 0;
+  color: var(--danger-text);
+  font-size: 12.5px;
+  font-weight: 650;
+}
+
+.theme-preview-samples__canvas {
+  position: relative;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.theme-preview-samples__canvas-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.theme-preview-samples__canvas-label {
+  position: absolute;
+  right: 8px;
+  top: 8px;
+  padding: 2px 7px;
+  border-radius: 5px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.theme-preview-samples__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.theme-preview-samples__chip-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 4px;
+  border: 1px solid var(--line-strong);
+}
+
+.theme-editor-footer-blocked {
+  margin-right: auto;
+  align-self: center;
+  color: var(--danger-text);
+  font-size: 12.5px;
+  font-weight: 650;
+}
+
+/* Contrast report */
+
+.theme-editor-contrast {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface-subtle);
+  padding: 10px 12px;
+  display: grid;
+  gap: 6px;
+}
+
+.theme-editor-contrast__title {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.theme-editor-contrast__ok {
+  margin: 0;
+  color: var(--add);
+  font-size: 12.5px;
+  font-weight: 650;
+}
+
+.theme-editor-contrast__item {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.theme-editor-contrast__item--block {
+  color: var(--danger-text);
+}
+
+.theme-editor-contrast__item--warn {
+  color: var(--warning-text);
+}
+
+.theme-editor-contrast__note {
+  margin: 2px 0 0;
+  color: var(--text-dim);
+  font-size: 11px;
+  font-style: italic;
+}
+
+/* Touch / narrow: theme dialogs stack and grow touch targets. Dialogs portal
+   to document.body (outside the [data-shell-mode] shell), so these use the
+   same media queries as the generic dialog touch rules in tablet.css. */
+
+@media (pointer: coarse), (max-width: 960px) {
+  .dialog--theme-manager,
+  .dialog--theme-editor {
+    max-width: min(880px, 98vw);
+    max-height: 96vh;
+  }
+
+  .dialog-body--theme-manager {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+  }
+
+  .theme-manager-list {
+    max-height: 26vh;
+    border-right: none;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .theme-manager-item {
+    min-height: 48px;
+  }
+
+  .theme-manager-detail {
+    max-height: none;
+  }
+
+  .dialog-body--theme-editor {
+    grid-template-columns: 1fr;
+    overflow-y: auto;
+  }
+
+  .theme-editor-fields,
+  .theme-editor-side {
+    overflow-y: visible;
+    padding-right: 0;
+  }
+}
+
+@media (pointer: coarse) {
+  .theme-editor-row {
+    min-height: 44px;
+    grid-template-columns: minmax(0, 1fr) 44px minmax(110px, 150px) 20px 44px;
+  }
+
+  .theme-editor-row__picker,
+  .theme-editor-row__reset {
+    width: 44px;
+    height: 36px;
+  }
+
+  .theme-manager-system__mode {
+    min-height: 44px;
+  }
+}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -583,10 +583,13 @@
   padding-top: 10px;
 }
 
-.appearance-menu__option--manage {
+/* Descendant selector (0,2,0) so this min-height beats the broad
+   `.app-shell button` hit-target rule (0,1,1); a bare
+   `.appearance-menu__option--manage` (0,1,0) loses to it and the swatch-less
+   row would fall back to content height — 43px under CI font metrics, below
+   the 44px touch minimum. */
+.appearance-menu .appearance-menu__option--manage {
   grid-template-columns: 1fr;
-  /* Above the 44px touch minimum with margin so fractional device-pixel
-     rounding cannot render it a sub-pixel short on tablet. */
   min-height: 48px;
 }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -577,6 +577,26 @@
   text-align: center;
 }
 
+.appearance-menu__heading--section {
+  margin-top: 6px;
+  border-top: 1px solid var(--line);
+  padding-top: 10px;
+}
+
+.appearance-menu__option--manage {
+  grid-template-columns: 1fr;
+  min-height: 44px;
+}
+
+.appearance-menu .theme-swatch {
+  justify-self: center;
+}
+
+.appearance-menu .theme-swatch__chip {
+  width: 6px;
+  height: 26px;
+}
+
 .toolbar-action:hover .toolbar-tooltip,
 .toolbar-action:focus-within .toolbar-tooltip {
   opacity: 1;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -585,7 +585,9 @@
 
 .appearance-menu__option--manage {
   grid-template-columns: 1fr;
-  min-height: 44px;
+  /* Above the 44px touch minimum with margin so fractional device-pixel
+     rounding cannot render it a sub-pixel short on tablet. */
+  min-height: 48px;
 }
 
 .appearance-menu .theme-swatch {

--- a/src/theme/INDEX.md
+++ b/src/theme/INDEX.md
@@ -1,9 +1,15 @@
 # INDEX — src/theme/
 
-Application-local appearance preferences. Theme state is deliberately separate from the `.camj` project store, so changing appearance never dirties a project or changes saved files.
+Application-local appearance preferences. Theme state is deliberately separate from the `.camj` project store, so changing appearance never dirties a project or changes saved files. Custom themes live in namespaced local storage and resolve against immutable built-in definitions.
 
-- `theme.ts` — theme preference types, persistence codec, system resolution, and pre-React root bootstrap.
-- `ThemeProvider.tsx` — React context, localStorage persistence, and the conditional system-theme listener.
+- `tokens.ts` — the allowlisted, typed set of editable semantic theme roles (CSS custom properties + canvas + Three.js colors), grouped for the guided editor. The single authority on what a custom theme may override.
+- `color.ts` — color parsing/normalization (hex + rgb()/rgba() only), WCAG contrast math with alpha compositing, and perceptual ΔE distance.
+- `registry.ts` — versioned theme registry: complete built-in Dark/Light definitions (CSS values mirrored from `index.css`, enforced by test), custom-theme schema validation, base+override resolution, duplication, and the versioned import/export envelope.
+- `selection.ts` — theme selection model (fixed theme or System light/dark pair), storage keys, legacy `dark|light|system` migration, and custom-theme list persistence.
+- `contrast.ts` — critical-pair contrast checks and semantic-separation warnings; failing blockers prevent a custom theme from becoming active.
+- `theme.ts` — legacy preference types/codec, system-scheme helper, and root application (`data-theme`, `color-scheme`, inline token overrides).
+- `bootstrap.ts` — applies the persisted selection (including custom overrides) before React renders to avoid a theme flash.
+- `ThemeProvider.tsx` — React provider: selection + custom theme persistence, system listener, preview state, resolved palette, and legacy-key write-back.
 - `themeContext.ts` — context contract and `useTheme()` consumer hook, separated for Fast Refresh.
-- `palette.ts` — typed 2D canvas and Three.js colors keyed by resolved theme.
-- `theme.test.ts` — pure preference, bootstrap-root, codec, and palette coverage.
+- `palette.ts` — typed 2D canvas and Three.js palette shapes plus the built-in color values consumed by the registry.
+- `*.test.ts` — coverage for color math, registry/schema/import, selection/migration, contrast gating, and root application (including the CSS ↔ registry sync test).

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -14,44 +14,180 @@
  * limitations under the License.
  */
 
-import { useEffect, useLayoutEffect, useMemo, useState, type ReactNode } from 'react'
-import { useLocalStorageState } from '../hooks/useLocalStorageState'
 import {
-  applyThemeToRoot,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import { useLocalStorageState, writeToStorage } from '../hooks/useLocalStorageState'
+import { themePaletteFromValues } from './registry'
+import type { CustomThemeData, ResolvedThemeDefinition } from './registry'
+import {
+  CUSTOM_THEMES_STORAGE_KEY,
+  customThemesCodec,
+  legacyPreferenceForSelection,
+  readThemeSelection,
+  resolveActiveTheme,
+  THEME_SELECTION_STORAGE_KEY,
+  themeSelectionCodec,
+  type ThemeSelection,
+} from './selection'
+import {
+  applyResolvedThemeToRoot,
   getSystemPrefersDark,
-  resolveThemePreference,
   THEME_STORAGE_KEY,
-  themePreferenceCodec,
   type ThemePreference,
 } from './theme'
 import { ThemeContext, type ThemeContextValue } from './themeContext'
+import { themeTokenKeys } from './tokens'
+
+const PALETTE_TOKEN_KEYS = themeTokenKeys().filter(
+  (key) => key.startsWith('canvas.') || key.startsWith('three.'),
+)
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [preference, setPreference] = useLocalStorageState<ThemePreference>(
-    THEME_STORAGE_KEY,
-    'dark',
-    { codec: themePreferenceCodec },
+  // Migrate the legacy dark|light|system preference once: the versioned
+  // selection key wins when present, and the very first selection write
+  // persists the migrated model.
+  const [initialSelection] = useState(() =>
+    readThemeSelection(typeof window === 'undefined' ? null : window.localStorage, THEME_STORAGE_KEY),
+  )
+  const [selection, setSelection] = useLocalStorageState<ThemeSelection>(
+    THEME_SELECTION_STORAGE_KEY,
+    initialSelection,
+    { codec: themeSelectionCodec },
+  )
+  const [customThemes, setCustomThemes] = useLocalStorageState<CustomThemeData[]>(
+    CUSTOM_THEMES_STORAGE_KEY,
+    [],
+    { codec: customThemesCodec },
   )
   const [systemPrefersDark, setSystemPrefersDark] = useState(getSystemPrefersDark)
-  const resolvedTheme = resolveThemePreference(preference, systemPrefersDark)
+  const [preview, setPreviewState] = useState<ResolvedThemeDefinition | null>(null)
 
+  const activeTheme = useMemo(
+    () => resolveActiveTheme(selection, systemPrefersDark, customThemes),
+    [selection, systemPrefersDark, customThemes],
+  )
+  const displayedTheme = preview ?? activeTheme
+
+  // Theme application is presentation-only: it retags the root and swaps
+  // custom properties/palette colors. No project, geometry, toolpath, or
+  // simulation state is touched here.
   useLayoutEffect(() => {
-    applyThemeToRoot(document.documentElement, preference, resolvedTheme)
-  }, [preference, resolvedTheme])
+    applyResolvedThemeToRoot(document.documentElement, selection.mode, displayedTheme)
+  }, [selection.mode, displayedTheme])
 
   useEffect(() => {
-    if (preference !== 'system' || typeof window.matchMedia !== 'function') return
-
+    if (typeof window.matchMedia !== 'function') return
     const query = window.matchMedia('(prefers-color-scheme: dark)')
     const syncSystemTheme = () => setSystemPrefersDark(query.matches)
     syncSystemTheme()
     query.addEventListener('change', syncSystemTheme)
     return () => query.removeEventListener('change', syncSystemTheme)
-  }, [preference])
+  }, [])
+
+  // Keep the legacy preference key in sync so downgrading the app (or the
+  // pre-React bootstrap of an older build) still lands on a sensible theme.
+  useEffect(() => {
+    const legacy = legacyPreferenceForSelection(selection, customThemes)
+    writeToStorage<ThemePreference>(
+      typeof window === 'undefined' ? null : window.localStorage,
+      THEME_STORAGE_KEY,
+      legacy,
+      { serialize: (value) => value },
+    )
+  }, [selection, customThemes])
+
+  // Canvas/3D/simulation redraw when their palette colors change — keyed by
+  // value so editing a UI-only token never forces a viewport rebuild.
+  const paletteKey = PALETTE_TOKEN_KEYS.map((key) => displayedTheme.values[key]).join('|')
+  const palette = useMemo(
+    () => themePaletteFromValues(displayedTheme.values),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- paletteKey is the value-identity of displayedTheme.values' palette subset
+    [paletteKey],
+  )
+
+  const setPreference = useCallback((preference: ThemePreference) => {
+    setSelection((previous) => {
+      if (preference === 'system') return { ...previous, mode: 'system' }
+      return { ...previous, mode: 'fixed', fixedThemeId: preference }
+    })
+  }, [setSelection])
+
+  const activateTheme = useCallback((themeId: string) => {
+    setSelection((previous) => ({ ...previous, mode: 'fixed', fixedThemeId: themeId }))
+  }, [setSelection])
+
+  const saveCustomTheme = useCallback((theme: CustomThemeData) => {
+    setCustomThemes((previous) => {
+      const index = previous.findIndex((existing) => existing.id === theme.id)
+      if (index === -1) return [...previous, theme]
+      const next = [...previous]
+      next[index] = theme
+      return next
+    })
+  }, [setCustomThemes])
+
+  const deleteCustomTheme = useCallback((themeId: string) => {
+    if (preview?.id === themeId) return
+    const target = customThemes.find((theme) => theme.id === themeId)
+    if (!target) return
+    setCustomThemes((previous) => previous.filter((theme) => theme.id !== themeId))
+    setSelection((previous) => {
+      const replace = (id: string) => (id === themeId ? target.baseThemeId : id)
+      return {
+        mode: previous.mode,
+        fixedThemeId: replace(previous.fixedThemeId),
+        systemLightThemeId: replace(previous.systemLightThemeId),
+        systemDarkThemeId: replace(previous.systemDarkThemeId),
+      }
+    })
+  }, [preview, customThemes, setCustomThemes, setSelection])
+
+  const setPreview = useCallback((theme: ResolvedThemeDefinition | null) => {
+    setPreviewState(theme)
+  }, [])
+
+  const preference: ThemePreference = selection.mode === 'system' ? 'system' : activeTheme.family
 
   const value = useMemo<ThemeContextValue>(
-    () => ({ preference, resolvedTheme, setPreference }),
-    [preference, resolvedTheme, setPreference],
+    () => ({
+      preference,
+      resolvedTheme: displayedTheme.family,
+      setPreference,
+      selection,
+      setSelection,
+      customThemes,
+      activeTheme,
+      displayedTheme,
+      palette,
+      systemPrefersDark,
+      activateTheme,
+      saveCustomTheme,
+      deleteCustomTheme,
+      setPreview,
+      isPreviewing: preview !== null,
+    }),
+    [
+      preference,
+      displayedTheme,
+      setPreference,
+      selection,
+      setSelection,
+      customThemes,
+      activeTheme,
+      palette,
+      systemPrefersDark,
+      activateTheme,
+      saveCustomTheme,
+      deleteCustomTheme,
+      setPreview,
+      preview,
+    ],
   )
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>

--- a/src/theme/bootstrap.ts
+++ b/src/theme/bootstrap.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  readStoredCustomThemes,
+  readThemeSelection,
+  resolveActiveTheme,
+} from './selection'
+import { applyResolvedThemeToRoot, getSystemPrefersDark, THEME_STORAGE_KEY } from './theme'
+
+/**
+ * Applies the persisted theme selection — including custom-theme overrides
+ * kept in namespaced local storage — before React renders, preventing an
+ * incorrect-theme flash. Any storage failure falls back to built-in Dark.
+ */
+export function bootstrapTheme(): void {
+  if (typeof document === 'undefined') return
+
+  const storage = typeof window === 'undefined' ? null : window.localStorage
+  const selection = readThemeSelection(storage, THEME_STORAGE_KEY)
+  const customThemes = readStoredCustomThemes(storage)
+  const resolved = resolveActiveTheme(selection, getSystemPrefersDark(), customThemes)
+  applyResolvedThemeToRoot(document.documentElement, selection.mode, resolved)
+}

--- a/src/theme/color.test.ts
+++ b/src/theme/color.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  compositeOver,
+  contrastRatio,
+  flattenStack,
+  formatColor,
+  normalizeColorValue,
+  opaqueHex,
+  parseColor,
+  perceptualDistance,
+} from './color'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function approx(actual: number, expected: number, tolerance: number, message: string): void {
+  assert(Math.abs(actual - expected) <= tolerance, `${message} (got ${actual}, expected ~${expected})`)
+}
+
+// Parsing.
+assert(JSON.stringify(parseColor('#fff')) === JSON.stringify({ r: 255, g: 255, b: 255, a: 1 }), '#fff parses')
+assert(JSON.stringify(parseColor('#dca56a')) === JSON.stringify({ r: 220, g: 165, b: 106, a: 1 }), 'six-digit hex parses')
+approx(parseColor('#00000080')!.a, 128 / 255, 0.001, 'eight-digit hex alpha parses')
+assert(parseColor('rgb(220, 165, 106)')!.g === 165, 'rgb() parses')
+approx(parseColor('rgba(16, 24, 33, 0.94)')!.a, 0.94, 0.0001, 'rgba() alpha parses')
+approx(parseColor('rgba(16, 24, 33, 50%)')!.a, 0.5, 0.0001, 'percent alpha parses')
+assert(parseColor('') === null, 'empty string rejected')
+assert(parseColor('red') === null, 'keywords rejected')
+assert(parseColor('url(evil)') === null, 'functions rejected')
+assert(parseColor('var(--text)') === null, 'var() rejected')
+assert(parseColor('#12345') === null, 'wrong hex length rejected')
+assert(parseColor('rgb(300, 0, 0)') === null, 'out-of-range channel rejected')
+assert(parseColor('linear-gradient(#000, #fff)') === null, 'gradients rejected')
+
+// Normalization.
+assert(formatColor({ r: 255, g: 255, b: 255, a: 1 }) === '#ffffff', 'opaque formats to 6-digit hex')
+assert(formatColor({ r: 0, g: 0, b: 0, a: 0.5 }) === '#00000080', 'translucent keeps alpha byte')
+assert(normalizeColorValue('RGB(220, 165, 106)') === '#dca56a', 'rgb normalizes to hex')
+assert(normalizeColorValue('#ABC') === '#aabbcc', 'short hex expands lowercase')
+assert(normalizeColorValue('nonsense') === null, 'invalid value normalizes to null')
+assert(opaqueHex(parseColor('rgba(16, 24, 33, 0.94)')!) === '#101821', 'opaque part extracted for color inputs')
+
+// Compositing.
+const half = compositeOver({ r: 255, g: 255, b: 255, a: 0.5 }, { r: 0, g: 0, b: 0, a: 1 })
+approx(half.r, 127.5, 0.01, 'source-over blends channels')
+assert(half.a === 1, 'compositing over opaque yields opaque')
+const flattened = flattenStack([
+  { r: 255, g: 0, b: 0, a: 0.5 },
+  { r: 0, g: 0, b: 255, a: 1 },
+])
+approx(flattened.r, 127.5, 0.01, 'stack flattens topmost first')
+assert(flattened.a === 1, 'flattened stack is opaque')
+
+// WCAG contrast.
+approx(contrastRatio(parseColor('#ffffff')!, parseColor('#000000')!), 21, 0.01, 'white on black is 21:1')
+approx(contrastRatio(parseColor('#000000')!, parseColor('#ffffff')!), 21, 0.01, 'ratio is symmetric')
+approx(contrastRatio(parseColor('#777777')!, parseColor('#777777')!), 1, 0.01, 'same color is 1:1')
+const composited = contrastRatio(parseColor('rgba(255, 255, 255, 0.5)')!, parseColor('#000000')!)
+assert(composited < 21 && composited > 4, 'translucent foreground is composited before measuring')
+
+// Perceptual distance.
+const base = parseColor('#0f151d')!
+assert(perceptualDistance(parseColor('#5a8fcc')!, parseColor('#9966cc')!, base) > 20, 'blue vs purple is distinguishable')
+approx(perceptualDistance(parseColor('#5a8fcc')!, parseColor('#5a8fcc')!, base), 0, 0.001, 'identical colors have zero distance')
+assert(
+  perceptualDistance(parseColor('#5a8fcc')!, parseColor('#5c91cd')!, base) < 5,
+  'near-identical colors measure as hard to distinguish',
+)
+
+console.log('color tests passed')

--- a/src/theme/color.ts
+++ b/src/theme/color.ts
@@ -1,0 +1,198 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Color math for the theme system: parsing the allowlisted color formats,
+ * normalizing to hex, WCAG contrast ratios (with alpha compositing), and a
+ * perceptual distance used to warn when semantic colors become hard to tell
+ * apart. No CSS keywords, gradients, or functions beyond rgb()/rgba() are
+ * accepted — theme values stay plain colors by construction.
+ */
+
+export interface RgbaColor {
+  /** 0–255 */
+  r: number
+  /** 0–255 */
+  g: number
+  /** 0–255 */
+  b: number
+  /** 0–1 */
+  a: number
+}
+
+const HEX_PATTERN = /^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+const RGB_PATTERN = /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*(?:,\s*([\d.]+%?)\s*)?\)$/i
+
+function clampChannel(value: number): number {
+  return Math.min(255, Math.max(0, Math.round(value)))
+}
+
+function clampAlpha(value: number): number {
+  return Math.min(1, Math.max(0, value))
+}
+
+/**
+ * Parse a theme color value. Accepts `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`,
+ * `rgb(r, g, b)`, and `rgba(r, g, b, a)`. Returns `null` for anything else,
+ * which callers treat as a validation failure.
+ */
+export function parseColor(value: string): RgbaColor | null {
+  const trimmed = value.trim()
+
+  const hexMatch = HEX_PATTERN.exec(trimmed)
+  if (hexMatch) {
+    const hex = hexMatch[1]
+    if (hex.length === 3 || hex.length === 4) {
+      const r = parseInt(hex[0] + hex[0], 16)
+      const g = parseInt(hex[1] + hex[1], 16)
+      const b = parseInt(hex[2] + hex[2], 16)
+      const a = hex.length === 4 ? parseInt(hex[3] + hex[3], 16) / 255 : 1
+      return { r, g, b, a }
+    }
+    const r = parseInt(hex.slice(0, 2), 16)
+    const g = parseInt(hex.slice(2, 4), 16)
+    const b = parseInt(hex.slice(4, 6), 16)
+    const a = hex.length === 8 ? parseInt(hex.slice(6, 8), 16) / 255 : 1
+    return { r, g, b, a }
+  }
+
+  const rgbMatch = RGB_PATTERN.exec(trimmed)
+  if (rgbMatch) {
+    const r = Number(rgbMatch[1])
+    const g = Number(rgbMatch[2])
+    const b = Number(rgbMatch[3])
+    if (![r, g, b].every((channel) => Number.isFinite(channel) && channel <= 255)) return null
+    let a = 1
+    if (rgbMatch[4] !== undefined) {
+      const rawAlpha = rgbMatch[4]
+      a = rawAlpha.endsWith('%') ? Number(rawAlpha.slice(0, -1)) / 100 : Number(rawAlpha)
+      if (!Number.isFinite(a)) return null
+    }
+    return { r: clampChannel(r), g: clampChannel(g), b: clampChannel(b), a: clampAlpha(a) }
+  }
+
+  return null
+}
+
+function channelHex(value: number): string {
+  return clampChannel(value).toString(16).padStart(2, '0')
+}
+
+/** Normalize to lowercase `#rrggbb`, or `#rrggbbaa` when alpha < 1. */
+export function formatColor(color: RgbaColor): string {
+  const base = `#${channelHex(color.r)}${channelHex(color.g)}${channelHex(color.b)}`
+  if (color.a >= 1) return base
+  return `${base}${channelHex(color.a * 255)}`
+}
+
+/** Normalize an accepted color string, or return `null` when unparseable. */
+export function normalizeColorValue(value: string): string | null {
+  const parsed = parseColor(value)
+  return parsed ? formatColor(parsed) : null
+}
+
+/** The opaque `#rrggbb` part, for `<input type="color">` which cannot show alpha. */
+export function opaqueHex(color: RgbaColor): string {
+  return `#${channelHex(color.r)}${channelHex(color.g)}${channelHex(color.b)}`
+}
+
+/** Source-over composite of `fg` onto `bg`. `bg` is treated as opaque. */
+export function compositeOver(fg: RgbaColor, bg: RgbaColor): RgbaColor {
+  const a = fg.a + bg.a * (1 - fg.a)
+  if (a === 0) return { r: 0, g: 0, b: 0, a: 0 }
+  return {
+    r: (fg.r * fg.a + bg.r * bg.a * (1 - fg.a)) / a,
+    g: (fg.g * fg.a + bg.g * bg.a * (1 - fg.a)) / a,
+    b: (fg.b * fg.a + bg.b * bg.a * (1 - fg.a)) / a,
+    a,
+  }
+}
+
+function linearChannel(channel: number): number {
+  const srgb = channel / 255
+  return srgb <= 0.04045 ? srgb / 12.92 : Math.pow((srgb + 0.055) / 1.055, 2.4)
+}
+
+/** WCAG 2.x relative luminance of an (assumed opaque) color. */
+export function relativeLuminance(color: RgbaColor): number {
+  return (
+    0.2126 * linearChannel(color.r)
+    + 0.7152 * linearChannel(color.g)
+    + 0.0722 * linearChannel(color.b)
+  )
+}
+
+/**
+ * WCAG 2.x contrast ratio between a foreground and a background. Translucent
+ * inputs are composited: the background stack must already be flattened to
+ * opaque by the caller (see `flattenStack`), then the foreground is composited
+ * over it before measuring.
+ */
+export function contrastRatio(fg: RgbaColor, bg: RgbaColor): number {
+  const solidFg = fg.a < 1 ? compositeOver(fg, bg) : fg
+  const fgLum = relativeLuminance(solidFg)
+  const bgLum = relativeLuminance(bg)
+  const lighter = Math.max(fgLum, bgLum)
+  const darker = Math.min(fgLum, bgLum)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+/**
+ * Flatten a stack of possibly-translucent layers (topmost first) into one
+ * opaque color. The last layer acts as the base; any residual translucency
+ * is composited over black to keep the result deterministic.
+ */
+export function flattenStack(layers: RgbaColor[]): RgbaColor {
+  let result: RgbaColor = { r: 0, g: 0, b: 0, a: 1 }
+  for (let i = layers.length - 1; i >= 0; i -= 1) {
+    result = compositeOver(layers[i], result)
+  }
+  return { ...result, a: 1 }
+}
+
+interface LabColor {
+  l: number
+  a: number
+  b: number
+}
+
+function toLab(color: RgbaColor): LabColor {
+  // sRGB → XYZ (D65) → CIELAB
+  const rl = linearChannel(color.r)
+  const gl = linearChannel(color.g)
+  const bl = linearChannel(color.b)
+  const x = (rl * 0.4124 + gl * 0.3576 + bl * 0.1805) / 0.95047
+  const y = rl * 0.2126 + gl * 0.7152 + bl * 0.0722
+  const z = (rl * 0.0193 + gl * 0.1192 + bl * 0.9505) / 1.08883
+  const f = (t: number) => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116)
+  const fx = f(x)
+  const fy = f(y)
+  const fz = f(z)
+  return { l: 116 * fy - 16, a: 500 * (fx - fy), b: 200 * (fy - fz) }
+}
+
+/**
+ * CIE76 ΔE between two colors (composited over `base` when translucent).
+ * Used as a "can a user tell these apart" heuristic: values below ~12 are
+ * hard to distinguish at small sizes.
+ */
+export function perceptualDistance(a: RgbaColor, b: RgbaColor, base: RgbaColor): number {
+  const labA = toLab(a.a < 1 ? compositeOver(a, base) : a)
+  const labB = toLab(b.a < 1 ? compositeOver(b, base) : b)
+  return Math.sqrt(
+    (labA.l - labB.l) ** 2 + (labA.a - labB.a) ** 2 + (labA.b - labB.b) ** 2,
+  )
+}

--- a/src/theme/contrast.test.ts
+++ b/src/theme/contrast.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { evaluateThemeContrast } from './contrast'
+import { BUILTIN_THEMES, resolveBuiltinTheme } from './registry'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+// Built-ins must pass every check cleanly — a shipped default that trips its
+// own validation gate would read as broken in the editor.
+for (const definition of BUILTIN_THEMES) {
+  const report = evaluateThemeContrast(definition.values)
+  assert(report.findings.length > 0, `${definition.id} produces findings`)
+  const failures = [...report.blockers, ...report.warnings].map((finding) => `${finding.id}=${finding.measured}`)
+  assert(
+    failures.length === 0,
+    `built-in ${definition.id} passes all contrast checks (failed: ${failures.join(', ')})`,
+  )
+}
+
+// An unreadable panel (text ≈ background) must block.
+const unreadable = { ...resolveBuiltinTheme('dark').values, text: '#101821' }
+const unreadableReport = evaluateThemeContrast(unreadable)
+assert(unreadableReport.blockers.some((finding) => finding.id === 'text-panel'), 'invisible panel text blocks')
+assert(unreadableReport.blockers.every((finding) => finding.severity === 'block'), 'blockers carry block severity')
+
+// A washed-out focus indicator must block (non-text contrast).
+const noFocus = { ...resolveBuiltinTheme('light').values, accent: '#f4efe6' }
+assert(
+  evaluateThemeContrast(noFocus).blockers.some((finding) => finding.id === 'focus-panel'),
+  'invisible focus indicator blocks',
+)
+
+// Muted text between 3:1 and 4.5:1 warns without blocking.
+const dimmed = { ...resolveBuiltinTheme('dark').values, 'text-dim': '#5a6b7c' }
+const dimmedReport = evaluateThemeContrast(dimmed)
+const dimFinding = dimmedReport.findings.find((finding) => finding.id === 'text-dim-panel')
+assert(dimFinding !== undefined && !dimFinding.pass, 'lowered muted text is flagged')
+assert(
+  dimmedReport.warnings.some((finding) => finding.id === 'text-dim-panel')
+    || dimmedReport.blockers.some((finding) => finding.id === 'text-dim-panel'),
+  'lowered muted text lands in warnings or blockers by measured value',
+)
+
+// Unreadable canvas labels must block (composited over translucent label chip).
+const badLabels = {
+  ...resolveBuiltinTheme('dark').values,
+  'canvas.labelText': 'rgba(18, 26, 36, 0.9)',
+}
+assert(
+  evaluateThemeContrast(badLabels).blockers.some((finding) => finding.id === 'canvas-label'),
+  'unreadable canvas labels block',
+)
+
+// Semantic role colors collapsing together must warn (distance check).
+const mergedRoles = {
+  ...resolveBuiltinTheme('dark').values,
+  'role-region': '#5a8fcc',
+}
+const mergedReport = evaluateThemeContrast(mergedRoles)
+assert(
+  mergedReport.warnings.some((finding) => finding.id === 'line-vs-region' && finding.kind === 'distance'),
+  'indistinguishable line/region roles warn',
+)
+assert(!mergedReport.blockers.some((finding) => finding.id === 'line-vs-region'), 'semantic distance warns, never blocks')
+
+// Add vs cut collapsing must warn.
+const mergedOps = {
+  ...resolveBuiltinTheme('dark').values,
+  add: '#5a8fcc',
+}
+assert(
+  evaluateThemeContrast(mergedOps).warnings.some((finding) => finding.id === 'add-vs-cut'),
+  'indistinguishable add/cut colors warn',
+)
+
+// Findings expose measured values for the editor UI.
+const report = evaluateThemeContrast(resolveBuiltinTheme('dark').values)
+for (const finding of report.findings) {
+  assert(Number.isFinite(finding.measured) && finding.measured > 0, `finding ${finding.id} has a measured value`)
+  assert(finding.required > 0, `finding ${finding.id} has a required threshold`)
+}
+
+console.log('contrast tests passed')

--- a/src/theme/contrast.ts
+++ b/src/theme/contrast.ts
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contrast and semantic-separation validation for theme palettes.
+ *
+ * Ratio checks measure WCAG 2.x contrast for critical foreground/background
+ * pairs (translucent layers are composited first). Distance checks measure
+ * perceptual ΔE between semantic drawing/CAM colors that must stay
+ * distinguishable. Failing a `block`-severity check prevents a custom theme
+ * from being applied; `warn` results are surfaced but do not block.
+ *
+ * These are automated spot checks of representative states — they cannot
+ * prove global WCAG compliance, so delivery keeps a manual review step.
+ */
+
+import { contrastRatio, flattenStack, parseColor, perceptualDistance, type RgbaColor } from './color'
+import type { ThemeValues } from './registry'
+import type { ThemeTokenKey } from './tokens'
+
+export type ContrastSeverity = 'block' | 'warn'
+
+interface RatioCheck {
+  id: string
+  label: string
+  /** Foreground token. */
+  fg: ThemeTokenKey
+  /** Background stack, topmost first; flattened over the last entry. */
+  bg: ThemeTokenKey[]
+  /** Measured below this ratio → blocker. */
+  blockBelow?: number
+  /** Measured below this ratio (but above blockBelow) → warning. */
+  warnBelow?: number
+}
+
+interface DistanceCheck {
+  id: string
+  label: string
+  a: ThemeTokenKey
+  b: ThemeTokenKey
+  /** Both colors are composited over this base before measuring. */
+  base: ThemeTokenKey
+  /** Measured ΔE below this → warning. */
+  warnBelow: number
+}
+
+/**
+ * Critical text/surface, control, focus, warning, and danger combinations.
+ * Core readability blocks Apply; secondary affordances only warn.
+ */
+const RATIO_CHECKS: readonly RatioCheck[] = [
+  { id: 'text-panel', label: 'Primary text on panels', fg: 'text', bg: ['surface-panel', 'surface-app'], blockBelow: 4.5 },
+  { id: 'text-app', label: 'Primary text on app background', fg: 'text', bg: ['bg'], blockBelow: 4.5 },
+  { id: 'text-raised', label: 'Primary text on dialogs', fg: 'text', bg: ['surface-raised', 'surface-app'], blockBelow: 4.5 },
+  { id: 'text-input', label: 'Primary text in inputs', fg: 'text', bg: ['surface-input', 'surface-panel', 'surface-app'], blockBelow: 4.5 },
+  { id: 'text-dim-panel', label: 'Muted text on panels', fg: 'text-dim', bg: ['surface-panel', 'surface-app'], blockBelow: 3, warnBelow: 4.5 },
+  { id: 'status-text', label: 'Status bar text', fg: 'status-text', bg: ['surface-translucent', 'bg'], blockBelow: 4.5 },
+  // The shipped dark accent (white on amber) measures ≈2.2:1, so this gate
+  // is calibrated to catch catastrophic edits, not to re-litigate the
+  // existing accent design.
+  { id: 'on-accent', label: 'Text on accent controls', fg: 'on-accent', bg: ['accent', 'surface-panel', 'surface-app'], blockBelow: 2 },
+  { id: 'danger-panel', label: 'Danger text on panels', fg: 'danger-text', bg: ['surface-panel', 'surface-app'], blockBelow: 4.5 },
+  { id: 'warning-panel', label: 'Warning text on panels', fg: 'warning-text', bg: ['surface-panel', 'surface-app'], blockBelow: 4.5 },
+  { id: 'focus-panel', label: 'Focus indicator on panels', fg: 'accent', bg: ['surface-panel', 'surface-app'], blockBelow: 3 },
+  { id: 'focus-raised', label: 'Focus indicator on dialogs', fg: 'accent', bg: ['surface-raised', 'surface-app'], warnBelow: 3 },
+  { id: 'canvas-label', label: 'Canvas measurement labels', fg: 'canvas.labelText', bg: ['canvas.labelBackground', 'canvas.background'], blockBelow: 4.5 },
+  { id: 'canvas-muted', label: 'Muted geometry on canvas', fg: 'canvas.mutedGeometry', bg: ['canvas.background'], warnBelow: 3 },
+  { id: 'role-line-text', label: 'Line role text on panels', fg: 'role-line-text', bg: ['surface-panel', 'surface-app'], warnBelow: 4.5 },
+  { id: 'role-region-text', label: 'Region role text on panels', fg: 'role-region-text', bg: ['surface-panel', 'surface-app'], warnBelow: 4.5 },
+  { id: 'role-construction-text', label: 'Construction role text on panels', fg: 'role-construction-text', bg: ['surface-panel', 'surface-app'], warnBelow: 4.5 },
+  { id: 'add-panel', label: 'Positive/add color on panels', fg: 'add', bg: ['surface-panel', 'surface-app'], warnBelow: 3 },
+  { id: 'cut-panel', label: 'Cut color on panels', fg: 'cut', bg: ['surface-panel', 'surface-app'], warnBelow: 3 },
+  { id: 'role-line-canvas', label: 'Line role on canvas', fg: 'role-line', bg: ['canvas.background'], warnBelow: 2 },
+  { id: 'role-region-canvas', label: 'Region role on canvas', fg: 'role-region', bg: ['canvas.background'], warnBelow: 2 },
+  { id: 'role-construction-canvas', label: 'Construction role on canvas', fg: 'role-construction', bg: ['canvas.background'], warnBelow: 2 },
+  { id: 'three-grid', label: '3D grid on viewport background', fg: 'three.gridMajor', bg: ['three.background'], warnBelow: 1.15 },
+]
+
+/**
+ * Project/CAM semantics that must not silently become indistinguishable:
+ * feature roles from each other, and add vs. cut operation colors.
+ */
+const DISTANCE_CHECKS: readonly DistanceCheck[] = [
+  { id: 'line-vs-region', label: 'Line vs. region role', a: 'role-line', b: 'role-region', base: 'canvas.background', warnBelow: 12 },
+  { id: 'line-vs-construction', label: 'Line vs. construction role', a: 'role-line', b: 'role-construction', base: 'canvas.background', warnBelow: 12 },
+  { id: 'region-vs-construction', label: 'Region vs. construction role', a: 'role-region', b: 'role-construction', base: 'canvas.background', warnBelow: 12 },
+  { id: 'add-vs-cut', label: 'Add vs. cut operation color', a: 'add', b: 'cut', base: 'surface-panel', warnBelow: 12 },
+]
+
+export interface ContrastFinding {
+  id: string
+  label: string
+  kind: 'ratio' | 'distance'
+  /** Contrast ratio (1–21) or perceptual ΔE, rounded for display. */
+  measured: number
+  /** The threshold the finding is judged against (block level if present). */
+  required: number
+  severity: ContrastSeverity
+  /** True when the measured value meets the strictest applicable threshold. */
+  pass: boolean
+  /** False only for the pass=false subset that blocks Apply. */
+  blocking: boolean
+}
+
+export interface ThemeContrastReport {
+  findings: ContrastFinding[]
+  blockers: ContrastFinding[]
+  warnings: ContrastFinding[]
+}
+
+function color(values: ThemeValues, key: ThemeTokenKey): RgbaColor | null {
+  return parseColor(values[key])
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+/** Evaluate every check against a complete theme value map. */
+export function evaluateThemeContrast(values: ThemeValues): ThemeContrastReport {
+  const findings: ContrastFinding[] = []
+
+  for (const check of RATIO_CHECKS) {
+    const fg = color(values, check.fg)
+    const bgLayers = check.bg.map((key) => color(values, key))
+    if (!fg || bgLayers.some((layer) => layer === null)) continue
+    const bg = flattenStack(bgLayers as RgbaColor[])
+    const measured = contrastRatio(fg, bg)
+
+    const blockLevel = check.blockBelow
+    const warnLevel = check.warnBelow
+    const strictest = Math.max(blockLevel ?? 0, warnLevel ?? 0)
+    const pass = measured >= strictest
+    const blocking = blockLevel !== undefined && measured < blockLevel
+    findings.push({
+      id: check.id,
+      label: check.label,
+      kind: 'ratio',
+      measured: round(measured),
+      required: strictest,
+      severity: blockLevel !== undefined ? 'block' : 'warn',
+      pass,
+      blocking,
+    })
+  }
+
+  for (const check of DISTANCE_CHECKS) {
+    const a = color(values, check.a)
+    const b = color(values, check.b)
+    const base = color(values, check.base)
+    if (!a || !b || !base) continue
+    const measured = perceptualDistance(a, b, base)
+    findings.push({
+      id: check.id,
+      label: check.label,
+      kind: 'distance',
+      measured: round(measured),
+      required: check.warnBelow,
+      severity: 'warn',
+      pass: measured >= check.warnBelow,
+      blocking: false,
+    })
+  }
+
+  return {
+    findings,
+    blockers: findings.filter((finding) => finding.blocking),
+    warnings: findings.filter((finding) => !finding.pass && !finding.blocking),
+  }
+}

--- a/src/theme/registry.test.ts
+++ b/src/theme/registry.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import {
+  BUILTIN_THEMES,
+  builtinTheme,
+  cssOverridesFromValues,
+  duplicateThemeAsCustom,
+  duplicateThemeName,
+  parseThemeImport,
+  resolveBuiltinTheme,
+  resolveCustomTheme,
+  resolveThemeById,
+  serializeThemeExport,
+  themePaletteFromValues,
+  validateCustomTheme,
+  type CustomThemeData,
+} from './registry'
+import { themeTokenKeys } from './tokens'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+// --- CSS ↔ registry sync -------------------------------------------------
+// The built-in `css` values must stay byte-identical to src/index.css so the
+// registry (editor base values, contrast checks) and the stylesheet cannot
+// drift apart.
+
+const indexCss = readFileSync(fileURLToPath(new URL('../index.css', import.meta.url)), 'utf8')
+
+function cssBlockTokens(source: string, selector: string): Map<string, string> {
+  const start = source.indexOf(selector)
+  assert(start >= 0, `stylesheet contains "${selector}"`)
+  const open = source.indexOf('{', start)
+  const close = source.indexOf('}', open)
+  const body = source.slice(open + 1, close)
+  const tokens = new Map<string, string>()
+  for (const match of body.matchAll(/--([a-z0-9-]+)\s*:\s*([^;]+);/gi)) {
+    tokens.set(match[1], match[2].trim())
+  }
+  return tokens
+}
+
+const cssBlocks = {
+  dark: cssBlockTokens(indexCss, ':root {'),
+  light: cssBlockTokens(indexCss, ":root[data-theme='light']"),
+}
+
+for (const definition of BUILTIN_THEMES) {
+  const block = cssBlocks[definition.family]
+  const cssKeys = themeTokenKeys('css')
+  assert(
+    block.size === cssKeys.length,
+    `index.css ${definition.family} block has ${block.size} tokens, registry allowlists ${cssKeys.length} — update both together`,
+  )
+  for (const key of cssKeys) {
+    const cssValue = block.get(key)
+    assert(cssValue !== undefined, `index.css ${definition.family} block defines --${key}`)
+    assert(
+      cssValue === definition.values[key],
+      `--${key} matches for ${definition.id}: css "${cssValue}" vs registry "${definition.values[key]}"`,
+    )
+  }
+}
+
+// --- Built-in registry ----------------------------------------------------
+
+assert(BUILTIN_THEMES.length === 2, 'two built-in themes are registered')
+assert(builtinTheme('dark').family === 'dark' && builtinTheme('light').family === 'light', 'families are stable')
+for (const definition of BUILTIN_THEMES) {
+  for (const key of themeTokenKeys()) {
+    assert(definition.values[key] !== undefined, `${definition.id} defines ${key}`)
+  }
+}
+const resolvedDark = resolveBuiltinTheme('dark')
+assert(resolvedDark.builtin && resolvedDark.overriddenKeys.length === 0, 'built-in resolves with no overrides')
+
+// --- Palette conversion ---------------------------------------------------
+
+const palette = themePaletteFromValues(resolvedDark.values)
+assert(palette.three.background === 0x141820, 'three background converts to the historical number')
+assert(palette.three.gridMajor === 0x51657a, 'three grid converts to the historical number')
+assert(palette.canvas.background === '#0f151d', 'canvas background carries through')
+assert(palette.canvas.veil === 'rgba(8, 12, 18, 0.5)', 'canvas alpha values carry through')
+
+// --- Custom theme validation ----------------------------------------------
+
+const validCustom: CustomThemeData = {
+  schemaVersion: 1,
+  id: 'custom-test-1',
+  name: 'Workshop Amber',
+  family: 'dark',
+  baseThemeId: 'dark',
+  overrides: { accent: '#ff8800', 'canvas.background': '#101418' },
+}
+
+assert(validateCustomTheme(validCustom).ok !== undefined, 'valid custom theme is accepted')
+assert(validateCustomTheme(null).error !== undefined, 'null rejected')
+assert(validateCustomTheme([]).error !== undefined, 'array rejected')
+assert(
+  validateCustomTheme({ ...validCustom, schemaVersion: 99 }).error!.includes('schema version'),
+  'incompatible schema version is rejected with a readable error',
+)
+assert(
+  validateCustomTheme({ ...validCustom, overrides: { 'not-a-token': '#fff' } }).error!.includes('Unknown theme token'),
+  'unknown token is rejected',
+)
+assert(
+  validateCustomTheme({ ...validCustom, overrides: { accent: 'javascript:alert(1)' } }).error!.includes('invalid color'),
+  'non-color value is rejected',
+)
+assert(
+  validateCustomTheme({ ...validCustom, overrides: { accent: 'url(http://x)' } }).error !== undefined,
+  'css functions are rejected',
+)
+assert(
+  validateCustomTheme({ ...validCustom, extraCss: '.panel { display: none }' }).error!.includes('Unknown theme property'),
+  'arbitrary extra properties are rejected',
+)
+assert(
+  validateCustomTheme({ ...validCustom, family: 'sepia' }).error !== undefined,
+  'unknown family is rejected',
+)
+assert(
+  validateCustomTheme({ ...validCustom, baseThemeId: 'custom-other' }).error !== undefined,
+  'custom base theme id is rejected',
+)
+assert(
+  validateCustomTheme({ ...validCustom, name: 'x'.repeat(100) }).error !== undefined,
+  'over-long names are rejected',
+)
+const normalized = validateCustomTheme({ ...validCustom, overrides: { accent: 'rgb(255, 136, 0)' } })
+assert(normalized.ok!.overrides.accent === '#ff8800', 'override colors are normalized on load')
+
+// --- Resolution -----------------------------------------------------------
+
+const resolvedCustom = resolveCustomTheme(validCustom)
+assert(resolvedCustom.values.accent === '#ff8800', 'override wins over base value')
+assert(resolvedCustom.values.text === builtinTheme('dark').values.text, 'unset tokens inherit the base')
+assert(resolvedCustom.overriddenKeys.length === 2, 'overridden keys are tracked')
+assert(resolvedCustom.baseThemeId === 'dark' && !resolvedCustom.builtin, 'custom resolution keeps identity')
+
+const sameAsBase = resolveCustomTheme({ ...validCustom, overrides: { accent: builtinTheme('dark').values.accent } })
+assert(sameAsBase.overriddenKeys.length === 0, 'override equal to base does not count as overridden')
+
+assert(resolveThemeById('light', []).id === 'light', 'built-in id resolves')
+assert(resolveThemeById('custom-test-1', [validCustom]).values.accent === '#ff8800', 'custom id resolves')
+assert(resolveThemeById('missing-id', [], 'light').id === 'light', 'unknown id falls back to the requested family')
+
+// --- CSS override projection ----------------------------------------------
+
+const overrides = cssOverridesFromValues(resolvedCustom.values, resolvedCustom.family)
+assert(overrides['--accent'] === '#ff8800', 'changed css token is projected as a custom property')
+assert(Object.keys(overrides).length === 1, 'canvas/three overrides do not leak into css projection')
+assert(
+  Object.keys(cssOverridesFromValues(resolvedDark.values, 'dark')).length === 0,
+  'built-in projects no inline overrides',
+)
+
+// --- Duplication ----------------------------------------------------------
+
+assert(duplicateThemeName('Dark', ['Dark']) === 'Dark copy', 'first duplicate gets "copy"')
+assert(duplicateThemeName('Dark', ['Dark', 'Dark copy']) === 'Dark copy 2', 'second duplicate counts up')
+const duplicated = duplicateThemeAsCustom(resolvedCustom, ['Workshop Amber'])
+assert(duplicated.id !== resolvedCustom.id, 'duplicate gets a fresh id')
+assert(duplicated.overrides.accent === '#ff8800', 'duplicate keeps effective overrides')
+assert(duplicated.baseThemeId === 'dark', 'duplicate keeps the built-in base')
+const duplicatedBuiltin = duplicateThemeAsCustom(resolveBuiltinTheme('light'), [])
+assert(duplicatedBuiltin.baseThemeId === 'light' && Object.keys(duplicatedBuiltin.overrides).length === 0,
+  'duplicating a built-in starts from a clean override set')
+
+// --- Import / export ------------------------------------------------------
+
+const exported = serializeThemeExport(validCustom)
+const reimported = parseThemeImport(exported)
+assert(reimported.ok !== undefined, 'exported theme re-imports')
+assert(reimported.ok!.name === 'Workshop Amber', 'import keeps the name')
+assert(reimported.ok!.id !== validCustom.id, 'import always assigns a fresh id')
+assert(reimported.ok!.overrides.accent === '#ff8800', 'import keeps overrides')
+
+assert(parseThemeImport('not json').error !== undefined, 'non-JSON import is rejected')
+assert(parseThemeImport('{"foo": 1}').error!.includes('format'), 'missing format marker is rejected')
+assert(
+  parseThemeImport(JSON.stringify({ format: 'purecutcnc-theme', schemaVersion: 2, theme: validCustom }))
+    .error!.includes('schema version'),
+  'newer schema version is rejected with a readable error',
+)
+assert(
+  parseThemeImport(JSON.stringify({
+    format: 'purecutcnc-theme',
+    schemaVersion: 1,
+    theme: { ...validCustom, overrides: { accent: 'expression(alert(1))' } },
+  })).error !== undefined,
+  'imports with invalid colors are rejected',
+)
+
+console.log('registry tests passed')

--- a/src/theme/registry.ts
+++ b/src/theme/registry.ts
@@ -1,0 +1,493 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Versioned theme registry. Built-in themes are complete, code-owned,
+ * immutable definitions; a custom theme stores only a base built-in ID plus
+ * allowlisted token overrides, and is resolved to a complete palette here.
+ *
+ * The `css`-kind values of the built-ins mirror the `:root` blocks in
+ * `src/index.css` (enforced by a structural test); `canvas`/`three` values
+ * come from `THEME_PALETTES`. A future curated theme is a new declarative
+ * definition in this file — never a component-specific CSS branch.
+ */
+
+import { normalizeColorValue, parseColor } from './color'
+import { THEME_PALETTES, type ThemePalette } from './palette'
+import { isThemeTokenKey, themeTokenKeys, type ThemeTokenKey } from './tokens'
+
+export type ThemeFamily = 'dark' | 'light'
+
+export const BUILTIN_THEME_IDS = ['dark', 'light'] as const
+export type BuiltinThemeId = (typeof BUILTIN_THEME_IDS)[number]
+
+export function isBuiltinThemeId(id: string): id is BuiltinThemeId {
+  return BUILTIN_THEME_IDS.some((builtin) => builtin === id)
+}
+
+/** Complete token → color value map for one theme. */
+export type ThemeValues = Record<ThemeTokenKey, string>
+
+export interface BuiltinThemeDefinition {
+  id: BuiltinThemeId
+  name: string
+  detail: string
+  family: ThemeFamily
+  values: ThemeValues
+}
+
+function threeHex(value: number): string {
+  return `#${value.toString(16).padStart(6, '0')}`
+}
+
+function paletteValues(family: ThemeFamily): Record<string, string> {
+  const palette = THEME_PALETTES[family]
+  return {
+    'canvas.background': palette.canvas.background,
+    'canvas.gridMajor': palette.canvas.gridMajor,
+    'canvas.gridMinor': palette.canvas.gridMinor,
+    'canvas.labelBackground': palette.canvas.labelBackground,
+    'canvas.labelText': palette.canvas.labelText,
+    'canvas.mutedGeometry': palette.canvas.mutedGeometry,
+    'canvas.veil': palette.canvas.veil,
+    'three.background': threeHex(palette.three.background),
+    'three.gridMinorCenter': threeHex(palette.three.gridMinorCenter),
+    'three.gridMinor': threeHex(palette.three.gridMinor),
+    'three.gridMajorCenter': threeHex(palette.three.gridMajorCenter),
+    'three.gridMajor': threeHex(palette.three.gridMajor),
+  }
+}
+
+/**
+ * Built-in `css` token values. These must stay byte-identical to the
+ * `:root` / `:root[data-theme='light']` declarations in `src/index.css`;
+ * `registry.test.ts` parses that file and fails on any drift.
+ */
+const DARK_CSS_VALUES: Record<string, string> = {
+  bg: '#0a1016',
+  'bg-elev-1': '#101821',
+  'bg-elev-2': '#16222d',
+  line: '#2a3a49',
+  'line-strong': '#3c5265',
+  text: '#d8e4ef',
+  'text-dim': '#94aabc',
+  'status-text': '#d8e4ef',
+  'status-text-muted': '#aebfcd',
+  accent: '#dca56a',
+  'accent-strong': '#eab982',
+  add: '#6abb81',
+  cut: '#5a8fcc',
+  'surface-app': '#0a1016',
+  'surface-canvas': '#0f151d',
+  'surface-panel': '#0f1820',
+  'surface-subtle': '#0d141c',
+  'surface-raised': 'rgba(16, 24, 33, 0.94)',
+  'surface-popover': 'rgba(12, 18, 26, 0.96)',
+  'surface-translucent': 'rgba(10, 18, 27, 0.85)',
+  'surface-input': 'rgba(7, 12, 17, 0.72)',
+  'surface-hover': 'rgba(255, 255, 255, 0.06)',
+  'surface-control-top': '#2a3a4c',
+  'surface-control-bottom': '#17232f',
+  'surface-button-top': '#24374a',
+  'surface-button-bottom': '#13202c',
+  'surface-sheen': 'rgba(255, 255, 255, 0.04)',
+  'surface-sheen-soft': 'rgba(255, 255, 255, 0.03)',
+  'surface-sheen-mid': 'rgba(255, 255, 255, 0.05)',
+  'surface-sheen-strong': 'rgba(255, 255, 255, 0.08)',
+  'surface-inset': 'rgba(0, 0, 0, 0.28)',
+  shadow: 'rgba(0, 0, 0, 0.35)',
+  'shadow-strong': 'rgba(0, 0, 0, 0.45)',
+  'accent-soft': 'rgba(220, 165, 106, 0.12)',
+  'surface-active-top': '#3d4f61',
+  'surface-active-bottom': '#202d3a',
+  'on-accent': '#fff',
+  'danger-text': '#f0bbb6',
+  'warning-text': '#f7b86a',
+  'role-line': '#5a8fcc',
+  'role-line-text': '#8fb6f4',
+  'role-region': '#9966cc',
+  'role-region-text': '#c4a6e0',
+  'role-construction': '#8a9aab',
+  'role-construction-text': '#a9b6c4',
+}
+
+const LIGHT_CSS_VALUES: Record<string, string> = {
+  bg: '#eee8dd',
+  'bg-elev-1': '#f8f4ec',
+  'bg-elev-2': '#e5ddcf',
+  line: '#c9bdab',
+  'line-strong': '#a99a84',
+  text: '#253039',
+  'text-dim': '#657078',
+  'status-text': '#253039',
+  'status-text-muted': '#4f5a61',
+  accent: '#a66126',
+  'accent-strong': '#874717',
+  add: '#39794d',
+  cut: '#356f9d',
+  'surface-app': '#eee8dd',
+  'surface-canvas': '#f6f1e7',
+  'surface-panel': '#f9f5ed',
+  'surface-subtle': '#e9e1d4',
+  'surface-raised': 'rgba(252, 249, 242, 0.97)',
+  'surface-popover': 'rgba(252, 249, 242, 0.98)',
+  'surface-translucent': 'rgba(247, 243, 235, 0.94)',
+  'surface-input': 'rgba(255, 252, 247, 0.94)',
+  'surface-hover': 'rgba(88, 70, 46, 0.08)',
+  'surface-control-top': '#fdfaf4',
+  'surface-control-bottom': '#e5dccd',
+  'surface-button-top': '#f8f3e9',
+  'surface-button-bottom': '#ddd3c3',
+  'surface-sheen': 'rgba(255, 255, 255, 0.54)',
+  'surface-sheen-soft': 'rgba(255, 255, 255, 0.34)',
+  'surface-sheen-mid': 'rgba(255, 255, 255, 0.46)',
+  'surface-sheen-strong': 'rgba(255, 255, 255, 0.72)',
+  'surface-inset': 'rgba(69, 54, 36, 0.13)',
+  shadow: 'rgba(55, 43, 28, 0.18)',
+  'shadow-strong': 'rgba(55, 43, 28, 0.24)',
+  'accent-soft': 'rgba(166, 97, 38, 0.12)',
+  'surface-active-top': '#ead6bf',
+  'surface-active-bottom': '#cbb293',
+  'on-accent': '#fffaf3',
+  'danger-text': '#91443e',
+  'warning-text': '#8b4c17',
+  'role-line': '#356f9d',
+  'role-line-text': '#285d87',
+  'role-region': '#7947a5',
+  'role-region-text': '#673b8c',
+  'role-construction': '#60778b',
+  'role-construction-text': '#4e6477',
+}
+
+function completeValues(family: ThemeFamily, cssValues: Record<string, string>): ThemeValues {
+  const merged: Record<string, string> = { ...cssValues, ...paletteValues(family) }
+  const values = {} as Record<ThemeTokenKey, string>
+  for (const key of themeTokenKeys()) {
+    const value = merged[key]
+    if (value === undefined) throw new Error(`Built-in ${family} theme is missing token: ${key}`)
+    values[key] = value
+  }
+  return values
+}
+
+export const BUILTIN_THEMES: readonly BuiltinThemeDefinition[] = [
+  {
+    id: 'dark',
+    name: 'Dark',
+    detail: 'Low-light workshop',
+    family: 'dark',
+    values: completeValues('dark', DARK_CSS_VALUES),
+  },
+  {
+    id: 'light',
+    name: 'Light',
+    detail: 'Drafting paper',
+    family: 'light',
+    values: completeValues('light', LIGHT_CSS_VALUES),
+  },
+] as const
+
+export function builtinTheme(id: BuiltinThemeId): BuiltinThemeDefinition {
+  const theme = BUILTIN_THEMES.find((definition) => definition.id === id)
+  if (!theme) throw new Error(`Unknown built-in theme: ${id}`)
+  return theme
+}
+
+export const CUSTOM_THEME_SCHEMA_VERSION = 1
+
+/** A user-created theme: application-local preference data, never project data. */
+export interface CustomThemeData {
+  schemaVersion: typeof CUSTOM_THEME_SCHEMA_VERSION
+  id: string
+  name: string
+  family: ThemeFamily
+  baseThemeId: BuiltinThemeId
+  overrides: Partial<Record<ThemeTokenKey, string>>
+}
+
+export type ThemeValidationResult =
+  | { ok: CustomThemeData; error?: undefined }
+  | { ok?: undefined; error: string }
+
+export const THEME_NAME_MAX_LENGTH = 60
+
+const ALLOWED_CUSTOM_THEME_KEYS = new Set([
+  'schemaVersion',
+  'id',
+  'name',
+  'family',
+  'baseThemeId',
+  'overrides',
+])
+
+/**
+ * Validate untrusted custom-theme data (storage, import). Unknown tokens,
+ * invalid color values, unknown properties, and incompatible schema versions
+ * are rejected with a readable message. Color values are normalized so stored
+ * data stays canonical.
+ */
+export function validateCustomTheme(input: unknown): ThemeValidationResult {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    return { error: 'Theme must be a JSON object.' }
+  }
+  const record = input as Record<string, unknown>
+
+  for (const key of Object.keys(record)) {
+    if (!ALLOWED_CUSTOM_THEME_KEYS.has(key)) {
+      return { error: `Unknown theme property: "${key}".` }
+    }
+  }
+
+  if (record.schemaVersion !== CUSTOM_THEME_SCHEMA_VERSION) {
+    return {
+      error: `Unsupported theme schema version: ${String(record.schemaVersion)}. This app supports version ${CUSTOM_THEME_SCHEMA_VERSION}.`,
+    }
+  }
+  if (typeof record.id !== 'string' || record.id.trim() === '') {
+    return { error: 'Theme is missing a valid "id".' }
+  }
+  const name = typeof record.name === 'string' ? record.name.trim() : ''
+  if (name === '') {
+    return { error: 'Theme is missing a display "name".' }
+  }
+  if (name.length > THEME_NAME_MAX_LENGTH) {
+    return { error: `Theme name is longer than ${THEME_NAME_MAX_LENGTH} characters.` }
+  }
+  if (record.family !== 'dark' && record.family !== 'light') {
+    return { error: 'Theme "family" must be "dark" or "light".' }
+  }
+  if (typeof record.baseThemeId !== 'string' || !isBuiltinThemeId(record.baseThemeId)) {
+    return { error: `Theme "baseThemeId" must be a built-in theme (${BUILTIN_THEME_IDS.join(', ')}).` }
+  }
+  if (typeof record.overrides !== 'object' || record.overrides === null || Array.isArray(record.overrides)) {
+    return { error: 'Theme "overrides" must be an object of token colors.' }
+  }
+
+  const overrides: Partial<Record<ThemeTokenKey, string>> = {}
+  for (const [key, value] of Object.entries(record.overrides as Record<string, unknown>)) {
+    if (!isThemeTokenKey(key)) {
+      return { error: `Unknown theme token: "${key}". Only allowlisted semantic colors can be themed.` }
+    }
+    if (typeof value !== 'string') {
+      return { error: `Token "${key}" must be a color string.` }
+    }
+    const normalized = normalizeColorValue(value)
+    if (normalized === null) {
+      return { error: `Token "${key}" has an invalid color value: "${value}". Use hex or rgb()/rgba().` }
+    }
+    overrides[key] = normalized
+  }
+
+  return {
+    ok: {
+      schemaVersion: CUSTOM_THEME_SCHEMA_VERSION,
+      id: record.id.trim(),
+      name,
+      family: record.family,
+      baseThemeId: record.baseThemeId,
+      overrides,
+    },
+  }
+}
+
+/** A theme resolved to its complete runtime palette. */
+export interface ResolvedThemeDefinition {
+  id: string
+  name: string
+  family: ThemeFamily
+  builtin: boolean
+  baseThemeId: BuiltinThemeId
+  values: ThemeValues
+  overriddenKeys: ThemeTokenKey[]
+}
+
+export function resolveBuiltinTheme(id: BuiltinThemeId): ResolvedThemeDefinition {
+  const definition = builtinTheme(id)
+  return {
+    id: definition.id,
+    name: definition.name,
+    family: definition.family,
+    builtin: true,
+    baseThemeId: definition.id,
+    values: { ...definition.values },
+    overriddenKeys: [],
+  }
+}
+
+export function resolveCustomTheme(custom: CustomThemeData): ResolvedThemeDefinition {
+  const base = builtinTheme(custom.baseThemeId)
+  const values = { ...base.values }
+  const overriddenKeys: ThemeTokenKey[] = []
+  for (const key of themeTokenKeys()) {
+    const override = custom.overrides[key]
+    if (override !== undefined && override !== base.values[key]) {
+      values[key] = override
+      overriddenKeys.push(key)
+    }
+  }
+  return {
+    id: custom.id,
+    name: custom.name,
+    family: custom.family,
+    builtin: false,
+    baseThemeId: custom.baseThemeId,
+    values,
+    overriddenKeys,
+  }
+}
+
+/**
+ * Resolve any theme ID to a complete palette. Unknown IDs (e.g. a deleted
+ * custom theme referenced by a stale preference) fall back to the built-in
+ * of the requested fallback family so the app always has a readable theme.
+ */
+export function resolveThemeById(
+  id: string,
+  customThemes: readonly CustomThemeData[],
+  fallbackFamily: ThemeFamily = 'dark',
+): ResolvedThemeDefinition {
+  if (isBuiltinThemeId(id)) return resolveBuiltinTheme(id)
+  const custom = customThemes.find((theme) => theme.id === id)
+  if (custom) return resolveCustomTheme(custom)
+  return resolveBuiltinTheme(fallbackFamily)
+}
+
+/** Convert a complete value map into the runtime canvas/Three palette shape. */
+export function themePaletteFromValues(values: ThemeValues): ThemePalette {
+  const threeNumber = (key: ThemeTokenKey): number => {
+    const parsed = parseColor(values[key])
+    if (!parsed) return 0
+    return (parsed.r << 16) | (parsed.g << 8) | parsed.b
+  }
+  return {
+    canvas: {
+      background: values['canvas.background'],
+      gridMajor: values['canvas.gridMajor'],
+      gridMinor: values['canvas.gridMinor'],
+      labelBackground: values['canvas.labelBackground'],
+      labelText: values['canvas.labelText'],
+      mutedGeometry: values['canvas.mutedGeometry'],
+      veil: values['canvas.veil'],
+    },
+    three: {
+      background: threeNumber('three.background'),
+      gridMinorCenter: threeNumber('three.gridMinorCenter'),
+      gridMinor: threeNumber('three.gridMinor'),
+      gridMajorCenter: threeNumber('three.gridMajorCenter'),
+      gridMajor: threeNumber('three.gridMajor'),
+    },
+  }
+}
+
+/**
+ * The `--*` custom properties a resolved theme needs inline on the root,
+ * on top of the family's static CSS block: exactly the `css`-kind values
+ * that differ from the family built-in.
+ */
+export function cssOverridesFromValues(values: ThemeValues, family: ThemeFamily): Record<string, string> {
+  const base = builtinTheme(family).values
+  const overrides: Record<string, string> = {}
+  for (const key of themeTokenKeys('css')) {
+    if (values[key] !== base[key]) overrides[`--${key}`] = values[key]
+  }
+  return overrides
+}
+
+export function createCustomThemeId(): string {
+  const cryptoApi = typeof globalThis.crypto !== 'undefined' ? globalThis.crypto : undefined
+  if (cryptoApi && typeof cryptoApi.randomUUID === 'function') {
+    return `custom-${cryptoApi.randomUUID()}`
+  }
+  return `custom-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+/** A unique "Name copy"/"Name copy 2" style name for a duplicated theme. */
+export function duplicateThemeName(sourceName: string, existingNames: readonly string[]): string {
+  const taken = new Set(existingNames.map((name) => name.toLowerCase()))
+  const base = `${sourceName} copy`.slice(0, THEME_NAME_MAX_LENGTH)
+  if (!taken.has(base.toLowerCase())) return base
+  for (let n = 2; ; n += 1) {
+    const suffix = ` ${n}`
+    const candidate = `${sourceName} copy`.slice(0, THEME_NAME_MAX_LENGTH - suffix.length) + suffix
+    if (!taken.has(candidate.toLowerCase())) return candidate
+  }
+}
+
+/** Duplicate any resolved theme into a new editable custom theme. */
+export function duplicateThemeAsCustom(
+  source: ResolvedThemeDefinition,
+  existingNames: readonly string[],
+): CustomThemeData {
+  const base = builtinTheme(source.baseThemeId)
+  const overrides: Partial<Record<ThemeTokenKey, string>> = {}
+  for (const key of themeTokenKeys()) {
+    if (source.values[key] !== base.values[key]) overrides[key] = source.values[key]
+  }
+  return {
+    schemaVersion: CUSTOM_THEME_SCHEMA_VERSION,
+    id: createCustomThemeId(),
+    name: duplicateThemeName(source.name, existingNames),
+    family: source.family,
+    baseThemeId: source.baseThemeId,
+    overrides,
+  }
+}
+
+export const THEME_EXPORT_FORMAT = 'purecutcnc-theme'
+
+interface ThemeExportEnvelope {
+  format: typeof THEME_EXPORT_FORMAT
+  schemaVersion: typeof CUSTOM_THEME_SCHEMA_VERSION
+  theme: CustomThemeData
+}
+
+export function serializeThemeExport(theme: CustomThemeData): string {
+  const envelope: ThemeExportEnvelope = {
+    format: THEME_EXPORT_FORMAT,
+    schemaVersion: CUSTOM_THEME_SCHEMA_VERSION,
+    theme,
+  }
+  return JSON.stringify(envelope, null, 2)
+}
+
+/**
+ * Parse and validate an imported theme JSON file. The imported theme keeps
+ * its colors but always receives a fresh local ID so it can never collide
+ * with an existing theme.
+ */
+export function parseThemeImport(json: string): ThemeValidationResult {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(json)
+  } catch {
+    return { error: 'Not a valid JSON file.' }
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { error: 'Theme file must contain a JSON object.' }
+  }
+  const record = parsed as Record<string, unknown>
+  if (record.format !== THEME_EXPORT_FORMAT) {
+    return { error: `Not a PureCutCNC theme file (missing "format": "${THEME_EXPORT_FORMAT}").` }
+  }
+  if (record.schemaVersion !== CUSTOM_THEME_SCHEMA_VERSION) {
+    return {
+      error: `Unsupported theme schema version: ${String(record.schemaVersion)}. This app supports version ${CUSTOM_THEME_SCHEMA_VERSION}.`,
+    }
+  }
+  const validated = validateCustomTheme(record.theme)
+  if (validated.error !== undefined) return validated
+  return { ok: { ...validated.ok, id: createCustomThemeId() } }
+}

--- a/src/theme/selection.test.ts
+++ b/src/theme/selection.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CustomThemeData } from './registry'
+import {
+  activeThemeIdForSelection,
+  CUSTOM_THEMES_STORAGE_KEY,
+  DEFAULT_THEME_SELECTION,
+  legacyPreferenceForSelection,
+  readStoredCustomThemes,
+  readThemeSelection,
+  resolveActiveTheme,
+  sanitizeStoredCustomThemes,
+  selectionFromLegacyPreference,
+  selectionWithThemeRemoved,
+  THEME_SELECTION_STORAGE_KEY,
+  themeSelectionCodec,
+  type ThemeSelection,
+} from './selection'
+import { THEME_STORAGE_KEY } from './theme'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+const customDark: CustomThemeData = {
+  schemaVersion: 1,
+  id: 'custom-night',
+  name: 'Night Shift',
+  family: 'dark',
+  baseThemeId: 'dark',
+  overrides: { accent: '#ff8800' },
+}
+
+const customLight: CustomThemeData = {
+  schemaVersion: 1,
+  id: 'custom-paper',
+  name: 'Paper',
+  family: 'light',
+  baseThemeId: 'light',
+  overrides: {},
+}
+
+function storageOf(entries: Record<string, string>): Pick<Storage, 'getItem'> {
+  return { getItem: (key: string) => (key in entries ? entries[key] : null) }
+}
+
+// --- Codec ------------------------------------------------------------------
+
+const roundTripped = themeSelectionCodec.deserialize(
+  themeSelectionCodec.serialize({
+    mode: 'system',
+    fixedThemeId: 'custom-night',
+    systemLightThemeId: 'custom-paper',
+    systemDarkThemeId: 'custom-night',
+  }),
+)
+assert(roundTripped.mode === 'system' && roundTripped.systemLightThemeId === 'custom-paper', 'selection codec round-trips')
+
+let codecThrew = false
+try {
+  themeSelectionCodec.deserialize('{"mode":"nope"}')
+} catch {
+  codecThrew = true
+}
+assert(codecThrew, 'invalid selection payload throws (falls back to default upstream)')
+
+// --- Legacy migration --------------------------------------------------------
+
+assert(selectionFromLegacyPreference('dark').mode === 'fixed', 'legacy dark migrates to fixed mode')
+assert(selectionFromLegacyPreference('light').fixedThemeId === 'light', 'legacy light migrates to the light theme')
+assert(selectionFromLegacyPreference('system').mode === 'system', 'legacy system migrates to system mode')
+assert(selectionFromLegacyPreference('system').systemLightThemeId === 'light', 'legacy system uses the default pair')
+
+assert(
+  readThemeSelection(storageOf({ [THEME_STORAGE_KEY]: 'light' }), THEME_STORAGE_KEY).fixedThemeId === 'light',
+  'legacy preference is migrated on read',
+)
+const v2Wins = readThemeSelection(
+  storageOf({
+    [THEME_STORAGE_KEY]: 'light',
+    [THEME_SELECTION_STORAGE_KEY]: JSON.stringify({
+      mode: 'fixed',
+      fixedThemeId: 'custom-night',
+      systemLightThemeId: 'light',
+      systemDarkThemeId: 'dark',
+    }),
+  }),
+  THEME_STORAGE_KEY,
+)
+assert(v2Wins.fixedThemeId === 'custom-night', 'versioned selection wins over legacy preference')
+assert(
+  readThemeSelection(storageOf({ [THEME_SELECTION_STORAGE_KEY]: 'garbage' }), THEME_STORAGE_KEY).fixedThemeId
+    === DEFAULT_THEME_SELECTION.fixedThemeId,
+  'corrupt selection falls back to the default',
+)
+assert(readThemeSelection(null, THEME_STORAGE_KEY).mode === 'fixed', 'missing storage falls back to the default')
+assert(
+  readThemeSelection({ getItem: () => { throw new Error('disabled') } }, THEME_STORAGE_KEY).fixedThemeId === 'dark',
+  'storage errors fall back to the default',
+)
+
+// --- Legacy write-back --------------------------------------------------------
+
+assert(
+  legacyPreferenceForSelection({ ...DEFAULT_THEME_SELECTION, fixedThemeId: 'custom-night' }, [customDark]) === 'dark',
+  'fixed custom dark-family theme writes back as legacy dark',
+)
+assert(
+  legacyPreferenceForSelection({ ...DEFAULT_THEME_SELECTION, fixedThemeId: 'custom-paper' }, [customLight]) === 'light',
+  'fixed custom light-family theme writes back as legacy light',
+)
+assert(
+  legacyPreferenceForSelection({ ...DEFAULT_THEME_SELECTION, mode: 'system' }, []) === 'system',
+  'system mode writes back as legacy system',
+)
+
+// --- Active theme resolution ---------------------------------------------------
+
+const pairSelection: ThemeSelection = {
+  mode: 'system',
+  fixedThemeId: 'dark',
+  systemLightThemeId: 'custom-paper',
+  systemDarkThemeId: 'custom-night',
+}
+assert(activeThemeIdForSelection(pairSelection, true) === 'custom-night', 'system+dark picks the dark slot')
+assert(activeThemeIdForSelection(pairSelection, false) === 'custom-paper', 'system+light picks the light slot')
+assert(
+  activeThemeIdForSelection({ ...pairSelection, mode: 'fixed' }, true) === 'dark',
+  'fixed mode ignores the system scheme',
+)
+
+const resolvedPairDark = resolveActiveTheme(pairSelection, true, [customDark, customLight])
+assert(resolvedPairDark.id === 'custom-night' && resolvedPairDark.values.accent === '#ff8800', 'system pair resolves the custom dark theme')
+const resolvedPairLight = resolveActiveTheme(pairSelection, false, [customDark, customLight])
+assert(resolvedPairLight.id === 'custom-paper' && resolvedPairLight.family === 'light', 'system pair resolves the custom light theme')
+
+const staleDark = resolveActiveTheme(pairSelection, true, [customLight])
+assert(staleDark.id === 'dark', 'a stale dark-slot id falls back to built-in dark')
+const staleLight = resolveActiveTheme(pairSelection, false, [customDark])
+assert(staleLight.id === 'light', 'a stale light-slot id falls back to built-in light')
+
+// --- Deletion fallback -----------------------------------------------------------
+
+const afterDelete = selectionWithThemeRemoved(pairSelection, 'custom-night', 'dark')
+assert(afterDelete.systemDarkThemeId === 'dark', 'deleting a theme rewrites the dark slot to its base')
+assert(afterDelete.systemLightThemeId === 'custom-paper', 'unrelated slots are untouched')
+const fixedDelete = selectionWithThemeRemoved(
+  { ...DEFAULT_THEME_SELECTION, fixedThemeId: 'custom-night' },
+  'custom-night',
+  'dark',
+)
+assert(fixedDelete.fixedThemeId === 'dark', 'deleting the active fixed theme falls back to its base')
+
+// --- Stored custom themes ----------------------------------------------------------
+
+const sanitized = sanitizeStoredCustomThemes([
+  customDark,
+  { ...customDark },
+  { ...customLight, overrides: { 'not-a-token': '#fff' } },
+  { ...customLight, id: 'dark' },
+  customLight,
+  'garbage',
+])
+assert(sanitized.length === 2, 'invalid, duplicate, and builtin-shadowing entries are dropped')
+assert(sanitized[0].id === 'custom-night' && sanitized[1].id === 'custom-paper', 'valid entries survive in order')
+
+assert(
+  readStoredCustomThemes(storageOf({ [CUSTOM_THEMES_STORAGE_KEY]: 'not json' })).length === 0,
+  'corrupt custom theme storage yields an empty list',
+)
+assert(
+  readStoredCustomThemes(storageOf({ [CUSTOM_THEMES_STORAGE_KEY]: JSON.stringify([customDark]) }))[0].id === 'custom-night',
+  'stored custom themes load',
+)
+
+console.log('selection tests passed')

--- a/src/theme/selection.ts
+++ b/src/theme/selection.ts
@@ -1,0 +1,203 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Theme selection model: which theme is active in fixed mode, and which
+ * light/dark pair System mode follows. Persisted in namespaced local storage
+ * as application preferences (never in `.camj` project data). The legacy
+ * `dark | light | system` preference from the first appearance release is
+ * migrated on read and kept in sync on write so older builds stay usable.
+ */
+
+import type { StorageCodec } from '../hooks/useLocalStorageState'
+import {
+  isBuiltinThemeId,
+  resolveThemeById,
+  validateCustomTheme,
+  type CustomThemeData,
+  type ResolvedThemeDefinition,
+} from './registry'
+import { isThemePreference, type ThemePreference } from './theme'
+
+export const THEME_SELECTION_STORAGE_KEY = 'purecutcnc.appearance.themeSelection'
+export const CUSTOM_THEMES_STORAGE_KEY = 'purecutcnc.appearance.customThemes'
+
+export type ThemeSelectionMode = 'fixed' | 'system'
+
+/**
+ * One record holds the fixed choice and the System pair so switching modes
+ * never forgets the other configuration.
+ */
+export interface ThemeSelection {
+  mode: ThemeSelectionMode
+  fixedThemeId: string
+  systemLightThemeId: string
+  systemDarkThemeId: string
+}
+
+export const DEFAULT_THEME_SELECTION: ThemeSelection = {
+  mode: 'fixed',
+  fixedThemeId: 'dark',
+  systemLightThemeId: 'light',
+  systemDarkThemeId: 'dark',
+}
+
+function isValidSelection(value: unknown): value is ThemeSelection {
+  if (typeof value !== 'object' || value === null) return false
+  const record = value as Record<string, unknown>
+  return (
+    (record.mode === 'fixed' || record.mode === 'system')
+    && typeof record.fixedThemeId === 'string' && record.fixedThemeId !== ''
+    && typeof record.systemLightThemeId === 'string' && record.systemLightThemeId !== ''
+    && typeof record.systemDarkThemeId === 'string' && record.systemDarkThemeId !== ''
+  )
+}
+
+export const themeSelectionCodec: StorageCodec<ThemeSelection> = {
+  serialize: (value) => JSON.stringify(value),
+  deserialize: (raw) => {
+    const parsed: unknown = JSON.parse(raw)
+    if (isValidSelection(parsed)) {
+      return {
+        mode: parsed.mode,
+        fixedThemeId: parsed.fixedThemeId,
+        systemLightThemeId: parsed.systemLightThemeId,
+        systemDarkThemeId: parsed.systemDarkThemeId,
+      }
+    }
+    throw new Error('Unsupported theme selection payload')
+  },
+}
+
+export function selectionFromLegacyPreference(preference: ThemePreference): ThemeSelection {
+  if (preference === 'system') return { ...DEFAULT_THEME_SELECTION, mode: 'system' }
+  return { ...DEFAULT_THEME_SELECTION, mode: 'fixed', fixedThemeId: preference }
+}
+
+/**
+ * The closest legacy `dark | light | system` value for a selection, written
+ * back to the original storage key so downgrading the app keeps a sensible
+ * appearance.
+ */
+export function legacyPreferenceForSelection(
+  selection: ThemeSelection,
+  customThemes: readonly CustomThemeData[],
+): ThemePreference {
+  if (selection.mode === 'system') return 'system'
+  return resolveThemeById(selection.fixedThemeId, customThemes).family
+}
+
+/**
+ * Read the persisted selection: the versioned key wins, a legacy preference
+ * migrates, and anything unreadable falls back to the default (Dark).
+ */
+export function readThemeSelection(
+  storage: Pick<Storage, 'getItem'> | null,
+  legacyStorageKey: string,
+): ThemeSelection {
+  if (!storage) return DEFAULT_THEME_SELECTION
+  try {
+    const stored = storage.getItem(THEME_SELECTION_STORAGE_KEY)
+    if (stored !== null) return themeSelectionCodec.deserialize(stored)
+  } catch {
+    // Fall through to legacy migration.
+  }
+  try {
+    const legacy = storage.getItem(legacyStorageKey)
+    if (legacy !== null && isThemePreference(legacy)) return selectionFromLegacyPreference(legacy)
+  } catch {
+    // Storage unavailable — use the default.
+  }
+  return DEFAULT_THEME_SELECTION
+}
+
+/**
+ * Parse the stored custom theme list. Invalid entries and duplicate IDs are
+ * dropped individually so one corrupt record can never take down the whole
+ * theme system.
+ */
+export function sanitizeStoredCustomThemes(raw: unknown): CustomThemeData[] {
+  if (!Array.isArray(raw)) return []
+  const themes: CustomThemeData[] = []
+  const seen = new Set<string>()
+  for (const entry of raw) {
+    const validated = validateCustomTheme(entry)
+    if (validated.ok !== undefined && !seen.has(validated.ok.id) && !isBuiltinThemeId(validated.ok.id)) {
+      seen.add(validated.ok.id)
+      themes.push(validated.ok)
+    }
+  }
+  return themes
+}
+
+export const customThemesCodec: StorageCodec<CustomThemeData[]> = {
+  serialize: (value) => JSON.stringify(value),
+  deserialize: (raw) => sanitizeStoredCustomThemes(JSON.parse(raw)),
+}
+
+export function readStoredCustomThemes(storage: Pick<Storage, 'getItem'> | null): CustomThemeData[] {
+  if (!storage) return []
+  try {
+    const stored = storage.getItem(CUSTOM_THEMES_STORAGE_KEY)
+    if (stored === null) return []
+    return customThemesCodec.deserialize(stored)
+  } catch {
+    return []
+  }
+}
+
+/** The theme ID the selection activates for the current system scheme. */
+export function activeThemeIdForSelection(selection: ThemeSelection, systemPrefersDark: boolean): string {
+  if (selection.mode === 'system') {
+    return systemPrefersDark ? selection.systemDarkThemeId : selection.systemLightThemeId
+  }
+  return selection.fixedThemeId
+}
+
+/**
+ * Resolve the active theme for a selection. A stale ID (e.g. a custom theme
+ * removed from storage out-of-band) falls back to the built-in matching the
+ * slot's family so System mode keeps following the OS scheme.
+ */
+export function resolveActiveTheme(
+  selection: ThemeSelection,
+  systemPrefersDark: boolean,
+  customThemes: readonly CustomThemeData[],
+): ResolvedThemeDefinition {
+  const id = activeThemeIdForSelection(selection, systemPrefersDark)
+  const fallbackFamily = selection.mode === 'system'
+    ? (systemPrefersDark ? 'dark' : 'light')
+    : 'dark'
+  return resolveThemeById(id, customThemes, fallbackFamily)
+}
+
+/**
+ * Rewrite a selection after a custom theme is deleted: every slot referencing
+ * the deleted theme explicitly falls back to that theme's base built-in.
+ */
+export function selectionWithThemeRemoved(
+  selection: ThemeSelection,
+  removedThemeId: string,
+  baseThemeId: string,
+): ThemeSelection {
+  const replace = (id: string) => (id === removedThemeId ? baseThemeId : id)
+  return {
+    mode: selection.mode,
+    fixedThemeId: replace(selection.fixedThemeId),
+    systemLightThemeId: replace(selection.systemLightThemeId),
+    systemDarkThemeId: replace(selection.systemDarkThemeId),
+  }
+}

--- a/src/theme/theme.test.ts
+++ b/src/theme/theme.test.ts
@@ -15,13 +15,15 @@
  */
 
 import {
-  applyThemeToRoot,
+  applyResolvedThemeToRoot,
   readThemePreference,
   resolveThemePreference,
   THEME_STORAGE_KEY,
   themePreferenceCodec,
+  type ThemeRoot,
 } from './theme'
 import { THEME_PALETTES } from './palette'
+import { resolveBuiltinTheme, resolveCustomTheme } from './registry'
 
 function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
@@ -40,14 +42,44 @@ assert(readThemePreference({ getItem: () => 'unknown' }) === 'dark', 'invalid pr
 assert(readThemePreference({ getItem: () => { throw new Error('disabled') } }) === 'dark', 'storage errors fall back')
 assert(themePreferenceCodec.deserialize(themePreferenceCodec.serialize('light')) === 'light', 'codec round-trips')
 
-const root: {
-  dataset: { theme?: string; themePreference?: string }
-  style: { colorScheme: string }
-} = { dataset: {}, style: { colorScheme: '' } }
-applyThemeToRoot(root, 'system', 'light')
-assert(root.dataset.theme === 'light', 'resolved theme is written to data-theme')
-assert(root.dataset.themePreference === 'system', 'preference is exposed for diagnostics')
+function makeRoot(): ThemeRoot & { properties: Map<string, string> } {
+  const properties = new Map<string, string>()
+  return {
+    dataset: {},
+    properties,
+    style: {
+      colorScheme: '',
+      setProperty: (name: string, value: string) => { properties.set(name, value) },
+      removeProperty: (name: string) => { properties.delete(name) },
+    },
+  }
+}
+
+const root = makeRoot()
+applyResolvedThemeToRoot(root, 'system', resolveBuiltinTheme('light'))
+assert(root.dataset.theme === 'light', 'resolved family is written to data-theme')
+assert(root.dataset.themePreference === 'system', 'selection mode is exposed for diagnostics')
+assert(root.dataset.themeId === 'light', 'active theme id is exposed for diagnostics')
 assert(root.style.colorScheme === 'light', 'native controls receive the resolved color scheme')
+assert(root.properties.size === 0, 'built-in themes apply no inline overrides')
+
+const customized = resolveCustomTheme({
+  schemaVersion: 1,
+  id: 'custom-test',
+  name: 'Test',
+  family: 'dark',
+  baseThemeId: 'dark',
+  overrides: { accent: '#ff8800' },
+})
+applyResolvedThemeToRoot(root, 'fixed', customized)
+assert(root.dataset.theme === 'dark', 'custom theme applies its family')
+assert(root.dataset.themePreference === 'dark', 'fixed mode reports the family for diagnostics')
+assert(root.dataset.themeId === 'custom-test', 'custom theme id is exposed')
+assert(root.properties.get('--accent') === '#ff8800', 'override lands as an inline custom property')
+assert(root.properties.size === 1, 'only changed tokens are applied inline')
+
+applyResolvedThemeToRoot(root, 'fixed', resolveBuiltinTheme('dark'))
+assert(root.properties.size === 0, 'switching back to a built-in clears stale inline overrides')
 
 assert(THEME_PALETTES.dark.canvas.background !== THEME_PALETTES.light.canvas.background, 'canvas palettes differ')
 assert(THEME_PALETTES.dark.three.background !== THEME_PALETTES.light.three.background, 'Three palettes differ')

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -15,6 +15,8 @@
  */
 
 import type { StorageCodec } from '../hooks/useLocalStorageState'
+import { cssOverridesFromValues, type ResolvedThemeDefinition } from './registry'
+import { themeTokenKeys } from './tokens'
 
 export const THEME_STORAGE_KEY = 'purecutcnc.appearance.theme'
 export const THEME_PREFERENCES = ['dark', 'light', 'system'] as const
@@ -42,13 +44,16 @@ export function resolveThemePreference(
   return preference
 }
 
-interface ThemeRoot {
+export interface ThemeRoot {
   dataset: {
     theme?: string
     themePreference?: string
+    themeId?: string
   }
   style: {
     colorScheme: string
+    setProperty(name: string, value: string): void
+    removeProperty(name: string): void
   }
 }
 
@@ -64,29 +69,33 @@ export function readThemePreference(
   }
 }
 
-export function applyThemeToRoot(
+/**
+ * Apply a resolved theme to the document root: the family drives the static
+ * CSS block via `data-theme` and native controls via `color-scheme`, while
+ * tokens that differ from the family built-in are set as inline custom
+ * properties. Previous inline tokens are always cleared first, so switching
+ * or cancelling a preview can never leave stale colors behind.
+ */
+export function applyResolvedThemeToRoot(
   root: ThemeRoot,
-  preference: ThemePreference,
-  resolvedTheme: ResolvedTheme,
+  mode: 'fixed' | 'system',
+  resolved: ResolvedThemeDefinition,
 ): void {
-  root.dataset.theme = resolvedTheme
-  root.dataset.themePreference = preference
-  root.style.colorScheme = resolvedTheme
+  root.dataset.theme = resolved.family
+  root.dataset.themePreference = mode === 'system' ? 'system' : resolved.family
+  root.dataset.themeId = resolved.id
+  root.style.colorScheme = resolved.family
+
+  for (const key of themeTokenKeys('css')) {
+    root.style.removeProperty(`--${key}`)
+  }
+  for (const [property, value] of Object.entries(cssOverridesFromValues(resolved.values, resolved.family))) {
+    root.style.setProperty(property, value)
+  }
 }
 
 export function getSystemPrefersDark(): boolean {
   return typeof window !== 'undefined'
     && typeof window.matchMedia === 'function'
     && window.matchMedia('(prefers-color-scheme: dark)').matches
-}
-
-/** Applies the stored preference before React renders, preventing a theme flash. */
-export function bootstrapTheme(): ThemePreference {
-  if (typeof document === 'undefined') return 'dark'
-
-  const storage = typeof window === 'undefined' ? null : window.localStorage
-  const preference = readThemePreference(storage)
-  const resolvedTheme = resolveThemePreference(preference, getSystemPrefersDark())
-  applyThemeToRoot(document.documentElement, preference, resolvedTheme)
-  return preference
 }

--- a/src/theme/themeContext.ts
+++ b/src/theme/themeContext.ts
@@ -15,12 +15,49 @@
  */
 
 import { createContext, useContext, type Dispatch, type SetStateAction } from 'react'
+import type { ThemePalette } from './palette'
+import type { CustomThemeData, ResolvedThemeDefinition } from './registry'
+import type { ThemeSelection } from './selection'
 import type { ResolvedTheme, ThemePreference } from './theme'
 
 export interface ThemeContextValue {
+  /** Legacy quick-preference view of the selection (`system` or the active family). */
   preference: ThemePreference
+  /** Family of the theme currently displayed (preview-aware). */
   resolvedTheme: ResolvedTheme
-  setPreference: Dispatch<SetStateAction<ThemePreference>>
+  /** Quick selector: `dark`/`light` activate the built-ins, `system` follows the OS pair. */
+  setPreference: (preference: ThemePreference) => void
+
+  /** Full selection model (fixed theme + System pair). */
+  selection: ThemeSelection
+  setSelection: Dispatch<SetStateAction<ThemeSelection>>
+  /** Locally saved custom themes. */
+  customThemes: CustomThemeData[]
+  /** The saved active theme (ignores any preview). */
+  activeTheme: ResolvedThemeDefinition
+  /** The theme currently displayed: an in-flight preview, or the active theme. */
+  displayedTheme: ResolvedThemeDefinition
+  /** Canvas/Three palette of the displayed theme. */
+  palette: ThemePalette
+  systemPrefersDark: boolean
+
+  /** Activate a theme as the fixed selection. */
+  activateTheme: (themeId: string) => void
+  /** Insert or update a custom theme by id. */
+  saveCustomTheme: (theme: CustomThemeData) => void
+  /**
+   * Delete a custom theme. Any selection slot referencing it explicitly
+   * falls back to the theme's base built-in. Ignored while that theme is
+   * being previewed (close the editor first).
+   */
+  deleteCustomTheme: (themeId: string) => void
+  /**
+   * Show a theme without persisting anything. Pass `null` to restore the
+   * active theme. Preview state never touches storage, so reload/cancel
+   * always returns to the last saved theme.
+   */
+  setPreview: (theme: ResolvedThemeDefinition | null) => void
+  isPreviewing: boolean
 }
 
 export const ThemeContext = createContext<ThemeContextValue | null>(null)

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The allowlisted, typed set of semantic theme roles a custom theme may
+ * override. This is the single authority on what is editable: schema
+ * validation, the guided editor, and import all reject keys outside this
+ * list. Tokens are colors only — never selectors, URLs, fonts, spacing, or
+ * arbitrary CSS.
+ *
+ * Keys map onto the runtime boundaries introduced by the appearance work:
+ * - `css` tokens are the `--<key>` custom properties in `src/index.css`;
+ * - `canvas` tokens feed the 2D sketch canvas palette;
+ * - `three` tokens feed the Three.js viewport/simulation palette.
+ */
+
+export type ThemeTokenGroup =
+  | 'surfaces'
+  | 'text'
+  | 'controls'
+  | 'status'
+  | 'sketch-roles'
+  | 'canvas'
+  | 'three'
+
+export interface ThemeTokenGroupMeta {
+  id: ThemeTokenGroup
+  label: string
+  description: string
+}
+
+export const THEME_TOKEN_GROUPS: readonly ThemeTokenGroupMeta[] = [
+  { id: 'surfaces', label: 'Surfaces', description: 'Application, panel, and input backgrounds.' },
+  { id: 'text', label: 'Text', description: 'Primary, muted, status, and on-accent text.' },
+  { id: 'controls', label: 'Borders & controls', description: 'Borders, hover, pressed, selected, and depth effects.' },
+  { id: 'status', label: 'Accent & status', description: 'Accent, focus, positive, informational, warning, and danger colors.' },
+  { id: 'sketch-roles', label: 'Sketch roles', description: 'Semantic colors for line, region, and construction features.' },
+  { id: 'canvas', label: 'Sketch canvas', description: 'Canvas background, grid, labels, and annotations.' },
+  { id: 'three', label: '3D & simulation', description: 'Viewport background and grid presentation.' },
+] as const
+
+export type ThemeTokenKind = 'css' | 'canvas' | 'three'
+
+export interface ThemeTokenMeta {
+  /** Stable token key, e.g. `text`, `canvas.background`, `three.gridMajor`. */
+  key: string
+  kind: ThemeTokenKind
+  group: ThemeTokenGroup
+  label: string
+}
+
+function css(key: string, group: ThemeTokenGroup, label: string): ThemeTokenMeta {
+  return { key, kind: 'css', group, label }
+}
+
+function canvas(name: string, label: string): ThemeTokenMeta {
+  return { key: `canvas.${name}`, kind: 'canvas', group: 'canvas', label }
+}
+
+function three(name: string, label: string): ThemeTokenMeta {
+  return { key: `three.${name}`, kind: 'three', group: 'three', label }
+}
+
+export const THEME_TOKENS: readonly ThemeTokenMeta[] = [
+  // Application and panel surfaces.
+  css('bg', 'surfaces', 'App background'),
+  css('bg-elev-1', 'surfaces', 'Raised background 1'),
+  css('bg-elev-2', 'surfaces', 'Raised background 2'),
+  css('surface-app', 'surfaces', 'App surface'),
+  css('surface-canvas', 'surfaces', 'Canvas surface'),
+  css('surface-panel', 'surfaces', 'Panel surface'),
+  css('surface-subtle', 'surfaces', 'Subtle surface'),
+  css('surface-raised', 'surfaces', 'Raised surface'),
+  css('surface-popover', 'surfaces', 'Popover surface'),
+  css('surface-translucent', 'surfaces', 'Translucent surface'),
+  css('surface-input', 'surfaces', 'Input surface'),
+
+  // Text.
+  css('text', 'text', 'Primary text'),
+  css('text-dim', 'text', 'Muted text'),
+  css('status-text', 'text', 'Status bar text'),
+  css('status-text-muted', 'text', 'Status bar muted text'),
+  css('on-accent', 'text', 'Text on accent'),
+
+  // Borders, interaction states, and depth effects.
+  css('line', 'controls', 'Border'),
+  css('line-strong', 'controls', 'Strong border'),
+  css('surface-hover', 'controls', 'Hover wash'),
+  css('surface-control-top', 'controls', 'Control gradient top'),
+  css('surface-control-bottom', 'controls', 'Control gradient bottom'),
+  css('surface-button-top', 'controls', 'Button gradient top'),
+  css('surface-button-bottom', 'controls', 'Button gradient bottom'),
+  css('surface-active-top', 'controls', 'Pressed gradient top'),
+  css('surface-active-bottom', 'controls', 'Pressed gradient bottom'),
+  css('surface-inset', 'controls', 'Inset shading'),
+  css('surface-sheen', 'controls', 'Sheen'),
+  css('surface-sheen-soft', 'controls', 'Sheen (soft)'),
+  css('surface-sheen-mid', 'controls', 'Sheen (mid)'),
+  css('surface-sheen-strong', 'controls', 'Sheen (strong)'),
+  css('shadow', 'controls', 'Shadow'),
+  css('shadow-strong', 'controls', 'Strong shadow'),
+
+  // Accent and status colors.
+  css('accent', 'status', 'Accent / focus'),
+  css('accent-strong', 'status', 'Accent (strong)'),
+  css('accent-soft', 'status', 'Accent wash'),
+  css('add', 'status', 'Positive / add'),
+  css('cut', 'status', 'Informational / cut'),
+  css('danger-text', 'status', 'Danger text'),
+  css('warning-text', 'status', 'Warning text'),
+
+  // Semantic sketch feature roles.
+  css('role-line', 'sketch-roles', 'Line role'),
+  css('role-line-text', 'sketch-roles', 'Line role text'),
+  css('role-region', 'sketch-roles', 'Region role'),
+  css('role-region-text', 'sketch-roles', 'Region role text'),
+  css('role-construction', 'sketch-roles', 'Construction role'),
+  css('role-construction-text', 'sketch-roles', 'Construction role text'),
+
+  // 2D sketch canvas presentation.
+  canvas('background', 'Canvas background'),
+  canvas('gridMajor', 'Grid (major)'),
+  canvas('gridMinor', 'Grid (minor)'),
+  canvas('labelBackground', 'Label background'),
+  canvas('labelText', 'Label text'),
+  canvas('mutedGeometry', 'Muted geometry'),
+  canvas('veil', 'Inactive veil'),
+
+  // Three.js viewport / simulation presentation.
+  three('background', '3D background'),
+  three('gridMinorCenter', '3D grid minor (center)'),
+  three('gridMinor', '3D grid minor'),
+  three('gridMajorCenter', '3D grid major (center)'),
+  three('gridMajor', '3D grid major'),
+] as const
+
+export type ThemeTokenKey = (typeof THEME_TOKENS)[number]['key']
+
+const TOKEN_BY_KEY = new Map<string, ThemeTokenMeta>(THEME_TOKENS.map((token) => [token.key, token]))
+
+export function isThemeTokenKey(key: string): key is ThemeTokenKey {
+  return TOKEN_BY_KEY.has(key)
+}
+
+export function themeTokenMeta(key: ThemeTokenKey): ThemeTokenMeta {
+  const meta = TOKEN_BY_KEY.get(key)
+  if (!meta) throw new Error(`Unknown theme token: ${key}`)
+  return meta
+}
+
+/** All token keys of one kind, in declaration order. */
+export function themeTokenKeys(kind?: ThemeTokenKind): ThemeTokenKey[] {
+  return THEME_TOKENS.filter((token) => (kind ? token.kind === kind : true)).map((token) => token.key)
+}
+
+/** The CSS custom property name for a `css`-kind token key. */
+export function cssVariableName(key: ThemeTokenKey): string {
+  return `--${key}`
+}


### PR DESCRIPTION
Closes #305

## What this adds

Builds on the #302 appearance foundation with a versioned theme registry, a Theme Manager, and a guided custom-theme editor.

### Theme model (`src/theme/`)
- **`tokens.ts`** — the allowlisted, typed set of editable semantic roles (45 CSS custom properties + 7 canvas + 5 Three.js colors), grouped for the editor. Schema validation, the editor, and import all reject anything outside this list — no selectors, URLs, fonts, spacing, or arbitrary CSS.
- **`registry.ts`** — built-in Dark/Light as complete, immutable, code-owned definitions with stable IDs. A future curated theme is a declarative entry here plus tests, not component CSS branches. A structural test parses `index.css` and fails on any drift between the stylesheet and the registry. Custom themes store `schemaVersion`, local ID, name, family, base built-in ID, and validated overrides only; resolution applies overrides to the base for a complete runtime palette.
- **`selection.ts`** — one selection record holds the fixed choice plus the System light/dark pair, so switching modes never forgets configuration. The legacy `dark|light|system` preference migrates on read and is written back on change, so older builds stay usable.
- **`color.ts` / `contrast.ts`** — color parsing/normalization (hex + rgb/rgba only), WCAG contrast with alpha compositing, perceptual ΔE. Critical text/surface, control, focus, warning, and danger pairs block Apply when unreadable; semantic role/canvas separation issues warn (roles vs each other, add vs cut, grid visibility).
- **`bootstrap.ts`** — applies the persisted selection including custom overrides before React renders (no wrong-theme flash).

### UI (`src/components/theme/`)
- **Theme Manager** (Appearance menu → Manage themes…): built-in + custom list with swatch previews; activate, duplicate(-to-edit), rename, reset-to-base, delete (explicit fallback to the base theme, including System slots), versioned JSON export/import with readable inline errors; System pairing constrained to family-compatible themes.
- **Guided editor**: semantic groups with native color input (alpha-preserving), normalized text value, base comparison chip, per-field reset; representative preview states (panel text, controls, selection/focus, status messages, sketch canvas annotations and role colors); live preview on the document root that is never persisted until Apply; Cancel/Escape/close restore the saved theme in the same commit; a hardcoded-palette recovery bar stays readable under any preview (screenshot below shows an intentionally broken preview — the recovery bar is the only readable element, as designed).
- The quick Appearance menu keeps Dark/Light/System behavior and lists custom themes.

### Applying without domain recomputation
`SketchCanvas`, `Viewport3D`, and `SimulationViewport` now read the resolved palette from context instead of `THEME_PALETTES[resolvedTheme]`. The palette is identity-memoized on its own values, so editing a UI-only token doesn't rebuild viewport grids, and theme switches redraw presentation only — no geometry, toolpath, or simulation recomputation. Custom themes are application-local; the e2e suite asserts the project snapshot is byte-identical across theme workflows.

## Verification

- `npm run build` — green (docs check, lint, tsc, structural tests incl. new color/registry/selection/contrast suites, vite build)
- `npm run test:e2e` — 56/56 passing, including the new `themeManager.smoke.spec.ts` (duplicate/edit/apply with live preview, Cancel + Escape restore, reload persistence, export→delete→import round-trip, invalid/unknown-token/wrong-version import rejection, contrast blocking + recovery action, custom System pair following `prefers-color-scheme`, legacy preference migration, project-untouched guarantee, tablet touch sizing) and the pre-existing `appearance.smoke.spec.ts` unchanged
- Manual: dark/light manager + editor states screenshotted at 1440×900, including the intentionally-unreadable preview to confirm the recovery path

## Notes for review

- The `on-accent`-on-accent gate is calibrated to 2:1 because the shipped dark accent (white on amber) measures ≈2.2:1 — the gate catches catastrophic edits without re-litigating the existing accent design.
- Built-in CSS stays the source of truth for built-in rendering (zero runtime change for Dark/Light); the registry mirrors it under test instead of generating it, keeping the stylesheet reviewable.
- Tablet dialog rules use `@media (pointer: coarse)` rather than `[data-shell-mode]` descendants because dialogs portal to `document.body` outside the shell — the equivalent machine-dialog rules are dead CSS today (flagged separately as a follow-up).