### PR TITLE
fix: normalize path separators in editorCoverage.test.ts for Windows

### DIFF
--- a/src/theme/editorCoverage.test.ts
+++ b/src/theme/editorCoverage.test.ts
@@ -120,7 +120,7 @@ function walk(dir: string, out: string[] = []): string[] {
 // The theme layer defines and plumbs tokens generically, so it never counts as
 // a consumer — otherwise every token would look used by its own definition.
 const consumers = walk(SRC)
-  .filter((file) => !relative(SRC, file).startsWith('theme/'))
+  .filter((file) => !relative(SRC, file).replaceAll('\\', '/').startsWith('theme/'))
   .map((file) => readFileSync(file, 'utf8'))
 
 function isConsumed(token: (typeof THEME_TOKENS)[number]): boolean {


### PR DESCRIPTION
The consumer filter in editorCoverage.test.ts compares `relative()` output against `'theme/'` (forward slash), but on Windows `relative()` returns `theme\\...`. So theme definition files leak into the consumer list, making the test think deprecated tokens like `bg` are still consumed.\n\nFix: normalize separators with `.replaceAll('\\\\', '/')`.