### PR TITLE
Add status-bar feature labels toggle

### DIFF
--- a/e2e/appearance.smoke.spec.ts
+++ b/e2e/appearance.smoke.spec.ts
@@ -75,6 +75,19 @@ test('keeps status and dialog text legible in both themes', async ({ app, ui }) 
   await expect(ui.aboutDialog.productName(app.page)).toHaveCSS('color', 'rgb(37, 48, 57)')
 })
 
+test('toggles feature labels from the status bar', async ({ app, ui }) => {
+  const featureLabels = ui.statusBar.toggle(app.page, 'Feature labels')
+
+  await expect(featureLabels).toHaveAttribute('aria-pressed', 'true')
+  await expect(featureLabels).toHaveAttribute('title', 'Hide feature labels')
+
+  await featureLabels.click()
+
+  await expect(featureLabels).toHaveAttribute('aria-pressed', 'false')
+  await expect(featureLabels).toHaveAttribute('title', 'Show feature labels')
+  expect((await getProject(app.page)).meta.showFeatureInfo).toBe(false)
+})
+
 test('keeps New Project template hover states within the light palette', async ({ app, ui }) => {
   await ui.appearance.trigger(app.page).click()
   await ui.appearance.option(app.page, 'Light').click()
@@ -136,5 +149,23 @@ test.describe('tablet appearance', () => {
 
     await lightOption.click()
     await expect(app.page.locator('html')).toHaveAttribute('data-theme', 'light')
+  })
+})
+
+test.describe('tablet status bar', () => {
+  test.use({ viewport: { width: 1024, height: 768 }, hasTouch: true })
+
+  test('keeps Feature labels touch-sized in the expanded status bar', async ({ app, ui }) => {
+    const statusBar = ui.statusBar.root(app.page)
+    await statusBar.getByRole('button', { name: 'Expand status bar' }).click()
+
+    const featureLabels = ui.statusBar.toggle(app.page, 'Feature labels')
+    await expect(featureLabels).toBeVisible()
+    const featureLabelsBox = await featureLabels.boundingBox()
+    expect(featureLabelsBox).not.toBeNull()
+    expect(featureLabelsBox!.height).toBeGreaterThanOrEqual(44)
+
+    await featureLabels.click()
+    await expect(featureLabels).toHaveAttribute('aria-pressed', 'false')
   })
 })

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -309,6 +309,7 @@ export function AppShell({
     setStock,
     setOrigin,
     updateBackdrop,
+    setShowFeatureInfo,
     setAllRegionsVisible,
     setAllConstructionVisible,
     setAllTabsVisible,
@@ -697,6 +698,15 @@ export function AppShell({
           </button>
         ) : null}
         <div className={`statusbar-visibility ${tabletShell && !statusBarExpanded ? 'statusbar-visibility--hidden' : ''}`} aria-label="View visibility">
+          <button
+            className={`statusbar-toggle ${project.meta.showFeatureInfo ? 'statusbar-toggle--active' : ''}`}
+            type="button"
+            aria-pressed={project.meta.showFeatureInfo}
+            title={project.meta.showFeatureInfo ? 'Hide feature labels' : 'Show feature labels'}
+            onClick={() => setShowFeatureInfo(!project.meta.showFeatureInfo)}
+          >
+            Feature labels
+          </button>
           <button
             className={`statusbar-toggle ${project.grid.visible ? 'statusbar-toggle--active' : ''}`}
             type="button"

--- a/src/styles/tablet.css
+++ b/src/styles/tablet.css
@@ -1129,8 +1129,32 @@
   font-size: 11px;
 }
 
-.app-statusbar--tablet-expanded {
+[data-shell-mode="tablet"] .app-statusbar--tablet-expanded,
+[data-shell-mode="tablet-compact"] .app-statusbar--tablet-expanded {
+  position: relative;
+  z-index: 6;
+  height: max-content;
+  min-height: var(--touch-target, 44px);
+  max-height: none;
+  align-content: flex-start;
   flex-wrap: wrap;
+  overflow: visible;
+  white-space: normal;
+}
+
+[data-shell-mode="tablet"] .app-statusbar--tablet-expanded .statusbar-visibility,
+[data-shell-mode="tablet-compact"] .app-statusbar--tablet-expanded .statusbar-visibility {
+  flex: 1 1 100%;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+[data-shell-mode="tablet"] .app-statusbar--tablet-expanded .statusbar-toggle,
+[data-shell-mode="tablet-compact"] .app-statusbar--tablet-expanded .statusbar-toggle {
+  height: var(--touch-target, 44px);
+  min-height: var(--touch-target, 44px);
+  padding: 0 10px;
+  font-size: 12px;
 }
 
 .app-statusbar--tablet-compact .statusbar-expand-btn,


### PR DESCRIPTION
## Summary

- Add a persistent Feature labels status-bar control backed by the existing project setting.
- Make expanded tablet status bars wrap visibility controls into 44px touch targets above canvas overlays.
- Cover desktop state/persistence and tablet tap behavior in browser smoke tests.

Closes #310

## Verification

- npm run build
- npm run test:e2e -- e2e/appearance.smoke.spec.ts