### PR TITLE
docs: clarify built-in subagents vs external worker delegation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,19 @@ the user's direction:
 
 - **Direct implementation (default):** one agent owns discovery, edits,
   verification, and delivery on the issue branch.
+- **Built-in subagents (in-process):** subagents provided by the agent's own
+  harness (its built-in task/subagent mechanism — same model, same session) may
+  be used proactively for parallel research and for bounded implementation
+  slices once the design is established and interface seams are frozen.
+  Partition slices by file ownership: in-process subagents share the working
+  tree, so overlapping edits conflict. No explicit authorization needed — the
+  explicit-authorization rule in **Delegated slices** applies only to the
+  external worker harness.
 - **Isolated worktree:** use when the user requests isolation or concurrent work
   would otherwise disturb the active checkout.
-- **Delegated slices:** use only when the user explicitly authorizes delegation
-  and the task divides into bounded, independently reviewable slices. Follow
+- **Delegated slices (external worker):** use only when the user explicitly
+  authorizes delegation and the task divides into bounded, independently
+  reviewable slices. Follow
   [`.agents/skills/manager-delegate/SKILL.md`](.agents/skills/manager-delegate/SKILL.md);
   the manager owns the real diff, verification, integration, and credentials.
 - **Review/diagnosis:** stay read-only unless the user separately authorizes a


### PR DESCRIPTION
Closes #363

The **Delegated slices** execution mode requires explicit user authorization — but that rule was written for the external Claude CLI worker harness (`manager-delegate` skill, DeepSeek-backed worker in an isolated worktree) and was being misread as also covering the agent's **built-in in-process subagents** (the harness's own task/subagent mechanism — same model, same session), which have a completely different trust profile.

## Changes

- Adds a harness-agnostic **Built-in subagents (in-process)** bullet: proactive use is fine for parallel research and bounded implementation slices once the design is established and interface seams are frozen; slices must be partitioned by file ownership since in-process subagents share the working tree.
- Renames **Delegated slices** → **Delegated slices (external worker)** so the scope of the explicit-authorization rule is unambiguous.

No behavior or workflow changes beyond the clarification. `npm run docs:check` passes.