### PR TITLE
fix: allow binary file writes on desktop for booklet/STL export

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "dialog:allow-message",
     "fs:allow-read-text-file",
     "fs:allow-write-text-file",
+    "fs:allow-write-file",
     "fs:allow-exists",
     {
       "identifier": "opener:allow-open-url",


### PR DESCRIPTION
## Summary

Booklet PDF export failed in the desktop app because the Tauri capabilities never granted `fs:allow-write-file`.

The export writes binary bytes via Tauri's `writeFile` (behind `platform.saveBinaryFile`), which is gated by `fs:allow-write-file`. The capabilities file granted `fs:allow-write-text-file` but not its binary sibling, so the desktop WebView denied the write and the export failed after the Save dialog. Every text-based save (project `.camj`, gcode, SVG, ASCII STL) kept working because those go through `writeTextFile` / `fs:allow-write-text-file`.

## Change

One line in `src-tauri/capabilities/default.json`:

```diff
     "fs:allow-write-text-file",
+    "fs:allow-write-file",
     "fs:allow-exists",
```

`fs:allow-write-file` is the autogenerated permission for the `write_file` command in `tauri-plugin-fs@2.5.0` — the exact sibling of the already-granted `fs:allow-write-text-file`.

## Blast radius

This also fixes **binary STL export** (`ModelExportDialog`, `output.encoding === 'binary'`), which routes through the same `saveBinaryFile` path and was broken on desktop for the identical reason — it was just never reported. History confirms the gap: `saveBinaryFile` landed in `5efe4ad` ("Add 3D model export with STL format") and `fs:allow-write-file` has never existed in the capabilities file.

## Verification

- `npm ci && npm run build` — green (docs check, lint, tsc, all 127 test files, vite build).
- JSON validated; permission identifier confirmed against `tauri-plugin-fs@2.5.0`.
- Manual desktop confirmation (`npm run tauri:build` / `tauri dev`) recommended, since the frontend build does not exercise the Tauri capability layer.

Closes #323
