### PR TITLE
Verify fitted arcs against source vertices, not chords

### DIFF
--- a/planning/G-code_Export_Design.md
+++ b/planning/G-code_Export_Design.md
@@ -1,7 +1,7 @@
 ---
 status: current
 authoritative-for: machine origin, machine definitions, postprocessing, and G-code export
-last-verified: 2026-07-23
+last-verified: 2026-07-27
 ---
 
 # G-code Export Design
@@ -167,6 +167,20 @@ Invariants:
   agreement at the configured 0.01 mm tolerance. It surfaces parser-unsupported,
   parser-failed, discontinuity, and tolerance-deviation warnings explicitly and
   never reports `verified` for a partial or unsupported parse.
+- The exported-vs-optimized deviation check compares like with like. Linear
+  moves are measured against the reference polyline directly; a fitted **arc**
+  is measured against the reference **vertices** it spans, which must lie within
+  tolerance of the swept arc. That is the arc-fitting contract above (a residual
+  bound on the source *points*). Measuring a fitted arc against the reference
+  *chords* instead would charge it the sagitta between them — the gap inherent
+  to approximating a curve with line segments, which grows with radius
+  (≈ 0.00095 × R at the 5° flattening used for source curves and corner
+  fillets) and so exceeds the tolerance above roughly 10.5 mm radius no matter
+  how well the arc was fitted. The arc is the more accurate path there: the
+  machine cuts the true curve rather than the chords standing in for it.
+- Both the tolerance the fitter accepts and the tolerance the diagnostic
+  verifies come from `exportGeometryTolerance()` in `src/utils/units.ts`, so the
+  two cannot drift apart.
 - Eligibility is motion-derived, not an operation-name allow-list: a non-empty
   planar cutting trace with discrete constant-Z cutting levels. Variable-Z cuts
   (V-carve, ramping surface paths) and drilling are unavailable, with a reason —

--- a/src/components/export/ExportedMotionDebugDialog.tsx
+++ b/src/components/export/ExportedMotionDebugDialog.tsx
@@ -16,6 +16,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useRestoreCanvasFocus } from '../../utils/useRestoreCanvasFocus'
+import { exportGeometryTolerance } from '../../utils/units'
 import { useI18n } from '../../i18n/i18nContext'
 import type { MessageKey } from '../../i18n/locales/en'
 import {
@@ -106,7 +107,7 @@ export function ExportedMotionDebugDialog({
       if (!eligibility.eligible) {
         throw new Error(`ineligible:${eligibility.reason ?? ''}`)
       }
-      const tolerance = project.meta.units === 'mm' ? 0.01 : 0.01 / 25.4
+      const tolerance = exportGeometryTolerance(project.meta.units)
       const postprocessorTrace = previewResult.motionTraces?.[0]
       if (!postprocessorTrace) {
         throw new Error('no-motion-trace')

--- a/src/engine/gcode/motionDebug.test.ts
+++ b/src/engine/gcode/motionDebug.test.ts
@@ -291,6 +291,176 @@ function testMirroredMachineFlipsExportedArc(): void {
     `180° mapping (-X/-Y) keeps machine CW, got ${JSON.stringify(rotated)}`)
 }
 
+// ── Arc-vs-source comparison (issue #370) ────────────────────────────
+// A fitted arc is verified against the reference *vertices* it spans, not the
+// chords between them. These cover both directions of that change: the false
+// positive it removes, and the real faults it must still catch.
+
+/** Chord approximation of a circular sweep at `stepDeg`, as the toolpath holds it. */
+function circleChords(radius: number, toDeg: number, stepDeg: number, z: number): ToolpathPoint[] {
+  const pts: ToolpathPoint[] = []
+  for (let deg = 0; deg <= toDeg; deg += stepDeg) {
+    const a = (deg * Math.PI) / 180
+    pts.push(pt(radius * Math.cos(a), radius * Math.sin(a), z))
+  }
+  return pts
+}
+
+function chordMoves(pts: ToolpathPoint[]): ToolpathMove[] {
+  const moves: ToolpathMove[] = []
+  for (let i = 0; i < pts.length - 1; i++) moves.push(cut(pts[i], pts[i + 1]))
+  return moves
+}
+
+/**
+ * Large-radius curve whose chord sagitta exceeds the tolerance. The exported
+ * arc is correct — it is the *more* accurate path — so this must verify.
+ * Before #370 the chord-based comparison charged it the full 0.0285 mm sagitta
+ * and reported a deviation.
+ */
+function testFittedArcOverCoarseChordsVerifies(): void {
+  console.log('Testing a correctly fitted arc over coarse source chords verifies (issue #370)...')
+  const radius = 30
+  const z = -1
+  const pts = circleChords(radius, 90, 5, z)
+  const sagitta = radius * (1 - Math.cos((2.5 * Math.PI) / 180))
+  assert(sagitta > 0.01, `fixture must exceed tolerance to be meaningful, sagitta ${sagitta}`)
+
+  const optimized = { operationId: 'op', moves: chordMoves(pts), warnings: [], bounds: null }
+  const trace = { operationId: 'op', raw: optimized, optimized }
+  // Project (x,y) → machine (x,-y) under identity axes at a zero origin, so the
+  // quarter circle runs machine (30,0) → (0,-30) clockwise about the centre.
+  const parsed = parseGcodeMotion(`G0 X${radius} Y0 Z${z}\nG2 X0 Y-${radius} Z${z} I-${radius} J0 F100`, 'ij', '(', ')')
+  const ppTrace: OperationMotionTrace = {
+    operationId: 'op',
+    machineMoves: [rapid(pt(radius, 0, 5), pt(radius, 0, z)), cut(pt(radius, 0, z), pt(0, -radius, z))],
+    descriptors: [
+      { kind: 'linear', point: pt(radius, 0, z), moveKind: 'rapid' },
+      {
+        kind: 'arc',
+        startPoint: pt(radius, 0, z),
+        endPoint: pt(0, -radius, z),
+        centerOffsets: { i: -radius, j: 0 },
+        clockwise: true,
+      },
+    ],
+    tryFit: true,
+  }
+  const model = buildExportedMotionDebugModel({
+    trace, parsed, postprocessorTrace: ppTrace,
+    origin: ZERO_ORIGIN, definition: grblDefinition(), tolerance: 0.01,
+  })
+  assert(model.diagnostic.state === 'verified',
+    `expected verified, got ${model.diagnostic.state}: ${JSON.stringify(model.diagnostic.warnings)}`)
+}
+
+/** Shared fixture builder for the fault cases: same chords, swapped-in G-code. */
+function modelForExportedGcode(gcode: string, pts: ToolpathPoint[], z: number) {
+  const optimized = { operationId: 'op', moves: chordMoves(pts), warnings: [], bounds: null }
+  const trace = { operationId: 'op', raw: optimized, optimized }
+  const first = pts[0]
+  const last = pts[pts.length - 1]
+  const ppTrace: OperationMotionTrace = {
+    operationId: 'op',
+    machineMoves: [
+      rapid(pt(first.x, -first.y, 5), pt(first.x, -first.y, z)),
+      cut(pt(first.x, -first.y, z), pt(last.x, -last.y, z)),
+    ],
+    descriptors: [],
+    tryFit: false,
+  }
+  return buildExportedMotionDebugModel({
+    trace, parsed: parseGcodeMotion(gcode, 'ij', '(', ')'), postprocessorTrace: ppTrace,
+    origin: ZERO_ORIGIN, definition: grblDefinition(), tolerance: 0.01,
+  })
+}
+
+/** A displaced arc centre lifts the source vertices off the arc. */
+function testWrongArcCentreStillWarns(): void {
+  console.log('Testing a displaced arc centre still warns (issue #370 must not mask faults)...')
+  const radius = 30
+  const z = -1
+  const pts = circleChords(radius, 90, 5, z)
+  // J0.2 puts the centre at (0, 0.2) instead of the origin.
+  const model = modelForExportedGcode(
+    `G0 X${radius} Y0 Z${z}\nG2 X0 Y-${radius} Z${z} I-${radius} J0.2 F100`, pts, z)
+  assert(model.diagnostic.warnings.some((w) => w.kind === 'arcDeviation'),
+    `expected an arcDeviation warning, got ${JSON.stringify(model.diagnostic.warnings)}`)
+}
+
+/** A spurious arc fitted across a straight run bulges away from its interior vertices. */
+function testSpuriousArcOverStraightRunStillWarns(): void {
+  console.log('Testing a spurious arc across a straight run still warns (issue #370)...')
+  const z = -1
+  const pts = [pt(0, 0, z), pt(10, 0, z), pt(20, 0, z)]
+  // Arc of radius ~50.99 about (10,-50) in machine space — bulges ~0.99 away
+  // from the collinear interior vertex at (10,0).
+  const model = modelForExportedGcode(`G0 X0 Y0 Z${z}\nG3 X20 Y0 Z${z} I10 J-50 F100`, pts, z)
+  assert(model.diagnostic.warnings.some((w) => w.kind === 'arcDeviation'),
+    `expected an arcDeviation warning, got ${JSON.stringify(model.diagnostic.warnings)}`)
+}
+
+/**
+ * A closed contour repeats its opening vertex at the end, so the last arc's end
+ * point matches both. Each arc must still be measured against only the run it
+ * covers — otherwise the final arc claims the whole loop and every vertex
+ * outside its 90° sweep is scored against an endpoint.
+ */
+function testClosedContourArcsSpanOnlyTheirOwnRun(): void {
+  console.log('Testing arcs on a closed contour span only their own run (issue #370)...')
+  const radius = 30
+  const z = -1
+  const pts = circleChords(radius, 360, 5, z)
+  const optimized = { operationId: 'op', moves: chordMoves(pts), warnings: [], bounds: null }
+  const trace = { operationId: 'op', raw: optimized, optimized }
+  // Full circle emitted the way arc fitting splits it: four ≤90° G2 sub-arcs.
+  const parsed = parseGcodeMotion([
+    `G0 X${radius} Y0 Z${z}`,
+    `G2 X0 Y-${radius} Z${z} I-${radius} J0 F100`,
+    `G2 X-${radius} Y0 Z${z} I0 J${radius}`,
+    `G2 X0 Y${radius} Z${z} I${radius} J0`,
+    `G2 X${radius} Y0 Z${z} I0 J-${radius}`,
+  ].join('\n'), 'ij', '(', ')')
+  const ppTrace: OperationMotionTrace = {
+    operationId: 'op',
+    machineMoves: [
+      rapid(pt(radius, 0, 5), pt(radius, 0, z)),
+      cut(pt(radius, 0, z), pt(0, -radius, z)),
+      cut(pt(0, -radius, z), pt(-radius, 0, z)),
+      cut(pt(-radius, 0, z), pt(0, radius, z)),
+      cut(pt(0, radius, z), pt(radius, 0, z)),
+    ],
+    descriptors: [],
+    tryFit: false,
+  }
+  const model = buildExportedMotionDebugModel({
+    trace, parsed, postprocessorTrace: ppTrace,
+    origin: ZERO_ORIGIN, definition: grblDefinition(), tolerance: 0.01,
+  })
+  const deviations = model.diagnostic.warnings.filter((w) => w.kind === 'arcDeviation')
+  assert(deviations.length === 0,
+    `closed contour should report no arc deviation, got ${JSON.stringify(deviations)}`)
+}
+
+/**
+ * An arc joining the right endpoints the *short* way, over a run that swept the
+ * long way round. Endpoints match, so an endpoint-only check would pass it, but
+ * the machine would cut a completely different path — the intervening vertices
+ * fall outside the arc's sweep.
+ */
+function testMajorArcTakenTheShortWayStillWarns(): void {
+  console.log('Testing an arc that takes the short way round a major-arc run still warns (issue #370)...')
+  const radius = 30
+  const z = -1
+  // Source sweeps 270°: project (30,0) → (0,-30) the long way round.
+  const pts = circleChords(radius, 270, 5, z)
+  // Exported joins the same endpoints with a 90° arc instead.
+  const model = modelForExportedGcode(
+    `G0 X${radius} Y0 Z${z}\nG3 X0 Y${radius} Z${z} I-${radius} J0 F100`, pts, z)
+  assert(model.diagnostic.warnings.some((w) => w.kind === 'arcDeviation'),
+    `expected an arcDeviation warning, got ${JSON.stringify(model.diagnostic.warnings)}`)
+}
+
 testEligibility()
 testInverseTransform()
 testArcDirectionFlipParity()
@@ -300,5 +470,10 @@ testBuildModelNoPositioningRapid()
 testInitialPlungeIsNotComparedAsPlanarCut()
 testDiagnosticCountMismatch()
 testExportedLayerInProjectCoords()
+testFittedArcOverCoarseChordsVerifies()
+testWrongArcCentreStillWarns()
+testSpuriousArcOverStraightRunStillWarns()
+testClosedContourArcsSpanOnlyTheirOwnRun()
+testMajorArcTakenTheShortWayStillWarns()
 
 console.log('motionDebug tests passed')

--- a/src/engine/gcode/motionDebug.ts
+++ b/src/engine/gcode/motionDebug.ts
@@ -349,41 +349,123 @@ function minDistToRef(p: XYP, ref: RefSeg[]): number {
   return min
 }
 
-function sampleSegment(seg: MotionDebugSegment, n: number): XYP[] {
-  const points: XYP[] = []
-  if (seg.kind === 'arc' && seg.center && seg.radius !== undefined && seg.clockwise !== undefined) {
-    const cx = seg.center.x, cy = seg.center.y, r = seg.radius
-    const startAngle = Math.atan2(seg.from.y - cy, seg.from.x - cx)
-    const endAngle = Math.atan2(seg.to.y - cy, seg.to.x - cx)
-    // Compute the directed sweep in (-π, π]. For CW arcs the sweep is negative
-    // (decreasing angle); for CCW arcs it is positive. This matches the SVG
-    // sweep-flag convention (sweep=1 → CW in Y-down space) and the
-    // signedSweep helper in arcFitting.ts.
-    let sweep = endAngle - startAngle
-    if (seg.clockwise && sweep > 0) sweep -= Math.PI * 2
-    else if (!seg.clockwise && sweep < 0) sweep += Math.PI * 2
-    // Normalise to (-π, π] so the short-arc sweep is used (large-arc is
-    // already handled by the SVG A command flags; for sampling we just need
-    // the directed angle from start to end).
-    if (sweep > Math.PI) sweep -= Math.PI * 2
-    else if (sweep <= -Math.PI) sweep += Math.PI * 2
-    for (let i = 0; i <= n; i++) {
-      const angle = startAngle + sweep * (i / n)
-      points.push({ x: cx + r * Math.cos(angle), y: cy + r * Math.sin(angle) })
-    }
-  } else {
-    points.push(seg.from, seg.to)
-  }
-  return points
+/**
+ * Directed sweep of an arc segment, in (-π, π]. Negative for clockwise
+ * (decreasing angle), positive for counter-clockwise — matching the SVG
+ * sweep-flag convention (sweep=1 → CW in Y-down space) and the `signedSweep`
+ * helper in arcFitting.ts.
+ */
+function arcSweep(seg: MotionDebugSegment, startAngle: number, endAngle: number): number {
+  let sweep = endAngle - startAngle
+  if (seg.clockwise && sweep > 0) sweep -= Math.PI * 2
+  else if (!seg.clockwise && sweep < 0) sweep += Math.PI * 2
+  if (sweep > Math.PI) sweep -= Math.PI * 2
+  else if (sweep <= -Math.PI) sweep += Math.PI * 2
+  return sweep
 }
 
 /**
- * Compare the exported (arc-fitted) path against the optimized (linear) toolpath
- * using sampled planar deviation. This catches arc-fitting bulges where G2/G3
- * arcs deviate from the straight lines they replaced — the diagnostic the issue
- * spec calls "a reconstructed exported path that exceeds the configured tolerance
- * from its source geometry." The "source geometry" here is the optimized toolpath,
- * not the postprocessor trace (which is also arc-fitted and would agree).
+ * Distance from a point to an arc *segment* — the swept portion only, not the
+ * whole circle. A point beyond either end measures to that endpoint, so an arc
+ * is not credited with covering points it never reaches.
+ *
+ * `withinSweep` is reported separately because the two cases mean different
+ * things to the caller: a radial distance is a genuine geometric comparison,
+ * while an endpoint distance only says "this point is not on this arc".
+ */
+function distToArc(p: XYP, seg: MotionDebugSegment): { distance: number; withinSweep: boolean } | null {
+  if (seg.center === undefined || seg.radius === undefined || seg.clockwise === undefined) {
+    return null
+  }
+  const { x: cx, y: cy } = seg.center
+  const r = seg.radius
+  const startAngle = Math.atan2(seg.from.y - cy, seg.from.x - cx)
+  const endAngle = Math.atan2(seg.to.y - cy, seg.to.x - cx)
+  const sweep = arcSweep(seg, startAngle, endAngle)
+
+  // Where the point sits within the sweep, as a fraction from start to end.
+  const pointAngle = Math.atan2(p.y - cy, p.x - cx)
+  let delta = pointAngle - startAngle
+  while (delta > Math.PI) delta -= Math.PI * 2
+  while (delta <= -Math.PI) delta += Math.PI * 2
+  const t = Math.abs(sweep) < 1e-12 ? 0 : delta / sweep
+
+  if (t >= 0 && t <= 1) {
+    return { distance: Math.abs(Math.hypot(p.x - cx, p.y - cy) - r), withinSweep: true }
+  }
+  return {
+    distance: Math.min(
+      Math.hypot(p.x - seg.from.x, p.y - seg.from.y),
+      Math.hypot(p.x - seg.to.x, p.y - seg.to.y),
+    ),
+    withinSweep: false,
+  }
+}
+
+/** Ordered vertex sequence of the reference polyline (non-rapid moves only). */
+function buildRefVertices(ref: RefSeg[]): XYP[] {
+  const verts: XYP[] = []
+  for (const seg of ref) {
+    const last = verts[verts.length - 1]
+    if (!last || Math.abs(last.x - seg.from.x) > 1e-9 || Math.abs(last.y - seg.from.y) > 1e-9) {
+      verts.push(seg.from)
+    }
+    verts.push(seg.to)
+  }
+  return verts
+}
+
+/**
+ * Index of the reference vertex nearest `p`, searching forward from `start`.
+ *
+ * The forward-only search matters on closed contours: a closed loop repeats its
+ * first vertex at the end, so a global search for the *last* arc's end point
+ * would match the loop's opening vertex and claim the arc spanned the entire
+ * contour. Anchoring the search at the arc's own start keeps each arc to the
+ * run it actually covers.
+ */
+function nearestVertexIndex(p: XYP, verts: XYP[], start = 0): number {
+  let best = start
+  let bestD = Infinity
+  for (let i = start; i < verts.length; i++) {
+    const d = Math.hypot(p.x - verts[i].x, p.y - verts[i].y)
+    if (d < bestD) { bestD = d; best = i }
+  }
+  return best
+}
+
+/**
+ * Compare the exported (arc-fitted) path against the optimized (linear) toolpath.
+ *
+ * The two layers are not the same *kind* of geometry, so they are compared
+ * differently (issue #370):
+ *
+ * - **Linear** exported moves are compared directly against the reference
+ *   polyline — both are straight, so any gap is real export error.
+ * - **Arc** moves are checked against the reference **vertices** they span:
+ *   every such vertex must lie within tolerance of the swept arc. This is the
+ *   arc-fitting contract in `planning/G-code_Export_Design.md` ("a conservative
+ *   0.01 mm residual tolerance"), which bounds the distance from the source
+ *   *points* to the fitted circle.
+ *
+ * Measuring a fitted arc against the reference *chords* instead would charge it
+ * for the sagitta between them — the gap inherent to approximating any curve
+ * with line segments. That gap grows with radius (≈ 0.00095 × R for the 5°
+ * flattening used for source curves and corner fillets), so above roughly
+ * 10.5 mm radius it exceeds the tolerance no matter how the arc was fitted,
+ * making the check unsatisfiable for ordinary circles and rounded corners. The
+ * arc is in fact the *more* accurate path there: the machine cuts the true
+ * curve rather than the chords standing in for it.
+ *
+ * Real faults are still caught, and a spurious fit more sharply than before:
+ * a wrong centre or radius lifts the vertices off the arc, an arc that joins
+ * its endpoints by a different route leaves the intervening vertices outside
+ * its sweep, and an arc fitted across a straight run puts that run's interior
+ * vertices far off the circle. Faults that change the *sequence* rather than an
+ * individual arc — a reversed arc, or one truncated so the rest of the run is
+ * emitted separately — are caught by the segment count, endpoint and `arcDir`
+ * checks in {@link compareMotionTraces}, since a span derived from an arc's own
+ * endpoints cannot see beyond them.
  */
 function compareExportedVsOptimized(
   exportedSegments: MotionDebugSegment[],
@@ -394,6 +476,15 @@ function compareExportedVsOptimized(
   const warnings: MotionDebugDiagnostic['warnings'] = []
   const ref = buildRefPolyline(optimizedMoves)
   if (ref.length === 0) return { state: 'verified', warnings }
+  const refVertices = buildRefVertices(ref)
+
+  const report = (seg: MotionDebugSegment, index: number, d: number) => {
+    warnings.push({
+      kind: 'arcDeviation',
+      message: `Z=${seg.z.toFixed(4)}: segment ${index + 1} deviates by ${d.toFixed(4)} (tolerance ${tolerance.toFixed(4)})`,
+    })
+  }
+
   for (let i = 0; i < exportedSegments.length; i++) {
     const seg = exportedSegments[i]
     // Parsed G-code has only G0/G1/G2/G3 motion kinds: it cannot distinguish
@@ -403,14 +494,36 @@ function compareExportedVsOptimized(
     const sourceKind = sourceMachineMoves[i]?.kind
     if (sourceKind != null && sourceKind !== 'cut') continue
     if (!seg.cutting) continue
-    const samples = sampleSegment(seg, seg.kind === 'arc' ? 8 : 2)
-    for (const p of samples) {
+
+    if (seg.kind === 'arc') {
+      // The arc replaced a contiguous run of reference segments; both layers
+      // walk the same route in order, so the run is bounded by the vertices
+      // nearest the arc's own endpoints.
+      const i0 = nearestVertexIndex(seg.from, refVertices)
+      const i1 = nearestVertexIndex(seg.to, refVertices, i0)
+      let worst = 0
+      for (let v = i0; v <= i1; v++) {
+        const result = distToArc(refVertices[v], seg)
+        if (result === null) continue
+        if (!result.withinSweep && (v === i0 || v === i1)) {
+          // Seam artefact, not a fault: fitted runs are split into ≤ 90°
+          // sub-arcs, so a split point lands *between* source vertices. The
+          // vertex nearest such an endpoint can sit a fraction of one chord
+          // outside this sub-arc's sweep — it belongs to the adjoining one,
+          // which checks it. Only the boundary pair is forgiven this way;
+          // an interior vertex outside the sweep is a genuine mismatch.
+          continue
+        }
+        if (result.distance > worst) worst = result.distance
+      }
+      if (worst > tolerance) report(seg, i, worst)
+      continue
+    }
+
+    for (const p of [seg.from, seg.to]) {
       const d = minDistToRef(p, ref)
       if (d > tolerance) {
-        warnings.push({
-          kind: 'arcDeviation',
-          message: `Z=${seg.z.toFixed(4)}: segment ${i + 1} deviates by ${d.toFixed(4)} (tolerance ${tolerance.toFixed(4)})`,
-        })
+        report(seg, i, d)
         break
       }
     }

--- a/src/engine/gcode/postprocessor.ts
+++ b/src/engine/gcode/postprocessor.ts
@@ -23,6 +23,7 @@ import type { ToolpathWarning } from '../toolpaths/warningCodes'
 import { projectToMachinePoint, formatGCodeNumber } from './utils'
 import type { ToolpathPoint, ToolpathMove } from '../toolpaths/types'
 import type { OperationTarget } from '../../types/project'
+import { exportGeometryTolerance } from '../../utils/units'
 import { fitArcsInMachineMoves } from './arcFitting'
 import type { ArcMoveDescriptor, FittedMoveDescriptor } from './arcFitting'
 
@@ -491,8 +492,7 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
       if (tryFit) {
         // Fit arcs and emit the mixed sequence.
         const machineMoves = transformMoves()
-        const tolerance =
-          project.meta.units === 'mm' ? 0.01 : 0.01 / 25.4
+        const tolerance = exportGeometryTolerance(project.meta.units)
         const descriptors = fitArcsInMachineMoves(machineMoves, tolerance, 90)
 
         for (const d of descriptors) {
@@ -514,8 +514,7 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
         if (arcEnabled && !machineHasArcs) {
           // Check whether arcs *would* have been found.
           const machineMoves = transformMoves()
-          const tolerance =
-            project.meta.units === 'mm' ? 0.01 : 0.01 / 25.4
+          const tolerance = exportGeometryTolerance(project.meta.units)
           const descriptors = fitArcsInMachineMoves(machineMoves, tolerance, 90)
           const foundArcs = descriptors.some((d) => d.kind === 'arc')
           if (foundArcs) {
@@ -546,8 +545,7 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
         const traceMachineMoves = transformMoves()
         let traceDescriptors: FittedMoveDescriptor[] = []
         if (tryFit) {
-          const tolerance =
-            project.meta.units === 'mm' ? 0.01 : 0.01 / 25.4
+          const tolerance = exportGeometryTolerance(project.meta.units)
           traceDescriptors = fitArcsInMachineMoves(traceMachineMoves, tolerance, 90)
         }
         motionTraces.push({

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -44,6 +44,23 @@ export type Units = ProjectMeta['units']
 
 const MM_PER_INCH = 25.4
 
+/**
+ * Geometric tolerance, in millimetres, shared by export-stage arc fitting and
+ * the exported-motion verification that checks its result.
+ *
+ * Both sides must read this same value: the fitter accepts a run whose points
+ * lie within this residual of the fitted circle, and the verifier confirms the
+ * emitted arc still holds those points to the same bound. If the two drifted
+ * apart, export would emit arcs the diagnostic then reports as deviations
+ * (issue #370).
+ */
+export const EXPORT_GEOMETRY_TOLERANCE_MM = 0.01
+
+/** {@link EXPORT_GEOMETRY_TOLERANCE_MM} expressed in the project's own units. */
+export function exportGeometryTolerance(units: Units): number {
+  return units === 'mm' ? EXPORT_GEOMETRY_TOLERANCE_MM : EXPORT_GEOMETRY_TOLERANCE_MM / MM_PER_INCH
+}
+
 export function convertLength(value: number, from: Units, to: Units): number {
   if (from === to) {
     return value


### PR DESCRIPTION
## Summary

The exported-motion diagnostic sampled each fitted arc and measured its distance to the reference **chord** segments. That charges the arc for the sagitta between those chords — the gap inherent to approximating any curve with line segments — which grows with radius (≈ 0.00095 × R at the 5° flattening used for source curves and corner fillets). Above roughly 10.5 mm radius it exceeds the 0.01 mm tolerance **no matter how well the arc was fitted**.

So the check was unsatisfiable for ordinary geometry:

| source | breaches when |
|---|---|
| source curve flattening | any curve radius ≥ ~10.5 mm — i.e. any circle over ~21 mm diameter, **today, on default settings** |
| `roundContourCorners` (fixed 5° step) | smoothing radius ≥ ~10.5 mm |
| Clipper `jtRound` in `edge.ts`/`pocket.ts` | all real tool sizes, once #367/#368 defaults `roundOutsideCorners` to `true` |

In each case arc fitting is doing its job — and the arc is the *more* accurate path: the machine cuts the true curve rather than the chords standing in for it.

Fitted arcs are now checked against the reference **vertices** they span, which must lie within tolerance of the swept arc. That is the contract already documented in `planning/G-code_Export_Design.md` ("a conservative 0.01 mm **residual** tolerance" — a bound on the source *points*). **The tolerance is unchanged at 0.01 mm**; only the reference is corrected. Linear moves keep the existing direct comparison.

Two subtleties the integration probes surfaced (both regressions I hit and fixed while building this):
- the span search walks **forward from the arc's own start**, so a closed contour's repeated opening vertex can't make the final arc claim the entire loop;
- a sub-arc split point falls *between* source vertices, so the vertex nearest such a boundary can sit a fraction of a chord outside the sweep. That seam is forgiven at the boundary pair only — never for an interior vertex.

Both the tolerance the fitter accepts and the tolerance the diagnostic verifies now come from `exportGeometryTolerance()` in `src/utils/units.ts`, replacing the literal duplicated at four sites so they can't drift apart again.

## Not a loosening

This was the main risk, so it is covered explicitly in both directions. Tests assert correctly fitted arcs over coarse chords and closed contours verify, **and** that real faults still warn: a displaced arc centre, a spurious fit across a straight run, and an arc joining its endpoints by a different route. Sequence-level faults (reversed or truncated arcs) remain covered by the segment-count/endpoint/`arcDir` checks in `compareMotionTraces`.

No tessellation density changed anywhere (`ArcTolerance`, `roundContourCorners`, `DEFAULT_FLATTEN_ARC_STEP`), so there is **no performance impact** — the fix removes sampling rather than adding points. The arc-fitting algorithm is untouched.

Analysis, benchmarks and the withdrawn first approach are in [issue #370](https://github.com/PureCutCNC/purecutcnc/issues/370).

Closes #370

## Test plan
- [x] `npm run build` — lint + tsc + 138 structural test files + vite, all green
- [x] `motionDebug.test.ts`: 14 tests, 5 new for this change (4 fault-detection, 1 closed-contour regression)
- [x] Real-pipeline verification, `edge_route_outside` with arc fitting on, across 1/8"/1/4"/1" and 3 mm/12 mm tools in both unit systems, `roundOutsideCorners` both true and false — all `verified`, 0 deviations (was 15–33 warnings each)
- [x] Real-pipeline verification, plain circle features at radius 3/5/10/15/30/60 mm — all `verified` (radius ≥ 10 previously warned, up to 0.045 mm)

## Note for #367/#368

PR #368 pinned `roundOutsideCorners: false` into the `e2e/gcodeExport.helpers.ts` fixture to work around this. Once both land, that pin can be dropped so the fixture exercises the real default again — it is not needed after this change.