### PR TITLE
feat: dynamically extend grid to cover drawing extent on all sides

### DIFF
--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -120,6 +120,7 @@ import {
   drawSketchEditPreviewPoint,
   drawStockOutline,
   drawTabFootprint,
+  getFeaturesWorldBounds,
   type StockLabelRect,
 } from './scenePrimitives'
 import { generateTextShapes } from '../../text'
@@ -899,7 +900,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     ctx.fillStyle = canvasPalette.background
     ctx.fillRect(0, 0, width, height)
 
-    drawGrid(ctx, vt, width, height, project.stock, project.grid, canvasPalette)
+    drawGrid(ctx, vt, width, height, project.stock, project.grid, canvasPalette, getFeaturesWorldBounds(features))
 
     if (project.backdrop?.visible && backdropImage) {
       drawBackdropImage(

--- a/src/components/canvas/scenePrimitives.ts
+++ b/src/components/canvas/scenePrimitives.ts
@@ -15,8 +15,9 @@
  */
 
 import type { SketchControlRef } from '../../store/types'
-import { getStockBounds, profileVertices, rectProfile } from '../../types/project'
-import type { BackdropImage, Clamp, GridSettings, Point, SketchProfile, Stock, Tab } from '../../types/project'
+import { getProfileBounds, getStockBounds, profileVertices, rectProfile } from '../../types/project'
+import type { BackdropImage, Bounds2D, Clamp, GridSettings, Point, SketchProfile, Stock, Tab } from '../../types/project'
+import type { ResolvedSketchFeature } from '../../store/helpers/resolveFeatures'
 import type { Units } from '../../utils/units'
 import { formatLength } from '../../utils/units'
 import { hexToRgba } from './previewPrimitives'
@@ -216,6 +217,34 @@ export function drawSketchEditPreviewPoint(
   ctx.stroke()
 }
 
+/**
+ * Compute the union bounding box of all resolved feature world-space profiles.
+ * Returns `null` when there are no features whose bounds should affect the grid.
+ * Skips invisible features.
+ */
+export function getFeaturesWorldBounds(
+  features: ResolvedSketchFeature[],
+): Bounds2D | null {
+  let bounds: Bounds2D | null = null
+
+  for (const feature of features) {
+    if (!feature.visible) continue
+
+    const profileBounds = getProfileBounds(feature.sketch.profile)
+
+    if (!bounds) {
+      bounds = { ...profileBounds }
+    } else {
+      if (profileBounds.minX < bounds.minX) bounds.minX = profileBounds.minX
+      if (profileBounds.maxX > bounds.maxX) bounds.maxX = profileBounds.maxX
+      if (profileBounds.minY < bounds.minY) bounds.minY = profileBounds.minY
+      if (profileBounds.maxY > bounds.maxY) bounds.maxY = profileBounds.maxY
+    }
+  }
+
+  return bounds
+}
+
 export function drawGrid(
   ctx: CanvasRenderingContext2D,
   vt: ViewTransform,
@@ -224,13 +253,26 @@ export function drawGrid(
   stock: Stock,
   grid: GridSettings,
   palette: CanvasThemePalette,
+  featureWorldBounds?: Bounds2D | null,
 ): void {
   if (!grid.visible) return
 
   const bounds = getStockBounds(stock)
   const centerX = bounds.minX + (bounds.maxX - bounds.minX) / 2
   const centerY = bounds.minY + (bounds.maxY - bounds.minY) / 2
-  const halfExtent = Math.max(grid.extent / 2, 10)
+  const defaultHalfExtent = Math.max(grid.extent / 2, 10)
+  let halfExtent = defaultHalfExtent
+
+  // Dynamically extend the grid to cover feature geometry on all sides.
+  if (featureWorldBounds) {
+    const toLeft = Math.abs(featureWorldBounds.minX - centerX)
+    const toRight = Math.abs(featureWorldBounds.maxX - centerX)
+    const toTop = Math.abs(featureWorldBounds.minY - centerY)
+    const toBottom = Math.abs(featureWorldBounds.maxY - centerY)
+    const neededReach = Math.max(toLeft, toRight, toTop, toBottom)
+    const padding = grid.majorSpacing
+    halfExtent = Math.max(defaultHalfExtent, neededReach + padding)
+  }
   const minX = centerX - halfExtent
   const maxX = centerX + halfExtent
   const minY = centerY - halfExtent

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -25,6 +25,7 @@ import { modelFeatures } from '../../store/helpers/featureRoles'
 import { resolvedProjectFeatures } from '../../store/helpers/resolveFeatures'
 import { applyClampHighlight, applyTabHighlight, buildOriginTriad, buildScene } from '../../engine/csg'
 import { getStockBounds, rectProfile } from '../../types/project'
+import { getFeaturesWorldBounds } from '../canvas/scenePrimitives'
 import { getFeatureGeometryProfiles } from '../../text'
 import { buildToolpathLinePositionChunks, toolpathPointToWorldTuple } from './toolpathOverlay'
 import { useTheme } from '../../theme/themeContext'
@@ -852,7 +853,22 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
     syncGridVisibility()
     if (!project.grid.visible) return
 
-    const extent = Math.max(project.grid.extent, project.grid.minorSpacing)
+    const defaultExtent = Math.max(project.grid.extent, project.grid.minorSpacing)
+    let extent = defaultExtent
+
+    // Dynamically extend the grid to cover feature geometry on all sides.
+    const featureWorldBounds = getFeaturesWorldBounds(resolvedProjectFeatures(project))
+    if (featureWorldBounds) {
+      const toLeft = Math.abs(featureWorldBounds.minX - centerX)
+      const toRight = Math.abs(featureWorldBounds.maxX - centerX)
+      const toTop = Math.abs(featureWorldBounds.minY - centerZ)
+      const toBottom = Math.abs(featureWorldBounds.maxY - centerZ)
+      const neededReach = Math.max(toLeft, toRight, toTop, toBottom)
+      const padding = project.grid.majorSpacing
+      extent = Math.max(defaultExtent, (neededReach + padding) * 2)
+    }
+
+    // THREE.GridHelper expects total extent, not half-extent.
     const minorDivisions = Math.max(1, Math.round(extent / project.grid.minorSpacing))
     const majorDivisions = Math.max(1, Math.round(extent / project.grid.majorSpacing))
 
@@ -865,7 +881,7 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
 
     gridGroup.add(minorGrid)
     gridGroup.add(majorGrid)
-  }, [disposeObjectMaterial, project.grid.extent, project.grid.majorSpacing, project.grid.minorSpacing, project.grid.visible, project.stock, syncGridVisibility])
+  }, [disposeObjectMaterial, project, syncGridVisibility])
 
   useEffect(() => {
     rendererRef.current?.setClearColor(threePalette.background, 1)


### PR DESCRIPTION
Computes the union bounding box of all visible resolved feature world-space
profiles and extends both the 2D sketch grid and 3D viewport grid from the
stock center to cover the farthest feature edge on all sides.

- `grid.extent` is now a **minimum** floor — the grid never shrinks below
  the default (200 mm / 8 in).
- Empty project / all features deleted → unchanged default grid.
- Construction geometry and invisible features are included/excluded as
  appropriate for the grid purpose.
- Pure presentation computation; no project state or schema changes.

## Changes

| File | Change |
|---|---|
| `src/components/canvas/scenePrimitives.ts` | Add `getFeaturesWorldBounds()`; extend `drawGrid()` with optional dynamic extent |
| `src/components/canvas/SketchCanvas.tsx` | Pass feature world bounds to `drawGrid()` in render loop |
| `src/components/viewport3d/Viewport3D.tsx` | Same dynamic extent logic in `rebuildGridHelpers` |

Closes #288