### PR TITLE
Bound arc-fitting candidate search

### DIFF
--- a/src/engine/toolpaths/INDEX.md
+++ b/src/engine/toolpaths/INDEX.md
@@ -43,7 +43,8 @@ Toolpath generators. Each file owns one strategy. `index.ts` re-exports everythi
 	- `camOperationSmoke.test.ts` --- per-operation-kind smoke: pocket parallel/waterline patterns, drill-type differentiation (simple/peck/dwell/chip_breaking), post smoke for thin ops (v_carve, surface_clean, follow_line, v_carve_medial; closed-Line V-carve smoke); also documents the stock-target resolver gap
 - `roughSurface.test.ts` / `finishSurface.test.ts` / `finishSurfaceCleanup.test.ts` / `meshSlicing.test.ts` / `vcarveMedial/vcarveMedial.test.ts` — strategy-specific
 - `pocketTessellationConsistency.test.ts` — regression for circle/arc sampling consistency (issue #359): full-circle and broken-circle pockets must have identical chord sagitta
-- arc-reconstruction coverage lives with its store-level callers: `store/helpers/offsetSimplify.test.ts` (offset simplification) and `store/second_cut_test.ts` (segment-preserving boolean reconstruction)
+- `arcReconstruction.test.ts` — direct partial-run arc-search coverage: greedy longest valid runs, sweep direction, and the bounded large non-fitting path (issue #369)
+- additional arc-reconstruction coverage lives with its store-level callers: `store/helpers/offsetSimplify.test.ts` (offset simplification) and `store/second_cut_test.ts` (segment-preserving boolean reconstruction)
 
 ## Adding a new strategy
 1. New file `myStrategy.ts` exporting a generator function.

--- a/src/engine/toolpaths/arcReconstruction.test.ts
+++ b/src/engine/toolpaths/arcReconstruction.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Direct regression coverage for the shared partial-run arc search.
+ *
+ * Run with: npx tsx src/engine/toolpaths/arcReconstruction.test.ts
+ */
+
+import { findArcRunsInPoints } from './arcReconstruction'
+import type { PartialArcFitOptions } from './arcReconstruction'
+import type { Point } from '../../types/project'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function approxEq(actual: number, expected: number, tolerance = 1e-6): boolean {
+  return Math.abs(actual - expected) <= tolerance
+}
+
+function sampledArc(
+  radius: number,
+  startAngle: number,
+  endAngle: number,
+  segments: number,
+): Point[] {
+  const points: Point[] = []
+  for (let i = 0; i <= segments; i += 1) {
+    const angle = startAngle + ((endAngle - startAngle) * i) / segments
+    points.push({ x: radius * Math.cos(angle), y: radius * Math.sin(angle) })
+  }
+  return points
+}
+
+const FIT_OPTIONS: PartialArcFitOptions = {
+  minArcPoints: 4,
+  maxResidual: 1e-6,
+  maxSegmentAngleDeg: 90,
+  minChordRatio: 0.15,
+  minTotalSweepRad: Math.PI / 180,
+  maxAngularStepRatio: 4,
+}
+
+function testFindsLongestValidArcRun(): void {
+  console.log('Testing longest valid arc run...')
+
+  const points = [
+    ...sampledArc(10, 0, Math.PI / 2, 12),
+    { x: 0, y: 11 },
+    { x: 1, y: 12 },
+    { x: 2, y: 11 },
+  ]
+  const runs = findArcRunsInPoints(points, FIT_OPTIONS)
+
+  assert(runs.length === 1, `expected one arc run, got ${runs.length}`)
+  const run = runs[0]
+  assert(run.startIndex === 0, `expected start index 0, got ${run.startIndex}`)
+  assert(run.endIndex === 12, `expected longest valid end index 12, got ${run.endIndex}`)
+  assert(approxEq(run.center.x, 0), `expected center.x 0, got ${run.center.x}`)
+  assert(approxEq(run.center.y, 0), `expected center.y 0, got ${run.center.y}`)
+  assert(approxEq(run.radius, 10), `expected radius 10, got ${run.radius}`)
+  assert(run.clockwise === false, 'expected counter-clockwise arc')
+}
+
+function testDetectsClockwiseArcRun(): void {
+  console.log('Testing clockwise arc run...')
+
+  const runs = findArcRunsInPoints(sampledArc(10, Math.PI / 2, 0, 12), FIT_OPTIONS)
+
+  assert(runs.length === 1, `expected one arc run, got ${runs.length}`)
+  assert(runs[0].clockwise === true, 'expected clockwise arc')
+}
+
+function testBoundsLargeNonFittingSearch(): void {
+  console.log('Testing bounded large non-fitting search...')
+
+  // Alternating points cannot fit a circle under the strict residual gate.
+  // This size used to take seconds because every starting point re-tested
+  // nearly every remaining endpoint. Keep the budget generous for CI while
+  // still catching a regression to the unbounded cubic search.
+  const points: Point[] = Array.from({ length: 1200 }, (_, index) => ({
+    x: index,
+    y: index % 2 === 0 ? 0 : 10,
+  }))
+  const startedAt = performance.now()
+  const runs = findArcRunsInPoints(points, FIT_OPTIONS)
+  const elapsedMs = performance.now() - startedAt
+
+  assert(runs.length === 0, `expected no arc runs, got ${runs.length}`)
+  assert(elapsedMs < 750, `expected bounded search below 750ms, took ${elapsedMs.toFixed(1)}ms`)
+}
+
+testFindsLongestValidArcRun()
+testDetectsClockwiseArcRun()
+testBoundsLargeNonFittingSearch()
+
+console.log('arcReconstruction tests passed.')

--- a/src/engine/toolpaths/arcReconstruction.test.ts
+++ b/src/engine/toolpaths/arcReconstruction.test.ts
@@ -55,6 +55,15 @@ const FIT_OPTIONS: PartialArcFitOptions = {
   maxAngularStepRatio: 4,
 }
 
+const EDITOR_FIT_OPTIONS: PartialArcFitOptions = {
+  minArcPoints: 7,
+  maxResidual: 0,
+  radiusToleranceFraction: 0.01,
+  maxSegmentAngleDeg: 20,
+  minChordRatio: 0.15,
+  sourceCenters: [{ x: 0, y: 0 }],
+}
+
 function testFindsLongestValidArcRun(): void {
   console.log('Testing longest valid arc run...')
 
@@ -85,6 +94,65 @@ function testDetectsClockwiseArcRun(): void {
   assert(runs[0].clockwise === true, 'expected clockwise arc')
 }
 
+function testSplitsLargeCircularRunWithoutChangingItsCircle(): void {
+  console.log('Testing large circular run splits on the same circle...')
+
+  const points = sampledArc(10, 0, Math.PI * 2, 360)
+  const runs = findArcRunsInPoints(points, FIT_OPTIONS)
+
+  assert(runs.length === 3, `expected 3 bounded runs, got ${runs.length}`)
+  let expectedStartIndex = 0
+  for (const run of runs) {
+    assert(run.startIndex === expectedStartIndex,
+      `expected run start ${expectedStartIndex}, got ${run.startIndex}`)
+    assert(run.endIndex - run.startIndex + 1 <= 128,
+      `run spans more than 128 points (${run.endIndex - run.startIndex + 1})`)
+    assert(approxEq(run.center.x, 0), `expected center.x 0, got ${run.center.x}`)
+    assert(approxEq(run.center.y, 0), `expected center.y 0, got ${run.center.y}`)
+    assert(approxEq(run.radius, 10), `expected radius 10, got ${run.radius}`)
+    assert(run.clockwise === false, 'expected counter-clockwise arc')
+    expectedStartIndex = run.endIndex
+  }
+  assert(expectedStartIndex === points.length - 1,
+    `expected runs to reach final point ${points.length - 1}, got ${expectedStartIndex}`)
+}
+
+function testUsesEditorRadiusRelativeValidation(): void {
+  console.log('Testing editor radius-relative validation...')
+
+  const runs = findArcRunsInPoints(sampledArc(10, 0, Math.PI / 2, 18), EDITOR_FIT_OPTIONS)
+
+  assert(runs.length === 1, `expected one editor arc run, got ${runs.length}`)
+  assert(approxEq(runs[0].center.x, 0), `expected center.x 0, got ${runs[0].center.x}`)
+  assert(approxEq(runs[0].center.y, 0), `expected center.y 0, got ${runs[0].center.y}`)
+  assert(approxEq(runs[0].radius, 10), `expected radius 10, got ${runs[0].radius}`)
+}
+
+function testMinimumRunCanExceedDefaultCandidateWindow(): void {
+  console.log('Testing minimum run above the default candidate window...')
+
+  const points = sampledArc(10, 0, Math.PI, 128)
+  const runs = findArcRunsInPoints(points, { ...FIT_OPTIONS, minArcPoints: points.length })
+
+  assert(runs.length === 1, `expected one minimum-sized arc run, got ${runs.length}`)
+  assert(runs[0].startIndex === 0, `expected start index 0, got ${runs[0].startIndex}`)
+  assert(runs[0].endIndex === points.length - 1,
+    `expected end index ${points.length - 1}, got ${runs[0].endIndex}`)
+}
+
+function nonFittingPoints(count: number): Point[] {
+  return Array.from({ length: count }, (_, index) => ({
+    x: index,
+    y: index % 2 === 0 ? 0 : 10,
+  }))
+}
+
+function measureNonFittingSearch(count: number): { runs: number; elapsedMs: number } {
+  const startedAt = performance.now()
+  const runs = findArcRunsInPoints(nonFittingPoints(count), FIT_OPTIONS)
+  return { runs: runs.length, elapsedMs: performance.now() - startedAt }
+}
+
 function testBoundsLargeNonFittingSearch(): void {
   console.log('Testing bounded large non-fitting search...')
 
@@ -92,20 +160,21 @@ function testBoundsLargeNonFittingSearch(): void {
   // This size used to take seconds because every starting point re-tested
   // nearly every remaining endpoint. Keep the budget generous for CI while
   // still catching a regression to the unbounded cubic search.
-  const points: Point[] = Array.from({ length: 1200 }, (_, index) => ({
-    x: index,
-    y: index % 2 === 0 ? 0 : 10,
-  }))
-  const startedAt = performance.now()
-  const runs = findArcRunsInPoints(points, FIT_OPTIONS)
-  const elapsedMs = performance.now() - startedAt
+  const result = measureNonFittingSearch(1200)
 
-  assert(runs.length === 0, `expected no arc runs, got ${runs.length}`)
-  assert(elapsedMs < 750, `expected bounded search below 750ms, took ${elapsedMs.toFixed(1)}ms`)
+  assert(result.runs === 0, `expected no arc runs, got ${result.runs}`)
+  // The exact-circle test above fixes the deterministic 128-point window
+  // contract. This broad budget catches restoring the cubic search without a
+  // flaky wall-clock scaling ratio while the full suite runs in parallel.
+  assert(result.elapsedMs < 750,
+    `expected bounded search below 750ms, took ${result.elapsedMs.toFixed(1)}ms`)
 }
 
 testFindsLongestValidArcRun()
 testDetectsClockwiseArcRun()
+testSplitsLargeCircularRunWithoutChangingItsCircle()
+testUsesEditorRadiusRelativeValidation()
+testMinimumRunCanExceedDefaultCandidateWindow()
 testBoundsLargeNonFittingSearch()
 
 console.log('arcReconstruction tests passed.')

--- a/src/engine/toolpaths/arcReconstruction.ts
+++ b/src/engine/toolpaths/arcReconstruction.ts
@@ -608,6 +608,12 @@ export interface FittedArcRun {
   clockwise: boolean
 }
 
+// A fitted arc can be split downstream without changing its geometry, while
+// scanning every possible endpoint makes a long non-fitting polyline cubic.
+// Keep each greedy search window bounded so the shared editor/export path is
+// linear in the input length for a fixed candidate budget.
+const MAX_ARC_FIT_CANDIDATE_POINTS = 128
+
 function dist2D(a: Point, b: Point): number {
   return Math.hypot(a.x - b.x, a.y - b.y)
 }
@@ -616,8 +622,8 @@ function dist2D(a: Point, b: Point): number {
  * Greedy partial-run arc finder.
  *
  * Walks the point sequence from left to right. At each position it attempts
- * the longest qualifying arc run (working backward from the end). When a fit
- * passes all validation gates the run is recorded and the walker advances
+ * the longest qualifying arc run within a bounded candidate window. When a
+ * fit passes all validation gates the run is recorded and the walker advances
  * past it; otherwise the walker advances by one point.
  *
  * Points not covered by any returned {@link FittedArcRun} are linear.
@@ -634,9 +640,11 @@ export function findArcRunsInPoints(
 
   while (i < n - opts.minArcPoints + 1) {
     let best: FittedArcRun | null = null
+    const minEnd = i + opts.minArcPoints - 1
+    const maxEnd = Math.min(n - 1, i + MAX_ARC_FIT_CANDIDATE_POINTS - 1)
 
-    // Try the longest qualifying sub-run first (greedy).
-    for (let end = n - 1; end >= i + opts.minArcPoints - 1; end -= 1) {
+    // Try the longest qualifying sub-run in the bounded window first (greedy).
+    for (let end = maxEnd; end >= minEnd; end -= 1) {
       const sub = points.slice(i, end + 1)
       const fit = fitCircleLeastSquares(sub)
       if (!fit) continue

--- a/src/engine/toolpaths/arcReconstruction.ts
+++ b/src/engine/toolpaths/arcReconstruction.ts
@@ -608,10 +608,11 @@ export interface FittedArcRun {
   clockwise: boolean
 }
 
-// A fitted arc can be split downstream without changing its geometry, while
-// scanning every possible endpoint makes a long non-fitting polyline cubic.
-// Keep each greedy search window bounded so the shared editor/export path is
-// linear in the input length for a fixed candidate budget.
+// Scanning every possible endpoint makes a long non-fitting polyline cubic.
+// The normal 5° flattener emits at most 73 points for a full circle, so 128
+// preserves that path while bounding the shared editor/export search. Exact
+// circles retain their fitted circle across windows; non-circular input can
+// produce tighter local fits that still use the existing validation gates.
 const MAX_ARC_FIT_CANDIDATE_POINTS = 128
 
 function dist2D(a: Point, b: Point): number {
@@ -637,11 +638,14 @@ export function findArcRunsInPoints(
 
   const runs: FittedArcRun[] = []
   let i = 0
+  // Honour a caller's minimum instead of creating an empty candidate range
+  // when it exceeds the default bounded window.
+  const candidatePointLimit = Math.max(MAX_ARC_FIT_CANDIDATE_POINTS, opts.minArcPoints)
 
   while (i < n - opts.minArcPoints + 1) {
     let best: FittedArcRun | null = null
     const minEnd = i + opts.minArcPoints - 1
-    const maxEnd = Math.min(n - 1, i + MAX_ARC_FIT_CANDIDATE_POINTS - 1)
+    const maxEnd = Math.min(n - 1, i + candidatePointLimit - 1)
 
     // Try the longest qualifying sub-run in the bounded window first (greedy).
     for (let end = maxEnd; end >= minEnd; end -= 1) {


### PR DESCRIPTION
## Summary

- Bound each `findArcRunsInPoints` greedy candidate search to 128 points, preventing long non-fitting polylines from triggering cubic work.
- Add direct shared-core tests for longest-run selection, sweep direction, exact-circle splitting, production editor validation, minimum-window handling, and non-fitting search scaling.
- Document the new test coverage in the toolpaths index.

## Why

The shared arc fitter re-tested nearly every remaining endpoint from every point on non-fitting input. That stalled both offset recomputation in the editor and export arc fitting.

## Fit contract

Fit tolerances and validation gates are unchanged. Exact circular input longer than the window is split into runs with the same center, radius, and direction. Slightly non-circular input can receive tighter local, within-tolerance fits, which can change run boundaries and fitted circle parameters. The revised, explicitly approved acceptance contract is recorded on issue #369.

## Verification

- `npx tsx src/engine/toolpaths/arcReconstruction.test.ts`
- `npx tsx src/store/helpers/offsetSimplify.test.ts`
- `npx tsx src/engine/gcode/arcFitting.test.ts`
- `npm run build`

No E2E test: this is a pure engine search change with direct unit coverage and existing caller-level tests.

Closes #369
