### PR TITLE
fix: preserve tool definitions when using project as template

### DIFF
--- a/src/components/project/NewProjectDialog.tsx
+++ b/src/components/project/NewProjectDialog.tsx
@@ -68,7 +68,6 @@ function setupOnlyTemplate(template: Project): Project {
     featureFolders: [],
     featureTree: [],
     global_constraints: [],
-    tools: [],
     operations: [],
     tabs: [],
     clamps: [],

--- a/src/store/helpers/normalize.ts
+++ b/src/store/helpers/normalize.ts
@@ -495,7 +495,6 @@ export function instantiateProjectTemplate(template?: Project, name?: string): P
     featureFolders: [],
     featureTree: [],
     global_constraints: [],
-    tools: [],
     operations: [],
     tabs: [],
     clamps: [],


### PR DESCRIPTION
Closes #330

When creating a new project from a template (current project or `.camj` file), tool definitions now carry over instead of being wiped. Tools are setup-level configuration, not feature-level content — a user's tool library (end mills, V-bits, drills, with their feeds/speeds/stepdowns) should survive template instantiation.

## Changes
- **`setupOnlyTemplate()`** — removed `tools: []` so current-project and file templates preserve the tool library
- **`instantiateProjectTemplate()`** — removed `tools: []` so the final project creation keeps tool definitions
- Blank templates (metric/imperial) are unaffected — `newProject()` already produces an empty tool list