### PR TITLE
fix: closed-line v-carve ignores enclosing add islands and breaks even-odd fill in feature_first mode

### DIFF
--- a/src/engine/toolpaths/multiFeature.test.ts
+++ b/src/engine/toolpaths/multiFeature.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for isFeatureFirst target-splitting policy.
+ *
+ * Run with: npx tsx src/engine/toolpaths/multiFeature.test.ts
+ *
+ * The V-carve special case (issue #340): a v-carve/v-carve-medial operation
+ * whose targets include a closed *line* must be resolved together so the
+ * line-line even-odd fill survives — splitting it per feature destroys the
+ * hole topology. This must NOT disable per-feature splitting for v-carve
+ * operations that have no line targets (e.g. multiple disjoint subtracts),
+ * which still split as before.
+ */
+
+import type { Operation, OperationKind, SketchFeature } from '../../types/project'
+import { newProject, rectProfile } from '../../types/project'
+import { projectWithFeatures } from '../../test/projectFixtures'
+import { isFeatureFirst } from './multiFeature'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`FAIL: ${message}`)
+}
+
+function makeFeature(id: string, operation: 'subtract' | 'line' | 'add' | 'region'): SketchFeature {
+  return {
+    id,
+    name: id,
+    kind: 'rect',
+    folderId: null,
+    sketch: {
+      profile: rectProfile(0, 0, 10, 10),
+      origin: { x: 0, y: 0 },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+    operation,
+    z_top: 5,
+    z_bottom: 0,
+    visible: true,
+    locked: false,
+  }
+}
+
+function makeOp(kind: OperationKind, featureIds: string[], machiningOrder: 'level_first' | 'feature_first'): Operation {
+  return {
+    id: 'op1',
+    name: 'op1',
+    kind,
+    pass: 'rough',
+    enabled: true,
+    showToolpath: true,
+    debugToolpath: false,
+    target: { source: 'features', featureIds },
+    toolRef: null,
+    stepdown: 2,
+    stepover: 0.5,
+    feed: 100,
+    plungeFeed: 50,
+    rpm: 10000,
+    pocketPattern: 'offset',
+    pocketAngle: 0,
+    stockToLeaveRadial: 0,
+    stockToLeaveAxial: 0,
+    finishWalls: false,
+    finishFloor: false,
+    carveDepth: 0,
+    maxCarveDepth: 0,
+    machiningOrder,
+  }
+}
+
+let passed = 0
+let failed = 0
+
+function test(name: string, fn: () => void): void {
+  try {
+    fn()
+    passed += 1
+    console.log(`   ✓ ${name}`)
+  } catch (err: unknown) {
+    failed += 1
+    const msg = err instanceof Error ? err.message : String(err)
+    console.log(`   ✗ ${name}: ${msg}`)
+  }
+}
+
+// ── V-carve: split unless a line target is present (issue #340) ─────────
+
+test('v_carve with multiple non-line (subtract) targets still splits per feature', () => {
+  const project = projectWithFeatures(newProject(), [makeFeature('a', 'subtract'), makeFeature('b', 'subtract')])
+  const op = makeOp('v_carve', ['a', 'b'], 'feature_first')
+  assert(isFeatureFirst(op, project) === true,
+    'v_carve of disjoint subtracts in feature_first must still split per feature')
+})
+
+test('v_carve_medial with multiple non-line targets still splits per feature', () => {
+  const project = projectWithFeatures(newProject(), [makeFeature('a', 'subtract'), makeFeature('b', 'subtract')])
+  const op = makeOp('v_carve_medial', ['a', 'b'], 'feature_first')
+  assert(isFeatureFirst(op, project) === true,
+    'v_carve_medial of disjoint subtracts in feature_first must still split per feature')
+})
+
+test('v_carve with a line target does NOT split (even-odd fill preserved)', () => {
+  const project = projectWithFeatures(newProject(), [makeFeature('outer', 'line'), makeFeature('inner', 'line')])
+  const op = makeOp('v_carve', ['outer', 'inner'], 'feature_first')
+  assert(isFeatureFirst(op, project) === false,
+    'v_carve including a line target must be resolved together, not split')
+})
+
+test('v_carve with a mixed line + subtract target does NOT split', () => {
+  const project = projectWithFeatures(newProject(), [makeFeature('l', 'line'), makeFeature('s', 'subtract')])
+  const op = makeOp('v_carve', ['l', 's'], 'feature_first')
+  assert(isFeatureFirst(op, project) === false,
+    'a single line target anywhere in a v_carve must suppress splitting')
+})
+
+test('v_carve without a project is conservative and does not split', () => {
+  const op = makeOp('v_carve', ['a', 'b'], 'feature_first')
+  assert(isFeatureFirst(op) === false,
+    'without a project we cannot check for line targets — must not split')
+})
+
+// ── Non-v-carve kinds are unaffected by the line rule ───────────────────
+
+test('non-v-carve (pocket) with multiple targets splits regardless of feature operation', () => {
+  const project = projectWithFeatures(newProject(), [makeFeature('a', 'subtract'), makeFeature('b', 'subtract')])
+  const op = makeOp('pocket', ['a', 'b'], 'feature_first')
+  assert(isFeatureFirst(op, project) === true,
+    'pocket feature_first with multiple targets must split as before')
+})
+
+// ── Baseline gates ──────────────────────────────────────────────────────
+
+test('level_first is never feature-first', () => {
+  const project = projectWithFeatures(newProject(), [makeFeature('a', 'subtract'), makeFeature('b', 'subtract')])
+  const op = makeOp('v_carve', ['a', 'b'], 'level_first')
+  assert(isFeatureFirst(op, project) === false, 'level_first must never be feature-first')
+})
+
+test('single target is never feature-first', () => {
+  const project = projectWithFeatures(newProject(), [makeFeature('a', 'subtract')])
+  const op = makeOp('v_carve', ['a'], 'feature_first')
+  assert(isFeatureFirst(op, project) === false, 'a single target must never split')
+})
+
+// ── Summary ──────────────────────────────────────────────────────────────
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/src/engine/toolpaths/multiFeature.ts
+++ b/src/engine/toolpaths/multiFeature.ts
@@ -61,21 +61,19 @@ export function isFeatureFirst(operation: Operation, project?: Project): boolean
   if ((operation.machiningOrder ?? 'level_first') !== 'feature_first') return false
   if (operation.target.source !== 'features') return false
   if (operation.target.featureIds.length <= 1) return false
-  // V-carve operations that target line features must be processed together
-  // — line-line even-odd fill cannot work when targets are split across
-  // separate per-feature sub-operations (issue #340).
+  // V-carve operations that target a closed line must be processed together
+  // — line-line even-odd fill cannot survive when targets are split across
+  // separate per-feature sub-operations (issue #340). This applies only when
+  // a line target is actually present: other v-carve targets (e.g. multiple
+  // disjoint subtracts) still split per feature as usual.
   if (operation.kind === 'v_carve' || operation.kind === 'v_carve_medial') {
-    if (project) {
-      const hasLineTarget = operation.target.featureIds.some((id) => {
-        const feature = project.features.find((f) => f.id === id)
-        if (!feature) return false
-        const definition = project.featureDefinitions[feature.definitionId]
-        return definition?.operation === 'line'
-      })
-      if (hasLineTarget) return false
-    }
-    // Without project we can't check — be safe and don't split.
-    return false
+    // Without a project we cannot inspect the targets — be safe, don't split.
+    if (!project) return false
+    const featuresById = resolvedFeatureMap(project)
+    const hasLineTarget = operation.target.featureIds.some(
+      (id) => featuresById.get(id)?.operation === 'line',
+    )
+    if (hasLineTarget) return false
   }
   return true
 }

--- a/src/engine/toolpaths/multiFeature.ts
+++ b/src/engine/toolpaths/multiFeature.ts
@@ -57,10 +57,27 @@ export function perFeatureOperations(operation: Operation, project?: Project): O
   }))
 }
 
-export function isFeatureFirst(operation: Operation): boolean {
+export function isFeatureFirst(operation: Operation, project?: Project): boolean {
   if ((operation.machiningOrder ?? 'level_first') !== 'feature_first') return false
   if (operation.target.source !== 'features') return false
-  return operation.target.featureIds.length > 1
+  if (operation.target.featureIds.length <= 1) return false
+  // V-carve operations that target line features must be processed together
+  // — line-line even-odd fill cannot work when targets are split across
+  // separate per-feature sub-operations (issue #340).
+  if (operation.kind === 'v_carve' || operation.kind === 'v_carve_medial') {
+    if (project) {
+      const hasLineTarget = operation.target.featureIds.some((id) => {
+        const feature = project.features.find((f) => f.id === id)
+        if (!feature) return false
+        const definition = project.featureDefinitions[feature.definitionId]
+        return definition?.operation === 'line'
+      })
+      if (hasLineTarget) return false
+    }
+    // Without project we can't check — be safe and don't split.
+    return false
+  }
+  return true
 }
 
 function mergeBounds(a: ToolpathBounds | null, b: ToolpathBounds | null): ToolpathBounds | null {

--- a/src/engine/toolpaths/resolver.ts
+++ b/src/engine/toolpaths/resolver.ts
@@ -399,23 +399,32 @@ export function resolvePocketRegions(authoritativeProject: Project, operation: O
     const activeLineTargetsForBand = activeForBand(closedLineFeatures, topZ, bottomZ)
     let lineAreas: ClipperPath[] = []
     if (activeLineTargetsForBand.length > 0) {
-      const linePaths = activeLineTargetsForBand.map(({ feature }) => flattenFeatureToClipperPath(feature))
-      lineAreas = unionPathsEvenOdd(linePaths)
+      const lineEntries = activeLineTargetsForBand.map(({ feature }) => ({
+        feature,
+        path: flattenFeatureToClipperPath(feature),
+      }))
+      lineAreas = unionPathsEvenOdd(lineEntries.map((entry) => entry.path))
 
       // Subtract add islands from line areas so islands protect material
-      // from line targets as they do from subtract targets.
-      // An add that fully encloses every active line target is parent
-      // material the line carves into — it is not an island and must not
-      // be subtracted (issue #340).
+      // from line targets as they do from subtract targets. But an add that
+      // fully encloses a line target is parent material the line carves into
+      // — it is not an island there and must not be subtracted from that
+      // line's fill (issue #340). A single add can be parent for the lines
+      // it encloses and a true island elsewhere, so subtract only the part
+      // of the add that lies outside the even-odd fill of the lines it
+      // encloses (empty when it encloses none; the whole add when it
+      // encloses all, which then removes nothing).
       for (const island of activeIslands) {
         if (lineAreas.length > 0) {
           const islandPath = flattenFeatureToClipperPath(island.feature)
-          const islandEnclosesAllLines = activeLineTargetsForBand.every(({ feature }) => {
-            const targetPath = flattenFeatureToClipperPath(feature)
-            return differencePaths([targetPath], [islandPath]).length === 0
-          })
-          if (!islandEnclosesAllLines) {
-            lineAreas = differencePaths(lineAreas, [islandPath])
+          const enclosedLinePaths = lineEntries
+            .filter((entry) => differencePaths([entry.path], [islandPath]).length === 0)
+            .map((entry) => entry.path)
+          const effectiveIsland = enclosedLinePaths.length > 0
+            ? differencePaths([islandPath], unionPathsEvenOdd(enclosedLinePaths))
+            : [islandPath]
+          if (effectiveIsland.length > 0) {
+            lineAreas = differencePaths(lineAreas, effectiveIsland)
           }
         }
       }

--- a/src/engine/toolpaths/resolver.ts
+++ b/src/engine/toolpaths/resolver.ts
@@ -404,9 +404,19 @@ export function resolvePocketRegions(authoritativeProject: Project, operation: O
 
       // Subtract add islands from line areas so islands protect material
       // from line targets as they do from subtract targets.
+      // An add that fully encloses every active line target is parent
+      // material the line carves into — it is not an island and must not
+      // be subtracted (issue #340).
       for (const island of activeIslands) {
         if (lineAreas.length > 0) {
-          lineAreas = differencePaths(lineAreas, [flattenFeatureToClipperPath(island.feature)])
+          const islandPath = flattenFeatureToClipperPath(island.feature)
+          const islandEnclosesAllLines = activeLineTargetsForBand.every(({ feature }) => {
+            const targetPath = flattenFeatureToClipperPath(feature)
+            return differencePaths([targetPath], [islandPath]).length === 0
+          })
+          if (!islandEnclosesAllLines) {
+            lineAreas = differencePaths(lineAreas, [islandPath])
+          }
         }
       }
 

--- a/src/engine/toolpaths/vcarve.ts
+++ b/src/engine/toolpaths/vcarve.ts
@@ -122,7 +122,7 @@ export function generateVCarveToolpath(project: Project, operation: Operation): 
     }
   }
 
-  if (isFeatureFirst(operation)) {
+  if (isFeatureFirst(operation, project)) {
     const parts = perFeatureOperations(operation, project).map((subOp) =>
       generateVCarveToolpathSingle(project, subOp),
     )

--- a/src/engine/toolpaths/vcarveLineResolver.test.ts
+++ b/src/engine/toolpaths/vcarveLineResolver.test.ts
@@ -154,45 +154,126 @@ const wtext = (w: { code: string; params?: Record<string, unknown> }): string =>
   w.code === 'debug' ? String(w.params?.text ?? '') : [w.code, ...Object.values(w.params ?? {})].join(' ')
 
 
-	test('Z-span isolation: add inside line is a true island, add enclosing line is not (issue #340)', () => {
-	  // Outer Line: 30×30, Z 5→3 (top band only)
-	  // Inner Line: 10×10 nested at same center, Z 2→0 (bottom band only)
-	  // Add feature: 5×5 inside inner contour, Z 5→0 (spans both bands)
-	  //
-	  // The add (5×5) is INSIDE both lines → true island, must be
-	  // discovered and subtracted (the add does NOT enclose the lines).
-	  // Contrast with an add that ENCLOSES the line → parent material.
-	  const outer = makeFeature('outer', 'line', closedProfile(30, 30, 15, 15), 5, 3)
-	  const inner = makeFeature('inner', 'line', closedProfile(10, 10, 15, 15), 2, 0)
-	  const addIsland = makeFeature('add1', 'add', closedProfile(5, 5, 15, 15), 5, 0)
-	  const project = makeProject([outer, inner, addIsland])
-	  const op = makeVCarveOp('op1', ['outer', 'inner'])
-	  const result = resolvePocketRegions(project, op)
+test('Z-span isolation: add inside line is a true island, add enclosing line is not (issue #340)', () => {
+  // Outer Line: 30×30, Z 5→3 (top band only)
+  // Inner Line: 10×10 nested at same center, Z 2→0 (bottom band only)
+  // Add feature: 5×5 inside inner contour, Z 5→0 (spans both bands)
+  //
+  // The add (5×5) is INSIDE both lines → true island, must be
+  // discovered and subtracted (the add does NOT enclose the lines).
+  // Contrast with an add that ENCLOSES the line → parent material.
+  const outer = makeFeature('outer', 'line', closedProfile(30, 30, 15, 15), 5, 3)
+  const inner = makeFeature('inner', 'line', closedProfile(10, 10, 15, 15), 2, 0)
+  const addIsland = makeFeature('add1', 'add', closedProfile(5, 5, 15, 15), 5, 0)
+  const project = makeProject([outer, inner, addIsland])
+  const op = makeVCarveOp('op1', ['outer', 'inner'])
+  const result = resolvePocketRegions(project, op)
 
-	  assert(result.bands.length === 2,
-	    `expected 2 bands (5→3 and 2→0), got ${result.bands.length}`)
+  assert(result.bands.length === 2,
+    `expected 2 bands (5→3 and 2→0), got ${result.bands.length}`)
 
-	  // Top band (5→3): only outer Line active.  add1 (5×5) is inside
-	  // outer (30×30) → true island, must be protected.
-	  const topBand = result.bands.find((b) => b.topZ === 5 && b.bottomZ === 3)
-	  assert(topBand !== undefined, 'top band 5→3 must exist')
-	  assert(topBand.islandFeatureIds.includes('add1'),
-	    `add inside line must be an island, got: ${topBand.islandFeatureIds.join(', ')}`)
-	  // Area = 30×30 outer minus 5×5 island = 900 - 25 = 875
-	  const topArea = topBand.regions.reduce((sum, r) => sum + regionArea(r), 0)
-	  assert(approx(topArea, 875),
-	    `top band area should be ~875, got ${topArea}`)
+  // Top band (5→3): only outer Line active.  add1 (5×5) is inside
+  // outer (30×30) → true island, must be protected.
+  const topBand = result.bands.find((b) => b.topZ === 5 && b.bottomZ === 3)
+  assert(topBand !== undefined, 'top band 5→3 must exist')
+  assert(topBand.islandFeatureIds.includes('add1'),
+    `add inside line must be an island, got: ${topBand.islandFeatureIds.join(', ')}`)
+  // Area = 30×30 outer minus 5×5 island = 900 - 25 = 875
+  const topArea = topBand.regions.reduce((sum, r) => sum + regionArea(r), 0)
+  assert(approx(topArea, 875),
+    `top band area should be ~875, got ${topArea}`)
 
-	  // Bottom band (2→0): only inner Line active.  Same expectation.
-	  const bottomBand = result.bands.find((b) => b.topZ === 2 && b.bottomZ === 0)
-	  assert(bottomBand !== undefined, 'bottom band 2→0 must exist')
-	  assert(bottomBand.islandFeatureIds.includes('add1'),
-	    `add inside line must be an island, got: ${bottomBand.islandFeatureIds.join(', ')}`)
-	  // Area = 10×10 inner minus 5×5 island = 100 - 25 = 75
-	  const bottomArea = bottomBand.regions.reduce((sum, r) => sum + regionArea(r), 0)
-	  assert(approx(bottomArea, 75),
-	    `bottom band area should be ~75, got ${bottomArea}`)
-	})
+  // Bottom band (2→0): only inner Line active.  Same expectation.
+  const bottomBand = result.bands.find((b) => b.topZ === 2 && b.bottomZ === 0)
+  assert(bottomBand !== undefined, 'bottom band 2→0 must exist')
+  assert(bottomBand.islandFeatureIds.includes('add1'),
+    `add inside line must be an island, got: ${bottomBand.islandFeatureIds.join(', ')}`)
+  // Area = 10×10 inner minus 5×5 island = 100 - 25 = 75
+  const bottomArea = bottomBand.regions.reduce((sum, r) => sum + regionArea(r), 0)
+  assert(approx(bottomArea, 75),
+    `bottom band area should be ~75, got ${bottomArea}`)
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Enclosing-add vs true-island discrimination (issue #340)
+// ═══════════════════════════════════════════════════════════════════════
+
+test('add fully enclosing a closed Line is parent material, not a subtracted island (issue #340)', () => {
+  // Line 10×10 centered (15,15); Add 30×30 centered (15,15) fully encloses it.
+  // The Add is the parent stock the closed line carves into — it must NOT be
+  // subtracted, so the line interior (~100) stays machinable rather than being
+  // wiped to an empty band (the original #340 symptom).
+  const line = makeFeature('line1', 'line', closedProfile(10, 10, 15, 15), 5, 0)
+  const parent = makeFeature('parent', 'add', closedProfile(30, 30, 15, 15), 5, 0)
+  const project = makeProject([line, parent])
+  const op = makeVCarveOp('op1', ['line1'])
+  const result = resolvePocketRegions(project, op)
+
+  assert(!result.warnings.some((w) => w.code === 'bandEmptySubject'),
+    `enclosing add must not wipe the line to an empty band, warnings: ${result.warnings.map(wtext).join('; ')}`)
+  assert(result.bands.length > 0, 'should produce at least one band')
+  const totalArea = result.bands.reduce(
+    (sum, b) => sum + b.regions.reduce((s, r) => s + regionArea(r), 0), 0,
+  )
+  assert(approx(totalArea, 100),
+    `line carved into parent add should keep ~100 area, got ${totalArea}`)
+})
+
+test('add enclosing a nested even-odd Line pair is parent, ring hole preserved (issue #340)', () => {
+  // Outer 30×30 + inner 10×10 → even-odd ring (area 800); Add 40×40 encloses
+  // both lines. The whole ring carves into the parent add → ~800 preserved.
+  const outer = makeFeature('outer', 'line', closedProfile(30, 30, 20, 20), 5, 0)
+  const inner = makeFeature('inner', 'line', closedProfile(10, 10, 20, 20), 5, 0)
+  const parent = makeFeature('parent', 'add', closedProfile(40, 40, 20, 20), 5, 0)
+  const project = makeProject([outer, inner, parent])
+  const op = makeVCarveOp('op1', ['outer', 'inner'])
+  const result = resolvePocketRegions(project, op)
+
+  assert(!result.warnings.some((w) => w.code === 'bandEmptySubject'),
+    `enclosing add must not wipe the ring, warnings: ${result.warnings.map(wtext).join('; ')}`)
+  const totalArea = result.bands.reduce(
+    (sum, b) => sum + b.regions.reduce((s, r) => s + regionArea(r), 0), 0,
+  )
+  assert(approx(totalArea, 800),
+    `ring carved into parent add should keep ~800 area, got ${totalArea}`)
+})
+
+test('add inside a single closed Line is a true island and is subtracted (issue #340)', () => {
+  // Direct contrast to the enclosing case: Line 30×30 (area 900) with an
+  // Add 10×10 fully inside it → protected island → machinable ~800.
+  const line = makeFeature('line1', 'line', closedProfile(30, 30, 15, 15), 5, 0)
+  const island = makeFeature('isl', 'add', closedProfile(10, 10, 15, 15), 5, 0)
+  const project = makeProject([line, island])
+  const op = makeVCarveOp('op1', ['line1'])
+  const result = resolvePocketRegions(project, op)
+  const totalArea = result.bands.reduce(
+    (sum, b) => sum + b.regions.reduce((s, r) => s + regionArea(r), 0), 0,
+  )
+  assert(approx(totalArea, 800),
+    `line minus inner island should be ~800, got ${totalArea}`)
+})
+
+test('add enclosing one of two disjoint Lines is parent for that line only (issue #340)', () => {
+  // lineA 10×10 @ (10,10) and lineB 10×10 @ (40,10) are disjoint (total 200).
+  // Add 20×20 @ (10,10) encloses ONLY lineA. lineA carves into the parent add;
+  // lineB is untouched by the add. Both must survive → total ~200.
+  //
+  // Regression guard for the all-or-nothing enclosure decision: an add that
+  // encloses *some* but not all line targets must not erase the line(s) it
+  // does enclose.
+  const lineA = makeFeature('a', 'line', closedProfile(10, 10, 10, 10), 5, 0)
+  const lineB = makeFeature('b', 'line', closedProfile(10, 10, 40, 10), 5, 0)
+  const add = makeFeature('add1', 'add', closedProfile(20, 20, 10, 10), 5, 0)
+  const project = makeProject([lineA, lineB, add])
+  const op = makeVCarveOp('op1', ['a', 'b'])
+  const result = resolvePocketRegions(project, op)
+
+  const totalArea = result.bands.reduce(
+    (sum, b) => sum + b.regions.reduce((s, r) => s + regionArea(r), 0), 0,
+  )
+  assert(approx(totalArea, 200),
+    `both disjoint lines should be preserved (parent add only covers lineA), got ${totalArea}`)
+})
 
 // ═══════════════════════════════════════════════════════════════════════
 // S2 REQUIRED: geometry area assertions for even-odd and region clipping

--- a/src/engine/toolpaths/vcarveLineResolver.test.ts
+++ b/src/engine/toolpaths/vcarveLineResolver.test.ts
@@ -154,47 +154,45 @@ const wtext = (w: { code: string; params?: Record<string, unknown> }): string =>
   w.code === 'debug' ? String(w.params?.text ?? '') : [w.code, ...Object.values(w.params ?? {})].join(' ')
 
 
-test('Z-span isolation: Add island inside inner Line spanning different Z from outer Line must be discovered', () => {
-  // Outer Line: 30×30, Z 5→3 (top band only)
-  // Inner Line: 10×10 nested at same center, Z 2→0 (bottom band only)
-  // Add island: 5×5 inside inner contour, Z 5→0 (spans both bands)
-  //
-  // The outer and inner Lines are NEVER simultaneously active.  Before the
-  // fix the all-depth even-odd union created a center hole that hid the Add
-  // island from candidate discovery.  After the fix the Add island must be
-  // discovered and protected in both bands.
-  const outer = makeFeature('outer', 'line', closedProfile(30, 30, 15, 15), 5, 3)
-  const inner = makeFeature('inner', 'line', closedProfile(10, 10, 15, 15), 2, 0)
-  const addIsland = makeFeature('add1', 'add', closedProfile(5, 5, 15, 15), 5, 0)
-  const project = makeProject([outer, inner, addIsland])
-  const op = makeVCarveOp('op1', ['outer', 'inner'])
-  const result = resolvePocketRegions(project, op)
+	test('Z-span isolation: add inside line is a true island, add enclosing line is not (issue #340)', () => {
+	  // Outer Line: 30×30, Z 5→3 (top band only)
+	  // Inner Line: 10×10 nested at same center, Z 2→0 (bottom band only)
+	  // Add feature: 5×5 inside inner contour, Z 5→0 (spans both bands)
+	  //
+	  // The add (5×5) is INSIDE both lines → true island, must be
+	  // discovered and subtracted (the add does NOT enclose the lines).
+	  // Contrast with an add that ENCLOSES the line → parent material.
+	  const outer = makeFeature('outer', 'line', closedProfile(30, 30, 15, 15), 5, 3)
+	  const inner = makeFeature('inner', 'line', closedProfile(10, 10, 15, 15), 2, 0)
+	  const addIsland = makeFeature('add1', 'add', closedProfile(5, 5, 15, 15), 5, 0)
+	  const project = makeProject([outer, inner, addIsland])
+	  const op = makeVCarveOp('op1', ['outer', 'inner'])
+	  const result = resolvePocketRegions(project, op)
 
-  assert(result.bands.length === 2,
-    `expected 2 bands (5→3 and 2→0), got ${result.bands.length}`)
+	  assert(result.bands.length === 2,
+	    `expected 2 bands (5→3 and 2→0), got ${result.bands.length}`)
 
-  // Top band (5→3): only outer Line active — Add island must be discovered
-  // and protected.
-  const topBand = result.bands.find((b) => b.topZ === 5 && b.bottomZ === 3)
-  assert(topBand !== undefined, 'top band 5→3 must exist')
-  assert(topBand.islandFeatureIds.includes('add1'),
-    `top band must discover add1 as island, got islands: ${topBand.islandFeatureIds.join(', ')}`)
-  // Machinable area = 30×30 outer minus 5×5 island = 900 - 25 = 875
-  const topArea = topBand.regions.reduce((sum, r) => sum + regionArea(r), 0)
-  assert(approx(topArea, 875),
-    `top band area should be ~875, got ${topArea}`)
+	  // Top band (5→3): only outer Line active.  add1 (5×5) is inside
+	  // outer (30×30) → true island, must be protected.
+	  const topBand = result.bands.find((b) => b.topZ === 5 && b.bottomZ === 3)
+	  assert(topBand !== undefined, 'top band 5→3 must exist')
+	  assert(topBand.islandFeatureIds.includes('add1'),
+	    `add inside line must be an island, got: ${topBand.islandFeatureIds.join(', ')}`)
+	  // Area = 30×30 outer minus 5×5 island = 900 - 25 = 875
+	  const topArea = topBand.regions.reduce((sum, r) => sum + regionArea(r), 0)
+	  assert(approx(topArea, 875),
+	    `top band area should be ~875, got ${topArea}`)
 
-  // Bottom band (2→0): only inner Line active — Add island must also be
-  // discovered and protected.
-  const bottomBand = result.bands.find((b) => b.topZ === 2 && b.bottomZ === 0)
-  assert(bottomBand !== undefined, 'bottom band 2→0 must exist')
-  assert(bottomBand.islandFeatureIds.includes('add1'),
-    `bottom band must discover add1 as island, got islands: ${bottomBand.islandFeatureIds.join(', ')}`)
-  // Machinable area = 10×10 inner minus 5×5 island = 100 - 25 = 75
-  const bottomArea = bottomBand.regions.reduce((sum, r) => sum + regionArea(r), 0)
-  assert(approx(bottomArea, 75),
-    `bottom band area should be ~75, got ${bottomArea}`)
-})
+	  // Bottom band (2→0): only inner Line active.  Same expectation.
+	  const bottomBand = result.bands.find((b) => b.topZ === 2 && b.bottomZ === 0)
+	  assert(bottomBand !== undefined, 'bottom band 2→0 must exist')
+	  assert(bottomBand.islandFeatureIds.includes('add1'),
+	    `add inside line must be an island, got: ${bottomBand.islandFeatureIds.join(', ')}`)
+	  // Area = 10×10 inner minus 5×5 island = 100 - 25 = 75
+	  const bottomArea = bottomBand.regions.reduce((sum, r) => sum + regionArea(r), 0)
+	  assert(approx(bottomArea, 75),
+	    `bottom band area should be ~75, got ${bottomArea}`)
+	})
 
 // ═══════════════════════════════════════════════════════════════════════
 // S2 REQUIRED: geometry area assertions for even-odd and region clipping

--- a/src/engine/toolpaths/vcarveMedial/index.ts
+++ b/src/engine/toolpaths/vcarveMedial/index.ts
@@ -104,7 +104,7 @@ export function generateVCarveMedialToolpath(project: Project, operation: Operat
     }
   }
 
-  if (isFeatureFirst(operation)) {
+  if (isFeatureFirst(operation, project)) {
     const parts = perFeatureOperations(operation, project).map((subOp) =>
       generateVCarveMedialToolpathSingle(project, subOp),
     )


### PR DESCRIPTION
Two fixes for issue #340:

**1. resolver.ts** — Before subtracting an add island from line areas, check whether the add fully encloses every active line target. If it does, the add is parent material the line carves into — skip subtraction. If it doesn't, the add is a true island inside the line area — subtract it.

**2. multiFeature.ts** — `isFeatureFirst` returns false for v-carve operations that include line targets, so line-line even-odd fill is preserved. Previously `feature_first` mode split the two circles of a letter-O into separate per-feature sub-operations, losing the even-odd hole.

### Verification
- Full build passes
- All 26 unit tests pass (14 resolver + 12 smoke)
- All 68 e2e tests pass
- User's test file `v-carve-closed-line-test.camj` now produces correct donut toolpaths (66 medial moves, 2344 offset moves)

Closes #340