### PR TITLE
docs: require rebase before PR; document the conflicting-PR CI gap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,9 @@ Always run `npm run build` from the project root to verify changes compile befor
 - Only commit on `main` if a human explicitly says "commit on `main`" / "commit directly to `main`".
 - **Enforcement (Claude Code):** a `PreToolUse` hook — [`.claude/hooks/block-default-branch-commit.sh`](.claude/hooks/block-default-branch-commit.sh), wired in [`.claude/settings.json`](.claude/settings.json) — blocks any `git commit` while `HEAD` is on `main`/`master`. Commits on other branches pass through untouched.
 - **Other tools (Codex, plain `git`, humans):** that hook only binds Claude Code sessions. Codex must follow this rule by reading this file (AGENTS.md). For tool-agnostic enforcement, a native git `pre-commit` hook can be added under a committed `.githooks/` dir + `git config core.hooksPath .githooks` — not set up yet.
+- **Rebase onto current `main` before opening a PR**, and again before asking for a merge if `main` has moved. Run `git fetch origin && git rebase origin/main`, then re-run `npm run build`.
+- **A conflicting PR gets no CI at all.** `pr-check.yml` runs on the merge ref, which GitHub cannot compute while the branch conflicts — so the `build` and `e2e` jobs never start. `gh pr checks <NN>` reporting *"no checks reported"* means **unverified**, not *pending*. This is not cosmetic: PR #380 sat with a TypeScript error nobody saw because a stale base suppressed the whole gate.
+- **Enforcement (all tools):** the `main-requires-pr` ruleset requires the `build` and `e2e` checks to pass **and** the branch to be up to date with `main` before merging. Unlike the commit hook above, this binds every author — Claude, Codex, and humans. Use GitHub's **Update branch** button or auto-merge when `main` moves under an open PR.
 
 ## Communication Style
 


### PR DESCRIPTION
## Summary

- Document that a feature branch must be rebased onto current `main` before opening a PR.
- Document that **a conflicting PR receives no CI at all** — `pr-check.yml` runs on the merge ref, which GitHub cannot compute while the branch conflicts, so `build` and `e2e` never start.
- Record that enforcement is the `main-requires-pr` ruleset and that, unlike the Claude Code commit hook, it binds every author.

## Ruleset change (already applied)

The code half of #381 is a repo setting, not a file. `main-requires-pr` (id `18129403`) now reads:

| | before | after |
|---|---|---|
| `strict_required_status_checks_policy` | `false` | **`true`** |
| required checks | `build` | **`build`, `e2e`** |

`deletion`, `non_fast_forward`, and the `pull_request` rule (0 required approvals) are unchanged. A backup of the prior ruleset JSON was taken before the edit.

## Why

PR #380 was five merged PRs behind `main`. The conflict was not the real damage:

```
$ gh pr checks 380
no checks reported on the 'refactor/issue-128-nearest-neighbor-consolidation' branch
```

No red X — just nothing, which reads as "hasn't run yet" rather than "will never run". A branch that did not compile (`geometry.ts:94`, two `TS18049` errors) sat there looking fine.

## Verification

- `npm run docs:check` — OK (48 active docs, 9 planning references, 7 agent entrypoints)
- `npm run build` — green
- Live ruleset re-read after the `PUT`: `strict: True`, required `['build', 'e2e']`, all other rules intact.

No e2e test: documentation plus a repo setting; no application code changes.

## Note — a pre-existing flaky test now sits in a required check

While verifying, `npm run build` failed once on `main` (before this branch's edit) in `src/engine/toolpaths/arcReconstruction.test.ts`:

```
Assertion failed: expected bounded search below 750ms, took 889.0ms
```

Not a regression — the test passes 5/5 standalone and passed on an immediate re-run of the full suite. It is load-dependent: the absolute-millisecond budget added in PR #377 has far less headroom than it appears once the whole suite is running, and CI runners are slower and busier than a dev machine.

This matters more now than it did yesterday, because `build` is a **required** check as of this change — so an intermittent failure will intermittently block merges. Raised separately rather than folded in here to keep this PR to its approved scope.

Closes #381
