### PR TITLE
Localize feature properties panel

### DIFF
--- a/e2e/language.smoke.spec.ts
+++ b/e2e/language.smoke.spec.ts
@@ -15,7 +15,8 @@
  */
 
 import { test, expect } from './fixtures'
-import { getProject } from './helpers'
+import { clickMenuItem, getProject, openRowContextMenu, seedProject } from './helpers'
+import { buildLinkedProjectJson } from './featureReferences.helpers'
 
 const STORAGE_KEY = 'purecutcnc.i18n.locale'
 
@@ -23,6 +24,74 @@ function withoutModified(snapshot: Record<string, unknown>): Record<string, unkn
   const meta = snapshot.meta as Record<string, unknown>
   const { modified: _modified, ...stableMeta } = meta
   return { ...snapshot, meta: stableMeta }
+}
+
+interface PropertiesFixtureFeature {
+  id: string
+  name: string
+  definitionId: string
+  transform: { a: number; b: number; c: number; d: number; e: number; f: number }
+  constraints: unknown[]
+  folderId: string | null
+  z_top: number
+  z_bottom: number
+  visible: boolean
+  locked: boolean
+}
+
+interface PropertiesFixtureProject {
+  featureDefinitions: Record<string, unknown>
+  features: PropertiesFixtureFeature[]
+}
+
+function buildPropertiesLocalizationProject(): string {
+  const project = JSON.parse(buildLinkedProjectJson()) as PropertiesFixtureProject
+  const linkedB = project.features.find((feature) => feature.id === 'f-linked-b')
+  if (!linkedB) throw new Error('linked fixture must include f-linked-b')
+  linkedB.z_top = 4
+
+  project.featureDefinitions['def-imported-model'] = {
+    id: 'def-imported-model',
+    kind: 'stl',
+    profile: {
+      start: { x: 0, y: 0 },
+      segments: [
+        { type: 'line', to: { x: 40, y: 0 } },
+        { type: 'line', to: { x: 40, y: 20 } },
+        { type: 'line', to: { x: 0, y: 20 } },
+        { type: 'line', to: { x: 0, y: 0 } },
+      ],
+      closed: true,
+    },
+    dimensions: [],
+    text: null,
+    stl: {
+      format: 'stl',
+      scale: 1,
+      axisSwap: 'none',
+      silhouettePaths: [[
+        { x: 0, y: 0 },
+        { x: 40, y: 0 },
+        { x: 40, y: 20 },
+        { x: 0, y: 20 },
+      ]],
+    },
+    operation: 'model',
+  }
+  project.features.push({
+    id: 'f-imported-model',
+    name: 'Imported Model',
+    definitionId: 'def-imported-model',
+    transform: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+    constraints: [],
+    folderId: null,
+    z_top: 5,
+    z_bottom: 0,
+    visible: true,
+    locked: false,
+  })
+
+  return JSON.stringify(project)
 }
 
 test('switches to Simplified Chinese, persists, and never touches the project', async ({ app, ui }) => {
@@ -70,6 +139,34 @@ test('keeps appearance menu copy translated and the theme selection intact', asy
   await ui.language.trigger(app.page).click()
   await ui.language.option(app.page, 'English').click()
   await expect(app.page.locator('html')).toHaveAttribute('data-theme', 'light')
+})
+
+test('updates selected feature properties when the interface language changes', async ({ app, ui }) => {
+  await seedProject(app.page, buildPropertiesLocalizationProject())
+  const before = await getProject(app.page)
+
+  const linkedA = ui.tree.rowByName(app.page, 'Linked A')
+  await linkedA.click()
+  await expect(linkedA).toHaveClass(/tree-row--selected/)
+  const menu = await openRowContextMenu(app.page, linkedA)
+  await clickMenuItem(menu, 'Select Linked Instances')
+  await expect(ui.properties.panel(app.page).getByPlaceholder('Mixed values')).toHaveCount(2)
+  await expect(ui.properties.exactText(app.page, 'Operation')).toBeVisible()
+
+  await ui.language.trigger(app.page).click()
+  await ui.language.option(app.page, '简体中文').click()
+
+  await expect(ui.properties.panel(app.page).getByPlaceholder('混合值')).toHaveCount(2)
+  await expect(ui.properties.exactText(app.page, '操作')).toBeVisible()
+  expect(withoutModified(await getProject(app.page))).toEqual(withoutModified(before))
+
+  await ui.tree.rowByName(app.page, 'Imported Model').click()
+  await ui.properties.panel(app.page).getByRole('button', { name: '形状', exact: true }).click()
+  await expect(ui.properties.exactText(app.page, '模型')).toBeVisible()
+  await expect(ui.properties.panel(app.page).locator('.properties-locked-field')).toHaveAttribute(
+    'title',
+    '模型特征是导入的 3D 对象，无法更改操作类型',
+  )
 })
 
 test.describe('tablet language selector', () => {

--- a/e2e/language.smoke.spec.ts
+++ b/e2e/language.smoke.spec.ts
@@ -156,16 +156,28 @@ test('updates selected feature properties when the interface language changes', 
   await ui.language.trigger(app.page).click()
   await ui.language.option(app.page, '简体中文').click()
 
+  const disabledTextInputs = ui.properties.panel(app.page).locator('input[type="text"]:disabled')
+  await expect(disabledTextInputs).toHaveCount(2)
+  await expect(disabledTextInputs.nth(0)).toHaveValue('2 个特征')
+  await expect(disabledTextInputs.nth(1)).toHaveValue('多选时禁用')
   await expect(ui.properties.panel(app.page).getByPlaceholder('混合值')).toHaveCount(2)
   await expect(ui.properties.exactText(app.page, '操作')).toBeVisible()
+
+  await ui.language.trigger(app.page).click()
+  await ui.language.option(app.page, 'English').click()
+
+  await expect(disabledTextInputs.nth(0)).toHaveValue('2 Features')
+  await expect(disabledTextInputs.nth(1)).toHaveValue('Disabled for multi-select')
+  await expect(ui.properties.panel(app.page).getByPlaceholder('Mixed values')).toHaveCount(2)
+  await expect(ui.properties.exactText(app.page, 'Operation')).toBeVisible()
   expect(withoutModified(await getProject(app.page))).toEqual(withoutModified(before))
 
   await ui.tree.rowByName(app.page, 'Imported Model').click()
-  await ui.properties.panel(app.page).getByRole('button', { name: '形状', exact: true }).click()
-  await expect(ui.properties.exactText(app.page, '模型')).toBeVisible()
+  await ui.properties.panel(app.page).getByRole('button', { name: 'Shape', exact: true }).click()
+  await expect(ui.properties.exactText(app.page, 'Model')).toBeVisible()
   await expect(ui.properties.panel(app.page).locator('.properties-locked-field')).toHaveAttribute(
     'title',
-    '模型特征是导入的 3D 对象，无法更改操作类型',
+    'Model features are imported 3D objects and cannot change operation type',
   )
 })
 

--- a/src/components/feature-tree/PropertiesPanel.tsx
+++ b/src/components/feature-tree/PropertiesPanel.tsx
@@ -60,6 +60,7 @@ function DraftTextInput({ value, disabled = false, onCommit }: DraftTextInputPro
 
   return (
     <input
+      key={disabled ? value : undefined}
       type="text"
       defaultValue={value}
       disabled={disabled}

--- a/src/components/feature-tree/PropertiesPanel.tsx
+++ b/src/components/feature-tree/PropertiesPanel.tsx
@@ -456,8 +456,8 @@ export function PropertiesPanel() {
                 type="button"
                 className="tree-action-btn properties-refresh-btn"
                 onClick={refreshMachineDefinitions}
-                aria-label="Refresh machine definitions"
-                title="Refresh machine definitions"
+                aria-label={t('featureTree.properties.machine.refresh')}
+                title={t('featureTree.properties.machine.refresh')}
               >
                 <Icon id="refresh" size={15} />
               </button>
@@ -498,7 +498,7 @@ export function PropertiesPanel() {
         <div className="properties-group">
           <label className="properties-field">
             <span>{t('featureTree.properties.name')}</span>
-            <DraftTextInput value="Grid" disabled />
+            <DraftTextInput value={t('featureTree.properties.name.grid')} disabled />
           </label>
           <label className="properties-field">
             <span>{t("featureTree.properties.gridExtent")}</span>
@@ -871,16 +871,16 @@ export function PropertiesPanel() {
             {backdropImageLoading ? t('featureTree.properties.backdrop.loading') : backdrop ? t('featureTree.properties.backdrop.replaceImage') : t('featureTree.properties.backdrop.loadImage')}
           </button>
           <button className="feat-btn" type="button" onClick={() => { startMoveBackdrop(); closeExpanded() }} disabled={!backdrop || backdropImageLoading}>
-            Move
+            {t('featureTree.properties.backdrop.move')}
           </button>
           <button className="feat-btn" type="button" onClick={() => { startResizeBackdrop(); closeExpanded() }} disabled={!backdrop || backdropImageLoading}>
-            Resize
+            {t('featureTree.properties.backdrop.resize')}
           </button>
           <button className="feat-btn" type="button" onClick={() => { startRotateBackdrop(); closeExpanded() }} disabled={!backdrop || backdropImageLoading}>
-            Rotate
+            {t('featureTree.properties.backdrop.rotate')}
           </button>
           <button className="feat-btn feat-btn--delete" type="button" onClick={() => { deleteBackdrop(); closeExpanded() }} disabled={!backdrop || backdropImageLoading}>
-            Delete
+            {t('featureTree.properties.backdrop.delete')}
           </button>
         </div>
         {backdropImageLoading ? (
@@ -907,7 +907,7 @@ export function PropertiesPanel() {
         <div className="properties-group">
           <label className="properties-field">
             <span>{t('featureTree.properties.name')}</span>
-            <DraftTextInput value="Features" disabled />
+            <DraftTextInput value={t('featureTree.properties.name.features')} disabled />
           </label>
           <label className="properties-field">
             <span>{t("featureTree.properties.folders")}</span>
@@ -920,7 +920,7 @@ export function PropertiesPanel() {
         </div>
         <div className="properties-actions">
           <button className="feat-btn" type="button" onClick={() => { addFeatureFolder(); closeExpanded() }}>
-            Add Folder
+            {t('featureTree.properties.actions.addFolder')}
           </button>
         </div>
       </div>
@@ -933,7 +933,7 @@ export function PropertiesPanel() {
         <div className="properties-group">
           <label className="properties-field">
             <span>{t('featureTree.properties.name')}</span>
-            <DraftTextInput value="Clamps" disabled />
+            <DraftTextInput value={t('featureTree.properties.name.clamps')} disabled />
           </label>
           <label className="properties-field">
             <span>{t("featureTree.properties.clamps")}</span>
@@ -942,7 +942,7 @@ export function PropertiesPanel() {
         </div>
         <div className="properties-actions">
           <button className="feat-btn" type="button" onClick={() => { startAddClampPlacement(); closeExpanded() }}>
-            Add Clamp
+            {t('featureTree.properties.actions.addClamp')}
           </button>
         </div>
       </div>
@@ -955,7 +955,7 @@ export function PropertiesPanel() {
         <div className="properties-group">
           <label className="properties-field">
             <span>{t('featureTree.properties.name')}</span>
-            <DraftTextInput value="Tabs" disabled />
+            <DraftTextInput value={t('featureTree.properties.name.tabs')} disabled />
           </label>
           <label className="properties-field">
             <span>{t("featureTree.properties.tabs")}</span>
@@ -964,7 +964,7 @@ export function PropertiesPanel() {
         </div>
         <div className="properties-actions">
           <button className="feat-btn" type="button" onClick={() => { startAddTabPlacement(); closeExpanded() }}>
-            Add Tab
+            {t('featureTree.properties.actions.addTab')}
           </button>
         </div>
       </div>
@@ -1002,7 +1002,7 @@ export function PropertiesPanel() {
         </div>
         <div className="properties-actions">
           <button className="feat-btn feat-btn--delete" type="button" onClick={() => { deleteFeatureFolder(selectedFolder.id); closeExpanded() }}>
-            Delete Folder
+            {t('featureTree.properties.actions.deleteFolder')}
           </button>
         </div>
       </div>
@@ -1057,7 +1057,7 @@ export function PropertiesPanel() {
             {t('featureTree.properties.stock.editSketch')}
           </button>
           <button className="feat-btn feat-btn--delete" type="button" onClick={() => { deleteClamp(selectedClamp.id); closeExpanded() }}>
-            Delete Clamp
+            {t('featureTree.properties.actions.deleteClamp')}
           </button>
         </div>
       </div>
@@ -1112,7 +1112,7 @@ export function PropertiesPanel() {
             {t('featureTree.properties.stock.editSketch')}
           </button>
           <button className="feat-btn feat-btn--delete" type="button" onClick={() => { deleteTab(selectedTab.id); closeExpanded() }}>
-            Delete Tab
+            {t('featureTree.properties.actions.deleteTab')}
           </button>
         </div>
       </div>
@@ -1171,7 +1171,7 @@ export function PropertiesPanel() {
                   <span className="properties-locked-hint" aria-hidden="true">🔒</span>
                 </div>
               ) : allSelectedFeatures.some((f) => f.operation === 'model') ? (
-                <div className="properties-locked-field" title="Model entries cannot change operation type here">
+                <div className="properties-locked-field" title={t('featureTree.properties.multi.modelLockedTooltip')}>
                   <span>{t('featureTree.properties.multi.containsModel')}</span>
                   <span className="properties-locked-hint" aria-hidden="true">🔒</span>
                 </div>
@@ -1221,7 +1221,7 @@ export function PropertiesPanel() {
                     value={commonSelectedZTop}
                     units={units}
                     min={0}
-                    placeholder="Mixed values"
+                    placeholder={t('featureTree.properties.select.mixedValues')}
                     validate={(next) => multiEditMinZTop === null || next >= multiEditMinZTop}
                     onCommit={(next) => updateFeatures(selectedZEditableFeatureIds, { z_top: next })}
                   />
@@ -1246,7 +1246,7 @@ export function PropertiesPanel() {
                       value={commonSelectedZBottom}
                       units={units}
                       min={0}
-                      placeholder="Mixed values"
+                      placeholder={t('featureTree.properties.select.mixedValues')}
                       validate={(next) => multiEditMaxZBottom === null || next <= multiEditMaxZBottom}
                       onCommit={(next) => updateFeatures(selectedClosedEditableFeatures.map((f) => f.id), { z_bottom: next })}
                     />
@@ -1259,7 +1259,7 @@ export function PropertiesPanel() {
                       value={commonSelectedZBottom}
                       units={units}
                       min={0}
-                      placeholder="Mixed values"
+                      placeholder={t('featureTree.properties.select.mixedValues')}
                       validate={(next) => multiEditMaxZBottom === null || next <= multiEditMaxZBottom}
                       onCommit={(next) => updateFeatures(selectedZEditableFeatureIds, { z_bottom: next })}
                     />
@@ -1339,8 +1339,8 @@ export function PropertiesPanel() {
                 })}
               />
             ) : selectedFeature.operation === 'model' ? (
-              <div className="properties-locked-field" title="Model features are imported 3D objects and cannot change operation type">
-                <span>Model</span>
+              <div className="properties-locked-field" title={t('featureTree.properties.operation.modelLockedTooltip')}>
+                <span>{t('featureTree.properties.operation.model')}</span>
                 <span className="properties-locked-hint" aria-hidden="true">🔒</span>
               </div>
             ) : subtractDisabled ? (
@@ -1483,7 +1483,7 @@ export function PropertiesPanel() {
             <>
               <label className="properties-field">
                 <span>{t("featureTree.properties.zRange")}</span>
-                <div className="properties-locked-field" title="Regions are vertical filters through the stock; their Z range follows the stock automatically">
+                <div className="properties-locked-field" title={t('featureTree.properties.z.followsStockTooltip')}>
                   <span>{t('featureTree.properties.z.followsStock', { thickness: formatLength(project.stock.thickness, units) })}</span>
                   <span className="properties-locked-hint" aria-hidden="true">🔒</span>
                 </div>
@@ -1610,7 +1610,7 @@ export function PropertiesPanel() {
               const refId = c.reference_feature_id ?? c.segment_ids[0]
               const refFeature = refId ? features.find((f) => f.id === refId) : null
               const label = typeof c.value === 'number' ? formatLength(c.value, units) : '—'
-              const refName = refFeature?.name ?? (refId ? `#${refId}` : 'World')
+              const refName = refFeature?.name ?? (refId ? `#${refId}` : t('featureTree.properties.constraints.world'))
               const isIntersectionConstraint = c.reference_type === 'intersection' || c.reference_snap_mode === 'intersection'
               const typeLabel = isIntersectionConstraint
                 ? t('featureTree.properties.constraints.type.intersect')

--- a/src/i18n/locales/en/featureTree.ts
+++ b/src/i18n/locales/en/featureTree.ts
@@ -239,6 +239,7 @@ export const featureTreeEn = {
   'featureTree.properties.multi.editSketchDisabled': 'Edit Sketch is only available for a single feature',
   'featureTree.properties.multi.openProfiles': 'Open profiles',
   'featureTree.properties.multi.containsModel': 'Contains model features',
+  'featureTree.properties.multi.modelLockedTooltip': 'Model entries cannot change operation type here',
 
   // ── Properties: select values ──
   'featureTree.properties.select.mixedFolders': 'Mixed folders',
@@ -254,6 +255,7 @@ export const featureTreeEn = {
   'featureTree.properties.operation.region': 'Region mask',
   'featureTree.properties.operation.construction': 'Construction',
   'featureTree.properties.operation.model': 'Model',
+  'featureTree.properties.operation.modelLockedTooltip': 'Model features are imported 3D objects and cannot change operation type',
 
   // ── Properties: mask mode ──
   'featureTree.properties.maskMode': 'Mask mode',
@@ -296,6 +298,7 @@ export const featureTreeEn = {
   'featureTree.properties.constraints.tooltip.featureCenter': 'Distance to feature center',
   'featureTree.properties.constraints.tooltip.distanceVertex': 'Distance to vertex',
   'featureTree.properties.constraints.tooltip.invalid': 'Invalid',
+  'featureTree.properties.constraints.world': 'World',
 
   // ── Properties: empty state ──
   'featureTree.properties.empty': 'Select Project, Grid, Stock, or a feature in the tree to edit its properties.',

--- a/src/i18n/locales/zh-CN/featureTree.ts
+++ b/src/i18n/locales/zh-CN/featureTree.ts
@@ -240,6 +240,7 @@ export const featureTreeZhCN: Record<keyof typeof featureTreeEn, string> = {
   'featureTree.properties.multi.editSketchDisabled': '编辑草图仅适用于单个特征',
   'featureTree.properties.multi.openProfiles': '开放轮廓',
   'featureTree.properties.multi.containsModel': '包含模型特征',
+  'featureTree.properties.multi.modelLockedTooltip': '模型条目无法在此更改操作类型',
 
   // ── Properties: select values ──
   'featureTree.properties.select.mixedFolders': '混合文件夹',
@@ -255,6 +256,7 @@ export const featureTreeZhCN: Record<keyof typeof featureTreeEn, string> = {
   'featureTree.properties.operation.region': '区域遮罩',
   'featureTree.properties.operation.construction': '构造',
   'featureTree.properties.operation.model': '模型',
+  'featureTree.properties.operation.modelLockedTooltip': '模型特征是导入的 3D 对象，无法更改操作类型',
 
   // ── Properties: mask mode ──
   'featureTree.properties.maskMode': '遮罩模式',
@@ -297,6 +299,7 @@ export const featureTreeZhCN: Record<keyof typeof featureTreeEn, string> = {
   'featureTree.properties.constraints.tooltip.featureCenter': '到特征中心的距离',
   'featureTree.properties.constraints.tooltip.distanceVertex': '到顶点的距离',
   'featureTree.properties.constraints.tooltip.invalid': '无效',
+  'featureTree.properties.constraints.world': '世界',
 
   // ── Properties: empty state ──
   'featureTree.properties.empty': '选择项目、网格、毛坯或树中的特征以编辑其属性。',


### PR DESCRIPTION
## Summary

- Localize the remaining feature-properties labels, actions, locked-operation copy, tooltips, and mixed-value placeholders.
- Add the missing English and Simplified Chinese catalog entries for model-operation and constraint labels.
- Add a browser regression that changes language with multi-selection and imported-model properties visible, while confirming the project data remains unchanged.

## Root cause

The feature properties panel already consumed the i18n context, but several controls still rendered English literals directly instead of catalog keys.

## Verification

- `npm run build`
- `npm test`
- Isolated Playwright language smoke suite (4 passed, including tablet selector coverage)

Closes #328
