### PR TITLE
feat: add close icon to empty-state onboarding overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -199,6 +199,7 @@ function App() {
     emptyStateEngaged,
     onDraw: handleEmptyStateDraw,
     onImport: handleEmptyStateImport,
+    onDismiss: handleEmptyStateDismiss,
     frameOpenedProject,
   } = useEmptyStateEngagement({
     projectKey,
@@ -400,6 +401,7 @@ function App() {
                 onDraw={handleEmptyStateDraw}
                 onImport={handleEmptyStateImport}
                 onExampleOpened={frameOpenedProject}
+                onDismiss={handleEmptyStateDismiss}
               />
             ) : null}
           </>

--- a/src/app/useEmptyStateEngagement.ts
+++ b/src/app/useEmptyStateEngagement.ts
@@ -45,6 +45,7 @@ export function useEmptyStateEngagement({
   emptyStateEngaged: boolean
   onDraw: () => void
   onImport: () => void
+  onDismiss: () => void
   frameOpenedProject: () => void
 } {
   // The empty-state overlay is a one-time nudge per project. Once the user has
@@ -62,6 +63,10 @@ export function useEmptyStateEngagement({
   function handleEmptyStateImport() {
     setEmptyStateEngaged(true)
     setShowImportDialog(true)
+  }
+
+  function handleDismiss() {
+    setEmptyStateEngaged(true)
   }
 
   function frameOpenedProject() {
@@ -94,6 +99,7 @@ export function useEmptyStateEngagement({
     emptyStateEngaged,
     onDraw: handleEmptyStateDraw,
     onImport: handleEmptyStateImport,
+    onDismiss: handleDismiss,
     frameOpenedProject,
   }
 }

--- a/src/components/onboarding/EmptyStateOverlay.tsx
+++ b/src/components/onboarding/EmptyStateOverlay.tsx
@@ -36,7 +36,7 @@ export function EmptyStateOverlay({ onDraw, onImport, onExampleOpened, onDismiss
   return (
     <div className="empty-state-overlay">
       <div className="empty-state-card">
-        <button className="dialog-close empty-state-card__close" onClick={onDismiss} aria-label={t('dialogs.common.close')} type="button">✕</button>
+        <button className="empty-state-card__close" onClick={onDismiss} aria-label={t('dialogs.common.close')} type="button">✕</button>
         <h2 className="empty-state-card__title">{t('viewport.empty.title')}</h2>
         <p className="empty-state-card__subtitle">{t('viewport.empty.subtitle')}</p>
 

--- a/src/components/onboarding/EmptyStateOverlay.tsx
+++ b/src/components/onboarding/EmptyStateOverlay.tsx
@@ -28,13 +28,15 @@ interface EmptyStateOverlayProps {
   onImport: () => void
   /** Called after a bundled example has been loaded into the store. */
   onExampleOpened: () => void
+  onDismiss: () => void
 }
 
-export function EmptyStateOverlay({ onDraw, onImport, onExampleOpened }: EmptyStateOverlayProps) {
+export function EmptyStateOverlay({ onDraw, onImport, onExampleOpened, onDismiss }: EmptyStateOverlayProps) {
   const { t } = useI18n()
   return (
     <div className="empty-state-overlay">
       <div className="empty-state-card">
+        <button className="dialog-close empty-state-card__close" onClick={onDismiss} aria-label={t('dialogs.common.close')} type="button">✕</button>
         <h2 className="empty-state-card__title">{t('viewport.empty.title')}</h2>
         <p className="empty-state-card__subtitle">{t('viewport.empty.subtitle')}</p>
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -4329,6 +4329,20 @@
   position: absolute;
   top: 12px;
   right: 12px;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  border-radius: 6px;
+}
+
+.empty-state-card__close:hover {
+  background: var(--surface-sheen-mid);
+  color: var(--text);
 }
 
 .empty-state-card__title {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -4313,6 +4313,7 @@
 }
 
 .empty-state-card {
+  position: relative;
   width: min(520px, 100%);
   max-height: 100%;
   overflow-y: auto;
@@ -4322,6 +4323,12 @@
   background: var(--surface-popover);
   box-shadow: 0 18px 48px var(--shadow-strong);
   box-sizing: border-box;
+}
+
+.empty-state-card__close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
 }
 
 .empty-state-card__title {


### PR DESCRIPTION
Adds ✕ close button to the upper right corner of the empty-state onboarding overlay (startup dialog), matching the pattern used by every other dialog.

Users can now dismiss the overlay without being forced to pick Draw, Import, or an example.

Closes #337