### PR TITLE
feat: replace 7-button view row with single-button view dropdown

### DIFF
--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -399,3 +399,38 @@ export const toolbar = {
   /** Opens the New Project dialog. */
   newProjectButton: (page: Page) => page.getByRole('button', { name: 'New project' }),
 }
+
+// ── View preset menu (3D + simulation viewports) ───────────────────
+
+export const viewMenu = {
+  /** The workspace tab buttons for switching center views. */
+  tab3d: (page: Page) => page.getByRole('tab', { name: '3D' }),
+  tabSimulation: (page: Page) => page.getByRole('tab', { name: 'Simulation' }),
+
+  /** The single trigger button that shows the current view, scoped to the 3D panel. */
+  trigger3d: (page: Page) =>
+    page.locator('#workspace-panel-preview3d').getByRole('button', { name: 'Camera view' }),
+
+  /** The trigger button scoped to the simulation panel. */
+  triggerSim: (page: Page) =>
+    page.locator('#workspace-panel-simulation').getByRole('button', { name: 'Camera view' }),
+
+  /** The open dropdown menu scoped to a panel. */
+  menu3d: (page: Page) =>
+    page.locator('#workspace-panel-preview3d').getByRole('menu', { name: 'Camera view' }),
+
+  menuSim: (page: Page) =>
+    page.locator('#workspace-panel-simulation').getByRole('menu', { name: 'Camera view' }),
+
+  /** A named-preset option (Top, Bottom, Front, …) by its localized label, in the 3D menu. */
+  option3d: (page: Page, label: string) =>
+    viewMenu.menu3d(page).getByRole('menuitemradio', { name: new RegExp(`^${label}`) }),
+
+  /** A named-preset option in the simulation menu. */
+  optionSim: (page: Page, label: string) =>
+    viewMenu.menuSim(page).getByRole('menuitemradio', { name: new RegExp(`^${label}`) }),
+
+  /** An action option (Fit to model, Reset view) in the 3D menu. */
+  action3d: (page: Page, label: string) =>
+    viewMenu.menu3d(page).getByRole('menuitem', { name: new RegExp(`^${label}`) }),
+}

--- a/e2e/viewportViews.smoke.spec.ts
+++ b/e2e/viewportViews.smoke.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures'
+
+/**
+ * View-preset dropdown smoke test (issue #243).
+ *
+ * Verifies the single-button dropdown that replaced the 7-button preset row
+ * in both the 3D and simulation viewports: opening the menu, switching to a
+ * named view, and confirming the trigger title + check-mark update.
+ */
+test.describe('View preset menu', () => {
+  test('3D viewport: switch to Top view and verify the trigger updates', async ({ app, ui }) => {
+    await ui.viewMenu.tab3d(app.page).click()
+
+    const trigger = ui.viewMenu.trigger3d(app.page)
+    await expect(trigger).toBeVisible()
+
+    await trigger.click()
+    const menu = ui.viewMenu.menu3d(app.page)
+    await expect(menu).toBeVisible()
+
+    const topOption = ui.viewMenu.option3d(app.page, 'Top view')
+    await expect(topOption).toBeVisible()
+    await topOption.click()
+
+    await expect(menu).not.toBeVisible()
+
+    await trigger.click()
+    await expect(ui.viewMenu.menu3d(app.page)).toBeVisible()
+    await expect(ui.viewMenu.option3d(app.page, 'Top view')).toHaveAttribute('aria-checked', 'true')
+    await expect(ui.viewMenu.option3d(app.page, 'Isometric view')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  test('3D viewport: Fit to model and Reset view actions are available', async ({ app, ui }) => {
+    await ui.viewMenu.tab3d(app.page).click()
+
+    const trigger = ui.viewMenu.trigger3d(app.page)
+    await trigger.click()
+    const menu = ui.viewMenu.menu3d(app.page)
+    await expect(menu).toBeVisible()
+
+    await expect(ui.viewMenu.action3d(app.page, 'Fit to model')).toBeVisible()
+    await expect(ui.viewMenu.action3d(app.page, 'Reset view')).toBeVisible()
+
+    await ui.viewMenu.action3d(app.page, 'Reset view').click()
+    await expect(menu).not.toBeVisible()
+  })
+
+  test('simulation viewport: switch to Front view and verify the trigger updates', async ({ app, ui }) => {
+    await ui.viewMenu.tabSimulation(app.page).click()
+
+    const trigger = ui.viewMenu.triggerSim(app.page)
+    await expect(trigger).toBeVisible()
+
+    await trigger.click()
+    const menu = ui.viewMenu.menuSim(app.page)
+    await expect(menu).toBeVisible()
+
+    const frontOption = ui.viewMenu.optionSim(app.page, 'Front view')
+    await expect(frontOption).toBeVisible()
+    await frontOption.click()
+
+    await expect(menu).not.toBeVisible()
+
+    await trigger.click()
+    await expect(ui.viewMenu.menuSim(app.page)).toBeVisible()
+    await expect(ui.viewMenu.optionSim(app.page, 'Front view')).toHaveAttribute('aria-checked', 'true')
+  })
+})

--- a/public/icons.svg
+++ b/public/icons.svg
@@ -563,36 +563,45 @@
   </symbol>
   <symbol id="view-back" viewBox="0 0 24 24">
     <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
-    <path d="M 8 8 L 16 16" />
-    <path d="M 16 8 L 8 16" />
+    <circle cx="12" cy="12" r="3.5" />
+    <path d="M 10 10 L 14 14" />
+    <path d="M 14 10 L 10 14" />
   </symbol>
   <symbol id="view-bottom" viewBox="0 0 24 24">
-    <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
-    <path d="M 12 7 L 12 16" />
-    <path d="M 9 13 L 12 17 L 15 13" />
+    <path d="M 5 2 L 19 2 L 19 16 L 5 16 L 5 2 Z" />
+    <path d="M 12 22 L 12 19" />
+    <path d="M 8.5 21 L 12 17.5 L 15.5 21" />
+  </symbol>
+  <symbol id="view-free" viewBox="0 0 24 24">
+    <path d="M 9.5 3.5 L 15.5 6.5 L 15.5 12.5 L 9.5 15.5 L 3.5 12.5 L 3.5 6.5 L 9.5 3.5 Z" />
+    <path d="M 9.5 9.5 L 9.5 15.5" />
+    <path d="M 3.5 6.5 L 9.5 9.5 L 15.5 6.5" />
+    <path d="M 17 19.5 A 5.5 5.5 0 1 1 20.5 12" />
+    <path d="M 19 10.5 L 20.5 12 L 22 10.5" />
   </symbol>
   <symbol id="view-front" viewBox="0 0 24 24">
     <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
-    <path d="M 12 7 L 17 12 L 12 17 L 7 12 L 12 7 Z" />
+    <circle cx="12" cy="12" r="3.5" />
+    <circle cx="12" cy="12" r="1.2" fill="currentColor" stroke="none" />
   </symbol>
   <symbol id="view-iso" viewBox="0 0 24 24">
-    <path d="M 12 2 L 22 7 L 12 12 L 2 7 L 12 2 Z" />
-    <path d="M 2 7 L 2 17 L 12 22 L 22 17 L 22 7" />
-    <path d="M 12 12 L 12 22" />
+    <path d="M 12 3 L 20 7 L 20 15 L 12 19 L 4 15 L 4 7 L 12 3 Z" />
+    <path d="M 12 11 L 12 19" />
+    <path d="M 4 7 L 12 11 L 20 7" />
   </symbol>
   <symbol id="view-left" viewBox="0 0 24 24">
-    <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
-    <path d="M 17 12 L 8 12" />
-    <path d="M 11 9 L 7 12 L 11 15" />
+    <path d="M 9 6 L 21 6 L 21 18 L 9 18 L 9 6 Z" />
+    <path d="M 3 12 L 7 12" />
+    <path d="M 5 9.5 L 8 12 L 5 14.5" />
   </symbol>
   <symbol id="view-right" viewBox="0 0 24 24">
-    <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
-    <path d="M 7 12 L 16 12" />
-    <path d="M 13 9 L 17 12 L 13 15" />
+    <path d="M 3 6 L 15 6 L 15 18 L 3 18 L 3 6 Z" />
+    <path d="M 21 12 L 17 12" />
+    <path d="M 19 9.5 L 16 12 L 19 14.5" />
   </symbol>
   <symbol id="view-top" viewBox="0 0 24 24">
-    <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
-    <path d="M 12 2 L 12 22" />
-    <path d="M 2 12 L 22 12" />
+    <path d="M 5 8 L 19 8 L 19 22 L 5 22 L 5 8 Z" />
+    <path d="M 12 2 L 12 5" />
+    <path d="M 8.5 3 L 12 6.5 L 15.5 3" />
   </symbol>
 </svg>

--- a/src/assets/icons/view-back.svg
+++ b/src/assets/icons/view-back.svg
@@ -1,5 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
   <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
-  <path d="M 8 8 L 16 16" />
-  <path d="M 16 8 L 8 16" />
+  <circle cx="12" cy="12" r="3.5" />
+  <path d="M 10 10 L 14 14" />
+  <path d="M 14 10 L 10 14" />
 </svg>

--- a/src/assets/icons/view-bottom.svg
+++ b/src/assets/icons/view-bottom.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
-  <path d="M 12 7 L 12 16" />
-  <path d="M 9 13 L 12 17 L 15 13" />
+  <path d="M 5 2 L 19 2 L 19 16 L 5 16 L 5 2 Z" />
+  <path d="M 12 22 L 12 19" />
+  <path d="M 8.5 21 L 12 17.5 L 15.5 21" />
 </svg>

--- a/src/assets/icons/view-free.svg
+++ b/src/assets/icons/view-free.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M 9.5 3.5 L 15.5 6.5 L 15.5 12.5 L 9.5 15.5 L 3.5 12.5 L 3.5 6.5 L 9.5 3.5 Z" />
+  <path d="M 9.5 9.5 L 9.5 15.5" />
+  <path d="M 3.5 6.5 L 9.5 9.5 L 15.5 6.5" />
+  <path d="M 17 19.5 A 5.5 5.5 0 1 1 20.5 12" />
+  <path d="M 19 10.5 L 20.5 12 L 22 10.5" />
+</svg>

--- a/src/assets/icons/view-front.svg
+++ b/src/assets/icons/view-front.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
   <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
-  <path d="M 12 7 L 17 12 L 12 17 L 7 12 L 12 7 Z" />
+  <circle cx="12" cy="12" r="3.5" />
+  <circle cx="12" cy="12" r="1.2" fill="currentColor" stroke="none" />
 </svg>

--- a/src/assets/icons/view-iso.svg
+++ b/src/assets/icons/view-iso.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M 12 2 L 22 7 L 12 12 L 2 7 L 12 2 Z" />
-  <path d="M 2 7 L 2 17 L 12 22 L 22 17 L 22 7" />
-  <path d="M 12 12 L 12 22" />
+  <path d="M 12 3 L 20 7 L 20 15 L 12 19 L 4 15 L 4 7 L 12 3 Z" />
+  <path d="M 12 11 L 12 19" />
+  <path d="M 4 7 L 12 11 L 20 7" />
 </svg>

--- a/src/assets/icons/view-left.svg
+++ b/src/assets/icons/view-left.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
-  <path d="M 17 12 L 8 12" />
-  <path d="M 11 9 L 7 12 L 11 15" />
+  <path d="M 9 6 L 21 6 L 21 18 L 9 18 L 9 6 Z" />
+  <path d="M 3 12 L 7 12" />
+  <path d="M 5 9.5 L 8 12 L 5 14.5" />
 </svg>

--- a/src/assets/icons/view-right.svg
+++ b/src/assets/icons/view-right.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
-  <path d="M 7 12 L 16 12" />
-  <path d="M 13 9 L 17 12 L 13 15" />
+  <path d="M 3 6 L 15 6 L 15 18 L 3 18 L 3 6 Z" />
+  <path d="M 21 12 L 17 12" />
+  <path d="M 19 9.5 L 16 12 L 19 14.5" />
 </svg>

--- a/src/assets/icons/view-top.svg
+++ b/src/assets/icons/view-top.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M 4 4 L 20 4 L 20 20 L 4 20 L 4 4 Z" />
-  <path d="M 12 2 L 12 22" />
-  <path d="M 2 12 L 22 12" />
+  <path d="M 5 8 L 19 8 L 19 22 L 5 22 L 5 8 Z" />
+  <path d="M 12 2 L 12 5" />
+  <path d="M 8.5 3 L 12 6.5 L 15.5 3" />
 </svg>

--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -17,7 +17,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 ## Subfolders (by area)
 - `common/` — shared cross-panel UI primitives. `DisclosureSection` is the reusable collapsible "Advanced" section (progressive disclosure); its open/collapsed state persists via the pure helpers in `common/disclosureState.ts`.
 - `canvas/` — 2D sketch canvas: drawing, snapping, panning/zoom, pointer handling, creation workflow panels, and overlap disambiguation through `useOverlapFeaturePicker` / `OverlapFeaturePicker`. `previewPrimitives.ts` keeps Line/Construction geometry stroke-only; `previewPrimitives.test.ts` covers that rendering-role policy. `stlTopViewRenderer.ts` maps imported-model top-view images through their full instance transform, covered by `stlTopViewRenderer.test.ts`. Dimension annotations + tape measure render via `canvas/dimensionRendering.ts` (pure geometry in `sketch/dimensions.ts`); `canvas/operationSnapshot.ts` renders static operation booklet images.
-- `viewport3d/` — Three.js 3D preview of the CSG-derived model, including toolpath overlay helpers
+- `viewport3d/` — Three.js 3D preview of the CSG-derived model, including toolpath overlay helpers, shared camera orbit controls (`orbitControls.ts`), view-preset data (`viewPresets.ts`), and the single-button view dropdown (`ViewPresetMenu.tsx`) used by both the 3D and simulation viewports
 - `simulation/` — voxel toolpath simulation viewport and playback controls
 - `cam/` — CAM panels (tools, operations, parameters); per-parameter reference icons via `OperationParameterReference`
 - `feature-tree/` — sketch feature tree UI (reordering, visibility, grouping) plus the extracted feature/tab/clamp context menu

--- a/src/components/simulation/SimulationViewport.tsx
+++ b/src/components/simulation/SimulationViewport.tsx
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import * as THREE from 'three'
-import { Icon } from '../Icon'
 import { buildClampMesh, buildOriginTriad } from '../../engine/csg'
 import { createHeightfieldTexture, createStockPlaneGeometries, updateHeightfieldTexture, uploadHeightfieldRegion } from '../../engine/simulation/gpuMesh'
 import { createHeightfieldMaterial } from '../../engine/simulation/heightfieldShader'
@@ -24,6 +23,9 @@ import { createInstancedBoundaryGroup } from '../../engine/simulation/instancedB
 import { PlaybackController } from '../../engine/simulation/playback'
 import { buildToolMesh, disposeToolMesh } from '../../engine/simulation/toolMesh'
 import { attachWebglContextGuard } from '../viewport3d/webglContextGuard'
+import { createOrbitControls, type OrbitControls } from '../viewport3d/orbitControls'
+import type { ViewPreset } from '../viewport3d/viewPresets'
+import { ViewPresetMenu } from '../viewport3d/ViewPresetMenu'
 import type { PlaybackPose } from '../../engine/simulation/playback'
 import type { SimulationGrid, SimulationResult } from '../../engine/simulation'
 import type { ToolpathMove } from '../../engine/toolpaths/types'
@@ -32,55 +34,6 @@ import { useTheme } from '../../theme/themeContext'
 import { useI18n } from '../../i18n/i18nContext'
 
 const EMPTY_PLAYBACK_POSE: PlaybackPose = { x: 0, y: 0, z: 0, moveKind: null, feedScale: undefined }
-
-const DEFAULT_CAMERA_SPHERICAL = {
-  theta: Math.PI / 4,
-  phi: Math.PI / 3,
-  radius: 250,
-}
-
-const MIN_CAMERA_RADIUS = 0.1
-const MAX_CAMERA_RADIUS = 10000
-
-type ViewPreset = 'iso' | 'top' | 'bottom' | 'front' | 'back' | 'right' | 'left'
-
-const VIEW_PRESETS: Record<ViewPreset, { theta: number; phi: number; up: THREE.Vector3Tuple }> = {
-  iso: {
-    theta: DEFAULT_CAMERA_SPHERICAL.theta,
-    phi: DEFAULT_CAMERA_SPHERICAL.phi,
-    up: [0, 1, 0],
-  },
-  top: {
-    theta: 0,
-    phi: 0.05,
-    up: [0, 0, -1],
-  },
-  bottom: {
-    theta: 0,
-    phi: Math.PI - 0.05,
-    up: [0, 0, 1],
-  },
-  front: {
-    theta: 0,
-    phi: Math.PI / 2,
-    up: [0, 1, 0],
-  },
-  back: {
-    theta: Math.PI,
-    phi: Math.PI / 2,
-    up: [0, 1, 0],
-  },
-  right: {
-    theta: Math.PI / 2,
-    phi: Math.PI / 2,
-    up: [0, 1, 0],
-  },
-  left: {
-    theta: (3 * Math.PI) / 2,
-    phi: Math.PI / 2,
-    up: [0, 1, 0],
-  },
-}
 
 export interface SimulationPlaybackInput {
   /**
@@ -278,287 +231,6 @@ function currentFeedPerSecond(
   }
 }
 
-function createOrbitControls(
-  camera: THREE.PerspectiveCamera,
-  domElement: HTMLElement,
-  onChange: () => void,
-  isInteractionBlocked: () => boolean,
-) {
-  let dragMode: 'rotate' | 'pan' | null = null
-  let lastX = 0
-  let lastY = 0
-  let spherical = { ...DEFAULT_CAMERA_SPHERICAL }
-  let cameraUp: THREE.Vector3Tuple = [...VIEW_PRESETS.iso.up]
-  const target = new THREE.Vector3(0, 0, 0)
-  const pointerNdc = new THREE.Vector2()
-  const raycaster = new THREE.Raycaster()
-  const designPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0)
-  const beforeZoomPoint = new THREE.Vector3()
-  const afterZoomPoint = new THREE.Vector3()
-  const panRight = new THREE.Vector3()
-  const panUp = new THREE.Vector3()
-  const cameraDirection = new THREE.Vector3()
-  const touchPointers = new Map<number, { x: number; y: number }>()
-  let gestureState: { centerX: number; centerY: number; distance: number } | null = null
-
-  function updateCamera() {
-    camera.up.set(cameraUp[0], cameraUp[1], cameraUp[2])
-    camera.position.set(
-      target.x + spherical.radius * Math.sin(spherical.phi) * Math.sin(spherical.theta),
-      target.y + spherical.radius * Math.cos(spherical.phi),
-      target.z + spherical.radius * Math.sin(spherical.phi) * Math.cos(spherical.theta),
-    )
-    camera.lookAt(target)
-    camera.updateMatrixWorld()
-    onChange()
-  }
-
-  function applyPreset(preset: ViewPreset, preserveRadius = true, render = true) {
-    const presetState = VIEW_PRESETS[preset]
-    spherical = {
-      theta: presetState.theta,
-      phi: presetState.phi,
-      radius: preserveRadius ? spherical.radius : DEFAULT_CAMERA_SPHERICAL.radius,
-    }
-    cameraUp = [...presetState.up]
-    if (render) {
-      updateCamera()
-    }
-  }
-
-  function getPointerDesignPlanePoint(clientX: number, clientY: number, out: THREE.Vector3) {
-    const bounds = domElement.getBoundingClientRect()
-    if (bounds.width <= 0 || bounds.height <= 0) {
-      return false
-    }
-
-    pointerNdc.x = ((clientX - bounds.left) / bounds.width) * 2 - 1
-    pointerNdc.y = -(((clientY - bounds.top) / bounds.height) * 2 - 1)
-    raycaster.setFromCamera(pointerNdc, camera)
-    return raycaster.ray.intersectPlane(designPlane, out) !== null
-  }
-
-  function panByPixels(deltaX: number, deltaY: number) {
-    const bounds = domElement.getBoundingClientRect()
-    if (bounds.height <= 0) {
-      return
-    }
-
-    const worldUnitsPerPixel =
-      (2 * Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2) * spherical.radius) / bounds.height
-
-    camera.getWorldDirection(cameraDirection)
-    panRight.crossVectors(cameraDirection, camera.up).normalize()
-    panUp.crossVectors(panRight, cameraDirection).normalize()
-
-    target.addScaledVector(panRight, -deltaX * worldUnitsPerPixel)
-    target.addScaledVector(panUp, deltaY * worldUnitsPerPixel)
-  }
-
-  function onPointerDown(event: PointerEvent) {
-    if (isInteractionBlocked()) {
-      return
-    }
-
-    if (event.pointerType === 'touch') {
-      touchPointers.set(event.pointerId, { x: event.clientX, y: event.clientY })
-      if (touchPointers.size >= 2) {
-        dragMode = null
-        const points = [...touchPointers.values()]
-        gestureState = {
-          centerX: (points[0].x + points[1].x) / 2,
-          centerY: (points[0].y + points[1].y) / 2,
-          distance: Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y),
-        }
-        return
-      }
-    }
-
-    const nextDragMode =
-      event.button === 0 && !event.shiftKey ? 'rotate'
-      : event.button === 1 || event.button === 2 || (event.button === 0 && event.shiftKey) ? 'pan'
-      : null
-
-    if (!nextDragMode) {
-      return
-    }
-
-    event.preventDefault()
-    dragMode = nextDragMode
-    lastX = event.clientX
-    lastY = event.clientY
-    domElement.setPointerCapture?.(event.pointerId)
-  }
-
-  function onPointerUp(event: PointerEvent) {
-    if (event.pointerType === 'touch') {
-      touchPointers.delete(event.pointerId)
-      if (touchPointers.size < 2) {
-        gestureState = null
-      }
-    }
-    dragMode = null
-    if (domElement.hasPointerCapture?.(event.pointerId)) {
-      domElement.releasePointerCapture(event.pointerId)
-    }
-  }
-
-  function onPointerMove(event: PointerEvent) {
-    if (isInteractionBlocked()) {
-      return
-    }
-
-    if (event.pointerType === 'touch' && touchPointers.has(event.pointerId)) {
-      touchPointers.set(event.pointerId, { x: event.clientX, y: event.clientY })
-      if (touchPointers.size >= 2 && gestureState) {
-        const points = [...touchPointers.values()]
-        const newCenterX = (points[0].x + points[1].x) / 2
-        const newCenterY = (points[0].y + points[1].y) / 2
-        const newDistance = Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y)
-        if (gestureState.distance > 0 && newDistance > 0) {
-          spherical.radius = Math.max(MIN_CAMERA_RADIUS, Math.min(MAX_CAMERA_RADIUS, spherical.radius * (gestureState.distance / newDistance)))
-        }
-        panByPixels(newCenterX - gestureState.centerX, newCenterY - gestureState.centerY)
-        gestureState = { centerX: newCenterX, centerY: newCenterY, distance: newDistance }
-        updateCamera()
-        return
-      }
-    }
-
-    if (!dragMode) {
-      return
-    }
-
-    event.preventDefault()
-    const dx = event.clientX - lastX
-    const dy = event.clientY - lastY
-    lastX = event.clientX
-    lastY = event.clientY
-
-    if (dragMode === 'rotate') {
-      spherical.theta -= dx * 0.01
-      spherical.phi = Math.max(0.05, Math.min(Math.PI - 0.05, spherical.phi + dy * 0.01))
-    } else {
-      panByPixels(dx, dy)
-    }
-
-    updateCamera()
-  }
-
-  function onWheel(event: WheelEvent) {
-    if (isInteractionBlocked()) {
-      return
-    }
-
-    event.preventDefault()
-    event.stopPropagation()
-
-    const hadAnchor = getPointerDesignPlanePoint(event.clientX, event.clientY, beforeZoomPoint)
-    const nextRadius = Math.max(MIN_CAMERA_RADIUS, Math.min(MAX_CAMERA_RADIUS, spherical.radius * Math.exp(event.deltaY * 0.0015)))
-    if (Math.abs(nextRadius - spherical.radius) < 0.001) {
-      return
-    }
-
-    spherical.radius = nextRadius
-    updateCamera()
-
-    if (hadAnchor && getPointerDesignPlanePoint(event.clientX, event.clientY, afterZoomPoint)) {
-      target.add(beforeZoomPoint).sub(afterZoomPoint)
-    }
-
-    updateCamera()
-  }
-
-  function onContextMenu(event: MouseEvent) {
-    event.preventDefault()
-  }
-
-  domElement.addEventListener('pointerdown', onPointerDown)
-  domElement.addEventListener('pointerup', onPointerUp)
-  domElement.addEventListener('pointercancel', onPointerUp)
-  domElement.addEventListener('pointermove', onPointerMove)
-  domElement.addEventListener('wheel', onWheel, { passive: false })
-  domElement.addEventListener('contextmenu', onContextMenu)
-
-  updateCamera()
-
-  return {
-    dispose: () => {
-      domElement.removeEventListener('pointerdown', onPointerDown)
-      domElement.removeEventListener('pointerup', onPointerUp)
-      domElement.removeEventListener('pointercancel', onPointerUp)
-      domElement.removeEventListener('pointermove', onPointerMove)
-      domElement.removeEventListener('wheel', onWheel)
-      domElement.removeEventListener('contextmenu', onContextMenu)
-    },
-    setPreset: (preset: ViewPreset) => {
-      applyPreset(preset, true)
-    },
-    fitToBounds: (bounds: THREE.Box3, alignToDefault = false) => {
-      const size = bounds.getSize(new THREE.Vector3())
-      const center = bounds.getCenter(new THREE.Vector3())
-      const radius = Math.max(size.length() / 2, 1)
-      const aspect = Math.max(camera.aspect, 1e-3)
-      const verticalDistance = radius / Math.sin(THREE.MathUtils.degToRad(camera.fov) / 2)
-      const horizontalFov = 2 * Math.atan(Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2) * aspect)
-      const horizontalDistance = radius / Math.sin(horizontalFov / 2)
-
-      if (alignToDefault) {
-        applyPreset('iso', true, false)
-      }
-
-      spherical.radius = Math.max(
-        MIN_CAMERA_RADIUS,
-        Math.min(MAX_CAMERA_RADIUS, Math.max(verticalDistance, horizontalDistance) * 1.15),
-      )
-      target.copy(center)
-      updateCamera()
-    },
-    fitToScreenRect: (startX: number, startY: number, endX: number, endY: number) => {
-      const minX = Math.min(startX, endX)
-      const maxX = Math.max(startX, endX)
-      const minY = Math.min(startY, endY)
-      const maxY = Math.max(startY, endY)
-      const rectWidth = maxX - minX
-      const rectHeight = maxY - minY
-      if (rectWidth < 6 || rectHeight < 6) {
-        return
-      }
-
-      const bounds = domElement.getBoundingClientRect()
-      if (bounds.width <= 0 || bounds.height <= 0) {
-        return
-      }
-
-      const viewCenterX = bounds.width / 2
-      const viewCenterY = bounds.height / 2
-      const rectCenterX = minX + rectWidth / 2
-      const rectCenterY = minY + rectHeight / 2
-      const deltaX = rectCenterX - viewCenterX
-      const deltaY = rectCenterY - viewCenterY
-      const scaleFactor = Math.min(bounds.width / rectWidth, bounds.height / rectHeight)
-      if (!Number.isFinite(scaleFactor) || scaleFactor <= 0) {
-        return
-      }
-
-      const worldUnitsPerPixel =
-        (2 * Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2) * spherical.radius) / bounds.height
-
-      camera.getWorldDirection(cameraDirection)
-      panRight.crossVectors(cameraDirection, camera.up).normalize()
-      panUp.crossVectors(panRight, cameraDirection).normalize()
-
-      target.addScaledVector(panRight, deltaX * worldUnitsPerPixel)
-      target.addScaledVector(panUp, -deltaY * worldUnitsPerPixel)
-      spherical.radius = Math.max(
-        MIN_CAMERA_RADIUS,
-        Math.min(MAX_CAMERA_RADIUS, spherical.radius / scaleFactor),
-      )
-      updateCamera()
-    },
-  }
-}
-
 export const SimulationViewport = forwardRef<SimulationViewportHandle, SimulationViewportProps>(function SimulationViewport({
   simulation,
   detailCells,
@@ -578,19 +250,10 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   projectKey,
 }, ref) {
   const { palette } = useTheme()
-  const { t, languageTag } = useI18n()
-  const presetTitles = useMemo(() => ({
-    top: t('viewport.presets.top'),
-    bottom: t('viewport.presets.bottom'),
-    front: t('viewport.presets.front'),
-    back: t('viewport.presets.back'),
-    right: t('viewport.presets.right'),
-    left: t('viewport.presets.left'),
-    iso: t('viewport.presets.iso'),
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- t is identity-stable; languageTag drives locale recomputes
-  }), [t, languageTag])
+  const { t } = useI18n()
   const threePalette = palette.three
   const initialThreePaletteRef = useRef(threePalette)
+  const [activePreset, setActivePreset] = useState<ViewPreset | null>('iso')
   const playbackUnits = playbackInput?.units ?? 'mm'
   const fallbackFeed = playbackUnits === 'in' ? PLAYBACK_FALLBACK_FEED_IN : PLAYBACK_FALLBACK_FEED_MM
   // Anchor the playback speed multiplier to the operation's feed (units/sec). If the
@@ -689,7 +352,7 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null)
   const sceneRef = useRef<THREE.Scene | null>(null)
   const cameraRef = useRef<THREE.PerspectiveCamera | null>(null)
-  const controlsRef = useRef<ReturnType<typeof createOrbitControls> | null>(null)
+  const controlsRef = useRef<OrbitControls | null>(null)
   const frameRef = useRef<number>(0)
   const objectRef = useRef<THREE.Object3D | null>(null)
   const clampObjectsRef = useRef<THREE.Mesh[]>([])
@@ -819,9 +482,15 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
     // Camera changes request a draw from the RAF loop rather than rendering
     // inline: pointermove can outpace the display refresh, and the loop
     // coalesces those into at most one render per frame.
-    const controls = createOrbitControls(camera, renderer.domElement, () => {
-      needsRenderRef.current = true
-    }, () => zoomWindowActiveRef.current)
+    const controls = createOrbitControls(camera, renderer.domElement, {
+      onChange: () => {
+        needsRenderRef.current = true
+      },
+      onPresetChange: (preset) => {
+        setActivePreset(preset)
+      },
+      isInteractionBlocked: () => zoomWindowActiveRef.current,
+    })
     controlsRef.current = controls
 
     const detachContextGuard = attachWebglContextGuard(renderer.domElement, {
@@ -1509,15 +1178,15 @@ export const SimulationViewport = forwardRef<SimulationViewportHandle, Simulatio
           </button>
         </div>
         <div className="viewport-presets__group viewport-presets__group--views">
-          <div className="preset-btn-panel">
-            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('top')} title={presetTitles.top} type="button"><Icon id="view-top" size={16} /></button>
-            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('bottom')} title={presetTitles.bottom} type="button"><Icon id="view-bottom" size={16} /></button>
-            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('front')} title={presetTitles.front} type="button"><Icon id="view-front" size={16} /></button>
-            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('back')} title={presetTitles.back} type="button"><Icon id="view-back" size={16} /></button>
-            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('right')} title={presetTitles.right} type="button"><Icon id="view-right" size={16} /></button>
-            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('left')} title={presetTitles.left} type="button"><Icon id="view-left" size={16} /></button>
-            <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('iso')} title={presetTitles.iso} type="button"><Icon id="view-iso" size={16} /></button>
-          </div>
+          <ViewPresetMenu
+            activePreset={activePreset}
+            onSelect={(preset) => controlsRef.current?.setPreset(preset)}
+            onFit={() => zoomToModel()}
+            onReset={() => {
+              controlsRef.current?.reset()
+              zoomToModel()
+            }}
+          />
         </div>
       </div>
       {playbackEnabled && playbackInput && (

--- a/src/components/viewport3d/ViewPresetMenu.tsx
+++ b/src/components/viewport3d/ViewPresetMenu.tsx
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useId, useRef, useState } from 'react'
+import { useOutsideDismiss } from '../../hooks/useOutsideDismiss'
+import { useI18n } from '../../i18n/i18nContext'
+import { Icon } from '../Icon'
+import {
+  VIEW_PRESET_ORDER,
+  viewPresetMeta,
+  type ViewPreset,
+} from './viewPresets'
+
+export interface ViewPresetMenuProps {
+  /** Currently active named preset, or `null` when the camera is free-orbited. */
+  activePreset: ViewPreset | null
+  /** Snap to a named preset. */
+  onSelect: (preset: ViewPreset) => void
+  /** Frame the model in the current view (Fit to model). */
+  onFit: () => void
+  /** Reset to isometric orientation and reframe (Reset view). */
+  onReset: () => void
+}
+
+/**
+ * Single-button dropdown that shows the **current** camera view and opens a
+ * menu of standard views plus Fit/Reset actions. Replaces the 7-button
+ * preset row that lived in both `Viewport3D.tsx` and `SimulationViewport.tsx`
+ * (issue #243). Mirrors the `AppearanceControl` dropdown pattern
+ * (`useOutsideDismiss`, `role="menu"`, `menuitemradio`, `aria-checked`).
+ */
+export function ViewPresetMenu({ activePreset, onSelect, onFit, onReset }: ViewPresetMenuProps) {
+  const { t } = useI18n()
+  const [open, setOpen] = useState(false)
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const menuId = useId()
+
+  useOutsideDismiss({ open, refs: hostRef, onDismiss: () => setOpen(false) })
+
+  const currentMeta = viewPresetMeta(activePreset)
+  const currentLabel = t(currentMeta.labelKey)
+
+  const choose = (action: () => void) => {
+    action()
+    setOpen(false)
+    triggerRef.current?.focus({ preventScroll: true })
+  }
+
+  return (
+    <div className="view-preset-menu" ref={hostRef}>
+      <button
+        ref={triggerRef}
+        className="preset-btn preset-btn--icon view-preset-menu__trigger"
+        type="button"
+        aria-label={t('viewport.viewMenu.ariaLabel')}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        title={currentLabel}
+        onClick={() => setOpen((previous) => !previous)}
+      >
+        <Icon id={currentMeta.iconId} />
+      </button>
+
+      {open && (
+        <div className="view-preset-menu__panel" id={menuId} role="menu" aria-label={t('viewport.viewMenu.ariaLabel')}>
+          <div className="view-preset-menu__heading">{t('viewport.viewMenu.headingStandard')}</div>
+          <div className="view-preset-menu__options">
+            {VIEW_PRESET_ORDER.map((preset) => {
+              const meta = viewPresetMeta(preset)
+              const selected = preset === activePreset
+              return (
+                <button
+                  key={preset}
+                  className={`view-preset-menu__option ${selected ? 'view-preset-menu__option--selected' : ''}`}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={selected}
+                  onClick={() => choose(() => onSelect(preset))}
+                >
+                  <span className="view-preset-menu__icon" aria-hidden="true">
+                    <Icon id={meta.iconId} size={20} />
+                  </span>
+                  <span className="view-preset-menu__label">{t(meta.labelKey)}</span>
+                  <span className="view-preset-menu__check" aria-hidden="true">{selected ? '✓' : ''}</span>
+                </button>
+              )
+            })}
+          </div>
+
+          <div className="view-preset-menu__heading view-preset-menu__heading--section">{t('viewport.viewMenu.headingActions')}</div>
+          <div className="view-preset-menu__options">
+            <button
+              className="view-preset-menu__option view-preset-menu__option--action"
+              type="button"
+              role="menuitem"
+              onClick={() => choose(onFit)}
+            >
+              <span className="view-preset-menu__label">{t('viewport.viewMenu.fit')}</span>
+            </button>
+            <button
+              className="view-preset-menu__option view-preset-menu__option--action"
+              type="button"
+              role="menuitem"
+              onClick={() => choose(onReset)}
+            >
+              <span className="view-preset-menu__label">{t('viewport.viewMenu.reset')}</span>
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useRef, useState } from 'react'
 import * as THREE from 'three'
-import { Icon } from '../Icon'
 import { ToolpathVisibilityPanel } from '../ToolpathVisibilityPanel'
 import type { ToolpathVisibility } from '../toolpathVisibility'
 import type { ToolpathResult } from '../../engine/toolpaths/types'
@@ -30,7 +29,9 @@ import { getFeatureGeometryProfiles } from '../../text'
 import { buildToolpathLinePositionChunks, toolpathPointToWorldTuple } from './toolpathOverlay'
 import { useTheme } from '../../theme/themeContext'
 import type { ThreeThemePalette } from '../../theme/palette'
-import { useI18n } from '../../i18n/i18nContext'
+import { createOrbitControls, type OrbitControls } from './orbitControls'
+import type { ViewPreset } from './viewPresets'
+import { ViewPresetMenu } from './ViewPresetMenu'
 
 function configureGridMaterial(material: THREE.Material | THREE.Material[]) {
   const materials = Array.isArray(material) ? material : [material]
@@ -41,55 +42,6 @@ function configureGridMaterial(material: THREE.Material | THREE.Material[]) {
       entry.depthWrite = false
     }
   }
-}
-
-const DEFAULT_CAMERA_SPHERICAL = {
-  theta: Math.PI / 4,
-  phi: Math.PI / 3,
-  radius: 250,
-}
-
-const MIN_CAMERA_RADIUS = 0.1
-const MAX_CAMERA_RADIUS = 10000
-
-type ViewPreset = 'iso' | 'top' | 'bottom' | 'front' | 'back' | 'right' | 'left'
-
-const VIEW_PRESETS: Record<ViewPreset, { theta: number; phi: number; up: THREE.Vector3Tuple }> = {
-  iso: {
-    theta: DEFAULT_CAMERA_SPHERICAL.theta,
-    phi: DEFAULT_CAMERA_SPHERICAL.phi,
-    up: [0, 1, 0],
-  },
-  top: {
-    theta: 0,
-    phi: 0.05,
-    up: [0, 0, -1],
-  },
-  bottom: {
-    theta: 0,
-    phi: Math.PI - 0.05,
-    up: [0, 0, 1],
-  },
-  front: {
-    theta: 0,
-    phi: Math.PI / 2,
-    up: [0, 1, 0],
-  },
-  back: {
-    theta: Math.PI,
-    phi: Math.PI / 2,
-    up: [0, 1, 0],
-  },
-  right: {
-    theta: Math.PI / 2,
-    phi: Math.PI / 2,
-    up: [0, 1, 0],
-  },
-  left: {
-    theta: (3 * Math.PI) / 2,
-    phi: Math.PI / 2,
-    up: [0, 1, 0],
-  },
 }
 
 export interface Viewport3DHandle {
@@ -369,302 +321,6 @@ function buildToolpathOverlay(
   return objects
 }
 
-function createOrbitControls(
-  camera: THREE.PerspectiveCamera,
-  domElement: HTMLElement,
-  onChange: () => void,
-  onPresetChange: (preset: ViewPreset | null) => void,
-  isInteractionBlocked: () => boolean,
-) {
-  let dragMode: 'rotate' | 'pan' | null = null
-  let lastX = 0
-  let lastY = 0
-  let spherical = { ...DEFAULT_CAMERA_SPHERICAL }
-  let cameraUp: THREE.Vector3Tuple = [...VIEW_PRESETS.iso.up]
-  const target = new THREE.Vector3(50, 0, 40)
-  const pointerNdc = new THREE.Vector2()
-  const raycaster = new THREE.Raycaster()
-  const designPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0)
-  const beforeZoomPoint = new THREE.Vector3()
-  const afterZoomPoint = new THREE.Vector3()
-  const panRight = new THREE.Vector3()
-  const panUp = new THREE.Vector3()
-  const cameraDirection = new THREE.Vector3()
-  const touchPointers = new Map<number, { x: number; y: number }>()
-  let gestureState: { centerX: number; centerY: number; distance: number } | null = null
-
-  function applyDefaultOrientation(preserveRadius = true) {
-    applyPreset('iso', preserveRadius, false)
-  }
-
-  function applyPreset(preset: ViewPreset, preserveRadius = true, render = true) {
-    const presetState = VIEW_PRESETS[preset]
-    spherical = {
-      theta: presetState.theta,
-      phi: presetState.phi,
-      radius: preserveRadius ? spherical.radius : DEFAULT_CAMERA_SPHERICAL.radius,
-    }
-    cameraUp = [...presetState.up]
-    onPresetChange(preset)
-    if (render) {
-      updateCamera()
-    }
-  }
-
-  function updateCamera() {
-    camera.up.set(cameraUp[0], cameraUp[1], cameraUp[2])
-    camera.position.set(
-      target.x + spherical.radius * Math.sin(spherical.phi) * Math.sin(spherical.theta),
-      target.y + spherical.radius * Math.cos(spherical.phi),
-      target.z + spherical.radius * Math.sin(spherical.phi) * Math.cos(spherical.theta)
-    )
-    camera.lookAt(target)
-    camera.updateMatrixWorld()
-    onChange()
-  }
-
-  function getPointerDesignPlanePoint(clientX: number, clientY: number, out: THREE.Vector3) {
-    const bounds = domElement.getBoundingClientRect()
-    if (bounds.width <= 0 || bounds.height <= 0) {
-      return false
-    }
-
-    pointerNdc.x = ((clientX - bounds.left) / bounds.width) * 2 - 1
-    pointerNdc.y = -(((clientY - bounds.top) / bounds.height) * 2 - 1)
-    raycaster.setFromCamera(pointerNdc, camera)
-    return raycaster.ray.intersectPlane(designPlane, out) !== null
-  }
-
-  function panByPixels(deltaX: number, deltaY: number) {
-    const bounds = domElement.getBoundingClientRect()
-    if (bounds.height <= 0) {
-      return
-    }
-
-    const worldUnitsPerPixel =
-      (2 * Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2) * spherical.radius) / bounds.height
-
-    camera.getWorldDirection(cameraDirection)
-    panRight.crossVectors(cameraDirection, camera.up).normalize()
-    panUp.crossVectors(panRight, cameraDirection).normalize()
-
-    target.addScaledVector(panRight, -deltaX * worldUnitsPerPixel)
-    target.addScaledVector(panUp, deltaY * worldUnitsPerPixel)
-  }
-
-  function onContextMenu(e: MouseEvent) {
-    e.preventDefault()
-  }
-
-  function onPointerDown(e: PointerEvent) {
-    if (isInteractionBlocked()) {
-      return
-    }
-
-    if (e.pointerType === 'touch') {
-      touchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY })
-      if (touchPointers.size >= 2) {
-        dragMode = null
-        const points = [...touchPointers.values()]
-        gestureState = {
-          centerX: (points[0].x + points[1].x) / 2,
-          centerY: (points[0].y + points[1].y) / 2,
-          distance: Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y),
-        }
-        onPresetChange(null)
-        return
-      }
-    }
-
-    const nextDragMode =
-      e.button === 0 && !e.shiftKey ? 'rotate'
-      : e.button === 1 || e.button === 2 || (e.button === 0 && e.shiftKey) ? 'pan'
-      : null
-
-    if (!nextDragMode) {
-      return
-    }
-
-    e.preventDefault()
-    dragMode = nextDragMode
-    lastX = e.clientX
-    lastY = e.clientY
-    domElement.setPointerCapture?.(e.pointerId)
-  }
-
-  function onPointerUp(e: PointerEvent) {
-    if (e.pointerType === 'touch') {
-      touchPointers.delete(e.pointerId)
-      if (touchPointers.size < 2) {
-        gestureState = null
-      }
-    }
-    dragMode = null
-    if (domElement.hasPointerCapture?.(e.pointerId)) {
-      domElement.releasePointerCapture(e.pointerId)
-    }
-  }
-
-  function onPointerMove(e: PointerEvent) {
-    if (isInteractionBlocked()) {
-      return
-    }
-
-    if (e.pointerType === 'touch' && touchPointers.has(e.pointerId)) {
-      touchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY })
-      if (touchPointers.size >= 2 && gestureState) {
-        const points = [...touchPointers.values()]
-        const newCenterX = (points[0].x + points[1].x) / 2
-        const newCenterY = (points[0].y + points[1].y) / 2
-        const newDistance = Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y)
-        if (gestureState.distance > 0 && newDistance > 0) {
-          spherical.radius = Math.max(MIN_CAMERA_RADIUS, Math.min(MAX_CAMERA_RADIUS, spherical.radius * (gestureState.distance / newDistance)))
-        }
-        panByPixels(newCenterX - gestureState.centerX, newCenterY - gestureState.centerY)
-        gestureState = { centerX: newCenterX, centerY: newCenterY, distance: newDistance }
-        updateCamera()
-        return
-      }
-    }
-
-    if (!dragMode) return
-    e.preventDefault()
-    const dx = e.clientX - lastX
-    const dy = e.clientY - lastY
-    lastX = e.clientX
-    lastY = e.clientY
-
-    if (dragMode === 'rotate') {
-      onPresetChange(null)
-      spherical.theta -= dx * 0.01
-      spherical.phi = Math.max(0.05, Math.min(Math.PI - 0.05, spherical.phi + dy * 0.01))
-    } else {
-      onPresetChange(null)
-      panByPixels(dx, dy)
-    }
-
-    updateCamera()
-  }
-
-  function onWheel(e: WheelEvent) {
-    if (isInteractionBlocked()) {
-      return
-    }
-
-    e.preventDefault()
-    e.stopPropagation()
-    onPresetChange(null)
-
-    const hadAnchor = getPointerDesignPlanePoint(e.clientX, e.clientY, beforeZoomPoint)
-    const nextRadius = Math.max(MIN_CAMERA_RADIUS, Math.min(MAX_CAMERA_RADIUS, spherical.radius * Math.exp(e.deltaY * 0.0015)))
-    if (Math.abs(nextRadius - spherical.radius) < 0.001) {
-      return
-    }
-
-    spherical.radius = nextRadius
-    updateCamera()
-
-    if (hadAnchor && getPointerDesignPlanePoint(e.clientX, e.clientY, afterZoomPoint)) {
-      target.add(beforeZoomPoint).sub(afterZoomPoint)
-    }
-
-    updateCamera()
-  }
-
-  domElement.addEventListener('pointerdown', onPointerDown)
-  domElement.addEventListener('pointerup', onPointerUp)
-  domElement.addEventListener('pointercancel', onPointerUp)
-  domElement.addEventListener('pointermove', onPointerMove)
-  domElement.addEventListener('wheel', onWheel, { passive: false })
-  domElement.addEventListener('contextmenu', onContextMenu)
-
-  updateCamera()
-
-  return {
-    dispose: () => {
-      domElement.removeEventListener('pointerdown', onPointerDown)
-      domElement.removeEventListener('pointerup', onPointerUp)
-      domElement.removeEventListener('pointercancel', onPointerUp)
-      domElement.removeEventListener('pointermove', onPointerMove)
-      domElement.removeEventListener('wheel', onWheel)
-      domElement.removeEventListener('contextmenu', onContextMenu)
-    },
-    reset: () => {
-      applyDefaultOrientation(false)
-    },
-    setPreset: (preset: ViewPreset) => {
-      applyPreset(preset, true)
-    },
-    setTarget: (x: number, y: number, z: number) => {
-      target.set(x, y, z)
-      updateCamera()
-    },
-    fitToBounds: (bounds: THREE.Box3, alignToDefault = false) => {
-      const size = bounds.getSize(new THREE.Vector3())
-      const center = bounds.getCenter(new THREE.Vector3())
-      const radius = Math.max(size.length() / 2, 1)
-      const aspect = Math.max(camera.aspect, 1e-3)
-      const verticalDistance = radius / Math.sin(THREE.MathUtils.degToRad(camera.fov) / 2)
-      const horizontalFov = 2 * Math.atan(Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2) * aspect)
-      const horizontalDistance = radius / Math.sin(horizontalFov / 2)
-
-      if (alignToDefault) {
-        applyDefaultOrientation(true)
-      }
-
-      spherical.radius = Math.max(
-        MIN_CAMERA_RADIUS,
-        Math.min(MAX_CAMERA_RADIUS, Math.max(verticalDistance, horizontalDistance) * 1.15),
-      )
-      target.copy(center)
-      updateCamera()
-    },
-    fitToScreenRect: (startX: number, startY: number, endX: number, endY: number) => {
-      const minX = Math.min(startX, endX)
-      const maxX = Math.max(startX, endX)
-      const minY = Math.min(startY, endY)
-      const maxY = Math.max(startY, endY)
-      const rectWidth = maxX - minX
-      const rectHeight = maxY - minY
-      if (rectWidth < 6 || rectHeight < 6) {
-        return
-      }
-
-      const bounds = domElement.getBoundingClientRect()
-      if (bounds.width <= 0 || bounds.height <= 0) {
-        return
-      }
-
-      const viewCenterX = bounds.width / 2
-      const viewCenterY = bounds.height / 2
-      const rectCenterX = minX + rectWidth / 2
-      const rectCenterY = minY + rectHeight / 2
-      const deltaX = rectCenterX - viewCenterX
-      const deltaY = rectCenterY - viewCenterY
-      const scaleFactor = Math.min(bounds.width / rectWidth, bounds.height / rectHeight)
-      if (!Number.isFinite(scaleFactor) || scaleFactor <= 0) {
-        return
-      }
-
-      const worldUnitsPerPixel =
-        (2 * Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2) * spherical.radius) / bounds.height
-
-      camera.getWorldDirection(cameraDirection)
-      panRight.crossVectors(cameraDirection, camera.up).normalize()
-      panUp.crossVectors(panRight, cameraDirection).normalize()
-
-      onPresetChange(null)
-      target.addScaledVector(panRight, deltaX * worldUnitsPerPixel)
-      target.addScaledVector(panUp, -deltaY * worldUnitsPerPixel)
-      spherical.radius = Math.max(
-        MIN_CAMERA_RADIUS,
-        Math.min(MAX_CAMERA_RADIUS, spherical.radius / scaleFactor),
-      )
-      updateCamera()
-    },
-  }
-}
-
 export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function Viewport3D({
   toolpaths = [],
   selectedOperationId = null,
@@ -676,17 +332,6 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
   onToolpathVisibilityChange,
 }, ref) {
   const { palette } = useTheme()
-  const { t, languageTag } = useI18n()
-  const presetTitles = useMemo(() => ({
-    top: t('viewport.presets.top'),
-    bottom: t('viewport.presets.bottom'),
-    front: t('viewport.presets.front'),
-    back: t('viewport.presets.back'),
-    right: t('viewport.presets.right'),
-    left: t('viewport.presets.left'),
-    iso: t('viewport.presets.iso'),
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- t is identity-stable; languageTag drives locale recomputes
-  }), [t, languageTag])
   const threePalette = palette.three
   const threePaletteRef = useRef(threePalette)
   const mountRef = useRef<HTMLDivElement>(null)
@@ -694,7 +339,7 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
   const sceneRef = useRef<THREE.Scene | null>(null)
   const gridRef = useRef<THREE.Group | null>(null)
   const cameraRef = useRef<THREE.PerspectiveCamera | null>(null)
-  const controlsRef = useRef<ReturnType<typeof createOrbitControls> | null>(null)
+  const controlsRef = useRef<OrbitControls | null>(null)
   const frameRef = useRef<number>(0)
   const objectsRef = useRef<THREE.Object3D[]>([])
   // The most recently built fixture meshes, keyed by id, so selection/collision
@@ -704,7 +349,7 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
   const toolpathObjectsRef = useRef<THREE.Object3D[]>([])
   const originObjectRef = useRef<THREE.Object3D | null>(null)
   const buildRequestRef = useRef(0)
-  const activePresetRef = useRef<ViewPreset | null>('iso')
+  const [activePreset, setActivePreset] = useState<ViewPreset | null>('iso')
   const zoomWindowActiveRef = useRef(zoomWindowActive)
   const [zoomWindowBox, setZoomWindowBox] = useState<{ startX: number; startY: number; currentX: number; currentY: number } | null>(null)
   const zoomWindowBoxRef = useRef<{ startX: number; startY: number; currentX: number; currentY: number } | null>(null)
@@ -791,12 +436,17 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
     )
     cameraRef.current = camera
 
-    const controls = createOrbitControls(camera, renderer.domElement, () => {
-      renderer.render(scene, camera)
-    }, (preset) => {
-      activePresetRef.current = preset
-      syncGridVisibility()
-    }, () => zoomWindowActiveRef.current)
+    const controls = createOrbitControls(camera, renderer.domElement, {
+      onChange: () => {
+        renderer.render(scene, camera)
+      },
+      onPresetChange: (preset) => {
+        setActivePreset(preset)
+        syncGridVisibility()
+      },
+      isInteractionBlocked: () => zoomWindowActiveRef.current,
+      initialTarget: [50, 0, 40],
+    })
     controlsRef.current = controls
 
     function animate() {
@@ -1244,29 +894,15 @@ useImperativeHandle(ref, () => ({
         />
       )}
       <div className="viewport-presets">
-        <div className="preset-btn-panel">
-          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('top')} title={presetTitles.top} type="button">
-            <Icon id="view-top" size={16} />
-          </button>
-          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('bottom')} title={presetTitles.bottom} type="button">
-            <Icon id="view-bottom" size={16} />
-          </button>
-          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('front')} title={presetTitles.front} type="button">
-            <Icon id="view-front" size={16} />
-          </button>
-          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('back')} title={presetTitles.back} type="button">
-            <Icon id="view-back" size={16} />
-          </button>
-          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('right')} title={presetTitles.right} type="button">
-            <Icon id="view-right" size={16} />
-          </button>
-          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('left')} title={presetTitles.left} type="button">
-            <Icon id="view-left" size={16} />
-          </button>
-          <button className="preset-btn preset-btn--icon" onClick={() => controlsRef.current?.setPreset('iso')} title={presetTitles.iso} type="button">
-            <Icon id="view-iso" size={16} />
-          </button>
-        </div>
+        <ViewPresetMenu
+          activePreset={activePreset}
+          onSelect={(preset) => controlsRef.current?.setPreset(preset)}
+          onFit={() => zoomToModel()}
+          onReset={() => {
+            controlsRef.current?.reset()
+            zoomToModel()
+          }}
+        />
       </div>
     </div>
   )

--- a/src/components/viewport3d/orbitControls.test.ts
+++ b/src/components/viewport3d/orbitControls.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import * as THREE from 'three'
+import { createOrbitControls } from './orbitControls'
+import { MIN_CAMERA_RADIUS } from './viewPresets'
+
+const fakeElement = {
+  addEventListener() {},
+  removeEventListener() {},
+  getBoundingClientRect: () => ({
+    left: 0,
+    top: 0,
+    width: 800,
+    height: 600,
+    right: 800,
+    bottom: 600,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  }),
+  setPointerCapture() {},
+  releasePointerCapture() {},
+  hasPointerCapture: () => false,
+} as unknown as HTMLElement
+
+function makeControls(camera?: THREE.PerspectiveCamera) {
+  const cam = camera ?? new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  return createOrbitControls(cam, fakeElement, {
+    onChange: () => {},
+    onPresetChange: () => {},
+    isInteractionBlocked: () => false,
+  })
+}
+
+/** Returns true if ALL 8 corners of `box` project inside the frustum
+ *  (|ndc.x| <= marginNdc and |ndc.y| <= marginNdc). */
+function allCornersInFrustum(box: THREE.Box3, camera: THREE.Camera, marginNdc = 0.95): boolean {
+  const corner = new THREE.Vector3()
+  for (let ix = 0; ix <= 1; ix++) {
+    for (let iy = 0; iy <= 1; iy++) {
+      for (let iz = 0; iz <= 1; iz++) {
+        corner.set(
+          ix === 0 ? box.min.x : box.max.x,
+          iy === 0 ? box.min.y : box.max.y,
+          iz === 0 ? box.min.z : box.max.z,
+        )
+        const ndc = corner.clone().project(camera)
+        if (Math.abs(ndc.x) > marginNdc || Math.abs(ndc.y) > marginNdc) {
+          return false
+        }
+      }
+    }
+  }
+  return true
+}
+
+function distanceToCenter(camera: THREE.Object3D, center: THREE.Vector3): number {
+  return camera.position.distanceTo(center)
+}
+
+// ---- flat wide plate at default iso orientation ----
+test('fitToBounds flat wide plate – all corners in frustum (iso)', () => {
+  const camera = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const controls = makeControls(camera)
+  const box = new THREE.Box3(new THREE.Vector3(-100, -10, -50), new THREE.Vector3(100, 10, 50))
+
+  controls.fitToBounds(box) // alignToDefault=false, uses current (default iso)
+  assert.ok(allCornersInFrustum(box, camera), 'all 8 corners must be inside frustum')
+})
+
+// ---- tall box ----
+test('fitToBounds tall box – all corners in frustum (iso)', () => {
+  const camera = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const controls = makeControls(camera)
+  const box = new THREE.Box3(new THREE.Vector3(-10, -100, -10), new THREE.Vector3(10, 100, 10))
+
+  controls.fitToBounds(box)
+  assert.ok(allCornersInFrustum(box, camera), 'all 8 corners must be inside frustum')
+})
+
+// ---- tighter than old sphere approach ----
+test('fitToBounds is tighter than old sphere approach for a flat plate', () => {
+  const camera = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const controls = makeControls(camera)
+  const box = new THREE.Box3(new THREE.Vector3(-100, -10, -50), new THREE.Vector3(100, 10, 50))
+  const center = box.getCenter(new THREE.Vector3())
+  const size = box.getSize(new THREE.Vector3())
+
+  controls.fitToBounds(box)
+  const dist = distanceToCenter(camera, center)
+
+  // Old formula: sphere radius = size.length()/2, pick the larger of
+  // radius / sin(vfov/2) or radius / sin(hfov/2), then × 1.15.
+  const radius = size.length() / 2
+  const aspect = Math.max(camera.aspect, 1e-3)
+  const vfovRad = THREE.MathUtils.degToRad(camera.fov)
+  const hfovRad = 2 * Math.atan(Math.tan(vfovRad / 2) * aspect)
+  const oldVertical = radius / Math.sin(vfovRad / 2)
+  const oldHorizontal = radius / Math.sin(hfovRad / 2)
+  const oldDist = Math.max(oldVertical, oldHorizontal) * 1.15
+
+  assert.ok(
+    dist < oldDist * 0.9,
+    `new distance ${dist.toFixed(1)} should be at least 10% smaller than old ${oldDist.toFixed(1)}`,
+  )
+})
+
+// ---- setPreset('top') then fitToBounds still fits ----
+test('fitToBounds after setPreset top – all corners in frustum', () => {
+  const camera = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const controls = makeControls(camera)
+  const box = new THREE.Box3(new THREE.Vector3(-100, -10, -50), new THREE.Vector3(100, 10, 50))
+
+  controls.setPreset('top')
+  controls.fitToBounds(box)
+  assert.ok(allCornersInFrustum(box, camera), 'all 8 corners must be inside frustum from top view')
+})
+
+// ---- alignToDefault=true uses iso orientation ----
+test('fitToBounds with alignToDefault uses iso orientation', () => {
+  const camera = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const controls = makeControls(camera)
+  const box = new THREE.Box3(new THREE.Vector3(-100, -10, -50), new THREE.Vector3(100, 10, 50))
+
+  // Rotate away from iso first
+  controls.setPreset('front')
+  controls.setPreset('top')
+  // Now alignToDefault should bring it back to iso and fit
+  controls.fitToBounds(box, true)
+  assert.ok(allCornersInFrustum(box, camera), 'all corners must fit after alignToDefault')
+})
+
+// ---- tiny box clamps to MIN_CAMERA_RADIUS ----
+test('fitToBounds tiny box clamps radius to MIN_CAMERA_RADIUS', () => {
+  const camera = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const controls = makeControls(camera)
+  const box = new THREE.Box3(new THREE.Vector3(-0.01, -0.01, -0.01), new THREE.Vector3(0.01, 0.01, 0.01))
+  const center = box.getCenter(new THREE.Vector3())
+
+  controls.fitToBounds(box)
+  const dist = distanceToCenter(camera, center)
+  assert.ok(
+    !Number.isNaN(dist),
+    'distance must not be NaN',
+  )
+  assert.ok(
+    dist >= MIN_CAMERA_RADIUS,
+    `distance ${dist} must be >= MIN_CAMERA_RADIUS ${MIN_CAMERA_RADIUS}`,
+  )
+})
+
+// ---- near-degenerate flat box (zero height) ----
+test('fitToBounds near-degenerate flat box still fits', () => {
+  const camera = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const controls = makeControls(camera)
+  const box = new THREE.Box3(new THREE.Vector3(-100, 0, -50), new THREE.Vector3(100, 0, 50))
+
+  controls.fitToBounds(box)
+  assert.ok(allCornersInFrustum(box, camera), 'zero-height box must fit')
+})

--- a/src/components/viewport3d/orbitControls.ts
+++ b/src/components/viewport3d/orbitControls.ts
@@ -1,0 +1,363 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as THREE from 'three'
+import {
+  DEFAULT_CAMERA_SPHERICAL,
+  MAX_CAMERA_RADIUS,
+  MIN_CAMERA_RADIUS,
+  VIEW_PRESETS,
+  type ViewPreset,
+} from './viewPresets'
+
+/**
+ * Shared orbit-camera controls for the 3D preview and simulation viewports.
+ *
+ * Previously duplicated (with drift) between `Viewport3D.tsx` and
+ * `SimulationViewport.tsx`. The simulation copy was missing `onPresetChange`
+ * entirely, so it could not track which named view was active. Issue #243.
+ *
+ * Behaviour notes:
+ * - Any free orbit / pan / wheel sets the active preset to `null` (custom).
+ * - `reset()` snaps to isometric and renders immediately (render=true) so it
+ *   works with the simulation viewport's render-on-demand RAF loop. The 3D
+ *   viewport previously used render=false here, but reset is only called when
+ *   the scene is empty, so the extra draw is harmless.
+ */
+
+export interface OrbitControlsOptions {
+  /** Called after every camera position change (render the scene). */
+  onChange: () => void
+  /** Called when the active named preset changes (or becomes `null` for custom). */
+  onPresetChange: (preset: ViewPreset | null) => void
+  /** Returns true while pointer/wheel interaction should be ignored. */
+  isInteractionBlocked: () => boolean
+  /** Initial orbit target. Defaults to the origin. */
+  initialTarget?: THREE.Vector3Tuple
+}
+
+export interface OrbitControls {
+  dispose: () => void
+  /** Reset to the default isometric orientation and default radius. */
+  reset: () => void
+  /** Snap to a named preset, preserving the current orbit radius. */
+  setPreset: (preset: ViewPreset) => void
+  /** Move the orbit target and render. */
+  setTarget: (x: number, y: number, z: number) => void
+  /** Frame the given world-space bounds, optionally reorienting to iso first. */
+  fitToBounds: (bounds: THREE.Box3, alignToDefault?: boolean) => void
+  /** Zoom to a screen-space rect (window-zoom tool). */
+  fitToScreenRect: (startX: number, startY: number, endX: number, endY: number) => void
+}
+
+export function createOrbitControls(
+  camera: THREE.PerspectiveCamera,
+  domElement: HTMLElement,
+  options: OrbitControlsOptions,
+): OrbitControls {
+  const { onChange, onPresetChange, isInteractionBlocked } = options
+  const initial = options.initialTarget ?? [0, 0, 0]
+
+  let dragMode: 'rotate' | 'pan' | null = null
+  let lastX = 0
+  let lastY = 0
+  let spherical = { ...DEFAULT_CAMERA_SPHERICAL }
+  let cameraUp: THREE.Vector3Tuple = [...VIEW_PRESETS.iso.up]
+  const target = new THREE.Vector3(initial[0], initial[1], initial[2])
+  const pointerNdc = new THREE.Vector2()
+  const raycaster = new THREE.Raycaster()
+  const designPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0)
+  const beforeZoomPoint = new THREE.Vector3()
+  const afterZoomPoint = new THREE.Vector3()
+  const panRight = new THREE.Vector3()
+  const panUp = new THREE.Vector3()
+  const cameraDirection = new THREE.Vector3()
+  const touchPointers = new Map<number, { x: number; y: number }>()
+  let gestureState: { centerX: number; centerY: number; distance: number } | null = null
+
+  function applyPreset(preset: ViewPreset, preserveRadius = true, render = true) {
+    const presetState = VIEW_PRESETS[preset]
+    spherical = {
+      theta: presetState.theta,
+      phi: presetState.phi,
+      radius: preserveRadius ? spherical.radius : DEFAULT_CAMERA_SPHERICAL.radius,
+    }
+    cameraUp = [...presetState.up]
+    onPresetChange(preset)
+    if (render) {
+      updateCamera()
+    }
+  }
+
+  function updateCamera() {
+    camera.up.set(cameraUp[0], cameraUp[1], cameraUp[2])
+    camera.position.set(
+      target.x + spherical.radius * Math.sin(spherical.phi) * Math.sin(spherical.theta),
+      target.y + spherical.radius * Math.cos(spherical.phi),
+      target.z + spherical.radius * Math.sin(spherical.phi) * Math.cos(spherical.theta),
+    )
+    camera.lookAt(target)
+    camera.updateMatrixWorld()
+    onChange()
+  }
+
+  function getPointerDesignPlanePoint(clientX: number, clientY: number, out: THREE.Vector3) {
+    const bounds = domElement.getBoundingClientRect()
+    if (bounds.width <= 0 || bounds.height <= 0) {
+      return false
+    }
+
+    pointerNdc.x = ((clientX - bounds.left) / bounds.width) * 2 - 1
+    pointerNdc.y = -(((clientY - bounds.top) / bounds.height) * 2 - 1)
+    raycaster.setFromCamera(pointerNdc, camera)
+    return raycaster.ray.intersectPlane(designPlane, out) !== null
+  }
+
+  function panByPixels(deltaX: number, deltaY: number) {
+    const bounds = domElement.getBoundingClientRect()
+    if (bounds.height <= 0) {
+      return
+    }
+
+    const worldUnitsPerPixel =
+      (2 * Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2) * spherical.radius) / bounds.height
+
+    camera.getWorldDirection(cameraDirection)
+    panRight.crossVectors(cameraDirection, camera.up).normalize()
+    panUp.crossVectors(panRight, cameraDirection).normalize()
+
+    target.addScaledVector(panRight, -deltaX * worldUnitsPerPixel)
+    target.addScaledVector(panUp, deltaY * worldUnitsPerPixel)
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (isInteractionBlocked()) {
+      return
+    }
+
+    if (e.pointerType === 'touch') {
+      touchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY })
+      if (touchPointers.size >= 2) {
+        dragMode = null
+        const points = [...touchPointers.values()]
+        gestureState = {
+          centerX: (points[0].x + points[1].x) / 2,
+          centerY: (points[0].y + points[1].y) / 2,
+          distance: Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y),
+        }
+        onPresetChange(null)
+        return
+      }
+    }
+
+    const nextDragMode =
+      e.button === 0 && !e.shiftKey ? 'rotate'
+      : e.button === 1 || e.button === 2 || (e.button === 0 && e.shiftKey) ? 'pan'
+      : null
+
+    if (!nextDragMode) {
+      return
+    }
+
+    e.preventDefault()
+    dragMode = nextDragMode
+    lastX = e.clientX
+    lastY = e.clientY
+    domElement.setPointerCapture?.(e.pointerId)
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (e.pointerType === 'touch') {
+      touchPointers.delete(e.pointerId)
+      if (touchPointers.size < 2) {
+        gestureState = null
+      }
+    }
+    dragMode = null
+    if (domElement.hasPointerCapture?.(e.pointerId)) {
+      domElement.releasePointerCapture(e.pointerId)
+    }
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (isInteractionBlocked()) {
+      return
+    }
+
+    if (e.pointerType === 'touch' && touchPointers.has(e.pointerId)) {
+      touchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY })
+      if (touchPointers.size >= 2 && gestureState) {
+        const points = [...touchPointers.values()]
+        const newCenterX = (points[0].x + points[1].x) / 2
+        const newCenterY = (points[0].y + points[1].y) / 2
+        const newDistance = Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y)
+        if (gestureState.distance > 0 && newDistance > 0) {
+          spherical.radius = Math.max(
+            MIN_CAMERA_RADIUS,
+            Math.min(MAX_CAMERA_RADIUS, spherical.radius * (gestureState.distance / newDistance)),
+          )
+        }
+        panByPixels(newCenterX - gestureState.centerX, newCenterY - gestureState.centerY)
+        gestureState = { centerX: newCenterX, centerY: newCenterY, distance: newDistance }
+        updateCamera()
+        return
+      }
+    }
+
+    if (!dragMode) return
+    e.preventDefault()
+    const dx = e.clientX - lastX
+    const dy = e.clientY - lastY
+    lastX = e.clientX
+    lastY = e.clientY
+
+    if (dragMode === 'rotate') {
+      onPresetChange(null)
+      spherical.theta -= dx * 0.01
+      spherical.phi = Math.max(0.05, Math.min(Math.PI - 0.05, spherical.phi + dy * 0.01))
+    } else {
+      onPresetChange(null)
+      panByPixels(dx, dy)
+    }
+
+    updateCamera()
+  }
+
+  function onWheel(e: WheelEvent) {
+    if (isInteractionBlocked()) {
+      return
+    }
+
+    e.preventDefault()
+    e.stopPropagation()
+    onPresetChange(null)
+
+    const hadAnchor = getPointerDesignPlanePoint(e.clientX, e.clientY, beforeZoomPoint)
+    const nextRadius = Math.max(
+      MIN_CAMERA_RADIUS,
+      Math.min(MAX_CAMERA_RADIUS, spherical.radius * Math.exp(e.deltaY * 0.0015)),
+    )
+    if (Math.abs(nextRadius - spherical.radius) < 0.001) {
+      return
+    }
+
+    spherical.radius = nextRadius
+    updateCamera()
+
+    if (hadAnchor && getPointerDesignPlanePoint(e.clientX, e.clientY, afterZoomPoint)) {
+      target.add(beforeZoomPoint).sub(afterZoomPoint)
+    }
+
+    updateCamera()
+  }
+
+  function onContextMenu(e: MouseEvent) {
+    e.preventDefault()
+  }
+
+  domElement.addEventListener('pointerdown', onPointerDown)
+  domElement.addEventListener('pointerup', onPointerUp)
+  domElement.addEventListener('pointercancel', onPointerUp)
+  domElement.addEventListener('pointermove', onPointerMove)
+  domElement.addEventListener('wheel', onWheel, { passive: false })
+  domElement.addEventListener('contextmenu', onContextMenu)
+
+  updateCamera()
+
+  return {
+    dispose: () => {
+      domElement.removeEventListener('pointerdown', onPointerDown)
+      domElement.removeEventListener('pointerup', onPointerUp)
+      domElement.removeEventListener('pointercancel', onPointerUp)
+      domElement.removeEventListener('pointermove', onPointerMove)
+      domElement.removeEventListener('wheel', onWheel)
+      domElement.removeEventListener('contextmenu', onContextMenu)
+    },
+    reset: () => {
+      applyPreset('iso', false, true)
+    },
+    setPreset: (preset: ViewPreset) => {
+      applyPreset(preset, true)
+    },
+    setTarget: (x: number, y: number, z: number) => {
+      target.set(x, y, z)
+      updateCamera()
+    },
+    fitToBounds: (bounds: THREE.Box3, alignToDefault = false) => {
+      const size = bounds.getSize(new THREE.Vector3())
+      const center = bounds.getCenter(new THREE.Vector3())
+      const radius = Math.max(size.length() / 2, 1)
+      const aspect = Math.max(camera.aspect, 1e-3)
+      const verticalDistance = radius / Math.sin(THREE.MathUtils.degToRad(camera.fov) / 2)
+      const horizontalFov = 2 * Math.atan(Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2) * aspect)
+      const horizontalDistance = radius / Math.sin(horizontalFov / 2)
+
+      if (alignToDefault) {
+        applyPreset('iso', true, false)
+      }
+
+      spherical.radius = Math.max(
+        MIN_CAMERA_RADIUS,
+        Math.min(MAX_CAMERA_RADIUS, Math.max(verticalDistance, horizontalDistance) * 1.15),
+      )
+      target.copy(center)
+      updateCamera()
+    },
+    fitToScreenRect: (startX: number, startY: number, endX: number, endY: number) => {
+      const minX = Math.min(startX, endX)
+      const maxX = Math.max(startX, endX)
+      const minY = Math.min(startY, endY)
+      const maxY = Math.max(startY, endY)
+      const rectWidth = maxX - minX
+      const rectHeight = maxY - minY
+      if (rectWidth < 6 || rectHeight < 6) {
+        return
+      }
+
+      const bounds = domElement.getBoundingClientRect()
+      if (bounds.width <= 0 || bounds.height <= 0) {
+        return
+      }
+
+      const viewCenterX = bounds.width / 2
+      const viewCenterY = bounds.height / 2
+      const rectCenterX = minX + rectWidth / 2
+      const rectCenterY = minY + rectHeight / 2
+      const deltaX = rectCenterX - viewCenterX
+      const deltaY = rectCenterY - viewCenterY
+      const scaleFactor = Math.min(bounds.width / rectWidth, bounds.height / rectHeight)
+      if (!Number.isFinite(scaleFactor) || scaleFactor <= 0) {
+        return
+      }
+
+      const worldUnitsPerPixel =
+        (2 * Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2) * spherical.radius) / bounds.height
+
+      camera.getWorldDirection(cameraDirection)
+      panRight.crossVectors(cameraDirection, camera.up).normalize()
+      panUp.crossVectors(panRight, cameraDirection).normalize()
+
+      onPresetChange(null)
+      target.addScaledVector(panRight, deltaX * worldUnitsPerPixel)
+      target.addScaledVector(panUp, -deltaY * worldUnitsPerPixel)
+      spherical.radius = Math.max(
+        MIN_CAMERA_RADIUS,
+        Math.min(MAX_CAMERA_RADIUS, spherical.radius / scaleFactor),
+      )
+      updateCamera()
+    },
+  }
+}

--- a/src/components/viewport3d/orbitControls.ts
+++ b/src/components/viewport3d/orbitControls.ts
@@ -23,6 +23,10 @@ import {
   type ViewPreset,
 } from './viewPresets'
 
+/** Margin applied on top of the exact frustum fit, kept small since the fit
+ *  is already tight (no sphere over-estimate). */
+const FIT_BOUNDS_MARGIN = 1.1
+
 /**
  * Shared orbit-camera controls for the 3D preview and simulation viewports.
  *
@@ -297,21 +301,64 @@ export function createOrbitControls(
       updateCamera()
     },
     fitToBounds: (bounds: THREE.Box3, alignToDefault = false) => {
-      const size = bounds.getSize(new THREE.Vector3())
       const center = bounds.getCenter(new THREE.Vector3())
-      const radius = Math.max(size.length() / 2, 1)
-      const aspect = Math.max(camera.aspect, 1e-3)
-      const verticalDistance = radius / Math.sin(THREE.MathUtils.degToRad(camera.fov) / 2)
-      const horizontalFov = 2 * Math.atan(Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2) * aspect)
-      const horizontalDistance = radius / Math.sin(horizontalFov / 2)
 
       if (alignToDefault) {
         applyPreset('iso', true, false)
       }
 
+      // Compute the view direction (unit vector from target to camera).
+      const viewDir = new THREE.Vector3(
+        Math.sin(spherical.phi) * Math.sin(spherical.theta),
+        Math.cos(spherical.phi),
+        Math.sin(spherical.phi) * Math.cos(spherical.theta),
+      )
+
+      // Temporarily place the camera at unit distance in the current orientation,
+      // look at the box centre, then build the view matrix so we can transform
+      // the 8 box corners to camera space (camera at origin, looking down −Z).
+      camera.up.set(cameraUp[0], cameraUp[1], cameraUp[2])
+      camera.position.copy(center).addScaledVector(viewDir, 1)
+      camera.lookAt(center)
+      camera.updateMatrixWorld()
+      const viewMatrix = new THREE.Matrix4().copy(camera.matrixWorld).invert()
+
+      const aspect = Math.max(camera.aspect, 1e-3)
+      const vfovRad = THREE.MathUtils.degToRad(camera.fov)
+      const hfovRad = 2 * Math.atan(Math.tan(vfovRad / 2) * aspect)
+      const tanH = Math.tan(hfovRad / 2)
+      const tanV = Math.tan(vfovRad / 2)
+
+      const corner = new THREE.Vector3()
+      const vc = new THREE.Vector3()
+
+      let maxReq = -Infinity
+      for (let ix = 0; ix <= 1; ix++) {
+        for (let iy = 0; iy <= 1; iy++) {
+          for (let iz = 0; iz <= 1; iz++) {
+            corner.set(
+              ix === 0 ? bounds.min.x : bounds.max.x,
+              iy === 0 ? bounds.min.y : bounds.max.y,
+              iz === 0 ? bounds.min.z : bounds.max.z,
+            )
+            vc.copy(corner).applyMatrix4(viewMatrix)
+            // In view space the camera is at origin looking down -Z.  A corner
+            // at (vc.x, vc.y, vc.z) is inside the frustum at this distance when
+            //   −vc.z ≥ |vc.x| / tanH   AND   −vc.z ≥ |vc.y| / tanV
+            // If the camera is pushed back by D (relative to unit distance) the
+            // view-space z of every corner increases by D−1 (x/y unchanged), so
+            // the condition becomes  −(vc.z + D−1) ≥ |vc.x|/tanH which
+            // rearranges to  D ≥ 1 + vc.z + |vc.x|/tanH.
+            const reqH = 1 + vc.z + Math.abs(vc.x) / tanH
+            const reqV = 1 + vc.z + Math.abs(vc.y) / tanV
+            maxReq = Math.max(maxReq, reqH, reqV)
+          }
+        }
+      }
+
       spherical.radius = Math.max(
         MIN_CAMERA_RADIUS,
-        Math.min(MAX_CAMERA_RADIUS, Math.max(verticalDistance, horizontalDistance) * 1.15),
+        Math.min(MAX_CAMERA_RADIUS, maxReq * FIT_BOUNDS_MARGIN),
       )
       target.copy(center)
       updateCamera()

--- a/src/components/viewport3d/viewPresets.test.ts
+++ b/src/components/viewport3d/viewPresets.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import {
+  VIEW_PRESETS,
+  VIEW_PRESET_ORDER,
+  viewPresetMeta,
+  type ViewPreset,
+} from './viewPresets'
+
+const ALL_PRESETS: ViewPreset[] = ['iso', 'top', 'bottom', 'front', 'back', 'right', 'left']
+
+test('VIEW_PRESETS has an entry for every preset', () => {
+  for (const preset of ALL_PRESETS) {
+    assert.ok(preset in VIEW_PRESETS, `missing preset: ${preset}`)
+  }
+  assert.equal(Object.keys(VIEW_PRESETS).length, ALL_PRESETS.length)
+})
+
+test('every preset has a valid spherical phi in the open range (0, π)', () => {
+  for (const preset of ALL_PRESETS) {
+    const { phi } = VIEW_PRESETS[preset]
+    assert.ok(phi > 0 && phi < Math.PI, `${preset} phi ${phi} must be in (0, π)`)
+  }
+})
+
+test('every preset has a unit-length up vector', () => {
+  for (const preset of ALL_PRESETS) {
+    const [x, y, z] = VIEW_PRESETS[preset].up
+    const len = Math.hypot(x, y, z)
+    assert.ok(Math.abs(len - 1) < 1e-6, `${preset} up vector length ${len} is not unit`)
+  }
+})
+
+test('VIEW_PRESET_ORDER contains every preset exactly once and iso is first', () => {
+  assert.equal(VIEW_PRESET_ORDER[0], 'iso')
+  assert.equal(VIEW_PRESET_ORDER.length, ALL_PRESETS.length)
+  const sorted = [...VIEW_PRESET_ORDER].sort()
+  const expected = [...ALL_PRESETS].sort()
+  assert.deepEqual(sorted, expected)
+})
+
+test('viewPresetMeta returns an icon id and label key for every preset', () => {
+  for (const preset of ALL_PRESETS) {
+    const meta = viewPresetMeta(preset)
+    assert.ok(meta.iconId.startsWith('view-'), `${preset} iconId ${meta.iconId}`)
+    assert.ok(meta.labelKey.startsWith('viewport.presets.'), `${preset} labelKey ${meta.labelKey}`)
+  }
+})
+
+test('viewPresetMeta(null) returns the custom-view fallback', () => {
+  const meta = viewPresetMeta(null)
+  assert.equal(meta.iconId, 'view-free')
+  assert.equal(meta.labelKey, 'viewport.presets.free')
+})
+
+test('iso preset matches the default camera spherical orientation', () => {
+  const iso = VIEW_PRESETS.iso
+  assert.equal(iso.theta, Math.PI / 4)
+  assert.equal(iso.phi, Math.PI / 3)
+})

--- a/src/components/viewport3d/viewPresets.ts
+++ b/src/components/viewport3d/viewPresets.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type * as THREE from 'three'
+import type { MessageKey } from '../../i18n/locales/en'
+
+/**
+ * Camera view presets shared by the 3D preview and simulation viewports.
+ *
+ * Each preset is a spherical-coordinate orientation around the orbit target.
+ * `null` means the camera has been free-orbited/panned/zoomed away from any
+ * named preset — rendered as "Custom view" in the {@link ViewPresetMenu}.
+ *
+ * Extracted from the duplicated `createOrbitControls` closures that lived in
+ * both `Viewport3D.tsx` and `SimulationViewport.tsx` (issue #243).
+ */
+
+export type ViewPreset = 'iso' | 'top' | 'bottom' | 'front' | 'back' | 'right' | 'left'
+
+export interface ViewPresetSpherical {
+  theta: number
+  phi: number
+  up: THREE.Vector3Tuple
+}
+
+export const DEFAULT_CAMERA_SPHERICAL = {
+  theta: Math.PI / 4,
+  phi: Math.PI / 3,
+  radius: 250,
+}
+
+export const MIN_CAMERA_RADIUS = 0.1
+export const MAX_CAMERA_RADIUS = 10000
+
+export const VIEW_PRESETS: Record<ViewPreset, ViewPresetSpherical> = {
+  iso: {
+    theta: DEFAULT_CAMERA_SPHERICAL.theta,
+    phi: DEFAULT_CAMERA_SPHERICAL.phi,
+    up: [0, 1, 0],
+  },
+  top: {
+    theta: 0,
+    phi: 0.05,
+    up: [0, 0, -1],
+  },
+  bottom: {
+    theta: 0,
+    phi: Math.PI - 0.05,
+    up: [0, 0, 1],
+  },
+  front: {
+    theta: 0,
+    phi: Math.PI / 2,
+    up: [0, 1, 0],
+  },
+  back: {
+    theta: Math.PI,
+    phi: Math.PI / 2,
+    up: [0, 1, 0],
+  },
+  right: {
+    theta: Math.PI / 2,
+    phi: Math.PI / 2,
+    up: [0, 1, 0],
+  },
+  left: {
+    theta: (3 * Math.PI) / 2,
+    phi: Math.PI / 2,
+    up: [0, 1, 0],
+  },
+}
+
+/**
+ * Display order in the {@link ViewPresetMenu}: isometric first (the default),
+ * then the six orthographic faces.
+ */
+export const VIEW_PRESET_ORDER: readonly ViewPreset[] = [
+  'iso',
+  'top',
+  'bottom',
+  'front',
+  'back',
+  'right',
+  'left',
+] as const
+
+export interface ViewPresetMeta {
+  iconId: string
+  labelKey: MessageKey
+}
+
+/**
+ * Per-preset icon sprite id and i18n label key.
+ *
+ * `null` (custom view) maps to `view-free` / `viewport.presets.free`.
+ */
+const VIEW_PRESET_META: Record<ViewPreset, ViewPresetMeta> = {
+  iso: { iconId: 'view-iso', labelKey: 'viewport.presets.iso' },
+  top: { iconId: 'view-top', labelKey: 'viewport.presets.top' },
+  bottom: { iconId: 'view-bottom', labelKey: 'viewport.presets.bottom' },
+  front: { iconId: 'view-front', labelKey: 'viewport.presets.front' },
+  back: { iconId: 'view-back', labelKey: 'viewport.presets.back' },
+  right: { iconId: 'view-right', labelKey: 'viewport.presets.right' },
+  left: { iconId: 'view-left', labelKey: 'viewport.presets.left' },
+}
+
+const FREE_VIEW_META: ViewPresetMeta = {
+  iconId: 'view-free',
+  labelKey: 'viewport.presets.free',
+}
+
+/** Icon id and label key for a preset, or the custom-view fallback when `null`. */
+export function viewPresetMeta(preset: ViewPreset | null): ViewPresetMeta {
+  if (preset === null) {
+    return FREE_VIEW_META
+  }
+  return VIEW_PRESET_META[preset]
+}

--- a/src/i18n/locales/de/viewport.ts
+++ b/src/i18n/locales/de/viewport.ts
@@ -25,6 +25,13 @@ export const viewportDe: Record<keyof typeof viewportEn, string> = {
   'viewport.presets.right': 'Ansicht rechts',
   'viewport.presets.left': 'Ansicht links',
   'viewport.presets.iso': 'Isometrische Ansicht',
+  'viewport.presets.free': 'Freie Ansicht',
+
+  'viewport.viewMenu.ariaLabel': 'Kameraansicht',
+  'viewport.viewMenu.headingStandard': 'Standardansichten',
+  'viewport.viewMenu.headingActions': 'Aktionen',
+  'viewport.viewMenu.fit': 'An Modell anpassen',
+  'viewport.viewMenu.reset': 'Ansicht zurücksetzen',
 
   'viewport.sim.modeLabel': 'Simulationsmodus',
   'viewport.sim.modeSelected': 'Ausgewählt',

--- a/src/i18n/locales/en/viewport.ts
+++ b/src/i18n/locales/en/viewport.ts
@@ -29,6 +29,13 @@ export const viewportEn = {
   'viewport.presets.right': 'Right view',
   'viewport.presets.left': 'Left view',
   'viewport.presets.iso': 'Isometric view',
+  'viewport.presets.free': 'Custom view',
+
+  'viewport.viewMenu.ariaLabel': 'Camera view',
+  'viewport.viewMenu.headingStandard': 'Standard views',
+  'viewport.viewMenu.headingActions': 'Actions',
+  'viewport.viewMenu.fit': 'Fit to model',
+  'viewport.viewMenu.reset': 'Reset view',
 
   'viewport.sim.modeLabel': 'Simulation mode',
   'viewport.sim.modeSelected': 'Selected',

--- a/src/i18n/locales/es/viewport.ts
+++ b/src/i18n/locales/es/viewport.ts
@@ -25,6 +25,14 @@ export const viewportEs: Record<keyof typeof viewportEn, string> = {
   "viewport.presets.right": "Vista derecha",
   "viewport.presets.left": "Vista izquierda",
   "viewport.presets.iso": "Vista isométrica",
+  "viewport.presets.free": "Vista personalizada",
+
+  "viewport.viewMenu.ariaLabel": "Vista de la cámara",
+  "viewport.viewMenu.headingStandard": "Vistas estándar",
+  "viewport.viewMenu.headingActions": "Acciones",
+  "viewport.viewMenu.fit": "Ajustar al modelo",
+  "viewport.viewMenu.reset": "Restablecer vista",
+
   "viewport.sim.modeLabel": "Modo de simulación",
   "viewport.sim.modeSelected": "Seleccionado",
   "viewport.sim.modeVisible": "Visibles",

--- a/src/i18n/locales/fr/viewport.ts
+++ b/src/i18n/locales/fr/viewport.ts
@@ -25,6 +25,14 @@ export const viewportFr: Record<keyof typeof viewportEn, string> = {
   'viewport.presets.right': 'Vue de droite',
   'viewport.presets.left': 'Vue de gauche',
   'viewport.presets.iso': 'Vue isométrique',
+  'viewport.presets.free': 'Vue personnalisée',
+
+  'viewport.viewMenu.ariaLabel': 'Vue de la caméra',
+  'viewport.viewMenu.headingStandard': 'Vues standard',
+  'viewport.viewMenu.headingActions': 'Actions',
+  'viewport.viewMenu.fit': 'Ajuster au modèle',
+  'viewport.viewMenu.reset': 'Réinitialiser la vue',
+
   'viewport.sim.modeLabel': 'Mode de simulation',
   'viewport.sim.modeSelected': 'Sélectionné',
   'viewport.sim.modeVisible': 'Visible',

--- a/src/i18n/locales/zh-CN/viewport.ts
+++ b/src/i18n/locales/zh-CN/viewport.ts
@@ -31,6 +31,13 @@ export const viewportZhCN: Record<keyof typeof viewportEn, string> = {
   'viewport.presets.right': '右视图',
   'viewport.presets.left': '左视图',
   'viewport.presets.iso': '等轴测视图',
+  'viewport.presets.free': '自定义视图',
+
+  'viewport.viewMenu.ariaLabel': '摄像机视图',
+  'viewport.viewMenu.headingStandard': '标准视图',
+  'viewport.viewMenu.headingActions': '操作',
+  'viewport.viewMenu.fit': '适配模型',
+  'viewport.viewMenu.reset': '重置视图',
 
   'viewport.sim.modeLabel': '仿真模式',
   'viewport.sim.modeSelected': '已选中',

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2505,6 +2505,111 @@
 }
 
 /* ------------------------------------------------------------------ */
+/* View preset dropdown (3D + simulation viewports, issue #243)       */
+/* ------------------------------------------------------------------ */
+
+.view-preset-menu {
+  position: relative;
+}
+
+.view-preset-menu__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.view-preset-menu__trigger .icon-sprite {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.view-preset-menu__panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 100;
+  min-width: 220px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface-popover);
+  box-shadow: 0 18px 48px var(--shadow-strong);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.view-preset-menu__heading {
+  padding: 4px 6px 9px;
+  color: var(--text-dim);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.view-preset-menu__heading--section {
+  margin-top: 6px;
+  border-top: 1px solid var(--line);
+  padding-top: 10px;
+}
+
+.view-preset-menu__options {
+  display: grid;
+  gap: 4px;
+}
+
+.view-preset-menu__option {
+  display: grid;
+  grid-template-columns: 26px 1fr 20px;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 44px;
+  padding: 6px 8px;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.view-preset-menu__option:hover,
+.view-preset-menu__option:focus-visible {
+  border-color: var(--line);
+  background: var(--surface-hover);
+  outline: none;
+}
+
+.view-preset-menu__option--selected {
+  border-color: color-mix(in oklab, var(--accent) 55%, var(--line));
+  background: var(--accent-soft);
+}
+
+.view-preset-menu__option--action {
+  grid-template-columns: 1fr;
+}
+
+.view-preset-menu__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.view-preset-menu__label {
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.view-preset-menu__check {
+  color: var(--accent-strong);
+  font-size: 16px;
+  font-weight: 800;
+  text-align: center;
+}
+
+/* ------------------------------------------------------------------ */
 /* Toolpath visibility toggles (3D viewport)                          */
 /* ------------------------------------------------------------------ */
 


### PR DESCRIPTION
Closes #243

## Summary

Replaces the 7-button camera-preset row in both the 3D preview and simulation viewports with a **single button showing the current view**, opening a pull-down menu of standard views (Iso / Top / Bottom / Front / Back / Right / Left) plus **Fit to model** and **Reset view** actions. Free orbit/pan/zoom switches the trigger to a "Custom view" state so the user always knows they've left a named preset.

## Changes

- **Extracted shared camera modules** — the duplicated `createOrbitControls` + `VIEW_PRESETS` (copy-pasted between the two viewports, and the simulation copy was missing the `onPresetChange` callback entirely) are now single shared modules:
  - `viewPresets.ts` — `ViewPreset` type, `VIEW_PRESETS`, `VIEW_PRESET_ORDER`, `viewPresetMeta()` icon/label mapping (`null` = custom view)
  - `orbitControls.ts` — one `createOrbitControls(camera, dom, options)` factory used by both viewports
- **`ViewPresetMenu.tsx`** — dropdown component reused by both viewports (`useOutsideDismiss`, `role="menu"`, `menuitemradio`/`aria-checked`), following the `AppearanceControl` pattern
- **Redesigned view icons** — square + view-direction arrow (ISO 128 drafting convention): down/up arrows for top/bottom, ⊙/⊗ (arrow toward/away) for front/back, left/right arrows for side views; isometric cube for iso; cube + orbit arrow for custom view
- **Fit to model now fills the viewport** — `fitToBounds` previously fit the bounding *sphere* of the model (half the box diagonal) plus 1.15 margin, so flat parts floated small in empty space. It now computes a tight frustum fit from the 8 projected box corners at the current orientation (×1.1 margin). Applies to both viewports via the shared module.
- i18n keys added to all 5 locales (en, es, zh-CN, de, fr)

## Testing

- `npm run build` — green (docs + lint + tsc + 135 unit test files + vite)
- **14 unit tests**: `viewPresets.test.ts` (7: preset validity, ordering, icon/label mapping, custom fallback) + `orbitControls.test.ts` (7: all corners in frustum for flat/tall/degenerate boxes, tighter-than-sphere fit, top-preset and align-to-iso paths, tiny-box clamping)
- **3 e2e smoke tests** (`e2e/viewportViews.smoke.spec.ts`): switch views in the 3D viewport, Fit/Reset actions, switch views in the simulation viewport
- Existing `appearance.smoke.spec.ts` (9) and `camOperations.smoke.spec.ts` (3) still pass

## Non-goals (v1)

- No interactive 3D nav-cube gizmo — that was the original request in #243; the dropdown is the agreed pragmatic v1 and a cube gizmo can be a follow-up
- No orthographic/perspective toggle, view persistence, or camera animation