### PR TITLE
perf: convert PropertiesPanel to per-field Zustand selectors (#233)

### DIFF
--- a/src/components/feature-tree/PropertiesPanel.tsx
+++ b/src/components/feature-tree/PropertiesPanel.tsx
@@ -159,50 +159,48 @@ function DraftNumberInput({
 }
 
 export function PropertiesPanel() {
-  const {
-    project,
-    selection,
-    addFeatureFolder,
-    startAddTabPlacement,
-    startAddClampPlacement,
-    assignFeaturesToFolder,
-    deleteTab,
-    deleteClamp,
-    deleteFeatureFolder,
-    toggleFolderGrouped,
-    setProjectName,
-    setShowFeatureInfo,
-    setProjectClearances,
-    setSelectedMachineId,
-    refreshMachineDefinitions,
-    setOrigin,
-    startPlaceOrigin,
-    loadBackdropImage,
-    backdropImageLoading,
-    setBackdropImageLoading,
-    updateBackdrop,
-    deleteBackdrop,
-    startMoveBackdrop,
-    startResizeBackdrop,
-    startRotateBackdrop,
-    setGrid,
-    setStock,
-    setStockSourceFeature,
-    updateTab,
-    updateClamp,
-    updateFeatureFolder,
-    updateFeature,
-    updateFeatures,
-    deleteFeature,
-    deleteFeatures,
-    enterSketchEdit,
-    enterStockSketchEdit,
-    enterTabEdit,
-    enterClampEdit,
-    deleteConstraint,
-    makeUnique,
-    expandTextFeature,
-  } = useProjectStore()
+  const project = useProjectStore((s) => s.project)
+  const selection = useProjectStore((s) => s.selection)
+  const addFeatureFolder = useProjectStore((s) => s.addFeatureFolder)
+  const startAddTabPlacement = useProjectStore((s) => s.startAddTabPlacement)
+  const startAddClampPlacement = useProjectStore((s) => s.startAddClampPlacement)
+  const assignFeaturesToFolder = useProjectStore((s) => s.assignFeaturesToFolder)
+  const deleteTab = useProjectStore((s) => s.deleteTab)
+  const deleteClamp = useProjectStore((s) => s.deleteClamp)
+  const deleteFeatureFolder = useProjectStore((s) => s.deleteFeatureFolder)
+  const toggleFolderGrouped = useProjectStore((s) => s.toggleFolderGrouped)
+  const setProjectName = useProjectStore((s) => s.setProjectName)
+  const setShowFeatureInfo = useProjectStore((s) => s.setShowFeatureInfo)
+  const setProjectClearances = useProjectStore((s) => s.setProjectClearances)
+  const setSelectedMachineId = useProjectStore((s) => s.setSelectedMachineId)
+  const refreshMachineDefinitions = useProjectStore((s) => s.refreshMachineDefinitions)
+  const setOrigin = useProjectStore((s) => s.setOrigin)
+  const startPlaceOrigin = useProjectStore((s) => s.startPlaceOrigin)
+  const loadBackdropImage = useProjectStore((s) => s.loadBackdropImage)
+  const backdropImageLoading = useProjectStore((s) => s.backdropImageLoading)
+  const setBackdropImageLoading = useProjectStore((s) => s.setBackdropImageLoading)
+  const updateBackdrop = useProjectStore((s) => s.updateBackdrop)
+  const deleteBackdrop = useProjectStore((s) => s.deleteBackdrop)
+  const startMoveBackdrop = useProjectStore((s) => s.startMoveBackdrop)
+  const startResizeBackdrop = useProjectStore((s) => s.startResizeBackdrop)
+  const startRotateBackdrop = useProjectStore((s) => s.startRotateBackdrop)
+  const setGrid = useProjectStore((s) => s.setGrid)
+  const setStock = useProjectStore((s) => s.setStock)
+  const setStockSourceFeature = useProjectStore((s) => s.setStockSourceFeature)
+  const updateTab = useProjectStore((s) => s.updateTab)
+  const updateClamp = useProjectStore((s) => s.updateClamp)
+  const updateFeatureFolder = useProjectStore((s) => s.updateFeatureFolder)
+  const updateFeature = useProjectStore((s) => s.updateFeature)
+  const updateFeatures = useProjectStore((s) => s.updateFeatures)
+  const deleteFeature = useProjectStore((s) => s.deleteFeature)
+  const deleteFeatures = useProjectStore((s) => s.deleteFeatures)
+  const enterSketchEdit = useProjectStore((s) => s.enterSketchEdit)
+  const enterStockSketchEdit = useProjectStore((s) => s.enterStockSketchEdit)
+  const enterTabEdit = useProjectStore((s) => s.enterTabEdit)
+  const enterClampEdit = useProjectStore((s) => s.enterClampEdit)
+  const deleteConstraint = useProjectStore((s) => s.deleteConstraint)
+  const makeUnique = useProjectStore((s) => s.makeUnique)
+  const expandTextFeature = useProjectStore((s) => s.expandTextFeature)
   const features = useMemo(() => resolvedProjectFeatures(project), [project])
   const { t } = useI18n()
   const backdropFileInputRef = useRef<HTMLInputElement>(null)

--- a/src/components/feature-tree/PropertiesPanel.tsx
+++ b/src/components/feature-tree/PropertiesPanel.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useContext, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useContext, useMemo, useRef, useState } from 'react'
 import type { ChangeEvent } from 'react'
 import { Icon } from '../Icon'
 import { ExpandedPanelContext } from '../layout/expandedPanelContext'
@@ -158,7 +158,16 @@ function DraftNumberInput({
   )
 }
 
-export function PropertiesPanel() {
+/**
+ * Memoised because `App` subscribes to the whole store without a selector and
+ * renders `<PropertiesPanel />` inline, so every store write re-renders this
+ * panel as a child regardless of its own per-field selectors. The component
+ * takes no props, so the comparison is free and can never go stale.
+ *
+ * Without this the selectors below are inert: a 30-event canvas drag produced
+ * 30 panel renders both before and after converting them. With it, 0.
+ */
+export const PropertiesPanel = memo(function PropertiesPanel() {
   const project = useProjectStore((s) => s.project)
   const selection = useProjectStore((s) => s.selection)
   const addFeatureFolder = useProjectStore((s) => s.addFeatureFolder)
@@ -1661,4 +1670,4 @@ export function PropertiesPanel() {
       )}
     </>
   )
-}
+})


### PR DESCRIPTION
Closes #233

Replaced the single selector-less `useProjectStore()` call (42-field destructure) with 42 per-field selectors, **and memoised the component** — the second half turned out to be load-bearing.

Of the 42 names, only `project`, `selection`, and `backdropImageLoading` are reactive; the 39 actions are stable refs.

### Why `memo` is required, not cosmetic

The selector conversion **on its own changed nothing measurable.** `src/App.tsx:115` subscribes to the whole store with no selector and renders `<PropertiesPanel />` inline at `:448`, so every store write re-rendered the panel as a child regardless of what it subscribed to. Per-field selectors stop a component re-rendering on its own account; they cannot stop a parent re-rendering it.

The component takes no props, so `memo` is unconditionally safe — the comparison is free and can never go stale.

### Measured

Render counter compiled into each build, Vite dev servers on isolated ports, real browser.

**Real canvas drag, 30 `pointermove` events:**

| build | panel renders |
|---|---|
| `main` | 30 / 30 |
| per-field selectors only | 30 / 30 |
| **selectors + `memo`** | **0 / 30** |

**Store actions, one per macrotask so React commits each, ×40:**

| driver | `main` | this PR |
|---|---|---|
| `hoverFeature`, id unchanged | 40 | **1** |
| `setConstraintAnchor` (top-level, unsubscribed) | 40 | **0** |
| `hoverFeature`, id changes | 40 | 39 |
| `setActiveControl` | 40 | 40 |

The bottom two rows are unchanged by design. Both actions rebuild the `selection` object (`selectionSlice.ts:621` and `:811` — the latter with no equality guard), and the panel legitimately subscribes to `selection` for `selectedFeatureIds`. It never displays `hoveredFeatureId` or `activeControl`, so those re-renders are still waste — but fixing that means narrowing the selector or lifting the transient fields out of `SelectionState`, which is separate work and the larger remaining win.

### Verification

- `npm run build` — green
- No unadorned `useProjectStore()` remains in the file
- Functional check with `memo` applied: panel still updates on `project`, `selection`, and `backdropImageLoading` changes; 37 interactive controls present; no console errors
- All instrumentation was stripped before committing — the diff is the `memo` wrap and the import only
