### PR TITLE
Preserve rest regions around gear islands

### DIFF
--- a/src/engine/toolpaths/restRegions.ts
+++ b/src/engine/toolpaths/restRegions.ts
@@ -379,14 +379,6 @@ function cornerCuspTriangles(
   return triangles
 }
 
-/** Morphological open: drop anything thinner than 2·clearance, keep fatter blobs. */
-function removeThinSlivers(paths: ClipperPath[], clearance: number): ClipperPath[] {
-  if (paths.length === 0 || clearance <= 0) return paths
-  const eroded = offsetClosedPaths(paths, -clearance, ClipperLib.JoinType.jtMiter)
-  if (eroded.length === 0) return []
-  return offsetClosedPaths(eroded, clearance, ClipperLib.JoinType.jtMiter)
-}
-
 function signedContourArea(contour: Point[]): number {
   let area = 0
   for (let index = 0; index < contour.length; index += 1) {
@@ -408,9 +400,13 @@ function pointInContour(point: Point, contour: Point[]): boolean {
   }).PointInPolygon(clipperPoint, clipperContour) > 0
 }
 
-function areaPathsToDrafts(paths: ClipperPath[], toolRadius: number, operation: Operation): RestRegionDraft[] {
+function areaPathsToDrafts(
+  paths: ClipperPath[],
+  toolRadius: number,
+  operation: Operation,
+  simplifyTolerance = Math.max(5 / DEFAULT_CLIPPER_SCALE, toolRadius * 0.04),
+): RestRegionDraft[] {
   const minArea = Math.max((100 / DEFAULT_CLIPPER_SCALE) ** 2, toolRadius * toolRadius * 0.0004)
-  const simplifyTolerance = Math.max(5 / DEFAULT_CLIPPER_SCALE, toolRadius * 0.04)
   const contours = clipperPathsToPointContours(paths)
     .filter((contour) => contour.length >= 3)
     .map((contour) => simplifyClosedContour(contour, simplifyTolerance))
@@ -446,12 +442,16 @@ function generateAreaRestRegionDrafts(
 ): RestRegionDraft[] {
   const sourceAreaPaths: ClipperPath[] = []
   const reachableAreaPaths: ClipperPath[] = []
+  const islandPaths: ClipperPath[] = []
   const radialLeave = Math.max(0, operation.stockToLeaveRadial)
   const centerInset = toolRadius + radialLeave
 
   for (const band of resolved.bands) {
     for (const region of band.regions) {
       sourceAreaPaths.push(...pocketRegionToAreaPaths(region))
+      islandPaths.push(...region.islands
+        .filter((island) => island.length >= 3)
+        .map((island) => toClipperPath(normalizeWinding(island, false), DEFAULT_CLIPPER_SCALE)))
 
       const centerRegions = buildInsetRegions(region, centerInset)
       const centerAreaPaths = centerRegions.flatMap(pocketRegionToAreaPaths)
@@ -465,11 +465,26 @@ function generateAreaRestRegionDrafts(
   }
   if (sourceUnion.length === 0) return []
 
+  // Clipper rounds each boundary to the integer grid. When a rest contour is
+  // converted back into a feature, a boundary vertex can otherwise round one
+  // grid unit into an additive island. Keep a two-grid-unit clearance from
+  // those islands so the generated include mask never asks a later operation
+  // to machine protected material.
+  const protectedIslandPaths = islandPaths.length > 0
+    ? offsetClosedPaths(unionClipperPaths(islandPaths), 2 / DEFAULT_CLIPPER_SCALE, ClipperLib.JoinType.jtRound)
+    : []
+  const safeSourceUnion = protectedIslandPaths.length > 0
+    ? differenceClipperPaths(sourceUnion, protectedIslandPaths)
+    : sourceUnion
+
   let reachableUnion = unionClipperPaths(reachableAreaPaths)
   if (sourceMask) {
     reachableUnion = applyRegionMaskToPaths(reachableUnion, sourceMask)
   }
-  const restPaths = unionClipperPaths(differenceClipperPaths(sourceUnion, reachableUnion))
+  const rawRestPaths = unionClipperPaths(differenceClipperPaths(sourceUnion, reachableUnion))
+  const restPaths = protectedIslandPaths.length > 0
+    ? differenceClipperPaths(rawRestPaths, protectedIslandPaths)
+    : rawRestPaths
   if (restPaths.length === 0) return []
 
   // Build one analytical cusp triangle per convex corner of every pocket
@@ -503,22 +518,24 @@ function generateAreaRestRegionDrafts(
     const remainingArea = remaining.reduce((sum, path) => sum + pathArea(path), 0)
     if (remainingArea < gateArea) continue
 
-    cornerRegions.push(...intersectClipperPaths([triangle], sourceUnion))
+    cornerRegions.push(...intersectClipperPaths([triangle], safeSourceUnion))
   }
 
   // Corners alone don't cover unreachable material away from a convex corner —
-  // e.g. a channel narrower than the tool, or a pocket the tool can't enter at
-  // all. Emit that residual too, but first open it to shed the thin corner-cusp
-  // remnants, the sub-grid slivers that run along walls, and the small crumbs a
-  // round tool leaves at a concave corner (all minor and visually noisy). A real
-  // unreachable channel or pocket is wider than this and survives.
+  // e.g. a channel narrower than the tool, or the narrow root wedges around a
+  // non-circular island. Keep that residual at its original Clipper resolution:
+  // a tool-relative sliver filter or contour simplification can erase legitimate
+  // wedges in inch-scale projects.
   const cornerUnion = unionClipperPaths(cornerRegions)
   const residual = cornerUnion.length > 0
     ? differenceClipperPaths(restPaths, cornerUnion)
     : restPaths
-  const residualBlobs = removeThinSlivers(residual, Math.max(3 / DEFAULT_CLIPPER_SCALE, toolRadius * 0.4))
+  const residualBlobs = residual
 
-  return areaPathsToDrafts([...cornerRegions, ...residualBlobs], toolRadius, operation)
+  return [
+    ...areaPathsToDrafts(cornerRegions, toolRadius, operation),
+    ...areaPathsToDrafts(residualBlobs, toolRadius, operation, 0),
+  ]
 }
 
 export function generatePocketRestRegionDrafts(project: Project, operation: Operation): RestRegionDraftResult {

--- a/src/engine/toolpaths/restRegions.ts
+++ b/src/engine/toolpaths/restRegions.ts
@@ -530,7 +530,28 @@ function generateAreaRestRegionDrafts(
   const residual = cornerUnion.length > 0
     ? differenceClipperPaths(restPaths, cornerUnion)
     : restPaths
-  const residualBlobs = residual
+  // Give a smaller rest tool half of the roughing-tool radius of overlap with
+  // the prior clearing pass. This avoids an exact-edge handoff at narrow island
+  // roots, while the safe source union keeps the extra coverage out of additive
+  // islands and inside the target pocket. Limit that growth to residuals next
+  // to an additive island: pocket-corner crumbs use their analytical regions
+  // and must not become additional masks. Full-area residuals can contain hole
+  // contours, so they retain their exact topology rather than being offset.
+  const residualOverlap = toolRadius * 0.5
+  const maxIslandWedgeArea = toolRadius * toolRadius * 4
+  const islandInfluencePaths = protectedIslandPaths.length > 0
+    ? offsetClosedPaths(protectedIslandPaths, toolRadius, ClipperLib.JoinType.jtRound)
+    : []
+  const residualBlobs = residual.flatMap((path) => {
+    const touchesIsland = pathArea(path) <= maxIslandWedgeArea
+      && islandInfluencePaths.length > 0
+      && intersectClipperPaths([path], islandInfluencePaths).length > 0
+    if (!touchesIsland) return [path]
+    return intersectClipperPaths(
+      offsetClosedPaths([path], residualOverlap, ClipperLib.JoinType.jtRound),
+      safeSourceUnion,
+    )
+  })
 
   return [
     ...areaPathsToDrafts(cornerRegions, toolRadius, operation),

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -1210,10 +1210,24 @@ function testPocketRestRegionsKeepGearIslandWedges() {
     }
     return Math.hypot(centroid.x - 2, centroid.y - 1.5) < 0.75
   })
+  const gearDraftArea = (draft: typeof result.drafts[number]) => {
+    const points = draftPoints(draft)
+    let area = 0
+    for (let index = 0; index < points.length; index += 1) {
+      const current = points[index]
+      const next = points[(index + 1) % points.length]
+      area += current.x * next.y - next.x * current.y
+    }
+    return Math.abs(area / 2)
+  }
 
   assert(result.drafts.length === 12, `expected 12 rest regions (4 corners + 8 gear wedges), got ${result.drafts.length}`)
   assert(gearDrafts.length === 8, `expected one rest region for each gear wedge, got ${gearDrafts.length}`)
   assert(result.drafts.every((draft) => draft.regionMaskMode === 'include'), 'gear rest regions should be include masks')
+  assert(
+    gearDrafts.every((draft) => gearDraftArea(draft) > 0.02),
+    'gear rest regions should overlap the preceding roughing pass instead of ending at the missed-material boundary',
+  )
   assert(
     gearDrafts.every((draft) => draftPoints(draft).every((point) => !pointInsidePolygon(point, gearPoints))),
     'gear rest regions must not cross into the additive island',

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -26,6 +26,7 @@
 import type { Operation, Project, RegionMaskMode, SketchFeature, Tool } from '../../types/project'
 import { circleProfile, defaultTool, newProject, polygonProfile, rectProfile } from '../../types/project'
 import { projectWithFeatures } from '../../test/projectFixtures'
+import { buildGearProfile, defaultGearCreationParams } from '../../sketch/gearProfile'
 import type { ToolpathBounds, ToolpathMove, ToolpathResult } from './types'
 import { mergePocketToolpathResults, mergeToolpathResults, perFeatureOperations } from './multiFeature'
 import { generatePocketToolpath } from './pocket'
@@ -1158,6 +1159,66 @@ function testPocketRestRegionsEmitHoleCapableMaskModes() {
   assert(mask.containsPoint({ x: 4, y: 4 }), 'rest mask should include pocket area')
   assert(!mask.containsPoint({ x: 20, y: 12 }), 'rest mask should exclude the island hole')
   console.log('pocket rest-region include/exclude mask modes: PASSED')
+}
+
+function testPocketRestRegionsKeepGearIslandWedges() {
+  // Regression for issue #352. This matches the supplied inch project: a 1/4"
+  // roughing tool clears a rectangular pocket around an 8-tooth involute gear.
+  // The narrow root wedges are valid rest material, not display noise.
+  console.log('Testing pocket rest-region generation keeps gear-island wedges...')
+  const tool: Tool = {
+    ...defaultTool('inch', 1),
+    id: 't1',
+    name: '1/4" Endmill',
+    diameter: 0.25,
+    defaultStepdown: 0.125,
+    defaultStepover: 0.32,
+  }
+  const gearProfile = buildGearProfile({
+    ...defaultGearCreationParams(0.625),
+    center: { x: 2, y: 1.5 },
+    outsideRadius: 0.625,
+    teeth: 8,
+    wholeDepth: 0.25,
+  })
+  const gearPoints = [gearProfile.start, ...gearProfile.segments.map((segment) => segment.to)]
+  const stockOutline = makeIslandFeature('stock', 0, 0, 4, 3, 0.75, 0)
+  const pocket = makePocketFeature('p1', 0.5, 0.5, 3, 2, 0.75, 0.5)
+  const gear = makePolygonIslandFeature('gear', gearPoints, 0.75, 0)
+  const project = projectWithFeatures(
+    { ...newProject('issue-352', 'inch'), tools: [tool] },
+    [stockOutline, pocket, gear],
+  )
+  const op = makePocketOp({
+    kind: 'pocket',
+    target: { source: 'features', featureIds: ['p1'] },
+    toolRef: 't1',
+    stepdown: 0.125,
+    stepover: 0.32,
+  })
+
+  const result = generatePocketRestRegionDrafts(project, op)
+  const draftPoints = (draft: typeof result.drafts[number]) => [
+    draft.profile.start,
+    ...draft.profile.segments.map((segment) => segment.to),
+  ]
+  const gearDrafts = result.drafts.filter((draft) => {
+    const points = draftPoints(draft)
+    const centroid = {
+      x: points.reduce((sum, point) => sum + point.x, 0) / points.length,
+      y: points.reduce((sum, point) => sum + point.y, 0) / points.length,
+    }
+    return Math.hypot(centroid.x - 2, centroid.y - 1.5) < 0.75
+  })
+
+  assert(result.drafts.length === 12, `expected 12 rest regions (4 corners + 8 gear wedges), got ${result.drafts.length}`)
+  assert(gearDrafts.length === 8, `expected one rest region for each gear wedge, got ${gearDrafts.length}`)
+  assert(result.drafts.every((draft) => draft.regionMaskMode === 'include'), 'gear rest regions should be include masks')
+  assert(
+    gearDrafts.every((draft) => draftPoints(draft).every((point) => !pointInsidePolygon(point, gearPoints))),
+    'gear rest regions must not cross into the additive island',
+  )
+  console.log('pocket gear-island rest regions: PASSED')
 }
 
 function testRegionMaskVisitsNearestRegionFirst() {
@@ -2672,6 +2733,7 @@ try {
   testPocketRegionClipsMachiningArea()
   testPocketRestRegionsFindUnreachableArea()
   testPocketRestRegionsFindCornerCusps()
+  testPocketRestRegionsKeepGearIslandWedges()
   testPocketRestRegionsUniformCorners()
   testRegionMaskHonorsOrderedIncludeExcludeNesting()
   testRegionMaskExcludeOnlyPreservesOutsideArea()


### PR DESCRIPTION
## Summary
- Preserve narrow residual rest geometry around non-circular additive islands instead of pruning or simplifying it away.
- Expand compact island-adjacent residual masks by half the source roughing-tool radius so the rest pass overlaps the prior clearing pass.
- Keep generated masks two Clipper grid units clear of additive islands, while leaving full-area hole masks and ordinary pocket corners unchanged.
- Add an inch-scale involute gear regression matching issue #352's supplied project, including the overlap and protection boundaries.

## Verification
- npx tsx src/engine/toolpaths/toolpaths.test.ts
- npx tsx src/store/createRestOperation.test.ts
- npm run build

Closes #352