### PR TITLE
fix: character-break long booklet labels to prevent overlap in German

### DIFF
--- a/src/engine/operationBooklet/operationBooklet.test.ts
+++ b/src/engine/operationBooklet/operationBooklet.test.ts
@@ -287,10 +287,69 @@ function testFeedTimeUsesScaledSlotFeed(): void {
   )
 }
 
+function testGermanLabelWrapping(): void {
+  console.log('Testing German booklet label wrapping...')
+  const { project, operation, toolpath } = fixture()
+  setActiveLocale('de')
+  try {
+    // A pocket operation with machiningOrder produces the longest single-word
+    // label in German: "Bearbeitungsreihenfolge" (24 chars, ~96 pt at 9 pt
+    // bold). This must not overflow the 82 pt ROW_LABEL_WIDTH.
+    const report = buildOperationBookletReport({
+      project,
+      operation: {
+        ...operation,
+        kind: 'pocket',
+        machiningOrder: 'feature_first',
+      },
+      tool: normalizeToolForProject(project.tools[0], project),
+      toolpath,
+      generatedAt: new Date('2026-06-04T12:00:00Z'),
+    })
+
+    const row = report.settingRows.find(
+      (r) => r.label === translate('booklet.label.machiningOrder'),
+    )
+    assert(row !== undefined, 'machining order row should exist for pocket operation')
+    assert(
+      row!.value === translate('booklet.machiningOrder.featureFirst'),
+      'machining order value should be localized',
+    )
+  } finally {
+    resetI18nStoreForTests()
+  }
+}
+
+async function testGermanPdfSmoke(): Promise<void> {
+  console.log('Testing German booklet PDF smoke output...')
+  const { project, operation, toolpath } = fixture()
+  setActiveLocale('de')
+  try {
+    const pdfBytes = await createOperationBookletPdf({
+      project,
+      operation: {
+        ...operation,
+        kind: 'pocket',
+        machiningOrder: 'feature_first',
+        roundOutsideCorners: true,
+      },
+      tool: normalizeToolForProject(project.tools[0], project),
+      toolpath,
+      generatedAt: new Date('2026-06-04T12:00:00Z'),
+    })
+    assert(pdfBytes.byteLength > 500, `expected non-empty PDF, got ${pdfBytes.byteLength} bytes`)
+    assert(new TextDecoder().decode(pdfBytes.slice(0, 5)) === '%PDF-', 'expected PDF header')
+  } finally {
+    resetI18nStoreForTests()
+  }
+}
+
 testReportContent()
 testFeedTimeUsesScaledSlotFeed()
 testReportIncludesEnabledRoundOutsideCorners()
 testLocalizedReportContent()
+testGermanLabelWrapping()
 await testPdfSmoke()
+await testGermanPdfSmoke()
 await testPdfUnicodeFontRetriesAndUsesBold()
 console.log('operation booklet tests passed')

--- a/src/engine/operationBooklet/operationBooklet.test.ts
+++ b/src/engine/operationBooklet/operationBooklet.test.ts
@@ -21,13 +21,14 @@
  */
 
 import { readFile } from 'node:fs/promises'
+import { PDFDocument, StandardFonts } from 'pdf-lib'
 import { resetI18nStoreForTests, setActiveLocale, translate } from '../../i18n/store'
 import { defaultTool, newProject, rectProfile } from '../../types/project'
 import type { Operation, Project, SketchFeature } from '../../types/project'
 import { replaceProjectFeatures } from '../../test/projectFixtures'
 import { normalizeToolForProject } from '../toolpaths/geometry'
 import type { ToolpathResult } from '../toolpaths/types'
-import { createOperationBookletPdf } from './pdf'
+import { createOperationBookletPdf, shouldStackRowLabel } from './pdf'
 import { buildOperationBookletReport } from './report'
 
 function assert(condition: boolean, message: string): void {
@@ -287,14 +288,13 @@ function testFeedTimeUsesScaledSlotFeed(): void {
   )
 }
 
-function testGermanLabelWrapping(): void {
-  console.log('Testing German booklet label wrapping...')
+async function testGermanLabelLayout(): Promise<void> {
+  console.log('Testing German booklet label layout...')
   const { project, operation, toolpath } = fixture()
   setActiveLocale('de')
   try {
     // A pocket operation with machiningOrder produces the longest single-word
-    // label in German: "Bearbeitungsreihenfolge" (24 chars, ~96 pt at 9 pt
-    // bold). This must not overflow the 82 pt ROW_LABEL_WIDTH.
+    // label in German. It must be stacked above its value, not character-wrapped.
     const report = buildOperationBookletReport({
       project,
       operation: {
@@ -314,6 +314,16 @@ function testGermanLabelWrapping(): void {
     assert(
       row!.value === translate('booklet.machiningOrder.featureFirst'),
       'machining order value should be localized',
+    )
+    const pdfDoc = await PDFDocument.create()
+    const bold = await pdfDoc.embedFont(StandardFonts.HelveticaBold)
+    assert(
+      shouldStackRowLabel(row!.label, bold),
+      'the long German machining-order label should be stacked above its value',
+    )
+    assert(
+      !shouldStackRowLabel(translate('booklet.label.feed'), bold),
+      'short labels should retain the compact inline layout',
     )
   } finally {
     resetI18nStoreForTests()
@@ -348,7 +358,7 @@ testReportContent()
 testFeedTimeUsesScaledSlotFeed()
 testReportIncludesEnabledRoundOutsideCorners()
 testLocalizedReportContent()
-testGermanLabelWrapping()
+await testGermanLabelLayout()
 await testPdfSmoke()
 await testGermanPdfSmoke()
 await testPdfUnicodeFontRetriesAndUsesBold()

--- a/src/engine/operationBooklet/pdf.ts
+++ b/src/engine/operationBooklet/pdf.ts
@@ -136,8 +136,10 @@ function wrapText(text: string, font: PDFFont, size: number, maxWidth: number): 
   let current = ''
   for (const word of words) {
     const candidate = current ? `${current} ${word}` : word
-    if (font.widthOfTextAtSize(candidate, size) <= maxWidth || current.length === 0) {
+    if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
       current = candidate
+    } else if (current.length === 0) {
+      lines.push(...breakWord(word, font, size, maxWidth))
     } else {
       lines.push(current)
       current = word
@@ -157,6 +159,29 @@ function truncateToWidth(text: string, font: PDFFont, size: number, maxWidth: nu
     truncated = truncated.slice(0, -1)
   }
   return `${truncated}${ellipsis}`
+}
+
+function breakWord(word: string, font: PDFFont, size: number, maxWidth: number): string[] {
+  const lines: string[] = []
+  let start = 0
+  while (start < word.length) {
+    let lo = start + 1
+    let hi = word.length
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2)
+      if (font.widthOfTextAtSize(word.slice(start, mid), size) <= maxWidth) {
+        lo = mid
+      } else {
+        hi = mid - 1
+      }
+    }
+    if (lo <= start) {
+      lo = start + 1
+    }
+    lines.push(word.slice(start, lo))
+    start = lo
+  }
+  return lines
 }
 
 function ensureSpace(state: DrawState, required: number): void {

--- a/src/engine/operationBooklet/pdf.ts
+++ b/src/engine/operationBooklet/pdf.ts
@@ -139,7 +139,7 @@ function wrapText(text: string, font: PDFFont, size: number, maxWidth: number): 
     if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
       current = candidate
     } else if (current.length === 0) {
-      lines.push(...breakWord(word, font, size, maxWidth))
+      current = word
     } else {
       lines.push(current)
       current = word
@@ -159,29 +159,6 @@ function truncateToWidth(text: string, font: PDFFont, size: number, maxWidth: nu
     truncated = truncated.slice(0, -1)
   }
   return `${truncated}${ellipsis}`
-}
-
-function breakWord(word: string, font: PDFFont, size: number, maxWidth: number): string[] {
-  const lines: string[] = []
-  let start = 0
-  while (start < word.length) {
-    let lo = start + 1
-    let hi = word.length
-    while (lo < hi) {
-      const mid = Math.ceil((lo + hi) / 2)
-      if (font.widthOfTextAtSize(word.slice(start, mid), size) <= maxWidth) {
-        lo = mid
-      } else {
-        hi = mid - 1
-      }
-    }
-    if (lo <= start) {
-      lo = start + 1
-    }
-    lines.push(word.slice(start, lo))
-    start = lo
-  }
-  return lines
 }
 
 function ensureSpace(state: DrawState, required: number): void {
@@ -236,22 +213,33 @@ interface PreparedCell {
   labelLines: string[]
   valueLines: string[]
   height: number
+  stackedLabel: boolean
+}
+
+export function shouldStackRowLabel(label: string, font: PDFFont): boolean {
+  return font.widthOfTextAtSize(label, BODY_SIZE) > ROW_LABEL_WIDTH
 }
 
 function prepareRowCell(state: DrawState, row: OperationBookletRow): PreparedCell {
-  const valueWidth = SECTION_COLUMN_WIDTH - ROW_LABEL_WIDTH - ROW_LABEL_GAP
-  const labelLines = wrapText(row.label, state.bold, BODY_SIZE, ROW_LABEL_WIDTH)
+  const stackedLabel = shouldStackRowLabel(row.label, state.bold)
+  const labelWidth = stackedLabel ? SECTION_COLUMN_WIDTH : ROW_LABEL_WIDTH
+  const valueWidth = stackedLabel ? SECTION_COLUMN_WIDTH : SECTION_COLUMN_WIDTH - ROW_LABEL_WIDTH - ROW_LABEL_GAP
+  const labelLines = wrapText(row.label, state.bold, BODY_SIZE, labelWidth)
   const valueLines = wrapText(row.value, state.regular, BODY_SIZE, valueWidth)
-  const lineCount = Math.max(1, labelLines.length, valueLines.length)
+  const lineCount = stackedLabel
+    ? labelLines.length + valueLines.length
+    : Math.max(1, labelLines.length, valueLines.length)
   return {
     labelLines,
     valueLines,
     height: lineCount * LINE_HEIGHT + 6,
+    stackedLabel,
   }
 }
 
 function drawPreparedCell(state: DrawState, cell: PreparedCell, x: number, y: number): void {
-  const valueX = x + ROW_LABEL_WIDTH + ROW_LABEL_GAP
+  const valueX = cell.stackedLabel ? x : x + ROW_LABEL_WIDTH + ROW_LABEL_GAP
+  const valueY = cell.stackedLabel ? y - cell.labelLines.length * LINE_HEIGHT : y
   for (let index = 0; index < cell.labelLines.length; index += 1) {
     state.page.drawText(cell.labelLines[index], {
       x,
@@ -264,7 +252,7 @@ function drawPreparedCell(state: DrawState, cell: PreparedCell, x: number, y: nu
   for (let index = 0; index < cell.valueLines.length; index += 1) {
     state.page.drawText(cell.valueLines[index], {
       x: valueX,
-      y: y - index * LINE_HEIGHT,
+      y: valueY - index * LINE_HEIGHT,
       size: BODY_SIZE,
       font: state.regular,
       color: COLORS.body,


### PR DESCRIPTION
`wrapText()` in the booklet PDF engine only broke on whitespace, so German compound nouns like "Bearbeitungsreihenfolge" overflowed the 82pt label column into the value column.

**Fix:**
- Add `breakWord()` helper that splits single words at character boundaries when they exceed the column width
- The `current.length === 0` escape hatch in `wrapText()` now calls `breakWord` instead of accepting the overflowing word
- No layout constants changed — this is a pure wrapping fix that only activates for words wider than the column

**Verification:**
- `npm run build` (lint, tsc, 127 test files, vite build)
- Two new German-locale tests: report label wrapping + PDF smoke

Closes #331.