### PR TITLE
Default rounded corners to true, hide stepover for edge routes

### DIFF
--- a/e2e/camOperations.smoke.spec.ts
+++ b/e2e/camOperations.smoke.spec.ts
@@ -76,7 +76,8 @@ test.describe('CAM operation browser smoke', () => {
     await expect(ui.operations.countBadge(app.page)).toHaveText('1')
     const operationRow = ui.operations.rowByName(app.page, 'Edge route outside Rough')
     await expect(operationRow).toBeVisible()
-    await expect(app.page.getByText('Stepover Ratio', { exact: true })).toBeVisible()
+    await expect(app.page.getByText('Stepdown', { exact: true })).toBeVisible()
+    await expect(app.page.getByText('Stepover Ratio', { exact: true })).not.toBeVisible()
 
     const project = await getProject(app.page)
     const operations = project.operations as OperationSnapshot[]

--- a/e2e/gcodeExport.helpers.ts
+++ b/e2e/gcodeExport.helpers.ts
@@ -48,6 +48,7 @@ function outsideRouteOperation(id: string, name: string) {
     rpm: 18000,
     pocketPattern: 'offset',
     pocketAngle: 0,
+    roundOutsideCorners: false,
     stockToLeaveRadial: 0,
     stockToLeaveAxial: 0,
     finishWalls: false,

--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -1291,6 +1291,8 @@ export function CAMPanel({
                   {selectedOperation.kind !== 'follow_line'
                     && selectedOperation.kind !== 'drilling'
                     && selectedOperation.kind !== 'v_carve_medial'
+                    && selectedOperation.kind !== 'edge_route_inside'
+                    && selectedOperation.kind !== 'edge_route_outside'
                     && !(selectedOperation.kind === 'finish_surface' && selectedOperation.pocketPattern === 'waterline') ? (
                     <label className="properties-field">
                       <span>

--- a/src/store/helpers/normalize.ts
+++ b/src/store/helpers/normalize.ts
@@ -247,7 +247,7 @@ export function normalizeOperation(rawOperation: Operation, project: Project, in
     ...defaults,
     ...operation,
     description: operation.description ?? '',
-    roundOutsideCorners: operation.roundOutsideCorners ?? false,
+    roundOutsideCorners: operation.roundOutsideCorners ?? true,
     machiningOrder: operation.machiningOrder ?? 'level_first',
     waterlineAdaptiveRefinement: operation.waterlineAdaptiveRefinement ?? true,
     waterlineMicroStepover: operation.waterlineMicroStepover ?? 0,

--- a/src/store/helpers/operationDefaults.ts
+++ b/src/store/helpers/operationDefaults.ts
@@ -309,7 +309,7 @@ export function defaultOperationForTarget(
     pocketPattern: kind === 'finish_surface' || kind === 'finish_surface_cleanup' ? 'parallel' : 'offset',
     pocketAngle: 0,
     pocketSlotFeedPercent: 100,
-    roundOutsideCorners: false,
+    roundOutsideCorners: true,
     stockToLeaveRadial: 0,
     stockToLeaveAxial: 0,
     finishWalls: true,


### PR DESCRIPTION
## Summary
- Default `roundOutsideCorners` to `true` for new operations (`operationDefaults.ts`) and for operations loaded without the field set (`normalize.ts`), instead of defaulting off.
- Hide the "Stepover Ratio" field in the operations panel for `edge_route_inside`/`edge_route_outside` — edge routing never reads `operation.stepover` (it follows a single offset contour with no stepover pattern), so the field was UI noise.

Plan and research detail in [issue #367](https://github.com/PureCutCNC/purecutcnc/issues/367#issuecomment-5083830062).

Closes #367

## Test plan
- [x] `npm run build` (lint + tsc + 138 structural test files + vite build) — all green
- [x] Manual (dev server + browser): created a new Pocket operation, confirmed the rounded-corners checkbox now defaults checked
- [x] Manual (dev server + browser): selected an existing edge-route-outside operation, confirmed Stepover Ratio field no longer appears