### PR TITLE
Refactor nearest-neighbor toolpath ordering

### DIFF
--- a/src/engine/toolpaths/INDEX.md
+++ b/src/engine/toolpaths/INDEX.md
@@ -36,6 +36,7 @@ Toolpath generators. Each file owns one strategy. `index.ts` re-exports everythi
 
 ## Tests
 - `linearMoveOptimization.test.ts` — zero-length removal, collinear merge, and boundary preservation
+- `geometry.test.ts` — shared nearest-neighbour ordering and squared-XY-distance behavior
 - `toolpaths.test.ts` — broad smoke tests across strategies
 - `resolverReadPath.test.ts` — resolved instance geometry and missing-definition behavior in toolpath resolution
 - `vcarveLineResolver.test.ts` — S2 closed-Line V-carve resolver tests: single Line, open-Line rejection, nested even-odd holes, disjoint Lines, mixed Subtract + Line, Subtract-only regression

--- a/src/engine/toolpaths/drilling.ts
+++ b/src/engine/toolpaths/drilling.ts
@@ -19,6 +19,7 @@ import type { ToolpathWarning } from './warningCodes'
 import type { DrillCycle, ToolpathBounds, ToolpathMove, ToolpathPoint, ToolpathResult } from './types'
 import {
   checkMaxCutDepthWarning,
+  greedyNearestNeighbor,
   getOperationSafeZ,
   normalizeToolForProject,
   resolveFeatureZSpan,
@@ -32,12 +33,6 @@ interface DrillTarget {
   center: Point
   span: ReturnType<typeof resolveFeatureZSpan>
   originalIndex: number
-}
-
-function xyDistanceSquared(a: ToolpathPoint, b: Point): number {
-  const dx = b.x - a.x
-  const dy = b.y - a.y
-  return dx * dx + dy * dy
 }
 
 function precomputeDrillTargets(
@@ -75,34 +70,11 @@ function precomputeDrillTargets(
 }
 
 export function sortTargetsByNearestNeighbor(targets: DrillTarget[], startPosition: ToolpathPoint | null): DrillTarget[] {
-  if (targets.length <= 1) return targets
-
-  const current: ToolpathPoint = startPosition ? { ...startPosition } : { x: 0, y: 0, z: 0 }
-  const ordered: DrillTarget[] = []
-  const remaining = [...targets]
-
-  while (remaining.length > 0) {
-    let bestIndex = 0
-    let bestDistance = xyDistanceSquared(current, remaining[0].center)
-
-    for (let i = 1; i < remaining.length; i += 1) {
-      const distance = xyDistanceSquared(current, remaining[i].center)
-      if (
-        distance < bestDistance
-        || (distance === bestDistance && remaining[i].originalIndex < remaining[bestIndex].originalIndex)
-      ) {
-        bestIndex = i
-        bestDistance = distance
-      }
-    }
-
-    const [next] = remaining.splice(bestIndex, 1)
-    ordered.push(next)
-    current.x = next.center.x
-    current.y = next.center.y
-  }
-
-  return ordered
+  return greedyNearestNeighbor(targets, {
+    positionOf: (target) => target.center,
+    start: startPosition ?? { x: 0, y: 0 },
+    tieBreakOf: (target) => target.originalIndex,
+  })
 }
 
 function updateBounds(bounds: ToolpathBounds | null, point: ToolpathPoint): ToolpathBounds {

--- a/src/engine/toolpaths/geometry.test.ts
+++ b/src/engine/toolpaths/geometry.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { greedyNearestNeighbor, xyDistanceSquared } from './geometry'
+
+interface Candidate {
+  id: string
+  position: { x: number; y: number }
+  exit?: { x: number; y: number }
+  originalIndex: number
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function ids(items: Candidate[]): string {
+  return items.map((item) => item.id).join(',')
+}
+
+function testXyDistanceSquared(): void {
+  console.log('Testing squared XY distance...')
+  assert(xyDistanceSquared({ x: -1, y: 2 }, { x: 2, y: 6 }) === 25, 'distance should ignore extra fields and square XY deltas')
+  console.log('squared XY distance: PASSED')
+}
+
+function testKeepsFirstItemAndUsesSeparateExit(): void {
+  console.log('Testing implicit seeding and separate exit point...')
+  const candidates: Candidate[] = [
+    { id: 'first', position: { x: 0, y: 0 }, exit: { x: 10, y: 0 }, originalIndex: 0 },
+    { id: 'near-exit', position: { x: 9, y: 0 }, originalIndex: 1 },
+    { id: 'near-start', position: { x: 1, y: 0 }, originalIndex: 2 },
+  ]
+
+  const ordered = greedyNearestNeighbor(candidates, {
+    positionOf: (candidate) => candidate.position,
+    exitOf: (candidate) => candidate.exit ?? candidate.position,
+  })
+
+  assert(ids(ordered) === 'first,near-exit,near-start', `unexpected order: ${ids(ordered)}`)
+  console.log('implicit seeding and separate exit point: PASSED')
+}
+
+function testTieBehaviorAndCachedPositions(): void {
+  console.log('Testing tie behavior and one-time position evaluation...')
+  const candidates: Candidate[] = [
+    { id: 'high', position: { x: -1, y: 0 }, originalIndex: 2 },
+    { id: 'low', position: { x: 1, y: 0 }, originalIndex: 1 },
+  ]
+  const positionCalls = new Map<string, number>()
+
+  const tieBroken = greedyNearestNeighbor(candidates, {
+    positionOf: (candidate) => {
+      positionCalls.set(candidate.id, (positionCalls.get(candidate.id) ?? 0) + 1)
+      return candidate.position
+    },
+    start: { x: 0, y: 0 },
+    tieBreakOf: (candidate) => candidate.originalIndex,
+  })
+  const firstEncountered = greedyNearestNeighbor(candidates, {
+    positionOf: (candidate) => candidate.position,
+    start: { x: 0, y: 0 },
+  })
+
+  assert(ids(tieBroken) === 'low,high', `tie-break should prefer lower original index: ${ids(tieBroken)}`)
+  assert(ids(firstEncountered) === 'high,low', `without a tie-break the first candidate should win: ${ids(firstEncountered)}`)
+  assert([...positionCalls.values()].every((calls) => calls === 1), 'each position should be evaluated exactly once')
+  console.log('tie behavior and cached positions: PASSED')
+}
+
+function testDoesNotMutateStartPoint(): void {
+  console.log('Testing explicit start point is not mutated...')
+  const start = { x: 5, y: 5 }
+  const candidates: Candidate[] = [
+    { id: 'first', position: { x: 7, y: 5 }, originalIndex: 0 },
+    { id: 'second', position: { x: 9, y: 5 }, originalIndex: 1 },
+  ]
+
+  const ordered = greedyNearestNeighbor(candidates, {
+    positionOf: (candidate) => candidate.position,
+    start,
+  })
+
+  assert(ids(ordered) === 'first,second', `unexpected order: ${ids(ordered)}`)
+  assert(start.x === 5 && start.y === 5, 'caller-owned start point should be unchanged')
+  console.log('explicit start point immutability: PASSED')
+}
+
+function testEmptyAndSingleInputs(): void {
+  console.log('Testing empty and single-item inputs...')
+  const empty: Candidate[] = []
+  const single: Candidate[] = [{ id: 'only', position: { x: 0, y: 0 }, originalIndex: 0 }]
+
+  assert(greedyNearestNeighbor(empty, { positionOf: (candidate) => candidate.position }) === empty, 'empty input should be returned unchanged')
+  assert(greedyNearestNeighbor(single, { positionOf: (candidate) => candidate.position }) === single, 'single input should be returned unchanged')
+  console.log('empty and single-item inputs: PASSED')
+}
+
+try {
+  testXyDistanceSquared()
+  testKeepsFirstItemAndUsesSeparateExit()
+  testTieBehaviorAndCachedPositions()
+  testDoesNotMutateStartPoint()
+  testEmptyAndSingleInputs()
+  console.log('\nAll geometry tests PASSED.')
+} catch (error) {
+  console.error(error)
+  throw error
+}

--- a/src/engine/toolpaths/geometry.ts
+++ b/src/engine/toolpaths/geometry.ts
@@ -48,6 +48,82 @@ function clonePoint(point: Point): Point {
   return { x: point.x, y: point.y }
 }
 
+export function xyDistanceSquared(
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+): number {
+  const dx = b.x - a.x
+  const dy = b.y - a.y
+  return dx * dx + dy * dy
+}
+
+export interface NearestNeighborOptions<T> {
+  /** Position used to measure distance to a candidate. */
+  positionOf: (item: T) => { x: number; y: number }
+  /** Where the tool ends after visiting the item. Defaults to positionOf. */
+  exitOf?: (item: T) => { x: number; y: number }
+  /** Explicit start point. Omit to keep the first item in place and seed from it. */
+  start?: { x: number; y: number } | null
+  /** When provided, exact ties prefer the lower value. Omit for first-encountered-wins. */
+  tieBreakOf?: (item: T) => number
+}
+
+interface NearestNeighborEntry<T> {
+  item: T
+  position: { x: number; y: number }
+  exit: { x: number; y: number }
+  tieBreak: number | null
+}
+
+export function greedyNearestNeighbor<T>(items: T[], options: NearestNeighborOptions<T>): T[] {
+  if (items.length <= 1) return items
+
+  const entries = items.map<NearestNeighborEntry<T>>((item) => {
+    const position = options.positionOf(item)
+    return {
+      item,
+      position,
+      exit: options.exitOf?.(item) ?? position,
+      tieBreak: options.tieBreakOf?.(item) ?? null,
+    }
+  })
+  const explicitStart = options.start ?? null
+  const ordered = explicitStart ? [] : [entries[0]]
+  const remaining = explicitStart ? entries : entries.slice(1)
+  let current = explicitStart
+    ? { x: explicitStart.x, y: explicitStart.y }
+    : { x: entries[0].exit.x, y: entries[0].exit.y }
+
+  while (remaining.length > 0) {
+    let bestIndex = 0
+    let bestDistance = xyDistanceSquared(current, remaining[0].position)
+    for (let index = 1; index < remaining.length; index += 1) {
+      const distance = xyDistanceSquared(current, remaining[index].position)
+      const candidateTieBreak = remaining[index].tieBreak
+      const bestTieBreak = remaining[bestIndex].tieBreak
+      if (
+        distance < bestDistance
+        || (
+          distance === bestDistance
+          && options.tieBreakOf !== undefined
+          && candidateTieBreak !== null
+          && bestTieBreak !== null
+          && candidateTieBreak < bestTieBreak
+        )
+      ) {
+        bestIndex = index
+        bestDistance = distance
+      }
+    }
+
+    const [next] = remaining.splice(bestIndex, 1)
+    ordered.push(next)
+    current = { x: next.exit.x, y: next.exit.y }
+  }
+
+  return ordered.map((entry) => entry.item)
+}
+
 export function resolveDimensionRef(project: Pick<Project, 'dimensions'>, value: DimensionRef): number {
   if (typeof value === 'number') {
     return value

--- a/src/engine/toolpaths/multiFeature.ts
+++ b/src/engine/toolpaths/multiFeature.ts
@@ -18,6 +18,7 @@ import { isConstruction } from '../../store/helpers/featureRoles'
 import { resolvedFeatureMap } from '../../store/helpers/resolveFeatures'
 import type { Operation, Project } from '../../types/project'
 import type { PocketToolpathResult, ToolpathBounds, ToolpathPoint, ToolpathResult } from './types'
+import { greedyNearestNeighbor } from './geometry'
 
 interface MergeToolpathOptions {
   orderBlocks?: 'input' | 'nearest'
@@ -102,12 +103,6 @@ function blockEnd(part: ToolpathResult): ToolpathPoint | null {
   return part.moves.at(-1)?.to ?? null
 }
 
-function xyDistanceSquared(a: ToolpathPoint, b: ToolpathPoint): number {
-  const dx = b.x - a.x
-  const dy = b.y - a.y
-  return dx * dx + dy * dy
-}
-
 function samePoint(a: ToolpathPoint, b: ToolpathPoint): boolean {
   return a.x === b.x && a.y === b.y && a.z === b.z
 }
@@ -121,30 +116,11 @@ function orderPartsByNearestBlock<T extends ToolpathResult>(parts: T[]): T[] {
   }, [])
   if (blocks.length <= 1) return parts
 
-  const ordered: IndexedToolpathPart<T>[] = [blocks[0]]
-  const remaining = blocks.slice(1)
-  let current = blocks[0].end
-
-  while (remaining.length > 0) {
-    let bestIndex = 0
-    let bestDistance = xyDistanceSquared(current, remaining[0].start)
-    for (let i = 1; i < remaining.length; i += 1) {
-      const distance = xyDistanceSquared(current, remaining[i].start)
-      if (
-        distance < bestDistance
-        || (distance === bestDistance && remaining[i].originalIndex < remaining[bestIndex].originalIndex)
-      ) {
-        bestIndex = i
-        bestDistance = distance
-      }
-    }
-
-    const [next] = remaining.splice(bestIndex, 1)
-    ordered.push(next)
-    current = next.end
-  }
-
-  return ordered.map((block) => block.part)
+  return greedyNearestNeighbor(blocks, {
+    positionOf: (block) => block.start,
+    exitOf: (block) => block.end,
+    tieBreakOf: (block) => block.originalIndex,
+  }).map((block) => block.part)
 }
 
 function mergeMoves(parts: ToolpathResult[], normalizeTransitions: boolean): ToolpathResult['moves'] {

--- a/src/engine/toolpaths/regions.ts
+++ b/src/engine/toolpaths/regions.ts
@@ -23,6 +23,7 @@ import {
   DEFAULT_CLIPPER_SCALE,
   flattenProfile,
   getOperationSafeZ,
+  greedyNearestNeighbor,
   normalizeWinding,
   toClipperPath,
 } from './geometry'
@@ -473,30 +474,10 @@ interface RegionCutGroup {
  * small disjoint corner regions). Mirrors orderPartsByNearestBlock.
  */
 function orderRegionCutGroupsByNearest(groups: RegionCutGroup[]): RegionCutGroup[] {
-  if (groups.length <= 1) return groups
-
-  const ordered: RegionCutGroup[] = [groups[0]]
-  const remaining = groups.slice(1)
-  let current = groups[0].end
-
-  while (remaining.length > 0) {
-    let bestIndex = 0
-    let bestDistance = Infinity
-    for (let index = 0; index < remaining.length; index += 1) {
-      const dx = remaining[index].start.x - current.x
-      const dy = remaining[index].start.y - current.y
-      const distance = dx * dx + dy * dy
-      if (distance < bestDistance) {
-        bestIndex = index
-        bestDistance = distance
-      }
-    }
-    const [next] = remaining.splice(bestIndex, 1)
-    ordered.push(next)
-    current = next.end
-  }
-
-  return ordered
+  return greedyNearestNeighbor(groups, {
+    positionOf: (group) => group.start,
+    exitOf: (group) => group.end,
+  })
 }
 
 export function clipToolpathResultToRegionMask(

--- a/src/engine/toolpaths/toolpaths.test.ts
+++ b/src/engine/toolpaths/toolpaths.test.ts
@@ -27,7 +27,7 @@ import type { Operation, Project, RegionMaskMode, SketchFeature, Tool } from '..
 import { circleProfile, defaultTool, newProject, polygonProfile, rectProfile } from '../../types/project'
 import { projectWithFeatures } from '../../test/projectFixtures'
 import { buildGearProfile, defaultGearCreationParams } from '../../sketch/gearProfile'
-import type { ToolpathBounds, ToolpathMove, ToolpathResult } from './types'
+import type { ResolvedPocketRegion, ToolpathBounds, ToolpathMove, ToolpathResult } from './types'
 import { mergePocketToolpathResults, mergeToolpathResults, perFeatureOperations } from './multiFeature'
 import { generatePocketToolpath } from './pocket'
 import { generateEdgeRouteToolpath } from './edge'
@@ -37,6 +37,7 @@ import { generateSurfaceCleanToolpath } from './surface'
 import { generateFollowLineToolpath } from './carving'
 import { generateDrillingToolpath, sortTargetsByNearestNeighbor } from './drilling'
 import { generatePocketRestRegionDrafts } from './restRegions'
+import { resolvePocketRegions } from './resolver'
 import {
   buildMaskFromClipperPaths,
   buildRegionMask,
@@ -46,7 +47,7 @@ import {
 import { DEFAULT_CLIPPER_SCALE } from './geometry'
 import type { ClipperPath } from './types'
 
-function assert(condition: boolean, message: string) {
+function assert(condition: boolean, message: string): asserts condition {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
 }
 
@@ -1659,6 +1660,55 @@ function testEdgeOutsideCombinedRoundCorners() {
 // V-carve: feature_first emits independent per-feature toolpath
 // ---------------------------------------------------------------------------
 
+function nearestResolvedRegionIndex(point: { x: number; y: number }, regions: ResolvedPocketRegion[]): number {
+  let nearestIndex = 0
+  let nearestDistance = Infinity
+  for (let index = 0; index < regions.length; index += 1) {
+    const centroid = regions[index].outer.reduce(
+      (sum, vertex) => ({ x: sum.x + vertex.x, y: sum.y + vertex.y }),
+      { x: 0, y: 0 },
+    )
+    const center = { x: centroid.x / regions[index].outer.length, y: centroid.y / regions[index].outer.length }
+    const dx = point.x - center.x
+    const dy = point.y - center.y
+    const distance = dx * dx + dy * dy
+    if (distance < nearestDistance) {
+      nearestIndex = index
+      nearestDistance = distance
+    }
+  }
+  return nearestIndex
+}
+
+function testVCarveVisitsNearestResolvedRegionFirst() {
+  console.log('Testing v_carve visits the nearest resolved region first...')
+  const tool = makeVBit('t1')
+  const far = makePocketFeature('far', 60, 0, 10, 10, 0, -2)
+  const near = makePocketFeature('near', 0, 0, 10, 10, 0, -2)
+  const project = baseProject([tool], [far, near])
+  const operation = makePocketOp({
+    kind: 'v_carve',
+    target: { source: 'features', featureIds: ['far', 'near'] },
+    toolRef: 't1',
+    maxCarveDepth: 2,
+    stepover: 0.3,
+  })
+  const regions = resolvePocketRegions(project, operation).bands[0]?.regions ?? []
+  assert(regions.length === 2, `expected two resolved regions, got ${regions.length}`)
+  assert(
+    nearestResolvedRegionIndex({ x: 0, y: 0 }, regions) === 1,
+    'fixture must retain far-first resolved-region order before nearest-neighbor traversal',
+  )
+
+  const firstCut = cutMoves(generateVCarveToolpath(project, operation).moves)[0]
+  assert(firstCut !== undefined, 'expected V-carve cut moves')
+  assert(
+    nearestResolvedRegionIndex(firstCut.from, regions) === 1,
+    'V-carve should start with the region nearest the origin, not resolver order',
+  )
+  console.log('v_carve nearest resolved-region ordering: PASSED')
+}
+
 function testVCarveDisjointFeaturesAreMachiningOrderInvariant() {
   console.log('Testing v_carve disjoint features are machiningOrder invariant...')
 
@@ -2794,6 +2844,7 @@ try {
   testEdgeOutsideClipsAroundNonSelectedAddFeatures()
   testEdgeOutsideRoundCornersOptIn()
   testEdgeOutsideCombinedRoundCorners()
+  testVCarveVisitsNearestResolvedRegionFirst()
   testVCarveDisjointFeaturesAreMachiningOrderInvariant()
   testSurfaceCleanMultiTargetProtectsTallerTarget()
   testSurfaceCleanRegionMaskClipsGeneratedToolpathOnly()

--- a/src/engine/toolpaths/vcarve.ts
+++ b/src/engine/toolpaths/vcarve.ts
@@ -17,7 +17,7 @@
 import ClipperLib from 'clipper-lib'
 import type { Operation, Point, Project } from '../../types/project'
 import type { ToolpathBounds, ToolpathMove, ToolpathPoint, ToolpathResult } from './types'
-import { applyContourDirection, checkMaxCutDepthWarning, getOperationSafeZ, normalizeToolForProject } from './geometry'
+import { applyContourDirection, checkMaxCutDepthWarning, getOperationSafeZ, greedyNearestNeighbor, normalizeToolForProject } from './geometry'
 import { isFeatureFirst, mergeToolpathResults, perFeatureOperations } from './multiFeature'
 import { buildContourLoops, buildInsetRegions, contourStartPoint, retractToSafe, toClosedCutMoves, transitionToCutEntry, updateBounds } from './pocket'
 import { resolvePocketRegions } from './resolver'
@@ -28,33 +28,6 @@ function regionCentroid(region: { outer: Point[] }): { x: number; y: number } {
   for (const p of region.outer) { sx += p.x; sy += p.y }
   const n = region.outer.length || 1
   return { x: sx / n, y: sy / n }
-}
-
-function sortRegionsNearestNeighbor<T extends { outer: Point[] }>(
-  regions: T[],
-  currentPosition: ToolpathPoint | null,
-): T[] {
-  if (regions.length <= 1) return regions
-  const remaining = regions.slice()
-  const sorted: T[] = []
-  let curX = currentPosition?.x ?? 0
-  let curY = currentPosition?.y ?? 0
-
-  while (remaining.length > 0) {
-    let bestIdx = 0
-    let bestDist = Infinity
-    for (let i = 0; i < remaining.length; i++) {
-      const c = regionCentroid(remaining[i])
-      const d = Math.hypot(c.x - curX, c.y - curY)
-      if (d < bestDist) { bestDist = d; bestIdx = i }
-    }
-    const chosen = remaining.splice(bestIdx, 1)[0]
-    const c = regionCentroid(chosen)
-    curX = c.x
-    curY = c.y
-    sorted.push(chosen)
-  }
-  return sorted
 }
 
 /**
@@ -214,7 +187,10 @@ function generateVCarveToolpathSingle(project: Project, operation: Operation): T
     }
 
     const vcarveJoinType = ClipperLib.JoinType.jtRound
-    const sortedRegions = sortRegionsNearestNeighbor(band.regions, currentPosition)
+    const sortedRegions = greedyNearestNeighbor(band.regions, {
+      positionOf: regionCentroid,
+      start: currentPosition ?? { x: 0, y: 0 },
+    })
 
     for (const region of sortedRegions) {
       let currentDepth = Math.min(stepoverDistance / slope, maxBandDepth)

--- a/src/engine/toolpaths/vcarveMedial/index.ts
+++ b/src/engine/toolpaths/vcarveMedial/index.ts
@@ -34,7 +34,7 @@ import type {
   ToolpathPoint,
   ToolpathResult,
 } from '../types'
-import { checkMaxCutDepthWarning, getOperationSafeZ, normalizeToolForProject } from '../geometry'
+import { checkMaxCutDepthWarning, getOperationSafeZ, greedyNearestNeighbor, normalizeToolForProject } from '../geometry'
 import { isFeatureFirst, mergeToolpathResults, perFeatureOperations } from '../multiFeature'
 import { updateBounds } from '../pocket'
 import { resolvePocketRegions } from '../resolver'
@@ -65,33 +65,6 @@ function regionCentroid(region: { outer: Point[] }): { x: number; y: number } {
   for (const p of region.outer) { sx += p.x; sy += p.y }
   const n = region.outer.length || 1
   return { x: sx / n, y: sy / n }
-}
-
-function sortRegionsNearestNeighbor<T extends { outer: Point[] }>(
-  regions: T[],
-  currentPosition: ToolpathPoint | null,
-): T[] {
-  if (regions.length <= 1) return regions
-  const remaining = regions.slice()
-  const sorted: T[] = []
-  let curX = currentPosition?.x ?? 0
-  let curY = currentPosition?.y ?? 0
-
-  while (remaining.length > 0) {
-    let bestIdx = 0
-    let bestDist = Infinity
-    for (let i = 0; i < remaining.length; i += 1) {
-      const c = regionCentroid(remaining[i])
-      const d = Math.hypot(c.x - curX, c.y - curY)
-      if (d < bestDist) { bestDist = d; bestIdx = i }
-    }
-    const chosen = remaining.splice(bestIdx, 1)[0]
-    const c = regionCentroid(chosen)
-    curX = c.x
-    curY = c.y
-    sorted.push(chosen)
-  }
-  return sorted
 }
 
 export function generateVCarveMedialToolpath(project: Project, operation: Operation): ToolpathResult {
@@ -184,7 +157,10 @@ function generateVCarveMedialToolpathSingle(project: Project, operation: Operati
       continue
     }
 
-    const sortedRegions = sortRegionsNearestNeighbor(band.regions, currentPosition)
+    const sortedRegions = greedyNearestNeighbor(band.regions, {
+      positionOf: regionCentroid,
+      start: currentPosition ?? { x: 0, y: 0 },
+    })
     for (const region of sortedRegions) {
       const resolvedResolution = resolveMedialResolution(region)
       if (!resolvedResolution) {

--- a/src/engine/toolpaths/vcarveMedial/vcarveMedial.test.ts
+++ b/src/engine/toolpaths/vcarveMedial/vcarveMedial.test.ts
@@ -24,7 +24,7 @@ import { defaultTool, newProject, polygonProfile, rectProfile } from '../../../t
 import { getTextFontOptions } from '../../../text'
 import { projectWithFeatures } from '../../../test/projectFixtures'
 import { resolvePocketRegions } from '../resolver'
-import type { ToolpathMove } from '../types'
+import type { ResolvedPocketRegion, ToolpathMove } from '../types'
 import {
   computeMedialAxis,
   emitMedialToolpath,
@@ -433,6 +433,26 @@ function assertContinuity(moves: ToolpathMove[]): void {
   }
 }
 
+function nearestResolvedRegionIndex(point: { x: number; y: number }, regions: ResolvedPocketRegion[]): number {
+  let nearestIndex = 0
+  let nearestDistance = Infinity
+  for (let index = 0; index < regions.length; index += 1) {
+    const centroid = regions[index].outer.reduce(
+      (sum, vertex) => ({ x: sum.x + vertex.x, y: sum.y + vertex.y }),
+      { x: 0, y: 0 },
+    )
+    const center = { x: centroid.x / regions[index].outer.length, y: centroid.y / regions[index].outer.length }
+    const dx = point.x - center.x
+    const dy = point.y - center.y
+    const distance = dx * dx + dy * dy
+    if (distance < nearestDistance) {
+      nearestIndex = index
+      nearestDistance = distance
+    }
+  }
+  return nearestIndex
+}
+
 function testGeneratorSquare(): void {
   console.log('Testing generateVCarveMedialToolpath on a 20×20 square...')
   const proj = baseProject([makeVBit()], [makeRectFeature('f1', 0, 0, 20, 20, -5)])
@@ -528,6 +548,32 @@ function testGeneratorMultipleFeatures(): void {
     assert(!inGap(move.from) || !inGap(move.to), 'cut crosses the gap between features')
   }
   console.log(`multi-feature: ${cuts.length} cuts PASSED`)
+}
+
+function testGeneratorVisitsNearestResolvedRegionFirst(): void {
+  console.log('Testing v_carve_medial visits the nearest resolved region first...')
+  const project = baseProject(
+    [makeVBit()],
+    [
+      makeRectFeature('far', 60, 0, 10, 10, -5),
+      makeRectFeature('near', 0, 0, 10, 10, -5),
+    ],
+  )
+  const operation = makeVCarveMedialOp(['far', 'near'])
+  const regions = resolvePocketRegions(project, operation).bands[0]?.regions ?? []
+  assert(regions.length === 2, `expected two resolved regions, got ${regions.length}`)
+  assert(
+    nearestResolvedRegionIndex({ x: 0, y: 0 }, regions) === 1,
+    'fixture must retain far-first resolved-region order before nearest-neighbor traversal',
+  )
+
+  const firstCut = cutMoves(generateVCarveMedialToolpath(project, operation).moves)[0]
+  assert(firstCut !== undefined, 'expected V-carve medial cut moves')
+  assert(
+    nearestResolvedRegionIndex(firstCut.from, regions) === 1,
+    'V-carve medial should start with the region nearest the origin, not resolver order',
+  )
+  console.log('v_carve_medial nearest resolved-region ordering: PASSED')
 }
 
 function makeOutlineTextFeature(
@@ -791,6 +837,7 @@ try {
   testGeneratorDeterminism()
   testGeneratorIgnoresLegacyStepover()
   testGeneratorMultipleFeatures()
+  testGeneratorVisitsNearestResolvedRegionFirst()
   testGeneratorTextFeatureTarget()
   testScaledOutlineTextTopologyStaysStable()
   testOutlineGRejectsFlatteningSpokesAcrossScales()


### PR DESCRIPTION
## Summary

- Centralize `xyDistanceSquared` and configurable greedy nearest-neighbour ordering in the toolpath geometry helpers.
- Migrate the five duplicate traversal implementations while preserving their distinct seed, exit-point, and tie-break semantics.
- Cache V-carve region centroids once per candidate and add direct helper coverage.

Closes #128

## Verification

- `npx tsx src/engine/toolpaths/geometry.test.ts`
- `npx tsx src/engine/toolpaths/toolpaths.test.ts`
- `npx tsx src/engine/toolpaths/vcarveMedial/vcarveMedial.test.ts`
- Bundled example-project G-code snapshots (`badge`, `purecutcnc`, and `t-style-body`) were byte-identical before and after.
- `npm run build`

No e2e coverage: this is a pure toolpath-engine refactor with no rendered-DOM or workflow change.
