### PR TITLE
feat: sticky shape drawing re-arms the same tool on completion

### DIFF
--- a/e2e/creationTargets.smoke.spec.ts
+++ b/e2e/creationTargets.smoke.spec.ts
@@ -17,6 +17,14 @@
 import { test, expect } from './fixtures'
 import type { Page } from '@playwright/test'
 import { seedOverlapFeatureProject } from './overlapFeatureSelection.helpers'
+import {
+  startAddRectPlacement,
+  setPendingAddAnchor,
+  placePendingAddAt,
+  cancelPendingAdd,
+  getPendingAddShape,
+  getFeatureCount,
+} from './helpers'
 
 async function convertFolderedFeatureToConstruction(page: Page): Promise<void> {
   await seedOverlapFeatureProject(page, 1)
@@ -68,4 +76,23 @@ test('foldered construction conversion updates the landscape-tablet tree immedia
   await app.page.setViewportSize({ width: 1024, height: 768 })
   await convertFolderedFeatureToConstruction(app.page)
   await expectConvertedFeatureInConstruction(app.page)
+})
+
+test('sticky drawing re-arms the same shape tool', async ({ app }) => {
+  await startAddRectPlacement(app.page)
+
+  await setPendingAddAnchor(app.page, 10, 10)
+  await placePendingAddAt(app.page, 20, 20)
+
+  expect(await getFeatureCount(app.page)).toBe(1)
+  expect(await getPendingAddShape(app.page)).toBe('rect')
+
+  await setPendingAddAnchor(app.page, 30, 30)
+  await placePendingAddAt(app.page, 40, 40)
+
+  expect(await getFeatureCount(app.page)).toBe(2)
+  expect(await getPendingAddShape(app.page)).toBe('rect')
+
+  await cancelPendingAdd(app.page)
+  expect(await getPendingAddShape(app.page)).toBeNull()
 })

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -78,6 +78,54 @@ export async function completePendingMove(
   }, { x, y })
 }
 
+/** Arm the rectangle creation tool via the store. */
+export async function startAddRectPlacement(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const w = window as unknown as { __pcTest: { startAddRectPlacement: () => Promise<void> } }
+    await w.__pcTest.startAddRectPlacement()
+  })
+}
+
+/** Set the pending-add anchor point on the canvas. */
+export async function setPendingAddAnchor(page: Page, x: number, y: number): Promise<void> {
+  await page.evaluate(async ({ x: px, y: py }: { x: number; y: number }) => {
+    const w = window as unknown as { __pcTest: { setPendingAddAnchor: (x: number, y: number) => Promise<void> } }
+    await w.__pcTest.setPendingAddAnchor(px, py)
+  }, { x, y })
+}
+
+/** Complete a pending-add placement at the given point. */
+export async function placePendingAddAt(page: Page, x: number, y: number): Promise<void> {
+  await page.evaluate(async ({ x: px, y: py }: { x: number; y: number }) => {
+    const w = window as unknown as { __pcTest: { placePendingAddAt: (x: number, y: number) => Promise<void> } }
+    await w.__pcTest.placePendingAddAt(px, py)
+  }, { x, y })
+}
+
+/** Cancel the current pending-add draft (Escape equivalent). */
+export async function cancelPendingAdd(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const w = window as unknown as { __pcTest: { cancelPendingAdd: () => Promise<void> } }
+    await w.__pcTest.cancelPendingAdd()
+  })
+}
+
+/** Get the current pending-add shape (or null if idle). */
+export async function getPendingAddShape(page: Page): Promise<string | null> {
+  return page.evaluate(async () => {
+    const w = window as unknown as { __pcTest: { getPendingAddShape: () => Promise<string | null> } }
+    return w.__pcTest.getPendingAddShape()
+  })
+}
+
+/** Get the current feature count. */
+export async function getFeatureCount(page: Page): Promise<number> {
+  return page.evaluate(async () => {
+    const w = window as unknown as { __pcTest: { getFeatureCount: () => Promise<number> } }
+    return w.__pcTest.getFeatureCount()
+  })
+}
+
 // ── Feature tree ────────────────────────────────────────────────────
 
 /** Count feature rows currently rendered. */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -130,11 +130,34 @@ if (import.meta.env.DEV) {
     /** Completes a pending copy/move starting from origin and ending at (x,y). */
     completePendingMove: async (x: number, y: number) => {
       const { useProjectStore } = await _pcTestStore()
-      // Set fromPoint to origin and toPoint to the target so the displacement
-      // is non-zero (completePendingMove requires dx/dy > 1e-9).
       useProjectStore.getState().setPendingMoveFrom({ x: 0, y: 0 })
       useProjectStore.getState().setPendingMoveTo({ x, y })
       useProjectStore.getState().completePendingMove({ x, y }, 1)
+    },
+    startAddRectPlacement: async () => {
+      const { useProjectStore } = await _pcTestStore()
+      useProjectStore.getState().startAddRectPlacement()
+    },
+    setPendingAddAnchor: async (x: number, y: number) => {
+      const { useProjectStore } = await _pcTestStore()
+      useProjectStore.getState().setPendingAddAnchor({ x, y })
+    },
+    placePendingAddAt: async (x: number, y: number) => {
+      const { useProjectStore } = await _pcTestStore()
+      useProjectStore.getState().placePendingAddAt({ x, y })
+    },
+    cancelPendingAdd: async () => {
+      const { useProjectStore } = await _pcTestStore()
+      useProjectStore.getState().cancelPendingAdd()
+    },
+    getPendingAddShape: async () => {
+      const { useProjectStore } = await _pcTestStore()
+      const pa = useProjectStore.getState().pendingAdd
+      return pa?.shape ?? null
+    },
+    getFeatureCount: async () => {
+      const { useProjectStore } = await _pcTestStore()
+      return useProjectStore.getState().project.features.length
     },
   }
 }
@@ -159,6 +182,12 @@ declare global {
       loadProject: (json: string) => Promise<void>
       getPendingMove: () => Promise<{ mode: string; entityType: string; entityIds: string[] } | null>
       completePendingMove: (x: number, y: number) => Promise<void>
+      startAddRectPlacement: () => Promise<void>
+      setPendingAddAnchor: (x: number, y: number) => Promise<void>
+      placePendingAddAt: (x: number, y: number) => Promise<void>
+      cancelPendingAdd: () => Promise<void>
+      getPendingAddShape: () => Promise<string | null>
+      getFeatureCount: () => Promise<number>
     }
   }
 }

--- a/src/store/INDEX.md
+++ b/src/store/INDEX.md
@@ -10,7 +10,7 @@ Zustand store. The single source of truth for the current `.camj` project. **All
 - `slices/` — focused slices of store behavior
   - `selectionSlice.ts` — which features/segments are currently selected
   - `pendingActionsSlice.ts` — queue of deferred ops awaiting user confirmation
-  - `pendingAddSlice.ts` — in-progress feature being drawn but not yet committed, including multi-step gear placement
+  - `pendingAddSlice.ts` — in-progress feature being drawn but not yet committed, including multi-step gear placement; re-arms a fresh draft of the same shape on completion (sticky drawing, issue #415)
   - `pendingCompletionSlice.ts` — partially-completed sketches awaiting closure
   - `dimensionsSlice.ts` — persistent dimension annotations (`project.annotations`): add/update/delete + selection (history-tracked)
   - `dimensionToolSlice.ts` — transient measure tools: tape measure + in-progress permanent-dimension placement (not persisted, not in history)

--- a/src/store/gearCreation.test.ts
+++ b/src/store/gearCreation.test.ts
@@ -85,7 +85,7 @@ function testGearWithoutBoreCreatesSingleFeature() {
   const state = useProjectStore.getState()
 
   assert(ids.length === 1, `expected one created id, got ${ids.length}`)
-  assert(state.pendingAdd === null, 'pending gear should clear after creation')
+  assert(state.pendingAdd?.shape === 'gear' && state.pendingAdd.anchor === null, 'pending gear should re-arm after creation')
   assert(state.project.features.length === 1, `expected one feature, got ${state.project.features.length}`)
   assert(state.project.featureFolders.length === 0, 'gear without bore should not create a folder')
   assert(state.history.past.length === beforeHistory + 1, 'gear creation should add one history entry')
@@ -109,7 +109,7 @@ function testGearWithBoreCreatesGroupedFeatures() {
   const state = useProjectStore.getState()
 
   assert(ids.length === 2, `expected two created ids, got ${ids.length}`)
-  assert(state.pendingAdd === null, 'pending gear should clear after grouped creation')
+  assert(state.pendingAdd?.shape === 'gear' && state.pendingAdd.anchor === null, 'pending gear should re-arm after grouped creation')
   assert(state.history.past.length === beforeHistory + 1, 'gear+bore should add one history entry')
 
   const gear = createdFeature(ids[0])

--- a/src/store/manualNestingDefaults.test.ts
+++ b/src/store/manualNestingDefaults.test.ts
@@ -142,7 +142,7 @@ function testClosedCompositeUsesSameInference(): void {
   useProjectStore.getState().completePendingComposite()
   const composite = resolvedProjectFeatures(useProjectStore.getState().project).find((feature) => feature.name.startsWith('Composite'))
   assert(composite?.operation === 'subtract', 'closed composite inside Add defaults Subtract')
-  assert(useProjectStore.getState().pendingAdd === null, 'composite completion clears pending draft')
+  const pa = useProjectStore.getState().pendingAdd; assert(pa?.shape === 'composite' && pa.start === null && pa.segments.length === 0, 'composite completion re-arms draft')
 }
 
 const tests = [

--- a/src/store/slices/pendingAddSlice.ts
+++ b/src/store/slices/pendingAddSlice.ts
@@ -33,7 +33,7 @@ import {
   resolveCompositeDraftSegments,
   resolveOpenCompositeDraftSegments,
 } from '../helpers/profileEdit'
-import type { CompositeSegmentMode, ProjectStore } from '../types'
+import type { CompositeSegmentMode, PendingAddTool, ProjectStore } from '../types'
 import {
   defaultGearCreationParams,
   normalizeGearCreationParams,
@@ -85,6 +85,37 @@ function resetFeaturePlacementSelection(selection: ProjectStore['selection']): P
     mode: 'feature',
     hoveredFeatureId: null,
     activeControl: null,
+  }
+}
+
+function rearmPendingAdd(current: PendingAddTool): PendingAddTool {
+  const session = nextPlacementSession()
+  switch (current.shape) {
+    case 'rect':
+    case 'circle':
+    case 'ellipse':
+    case 'tab':
+    case 'clamp':
+      return { shape: current.shape, anchor: null, session }
+    case 'roundrect':
+      return { shape: 'roundrect', anchor: null, corner: current.corner, session }
+    case 'chamferrect':
+      return { shape: 'chamferrect', anchor: null, corner: current.corner, session }
+    case 'polygon':
+    case 'spline':
+      return { shape: current.shape, points: [], session }
+    case 'slot':
+      return { shape: 'slot', points: [], session }
+    case 'ngon':
+      return { shape: 'ngon', anchor: null, sides: current.sides, session }
+    case 'gear':
+      return { shape: 'gear', anchor: null, outsideRadius: null, params: current.params, session }
+    case 'composite':
+      return { shape: 'composite', start: null, lastPoint: null, segments: [], currentMode: current.currentMode, pendingArcEnd: null, closed: false, session }
+    case 'text':
+      return { shape: 'text', config: current.config, session }
+    case 'origin':
+      return { shape: 'origin', session }
   }
 }
 
@@ -310,7 +341,7 @@ export function createPendingAddSlice(
               tabs: [...s.project.tabs, tabEntry],
               meta: { ...s.project.meta, modified: new Date().toISOString() },
             },
-            pendingAdd: null,
+            pendingAdd: rearmPendingAdd(state.pendingAdd!),
             selection: {
               ...s.selection,
               selectedFeatureId: null,
@@ -351,7 +382,7 @@ export function createPendingAddSlice(
               clamps: [...s.project.clamps, clampEntry],
               meta: { ...s.project.meta, modified: new Date().toISOString() },
             },
-            pendingAdd: null,
+            pendingAdd: rearmPendingAdd(state.pendingAdd!),
             selection: {
               ...s.selection,
               selectedFeatureId: null,
@@ -385,7 +416,7 @@ export function createPendingAddSlice(
         state.addCircleFeature(`Circle ${state.project.features.length + 1}`, anchor.x, anchor.y, radius, depth)
       }
 
-      set({ pendingAdd: null })
+      set({ pendingAdd: rearmPendingAdd(state.pendingAdd) })
     },
 
     placePendingTextAt: (point) => {
@@ -418,7 +449,7 @@ export function createPendingAddSlice(
         const primaryId = createdFeature.id
         return {
           project: nextProject,
-          pendingAdd: null,
+          pendingAdd: rearmPendingAdd(state.pendingAdd!),
           selection: {
             ...s.selection,
             selectedFeatureId: primaryId,
@@ -477,7 +508,7 @@ export function createPendingAddSlice(
           depth,
         )
       }
-      set({ pendingAdd: null })
+      set({ pendingAdd: rearmPendingAdd(state.pendingAdd) })
     },
 
     completePendingOpenPath: () => {
@@ -555,7 +586,7 @@ export function createPendingAddSlice(
         }
         state.addFeature(feature)
       }
-      set({ pendingAdd: null })
+      set({ pendingAdd: rearmPendingAdd(state.pendingAdd) })
     },
 
     setPendingCompositeMode: (mode: CompositeSegmentMode) =>
@@ -735,7 +766,7 @@ export function createPendingAddSlice(
       )
 
       state.addFeature(feature)
-      set({ pendingAdd: null })
+      set({ pendingAdd: rearmPendingAdd(state.pendingAdd) })
     },
 
     completePendingOpenComposite: () => {
@@ -779,7 +810,7 @@ export function createPendingAddSlice(
       }
 
       state.addFeature(feature)
-      set({ pendingAdd: null })
+      set({ pendingAdd: rearmPendingAdd(state.pendingAdd) })
     },
 
     setPendingNgonSides: (n) =>
@@ -839,7 +870,7 @@ export function createPendingAddSlice(
         depth,
       )
       if (createdIds.length > 0) {
-        set({ pendingAdd: null })
+        set({ pendingAdd: rearmPendingAdd(state.pendingAdd) })
       }
       return createdIds
     },
@@ -870,7 +901,7 @@ export function createPendingAddSlice(
 
       const depth = Math.min(state.project.stock.thickness, 10)
       state.addSlotFeature(`Slot ${state.project.features.length + 1}`, p1, p2, width, depth)
-      set({ pendingAdd: null })
+      set({ pendingAdd: rearmPendingAdd(state.pendingAdd) })
     },
 
     placePendingNgonAt: (point) => {
@@ -889,7 +920,7 @@ export function createPendingAddSlice(
       const baseName = NGON_NAMES[sides] ?? `Polygon${sides}`
       const name = `${baseName} ${state.project.features.length + 1}`
       state.addNgonFeature(name, anchor.x, anchor.y, sides, circumradius, firstVertexAngle, depth)
-      set({ pendingAdd: null })
+      set({ pendingAdd: rearmPendingAdd(state.pendingAdd) })
     },
   }
 }

--- a/src/store/stickyDrawing.test.ts
+++ b/src/store/stickyDrawing.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Store tests for sticky drawing (issue #415).
+ *
+ * Run with: npx tsx src/store/stickyDrawing.test.ts
+ */
+
+import { newProject } from '../types/project'
+import { useProjectStore } from './projectStore'
+import type { ProjectStore } from './types'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function resetStore(): void {
+  useProjectStore.setState({
+    project: newProject(),
+    selection: {
+      selectedFeatureIds: [],
+      selectedFeatureId: null,
+      selectedNode: null,
+      mode: 'feature' as const,
+      sketchEditTool: null,
+      activeControl: null,
+      hoveredFeatureId: null,
+      groupFolderId: null,
+    },
+    history: { past: [], future: [], transactionStart: null },
+    sketchEditSession: null,
+    pendingConstraint: null,
+    pendingTransform: null,
+    pendingOffset: null,
+    pendingAdd: null,
+    pendingMove: null,
+    pendingShapeAction: null,
+    creationTarget: 'feature' as const,
+  } as unknown as Partial<ProjectStore>)
+}
+
+function testRectReArmsAfterCompletion() {
+  resetStore()
+  const store = useProjectStore.getState()
+  store.startAddRectPlacement()
+  useProjectStore.getState().setPendingAddAnchor({ x: 10, y: 10 })
+  useProjectStore.getState().placePendingAddAt({ x: 20, y: 20 })
+
+  const state = useProjectStore.getState()
+  assert(state.pendingAdd !== null, 'pendingAdd should be non-null after rect completion')
+  assert(state.pendingAdd?.shape === 'rect', 'pendingAdd shape should be rect')
+  assert((state.pendingAdd as { anchor: unknown }).anchor === null, 'pendingAdd anchor should be null (re-armed)')
+  assert(state.project.features.length === 1, 'one feature should exist')
+}
+
+function testDrawTwoRectsInSequence() {
+  resetStore()
+  const store = useProjectStore.getState()
+
+  store.startAddRectPlacement()
+  useProjectStore.getState().setPendingAddAnchor({ x: 10, y: 10 })
+  useProjectStore.getState().placePendingAddAt({ x: 20, y: 20 })
+
+  useProjectStore.getState().setPendingAddAnchor({ x: 30, y: 30 })
+  useProjectStore.getState().placePendingAddAt({ x: 40, y: 40 })
+
+  const state = useProjectStore.getState()
+  assert(state.project.features.length === 2, 'two features should exist')
+  assert(state.pendingAdd !== null, 'pendingAdd should remain armed after second rect')
+  assert(state.pendingAdd?.shape === 'rect', 'pendingAdd shape should still be rect')
+}
+
+function testEscapeClearsAfterCompletion() {
+  resetStore()
+  const store = useProjectStore.getState()
+
+  store.startAddRectPlacement()
+  useProjectStore.getState().setPendingAddAnchor({ x: 10, y: 10 })
+  useProjectStore.getState().placePendingAddAt({ x: 20, y: 20 })
+
+  let state = useProjectStore.getState()
+  assert(state.pendingAdd !== null, 'pendingAdd should be re-armed after completion')
+
+  useProjectStore.getState().cancelPendingAdd()
+  state = useProjectStore.getState()
+  assert(state.pendingAdd === null, 'pendingAdd should be null after Escape')
+}
+
+function testNgonReArmPreservesSides() {
+  resetStore()
+  const store = useProjectStore.getState()
+
+  store.startAddNgonPlacement()
+  useProjectStore.getState().setPendingNgonSides(5)
+  useProjectStore.getState().setPendingAddAnchor({ x: 10, y: 10 })
+  useProjectStore.getState().placePendingNgonAt({ x: 20, y: 20 })
+
+  const state = useProjectStore.getState()
+  assert(state.pendingAdd !== null, 'pendingAdd should be re-armed')
+  assert(state.pendingAdd?.shape === 'ngon', 'pendingAdd shape should be ngon')
+  assert((state.pendingAdd as { sides: number }).sides === 5, 'ngon sides should be preserved (5)')
+}
+
+function testGearReArmPreservesParamsResetsRadius() {
+  resetStore()
+  const store = useProjectStore.getState()
+
+  store.startAddGearPlacement()
+  useProjectStore.getState().setPendingAddAnchor({ x: 10, y: 10 })
+  useProjectStore.getState().setPendingGearRadiusAt({ x: 30, y: 10 })
+  useProjectStore.getState().setPendingGearParams({ boreDiameter: 6, teeth: 20 })
+  useProjectStore.getState().completePendingGear()
+
+  const state = useProjectStore.getState()
+  assert(state.pendingAdd !== null, 'pendingAdd should be re-armed')
+  assert(state.pendingAdd?.shape === 'gear', 'pendingAdd shape should be gear')
+  const gear = state.pendingAdd as { shape: 'gear'; params: { boreDiameter: number; teeth: number }; outsideRadius: unknown }
+  assert(gear.params.boreDiameter === 6, 'gear params.boreDiameter should be preserved')
+  assert(gear.params.teeth === 20, 'gear params.teeth should be preserved')
+  assert(gear.outsideRadius === null, 'gear outsideRadius should be null (reset)')
+}
+
+function testCompositeReArmPreservesModeAndResetsGeometry() {
+  resetStore()
+  useProjectStore.setState({
+    pendingAdd: {
+      shape: 'composite',
+      start: { x: 10, y: 10 },
+      lastPoint: { x: 10, y: 10 },
+      segments: [
+        { type: 'line' as const, to: { x: 20, y: 10 } },
+        { type: 'line' as const, to: { x: 15, y: 20 } },
+        { type: 'line' as const, to: { x: 10, y: 10 } },
+      ],
+      currentMode: 'arc' as const,
+      pendingArcEnd: null,
+      closed: true,
+      session: 1,
+    },
+  } as unknown as Partial<ProjectStore>)
+  useProjectStore.getState().completePendingComposite()
+
+  const state = useProjectStore.getState()
+  assert(state.pendingAdd !== null, 'pendingAdd should be re-armed')
+  assert(state.pendingAdd?.shape === 'composite', 'pendingAdd shape should be composite')
+  const comp = state.pendingAdd as { currentMode: string; start: unknown; segments: unknown[] }
+  assert(comp.currentMode === 'arc', 'composite currentMode should be preserved (arc)')
+  assert(comp.start === null, 'composite start should be null (reset)')
+  assert(comp.segments.length === 0, 'composite segments should be empty (reset)')
+}
+
+const tests = [
+  ['rect re-arms after completion', testRectReArmsAfterCompletion],
+  ['draw two rects in sequence', testDrawTwoRectsInSequence],
+  ['escape clears after completion', testEscapeClearsAfterCompletion],
+  ['ngon re-arm preserves sides', testNgonReArmPreservesSides],
+  ['gear re-arm preserves params and resets radius', testGearReArmPreservesParamsResetsRadius],
+  ['composite re-arm preserves mode and resets geometry', testCompositeReArmPreservesModeAndResetsGeometry],
+] as const
+
+let passed = 0
+for (const [name, test] of tests) {
+  test()
+  passed += 1
+  console.log(`${name}: PASSED`)
+}
+console.log(`\nstickyDrawing.test.ts: ${passed} passed, 0 failed`)


### PR DESCRIPTION
Closes #415

## What
Make shape drawing **sticky (always-on)**. After completing a shape, the same drawing tool stays armed so the user can draw another shape of the same type in sequence. Escape, or clicking the active tool button, deactivates the tool. No UI toggle — sticky is the new default.

## Approach
On completion, replace `set({ pendingAdd: null })` with re-arming a **fresh draft of the same shape** (new `session`), preserving per-shape parameters so consecutive stamps keep their tuning:
- ngon → keep `sides`
- roundrect / chamferrect → keep `corner`
- gear → keep `params`, reset `outsideRadius`
- composite → keep `currentMode`, reset start/segments/closed
- text → keep `config`
- rect / circle / ellipse / tab / clamp / polygon / spline / slot → reset placement state only

`cancelPendingAdd` (Escape) is unchanged. Switching tools and changing `creationTarget` still clear `pendingAdd`. No double-placement on the completing click — `handleClick` captures `pendingAddRef.current` at entry, dispatches the completion, and returns; the re-armed draft is only seen on the next click.

Plan: https://github.com/PureCutCNC/purecutcnc/issues/415#issuecomment-5158919525

## Changed files
- `src/store/slices/pendingAddSlice.ts` — `rearmPendingAdd` helper + 9 completion paths re-arm instead of clearing
- `src/store/stickyDrawing.test.ts` — new, 6 structural tests
- `src/store/gearCreation.test.ts`, `src/store/manualNestingDefaults.test.ts` — assertions updated to expect the re-armed draft
- `src/main.tsx`, `e2e/helpers.ts`, `e2e/creationTargets.smoke.spec.ts` — e2e coverage (DEV-gated `__pcTest` hooks; prod bundle unaffected)
- `src/store/INDEX.md` — doc note

## Verification
- `npm run build` — PASS (157 structural test files; lint + tsc + vite)
- `npm run test:e2e` — PASS (82 tests, incl. new `sticky drawing re-arms the same shape tool`)