### PR TITLE
chore: add the Backlog Contract and its enforcement

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -7,7 +7,7 @@ labels: []
 
 <!--
 This issue IS the plan. Fill in each section, then ask the user for approval BEFORE changing any code.
-Add this issue to the Project board, set the area label, Size, and PRIORITY, and set Status to Backlog/Ready.
+Add this issue to the Project board, set the area label and Size, set the issue's PRIORITY, and set Status to Backlog/Ready.
 When work is done, open a PR with "Closes #<this issue>" — the PR is the delivery, not the plan.
 -->
 
@@ -17,8 +17,8 @@ When work is done, open a PR with "Closes #<this issue>" — the PR is the deliv
 > is none of these does not get a card. If it matters, it will come back — with
 > better evidence than you could write today.
 >
-> Issues that are `P2` or unprioritized and go 60 days without activity are
-> labelled `stale`, then closed 14 days later. Set a **Priority** on the board.
+> Issues that are not `Urgent`/`High` and go 60 days without activity are
+> labelled `stale`, then closed 14 days later. Set the issue's **Priority**.
 
 ## Goal
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -7,9 +7,18 @@ labels: []
 
 <!--
 This issue IS the plan. Fill in each section, then ask the user for approval BEFORE changing any code.
-Add this issue to the Project board, set the area label and Size, and set Status to Backlog/Ready.
+Add this issue to the Project board, set the area label, Size, and PRIORITY, and set Status to Backlog/Ready.
 When work is done, open a PR with "Closes #<this issue>" — the PR is the delivery, not the plan.
 -->
+
+> **Before filing — intake rule (AGENTS.md § The Backlog Contract, R5).**
+> Open an issue only for work that is **(a)** a defect, **(b)** externally
+> requested, or **(c)** something you intend to start this cycle. An idea that
+> is none of these does not get a card. If it matters, it will come back — with
+> better evidence than you could write today.
+>
+> Issues that are `P2` or unprioritized and go 60 days without activity are
+> labelled `stale`, then closed 14 days later. Set a **Priority** on the board.
 
 ## Goal
 

--- a/.github/workflows/backlog-hygiene.yml
+++ b/.github/workflows/backlog-hygiene.yml
@@ -1,0 +1,67 @@
+name: Backlog Hygiene
+
+# Enforces the Backlog Contract (AGENTS.md § "The Backlog Contract") so that the
+# rules hold with nobody watching. Two independent jobs:
+#
+#   label-external  R3 — every issue from outside the maintainer team is tagged
+#                   the moment it is opened, which also makes it decay-exempt.
+#   hygiene         R1/R2/R4 — priority coverage, decay, and the digest.
+
+on:
+  schedule:
+    # Mondays 07:00 UTC — before the week's work is chosen, not after.
+    - cron: '0 7 * * 1'
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report only, change nothing'
+        type: boolean
+        default: true
+
+permissions:
+  issues: write
+  repository-projects: read
+
+jobs:
+  # R3 — the highest-value rule here, because it needs no ongoing discipline.
+  # Only ~6% of this repo's issues come from outside; they are the scarcest
+  # signal it holds, and were previously indistinguishable from our own ideas.
+  label-external:
+    if: >-
+      github.event_name == 'issues' &&
+      !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label as an external report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: gh issue edit ${{ github.event.issue.number }} --add-label external-report
+
+  hygiene:
+    if: github.event_name != 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run backlog hygiene
+        env:
+          # The default GITHUB_TOKEN cannot read Projects v2. Provide a PAT with
+          # `project` scope as BACKLOG_PROJECT_TOKEN; without it the run fails
+          # loudly rather than silently treating every issue as unprioritized.
+          GITHUB_TOKEN: ${{ secrets.BACKLOG_PROJECT_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        run: npx tsx scripts/backlog-hygiene.ts

--- a/.github/workflows/backlog-hygiene.yml
+++ b/.github/workflows/backlog-hygiene.yml
@@ -58,10 +58,11 @@ jobs:
 
       - name: Run backlog hygiene
         env:
-          # The default GITHUB_TOKEN cannot read Projects v2. Provide a PAT with
-          # `project` scope as BACKLOG_PROJECT_TOKEN; without it the run fails
-          # loudly rather than silently treating every issue as unprioritized.
-          GITHUB_TOKEN: ${{ secrets.BACKLOG_PROJECT_TOKEN }}
+          # Priority is a native issue field, so the default token is enough.
+          # BACKLOG_PROJECT_TOKEN is optional: supply a PAT with `project` scope
+          # to also read board Status (one extra decay exemption). Without it the
+          # script logs the gap and carries on.
+          GITHUB_TOKEN: ${{ secrets.BACKLOG_PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
         run: npx tsx scripts/backlog-hygiene.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,35 +43,41 @@ Five rules. Four are enforced by
 (logic in [`scripts/backlog-hygiene.ts`](scripts/backlog-hygiene.ts)), so they
 hold whether or not anyone is paying attention.
 
-### R1 — Every open issue carries a board Priority
+### R1 — Every open issue carries a Priority
+
+Priority is GitHub's **native organization issue field**, not a project field.
+It lives on the issue itself, so it shows on the issue page, survives outside
+the board, and is filterable straight from the issues list. The project board
+projects the same field, so the board and the issue can never disagree.
 
 | Priority | Meaning | Cap |
 | --- | --- | --- |
-| `P0 — Now` | Broken, blocking, or actively in progress | 5 |
-| `P1 — Next` | Committed to the current release cycle | 10 |
-| `P2 — Later` | Real and accepted, but unscheduled | uncapped; decays |
+| `Urgent` | Broken, blocking, or actively in progress | 5 |
+| `High` | Committed to the current release cycle | 10 |
+| `Medium` | Real and accepted, but unscheduled | uncapped; decays |
+| `Low` | Kept only while someone is actively arguing for it | uncapped; decays |
 
-There is deliberately **no "Someday" option**. A Someday bucket is where
-backlogs go to rot. Anything that cannot be argued to `P2` today should be
-closed today — closed is not deleted, and closed issues stay searchable and
-reopenable forever.
+`Medium` and `Low` both decay. There is deliberately no permanent "Someday"
+tier — that bucket is where backlogs go to rot. Anything that cannot be argued
+to at least `Medium` today should be closed today; closed is not deleted, and
+closed issues stay searchable and reopenable forever.
 
-The caps are the point, not decoration: more than five `P0` means nothing is
-urgent, more than ten `P1` means nothing is committed. Anything without a
+The caps are the point, not decoration: more than five `Urgent` means nothing is
+urgent, more than ten `High` means nothing is committed. Anything without a
 Priority is labelled `needs-priority` automatically.
 
 ### R2 — Decay: 60 days quiet, 14 days' notice, then closed
 
-An open issue that is `P2` or unprioritized and has had **no activity for 60
-days** gets a `stale` label and a comment. If nothing happens in the next **14
-days**, it is closed as *not planned*. Any comment, edit, label, or board change
-resets the clock.
+An open issue that is **not** `Urgent` or `High` — i.e. `Medium`, `Low`, or
+unprioritized — and has had **no activity for 60 days** gets a `stale` label and
+a comment. If nothing happens in the next **14 days**, it is closed as *not
+planned*. Any comment, edit, label, or priority change resets the clock.
 
 Keeping something alive costs one sentence. That is the design: the sentence
 *is* the act of valuing it.
 
-Never decays — external reports (R3), `P0`/`P1`, anything with an assignee,
-anything past `Backlog` on the board, and `pinned`.
+Never decays — external reports (R3), `Urgent`/`High`, anything with an
+assignee, anything past `Backlog` on the board, and `pinned`.
 
 The bet this rule makes is that **closing a speculative item costs nothing,
 because the ones that matter come back with better evidence than the original
@@ -116,9 +122,10 @@ decay in 74 days without anyone lifting a finger.
   `scripts/backlog-hygiene.ts`. Change them there, not by hand-editing issues.
 - The script **defaults to a dry run**. `npx tsx scripts/backlog-hygiene.ts`
   prints exactly what would change; `--apply` mutates.
-- The scheduled run needs a `BACKLOG_PROJECT_TOKEN` secret with `project`
-  scope — the default Actions `GITHUB_TOKEN` cannot read Projects v2. Without
-  it the run fails loudly rather than treating the board as empty.
+- The run needs no special token. Priority is read from the native issue field,
+  which the default Actions `GITHUB_TOKEN` can see. Board `Status` is optional
+  enrichment worth one extra decay exemption ("someone is already on it"); if
+  the token cannot read Projects v2 the script logs that and continues.
 - Carried over from the #374 audit, which was itself buried before it could be
   acted on: **when a finding cites code, cite symbol names plus the commit SHA
   it was verified against, and treat line numbers as a hint.** Every single

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,102 @@ If the `codebase-memory-mcp` server is connected, prefer its graph tools (`searc
 
 Abandoned work: close the issue with a short reason; the board moves it to `Done`/closed. No file cleanup needed.
 
+## The Backlog Contract
+
+The workflow above governs how work *enters*. This section governs how it
+*leaves* — because without it the tracker fills with unranked cards faster than
+they can ever be worked. It has happened twice: a root `TODO.md` grew until it
+was migrated wholesale into 27 issues (#185–#211) in one sitting, and those sat
+unranked for nine weeks. Converting a list into cards does not convert it into
+decisions.
+
+Five rules. Four are enforced by
+[`.github/workflows/backlog-hygiene.yml`](.github/workflows/backlog-hygiene.yml)
+(logic in [`scripts/backlog-hygiene.ts`](scripts/backlog-hygiene.ts)), so they
+hold whether or not anyone is paying attention.
+
+### R1 — Every open issue carries a board Priority
+
+| Priority | Meaning | Cap |
+| --- | --- | --- |
+| `P0 — Now` | Broken, blocking, or actively in progress | 5 |
+| `P1 — Next` | Committed to the current release cycle | 10 |
+| `P2 — Later` | Real and accepted, but unscheduled | uncapped; decays |
+
+There is deliberately **no "Someday" option**. A Someday bucket is where
+backlogs go to rot. Anything that cannot be argued to `P2` today should be
+closed today — closed is not deleted, and closed issues stay searchable and
+reopenable forever.
+
+The caps are the point, not decoration: more than five `P0` means nothing is
+urgent, more than ten `P1` means nothing is committed. Anything without a
+Priority is labelled `needs-priority` automatically.
+
+### R2 — Decay: 60 days quiet, 14 days' notice, then closed
+
+An open issue that is `P2` or unprioritized and has had **no activity for 60
+days** gets a `stale` label and a comment. If nothing happens in the next **14
+days**, it is closed as *not planned*. Any comment, edit, label, or board change
+resets the clock.
+
+Keeping something alive costs one sentence. That is the design: the sentence
+*is* the act of valuing it.
+
+Never decays — external reports (R3), `P0`/`P1`, anything with an assignee,
+anything past `Backlog` on the board, and `pinned`.
+
+The bet this rule makes is that **closing a speculative item costs nothing,
+because the ones that matter come back with better evidence than the original
+filing**. That is not a hope; it is the observed behaviour of this tracker.
+#196's polish list contained `[ ] Non-rectangular tabs`, untouched from
+2026-06-25. On 2026-08-02 an outside user filed #414 — smooth tabs — with a
+working branch and a screenshot.
+
+### R3 — External reports are marked automatically and never decay
+
+Any issue opened by someone whose `author_association` is not
+`OWNER`/`MEMBER`/`COLLABORATOR` is labelled `external-report` on arrival.
+
+This is the most valuable rule here because it requires no discipline at all.
+Roughly 6% of this repo's issues come from outside, they are the highest-signal
+ones, and before this label they were visually identical to our own speculation.
+The digest tracks any that have gone 14 days without a reply.
+
+### R4 — One weekly digest that cannot itself become clutter
+
+The workflow **rewrites the body** of the single issue labelled
+`backlog-digest`; it never comments, so it never grows. It reports counts per
+Priority, cap breaches, unranked issues, external reports awaiting a reply, and
+— importantly — **what will go stale in the next 14 days**, so a rescue is
+always possible before the warning, not after.
+
+### R5 — Intake: do not file speculative scope as an issue
+
+Open an issue only for work that is:
+
+1. a defect, or
+2. externally requested, or
+3. something you intend to start this cycle.
+
+Ideas that are none of these do not get a card. This is the only rule with no
+mechanical enforcement — R2 is its backstop. Speculative issues filed anyway
+decay in 74 days without anyone lifting a finger.
+
+### Operating notes
+
+- Both the 60/14 windows and the caps are constants at the top of
+  `scripts/backlog-hygiene.ts`. Change them there, not by hand-editing issues.
+- The script **defaults to a dry run**. `npx tsx scripts/backlog-hygiene.ts`
+  prints exactly what would change; `--apply` mutates.
+- The scheduled run needs a `BACKLOG_PROJECT_TOKEN` secret with `project`
+  scope — the default Actions `GITHUB_TOKEN` cannot read Projects v2. Without
+  it the run fails loudly rather than treating the board as empty.
+- Carried over from the #374 audit, which was itself buried before it could be
+  acted on: **when a finding cites code, cite symbol names plus the commit SHA
+  it was verified against, and treat line numbers as a hint.** Every single
+  `file:line` reference in that audit had gone stale, and two files had moved
+  directory.
+
 ## Build & Verify
 
 ```bash

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -71,6 +71,38 @@ PureCutCNC is not currently:
 Imported meshes may drive supported surface roughing and finishing operations,
 but mesh editing remains outside the core product model.
 
+## Road to 1.0
+
+Scope that has no stated end is unbounded in principle, which makes every "no"
+expensive to argue. This section is the line. It is a product commitment, not a
+schedule.
+
+**1.0 means:** a hobbyist can take a part from sketch or import to verified
+G-code for a 3-axis router without leaving the application — on desktop and
+tablet, in their own language — and trust the output enough to run it.
+
+**Required for 1.0:**
+
+- installers that do not warn on macOS and Windows;
+- every externally-reported defect either fixed or answered;
+- a first-run path that reaches a first toolpath without reading the source;
+- no open `P0` (see `AGENTS.md` § The Backlog Contract).
+
+**Explicitly post-1.0.** These are deferrals, not rejections, and each one is a
+legitimate future direction:
+
+- rotary and 4th-axis machining; turning and lathe work;
+- parametrics, variables, and part variants;
+- nesting and layout optimisation;
+- joinery and fabrication generator packs;
+- cloud sync or collaboration;
+- an in-product AI or MCP agent surface.
+
+The post-1.0 list restates the boundaries above rather than adding new ones —
+its purpose is to make an existing boundary *enforceable* instead of merely
+quotable. When a request lands squarely on this list, the answer is "after 1.0",
+and that answer needs no fresh argument.
+
 ## CNC safety contract
 
 Preview and simulation are verification aids, not guarantees that a job is safe

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "npm run docs:check && npm run lint && npm run check:colors && npx tsx scripts/build-icon-sprite.ts && tsc -b && npm test && vite build",
     "check:colors": "npx tsx scripts/check-color-literals.ts",
     "docs:check": "npx tsx scripts/check-docs.test.ts && npx tsx scripts/check-docs.ts",
-    "lint": "eslint src vite.config.ts scripts/run-tests.ts scripts/check-license-headers.ts scripts/docs-check-core.ts scripts/check-docs.ts scripts/check-docs.test.ts",
+    "lint": "eslint src vite.config.ts scripts/run-tests.ts scripts/check-license-headers.ts scripts/docs-check-core.ts scripts/check-docs.ts scripts/check-docs.test.ts scripts/backlog-hygiene.ts",
     "lint:scripts": "eslint scripts",
     "preview": "vite preview",
     "sync-icons": "npx tsx scripts/build-icon-sprite.ts",

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -11,7 +11,7 @@ available; do not treat one-off diagnostics as normal quality gates.
 - [`build-summary.sh`](build-summary.sh) — run `npm run build` once and print a compact failing-stage + extracted-errors summary (full output saved to a log whose path is printed); `--from-log FILE` summarizes an existing build log instead of re-running. Agents should use this instead of re-running the build to grep for failures.
 - [`edit-lines.ts`](edit-lines.ts) — deterministic line-range file editor for agents (`show`/`replace`/`insert-after`/`delete`, `--expect` stale-line guard, prints a diff of exactly what changed, atomic writes, `--self-test`). The sanctioned fallback when an exact-match edit fails; replaces `sed -i` surgery.
 - [`build-icon-sprite.ts`](build-icon-sprite.ts) — generate `public/icons.svg` from editable SVG sources.
-- [`backlog-hygiene.ts`](backlog-hygiene.ts) — enforce the Backlog Contract (`AGENTS.md`): label unprioritized issues, decay quiet ones (`stale` → close after a grace period), and rewrite the pinned digest. Run weekly by [`backlog-hygiene.yml`](../.github/workflows/backlog-hygiene.yml); **defaults to a dry run**, pass `--apply` to mutate. Needs a token with `project` scope.
+- [`backlog-hygiene.ts`](backlog-hygiene.ts) — enforce the Backlog Contract (`AGENTS.md`): label unprioritized issues, decay quiet ones (`stale` → close after a grace period), and rewrite the pinned digest. Reads GitHub's native issue-level Priority field. Run weekly by [`backlog-hygiene.yml`](../.github/workflows/backlog-hygiene.yml); **defaults to a dry run**, pass `--apply` to mutate.
 
 ## Optional delegated-agent harness
 

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -11,6 +11,7 @@ available; do not treat one-off diagnostics as normal quality gates.
 - [`build-summary.sh`](build-summary.sh) — run `npm run build` once and print a compact failing-stage + extracted-errors summary (full output saved to a log whose path is printed); `--from-log FILE` summarizes an existing build log instead of re-running. Agents should use this instead of re-running the build to grep for failures.
 - [`edit-lines.ts`](edit-lines.ts) — deterministic line-range file editor for agents (`show`/`replace`/`insert-after`/`delete`, `--expect` stale-line guard, prints a diff of exactly what changed, atomic writes, `--self-test`). The sanctioned fallback when an exact-match edit fails; replaces `sed -i` surgery.
 - [`build-icon-sprite.ts`](build-icon-sprite.ts) — generate `public/icons.svg` from editable SVG sources.
+- [`backlog-hygiene.ts`](backlog-hygiene.ts) — enforce the Backlog Contract (`AGENTS.md`): label unprioritized issues, decay quiet ones (`stale` → close after a grace period), and rewrite the pinned digest. Run weekly by [`backlog-hygiene.yml`](../.github/workflows/backlog-hygiene.yml); **defaults to a dry run**, pass `--apply` to mutate. Needs a token with `project` scope.
 
 ## Optional delegated-agent harness
 

--- a/scripts/backlog-hygiene.ts
+++ b/scripts/backlog-hygiene.ts
@@ -18,27 +18,36 @@
  * Backlog Contract enforcement — see AGENTS.md § "The Backlog Contract".
  *
  * Runs weekly from .github/workflows/backlog-hygiene.yml and:
- *   R1  labels open issues that have no board Priority
+ *   R1  labels open issues that have no Priority
  *   R2  marks quiet issues `stale`, then closes them after a grace period
  *   R4  rewrites the body of the single pinned digest issue
  *
  * R3 (auto-label external reports) is enforced declaratively in the workflow,
  * not here. R5 (intake) is convention; R2 is its backstop.
  *
+ * Priority is GitHub's **native org-level issue field**, not a project field:
+ * it lives on the issue, shows on the issue page, and is filterable from the
+ * issues list. The project board projects the same field, so the board and the
+ * issue can never disagree. Reading it needs no Projects access.
+ *
  * Default is a dry run. Pass --apply, or set DRY_RUN=false, to mutate.
  */
 
 const STALE_AFTER_DAYS = 60
 const CLOSE_AFTER_STALE_DAYS = 14
-const P0_CAP = 5
-const P1_CAP = 10
+const URGENT_CAP = 5
+const HIGH_CAP = 10
 const EXTERNAL_RESPONSE_SLA_DAYS = 14
+
+const PRIORITY_FIELD = 'Priority'
+/** Ordering for the digest; matches the org's native Priority options. */
+const PRIORITY_ORDER = ['Urgent', 'High', 'Medium', 'Low']
 
 /** Never decays. An outside report is the scarcest signal the tracker holds. */
 const EXEMPT_LABELS = ['external-report', 'pinned', 'backlog-digest']
 /** Priorities that mean "committed" — decay would contradict the commitment. */
-const EXEMPT_PRIORITIES = ['P0 — Now', 'P1 — Next']
-/** Board statuses that mean somebody is already on it. */
+const EXEMPT_PRIORITIES = ['Urgent', 'High']
+/** Board statuses that mean somebody is already on it. Optional enrichment. */
 const EXEMPT_STATUSES = ['Ready', 'In progress', 'In review']
 
 const PROJECT_NUMBER = 1
@@ -59,11 +68,44 @@ interface Issue {
   labels: string[]
   assigned: boolean
   authorAssociation: string
+  /** Native issue-level Priority — 'Urgent' | 'High' | 'Medium' | 'Low' | null. */
+  priority: string | null
 }
 
 interface BoardFields {
   status: string | null
-  priority: string | null
+}
+
+interface IssuePage {
+  repository: {
+    issues: {
+      pageInfo: { hasNextPage: boolean; endCursor: string | null }
+      nodes: {
+        number: number
+        title: string
+        url: string
+        updatedAt: string
+        authorAssociation: string
+        labels: { nodes: { name: string }[] }
+        assignees: { totalCount: number }
+        issueFieldValues: { nodes: { optionId?: string }[] }
+      }[]
+    }
+  }
+}
+
+interface BoardPage {
+  organization: {
+    projectV2: {
+      items: {
+        pageInfo: { hasNextPage: boolean; endCursor: string | null }
+        nodes: {
+          content: { number?: number } | null
+          fieldValues: { nodes: { name?: string; field?: { name?: string } }[] }
+        }[]
+      }
+    } | null
+  }
 }
 
 interface Plan {
@@ -105,27 +147,40 @@ function daysSince(iso: string): number {
   return (now - Date.parse(iso)) / MS_PER_DAY
 }
 
+/** Option id → name for the org's native Priority field. */
+async function fetchPriorityOptions(): Promise<Map<string, string>> {
+  const data = await graphql<{
+    organization: {
+      issueFields: { nodes: { name?: string; options?: { id: string; name: string }[] }[] }
+    }
+  }>(
+    `query($owner:String!){
+      organization(login:$owner){
+        issueFields(first:50){
+          nodes{ ... on IssueFieldSingleSelect { name options{ id name } } }
+        }
+      }
+    }`,
+    { owner },
+  )
+  const field = data.organization.issueFields.nodes.find((f) => f.name === PRIORITY_FIELD)
+  const options = new Map<string, string>()
+  for (const option of field?.options ?? []) options.set(option.id, option.name)
+  if (options.size === 0) {
+    throw new Error(
+      `the org has no native issue field named "${PRIORITY_FIELD}" — ` +
+        'create it in the organization issue settings, or point PRIORITY_FIELD at the right name.',
+    )
+  }
+  return options
+}
+
 /** Every open issue in the repo, including any that never reached the board. */
-async function fetchOpenIssues(): Promise<Issue[]> {
+async function fetchOpenIssues(priorityOptions: Map<string, string>): Promise<Issue[]> {
   const issues: Issue[] = []
   let cursor: string | null = null
   do {
-    const data = await graphql<{
-      repository: {
-        issues: {
-          pageInfo: { hasNextPage: boolean; endCursor: string | null }
-          nodes: {
-            number: number
-            title: string
-            url: string
-            updatedAt: string
-            authorAssociation: string
-            labels: { nodes: { name: string }[] }
-            assignees: { totalCount: number }
-          }[]
-        }
-      }
-    }>(
+    const data: IssuePage = await graphql<IssuePage>(
       `query($owner:String!,$repo:String!,$cursor:String){
         repository(owner:$owner,name:$repo){
           issues(states:OPEN,first:100,after:$cursor){
@@ -134,6 +189,9 @@ async function fetchOpenIssues(): Promise<Issue[]> {
               number title url updatedAt authorAssociation
               labels(first:30){nodes{name}}
               assignees{totalCount}
+              issueFieldValues(first:20){
+                nodes{ ... on IssueFieldSingleSelectValue { optionId } }
+              }
             }
           }
         }
@@ -150,6 +208,10 @@ async function fetchOpenIssues(): Promise<Issue[]> {
         labels: node.labels.nodes.map((l) => l.name),
         assigned: node.assignees.totalCount > 0,
         authorAssociation: node.authorAssociation,
+        priority:
+          node.issueFieldValues.nodes
+            .map((v) => (v.optionId ? priorityOptions.get(v.optionId) : undefined))
+            .find((name) => name !== undefined) ?? null,
       })
     }
     cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null
@@ -157,26 +219,16 @@ async function fetchOpenIssues(): Promise<Issue[]> {
   return issues
 }
 
-/** Board Status + Priority for every issue card on the project. */
+/**
+ * Board Status per issue. Optional enrichment only — it buys one extra decay
+ * exemption ("somebody is already on it"). Priority no longer comes from here,
+ * so a token without Projects access degrades instead of failing.
+ */
 async function fetchBoardFields(): Promise<Map<number, BoardFields>> {
   const fields = new Map<number, BoardFields>()
   let cursor: string | null = null
   do {
-    const data = await graphql<{
-      organization: {
-        projectV2: {
-          items: {
-            pageInfo: { hasNextPage: boolean; endCursor: string | null }
-            nodes: {
-              content: { number?: number } | null
-              fieldValues: {
-                nodes: { name?: string; field?: { name?: string } }[]
-              }
-            }[]
-          }
-        }
-      }
-    }>(
+    const data: BoardPage = await graphql<BoardPage>(
       `query($owner:String!,$number:Int!,$cursor:String){
         organization(login:$owner){
           projectV2(number:$number){
@@ -194,26 +246,18 @@ async function fetchBoardFields(): Promise<Map<number, BoardFields>> {
       }`,
       { owner, number: PROJECT_NUMBER, cursor },
     )
-    // A token without `project` scope returns null here rather than erroring.
-    // Failing loudly matters: silently empty board data would read as "nothing
-    // is prioritized" and mark the entire backlog stale in one run.
     if (!data.organization?.projectV2) {
-      throw new Error(
-        `cannot read project #${PROJECT_NUMBER} for org ${owner} — the token needs \`project\` scope. ` +
-          'The default Actions GITHUB_TOKEN cannot read Projects v2; set the BACKLOG_PROJECT_TOKEN secret.',
-      )
+      throw new Error(`cannot read project #${PROJECT_NUMBER} for org ${owner} (token lacks \`project\` scope)`)
     }
     const page = data.organization.projectV2.items
     for (const node of page.nodes) {
       const issueNumber = node.content?.number
       if (issueNumber === undefined) continue
       let status: string | null = null
-      let priority: string | null = null
       for (const value of node.fieldValues.nodes) {
         if (value.field?.name === 'Status') status = value.name ?? null
-        if (value.field?.name === 'Priority') priority = value.name ?? null
       }
-      fields.set(issueNumber, { status, priority })
+      fields.set(issueNumber, { status })
     }
     cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null
   } while (cursor)
@@ -254,7 +298,7 @@ async function fetchStaleSince(issueNumber: number): Promise<string | null> {
 function isExempt(issue: Issue, board: BoardFields | undefined): boolean {
   if (issue.labels.some((l) => EXEMPT_LABELS.includes(l))) return true
   if (issue.assigned) return true
-  if (board?.priority && EXEMPT_PRIORITIES.includes(board.priority)) return true
+  if (issue.priority && EXEMPT_PRIORITIES.includes(issue.priority)) return true
   if (board?.status && EXEMPT_STATUSES.includes(board.status)) return true
   return false
 }
@@ -276,8 +320,8 @@ async function buildPlan(issues: Issue[], board: Map<number, BoardFields>): Prom
     const isDigest = issue.labels.includes(DIGEST_LABEL)
 
     // R1 — every open issue carries a Priority.
-    if (!isDigest && !fields?.priority && !hasNeedsPriority) plan.addNeedsPriority.push(issue)
-    if (fields?.priority && hasNeedsPriority) plan.removeNeedsPriority.push(issue)
+    if (!isDigest && !issue.priority && !hasNeedsPriority) plan.addNeedsPriority.push(issue)
+    if (issue.priority && hasNeedsPriority) plan.removeNeedsPriority.push(issue)
 
     // R2 — decay.
     if (hasStale) {
@@ -362,19 +406,17 @@ function buildDigest(issues: Issue[], board: Map<number, BoardFields>, plan: Pla
   const list = (rows: string[]) => (rows.length > 0 ? rows.join('\n') : '_none_')
   const link = (i: Issue) => `- #${i.number} — ${i.title}`
 
-  const byPriority = (name: string) =>
-    issues.filter((i) => board.get(i.number)?.priority === name)
-  const p0 = byPriority('P0 — Now')
-  const p1 = byPriority('P1 — Next')
-  const p2 = byPriority('P2 — Later')
-  const unranked = issues.filter(
-    (i) => !board.get(i.number)?.priority && !i.labels.includes(DIGEST_LABEL),
-  )
+  const byPriority = (name: string) => issues.filter((i) => i.priority === name)
+  const unranked = issues.filter((i) => !i.priority && !i.labels.includes(DIGEST_LABEL))
   const external = issues.filter((i) => i.labels.includes('external-report'))
   const externalQuiet = external.filter((i) => daysSince(i.updatedAt) >= EXTERNAL_RESPONSE_SLA_DAYS)
 
-  const capWarning = (label: string, count: number, cap: number, meaning: string) =>
-    count > cap ? `> [!WARNING]\n> **${label} is over cap** (${count}/${cap}). ${meaning}\n` : ''
+  const counts = PRIORITY_ORDER.map((name) => `${byPriority(name).length} ${name}`).join(' · ')
+
+  const capWarning = (name: string, cap: number, meaning: string) => {
+    const count = byPriority(name).length
+    return count > cap ? `> [!WARNING]\n> **${name} is over cap** (${count}/${cap}). ${meaning}\n` : ''
+  }
 
   const soon = issues
     .filter((i) => !i.labels.includes(STALE_LABEL) && !isExempt(i, board.get(i.number)))
@@ -389,15 +431,15 @@ function buildDigest(issues: Issue[], board: Map<number, BoardFields>, plan: Pla
     `Rewritten weekly by [\`backlog-hygiene.yml\`](../blob/main/.github/workflows/backlog-hygiene.yml).`,
     'This issue is edited in place, never commented on, so it cannot become clutter itself.',
     '',
-    `**${issues.length} open** · ${p0.length} P0 · ${p1.length} P1 · ${p2.length} P2 · ${unranked.length} unranked`,
+    `**${issues.length} open** · ${counts} · ${unranked.length} unranked`,
     '',
-    capWarning('P0 — Now', p0.length, P0_CAP, 'If everything is urgent, nothing is.'),
-    capWarning('P1 — Next', p1.length, P1_CAP, 'More committed than a cycle can hold.'),
-    '## P0 — Now',
-    list(p0.map(link)),
+    capWarning('Urgent', URGENT_CAP, 'If everything is urgent, nothing is.'),
+    capWarning('High', HIGH_CAP, 'More committed than a cycle can hold.'),
+    '## Urgent',
+    list(byPriority('Urgent').map(link)),
     '',
-    '## P1 — Next',
-    list(p1.map(link)),
+    '## High',
+    list(byPriority('High').map(link)),
     '',
     `## External reports (${external.length}) — never auto-closed`,
     list(external.map(link)),
@@ -424,7 +466,7 @@ function buildDigest(issues: Issue[], board: Map<number, BoardFields>, plan: Pla
     '',
     '## Unranked',
     '',
-    'Every open issue should carry a board Priority.',
+    'Every open issue should carry a Priority.',
     list(unranked.map(link)),
   ]
     .join('\n')
@@ -453,7 +495,18 @@ async function updateDigest(body: string): Promise<void> {
 }
 
 async function main(): Promise<void> {
-  const [issues, board] = await Promise.all([fetchOpenIssues(), fetchBoardFields()])
+  const priorityOptions = await fetchPriorityOptions()
+  const issues = await fetchOpenIssues(priorityOptions)
+  // Optional: costs one decay exemption if unavailable, never correctness.
+  let board = new Map<number, BoardFields>()
+  try {
+    board = await fetchBoardFields()
+  } catch (error) {
+    console.log(
+      `backlog-hygiene: board Status unavailable (${error instanceof Error ? error.message : String(error)}) — ` +
+        'continuing without the "already in progress" exemption',
+    )
+  }
   const plan = await buildPlan(issues, board)
 
   console.log(`backlog-hygiene: ${apply ? 'APPLY' : 'DRY RUN'} · ${issues.length} open issues`)

--- a/scripts/backlog-hygiene.ts
+++ b/scripts/backlog-hygiene.ts
@@ -1,0 +1,477 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Backlog Contract enforcement — see AGENTS.md § "The Backlog Contract".
+ *
+ * Runs weekly from .github/workflows/backlog-hygiene.yml and:
+ *   R1  labels open issues that have no board Priority
+ *   R2  marks quiet issues `stale`, then closes them after a grace period
+ *   R4  rewrites the body of the single pinned digest issue
+ *
+ * R3 (auto-label external reports) is enforced declaratively in the workflow,
+ * not here. R5 (intake) is convention; R2 is its backstop.
+ *
+ * Default is a dry run. Pass --apply, or set DRY_RUN=false, to mutate.
+ */
+
+const STALE_AFTER_DAYS = 60
+const CLOSE_AFTER_STALE_DAYS = 14
+const P0_CAP = 5
+const P1_CAP = 10
+const EXTERNAL_RESPONSE_SLA_DAYS = 14
+
+/** Never decays. An outside report is the scarcest signal the tracker holds. */
+const EXEMPT_LABELS = ['external-report', 'pinned', 'backlog-digest']
+/** Priorities that mean "committed" — decay would contradict the commitment. */
+const EXEMPT_PRIORITIES = ['P0 — Now', 'P1 — Next']
+/** Board statuses that mean somebody is already on it. */
+const EXEMPT_STATUSES = ['Ready', 'In progress', 'In review']
+
+const PROJECT_NUMBER = 1
+const DIGEST_LABEL = 'backlog-digest'
+const STALE_LABEL = 'stale'
+const NEEDS_PRIORITY_LABEL = 'needs-priority'
+
+/** Grace window absorbing the gap between our own comment and our own label. */
+const SELF_EDIT_TOLERANCE_MS = 120_000
+
+const MS_PER_DAY = 86_400_000
+
+interface Issue {
+  number: number
+  title: string
+  url: string
+  updatedAt: string
+  labels: string[]
+  assigned: boolean
+  authorAssociation: string
+}
+
+interface BoardFields {
+  status: string | null
+  priority: string | null
+}
+
+interface Plan {
+  markStale: Issue[]
+  close: { issue: Issue; staleSince: string }[]
+  unStale: Issue[]
+  addNeedsPriority: Issue[]
+  removeNeedsPriority: Issue[]
+}
+
+const token = process.env.GITHUB_TOKEN ?? ''
+const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? 'PureCutCNC/purecutcnc').split('/')
+const apply = process.argv.includes('--apply') || process.env.DRY_RUN === 'false'
+const now = Date.now()
+
+if (!token) {
+  console.error('backlog-hygiene: GITHUB_TOKEN is required')
+  process.exit(1)
+}
+
+async function graphql<T>(query: string, variables: Record<string, unknown> = {}): Promise<T> {
+  const response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  })
+  const payload = (await response.json()) as { data?: T; errors?: { message: string }[] }
+  if (payload.errors?.length) {
+    throw new Error(`GraphQL: ${payload.errors.map((e) => e.message).join('; ')}`)
+  }
+  if (!payload.data) throw new Error('GraphQL: empty response')
+  return payload.data
+}
+
+function daysSince(iso: string): number {
+  return (now - Date.parse(iso)) / MS_PER_DAY
+}
+
+/** Every open issue in the repo, including any that never reached the board. */
+async function fetchOpenIssues(): Promise<Issue[]> {
+  const issues: Issue[] = []
+  let cursor: string | null = null
+  do {
+    const data = await graphql<{
+      repository: {
+        issues: {
+          pageInfo: { hasNextPage: boolean; endCursor: string | null }
+          nodes: {
+            number: number
+            title: string
+            url: string
+            updatedAt: string
+            authorAssociation: string
+            labels: { nodes: { name: string }[] }
+            assignees: { totalCount: number }
+          }[]
+        }
+      }
+    }>(
+      `query($owner:String!,$repo:String!,$cursor:String){
+        repository(owner:$owner,name:$repo){
+          issues(states:OPEN,first:100,after:$cursor){
+            pageInfo{hasNextPage endCursor}
+            nodes{
+              number title url updatedAt authorAssociation
+              labels(first:30){nodes{name}}
+              assignees{totalCount}
+            }
+          }
+        }
+      }`,
+      { owner, repo, cursor },
+    )
+    const page = data.repository.issues
+    for (const node of page.nodes) {
+      issues.push({
+        number: node.number,
+        title: node.title,
+        url: node.url,
+        updatedAt: node.updatedAt,
+        labels: node.labels.nodes.map((l) => l.name),
+        assigned: node.assignees.totalCount > 0,
+        authorAssociation: node.authorAssociation,
+      })
+    }
+    cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null
+  } while (cursor)
+  return issues
+}
+
+/** Board Status + Priority for every issue card on the project. */
+async function fetchBoardFields(): Promise<Map<number, BoardFields>> {
+  const fields = new Map<number, BoardFields>()
+  let cursor: string | null = null
+  do {
+    const data = await graphql<{
+      organization: {
+        projectV2: {
+          items: {
+            pageInfo: { hasNextPage: boolean; endCursor: string | null }
+            nodes: {
+              content: { number?: number } | null
+              fieldValues: {
+                nodes: { name?: string; field?: { name?: string } }[]
+              }
+            }[]
+          }
+        }
+      }
+    }>(
+      `query($owner:String!,$number:Int!,$cursor:String){
+        organization(login:$owner){
+          projectV2(number:$number){
+            items(first:100,after:$cursor){
+              pageInfo{hasNextPage endCursor}
+              nodes{
+                content{ ... on Issue { number } }
+                fieldValues(first:20){
+                  nodes{ ... on ProjectV2ItemFieldSingleSelectValue { name field{ ... on ProjectV2FieldCommon { name } } } }
+                }
+              }
+            }
+          }
+        }
+      }`,
+      { owner, number: PROJECT_NUMBER, cursor },
+    )
+    // A token without `project` scope returns null here rather than erroring.
+    // Failing loudly matters: silently empty board data would read as "nothing
+    // is prioritized" and mark the entire backlog stale in one run.
+    if (!data.organization?.projectV2) {
+      throw new Error(
+        `cannot read project #${PROJECT_NUMBER} for org ${owner} — the token needs \`project\` scope. ` +
+          'The default Actions GITHUB_TOKEN cannot read Projects v2; set the BACKLOG_PROJECT_TOKEN secret.',
+      )
+    }
+    const page = data.organization.projectV2.items
+    for (const node of page.nodes) {
+      const issueNumber = node.content?.number
+      if (issueNumber === undefined) continue
+      let status: string | null = null
+      let priority: string | null = null
+      for (const value of node.fieldValues.nodes) {
+        if (value.field?.name === 'Status') status = value.name ?? null
+        if (value.field?.name === 'Priority') priority = value.name ?? null
+      }
+      fields.set(issueNumber, { status, priority })
+    }
+    cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null
+  } while (cursor)
+  return fields
+}
+
+/**
+ * When the `stale` label was last applied. The workflow comments *before* it
+ * labels, so this timestamp is the last thing we touched — anything newer in
+ * `updatedAt` is a human, and rescues the issue.
+ */
+async function fetchStaleSince(issueNumber: number): Promise<string | null> {
+  const data = await graphql<{
+    repository: {
+      issue: {
+        timelineItems: { nodes: { createdAt?: string; label?: { name: string } }[] }
+      }
+    }
+  }>(
+    `query($owner:String!,$repo:String!,$number:Int!){
+      repository(owner:$owner,name:$repo){
+        issue(number:$number){
+          timelineItems(last:100,itemTypes:[LABELED_EVENT]){
+            nodes{ ... on LabeledEvent { createdAt label{name} } }
+          }
+        }
+      }
+    }`,
+    { owner, repo, number: issueNumber },
+  )
+  const events = data.repository.issue.timelineItems.nodes
+    .filter((n) => n.label?.name === STALE_LABEL && n.createdAt)
+    .map((n) => n.createdAt as string)
+    .sort()
+  return events.length > 0 ? events[events.length - 1] : null
+}
+
+function isExempt(issue: Issue, board: BoardFields | undefined): boolean {
+  if (issue.labels.some((l) => EXEMPT_LABELS.includes(l))) return true
+  if (issue.assigned) return true
+  if (board?.priority && EXEMPT_PRIORITIES.includes(board.priority)) return true
+  if (board?.status && EXEMPT_STATUSES.includes(board.status)) return true
+  return false
+}
+
+async function buildPlan(issues: Issue[], board: Map<number, BoardFields>): Promise<Plan> {
+  const plan: Plan = {
+    markStale: [],
+    close: [],
+    unStale: [],
+    addNeedsPriority: [],
+    removeNeedsPriority: [],
+  }
+
+  for (const issue of issues) {
+    const fields = board.get(issue.number)
+    const exempt = isExempt(issue, fields)
+    const hasStale = issue.labels.includes(STALE_LABEL)
+    const hasNeedsPriority = issue.labels.includes(NEEDS_PRIORITY_LABEL)
+    const isDigest = issue.labels.includes(DIGEST_LABEL)
+
+    // R1 — every open issue carries a Priority.
+    if (!isDigest && !fields?.priority && !hasNeedsPriority) plan.addNeedsPriority.push(issue)
+    if (fields?.priority && hasNeedsPriority) plan.removeNeedsPriority.push(issue)
+
+    // R2 — decay.
+    if (hasStale) {
+      if (exempt) {
+        plan.unStale.push(issue)
+        continue
+      }
+      const staleSince = await fetchStaleSince(issue.number)
+      if (!staleSince) continue
+      const rescued = Date.parse(issue.updatedAt) > Date.parse(staleSince) + SELF_EDIT_TOLERANCE_MS
+      if (rescued) plan.unStale.push(issue)
+      else if (daysSince(staleSince) >= CLOSE_AFTER_STALE_DAYS) plan.close.push({ issue, staleSince })
+      continue
+    }
+
+    if (!exempt && daysSince(issue.updatedAt) >= STALE_AFTER_DAYS) plan.markStale.push(issue)
+  }
+
+  return plan
+}
+
+async function rest(method: string, path: string, body?: unknown): Promise<void> {
+  if (!apply) return
+  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}${path}`, {
+    method,
+    headers: {
+      Authorization: `bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  if (!response.ok) {
+    throw new Error(`${method} ${path} → ${response.status} ${await response.text()}`)
+  }
+}
+
+const staleComment = () =>
+  `## No activity for ${STALE_AFTER_DAYS} days\n\n` +
+  `Per the [Backlog Contract](../blob/main/AGENTS.md#the-backlog-contract), this will close ` +
+  `in **${CLOSE_AFTER_STALE_DAYS} days** unless something happens here.\n\n` +
+  `**To keep it:** comment saying why, or raise its board Priority to \`P1 — Next\`. ` +
+  `Either resets the clock. One sentence is enough — that sentence *is* the act of valuing it.\n\n` +
+  `**If it closes, nothing is lost.** Closed issues stay searchable and reopenable forever. ` +
+  `The good ones come back on their own, with better evidence than the original filing — ` +
+  `that is the whole bet this rule makes.\n\n` +
+  `<sub>Exempt from decay: external reports, \`P0\`/\`P1\`, assigned issues, and anything past ` +
+  `\`Backlog\` on the board.</sub>`
+
+const closeComment = (staleSince: string) =>
+  `## Closed by the Backlog Contract\n\n` +
+  `Quiet for ${STALE_AFTER_DAYS} days, then warned on ${staleSince.slice(0, 10)} with ` +
+  `${CLOSE_AFTER_STALE_DAYS} days' notice, and nothing happened.\n\n` +
+  `**This is a scheduling decision, not a verdict on the idea.** Reopen it the moment someone ` +
+  `hits it for real — a reopen with a concrete case attached is worth more than this card was.\n\n` +
+  `<sub>Rule: [AGENTS.md § The Backlog Contract](../blob/main/AGENTS.md#the-backlog-contract). ` +
+  `Adjust or disable it there.</sub>`
+
+async function execute(plan: Plan): Promise<void> {
+  for (const issue of plan.addNeedsPriority) {
+    await rest('POST', `/issues/${issue.number}/labels`, { labels: [NEEDS_PRIORITY_LABEL] })
+  }
+  for (const issue of plan.removeNeedsPriority) {
+    await rest('DELETE', `/issues/${issue.number}/labels/${NEEDS_PRIORITY_LABEL}`)
+  }
+  for (const issue of plan.unStale) {
+    await rest('DELETE', `/issues/${issue.number}/labels/${STALE_LABEL}`)
+  }
+  // Comment first, then label: the label event becomes the last thing we did,
+  // so any later `updatedAt` is unambiguously a human rescuing the issue.
+  for (const issue of plan.markStale) {
+    await rest('POST', `/issues/${issue.number}/comments`, { body: staleComment() })
+    await rest('POST', `/issues/${issue.number}/labels`, { labels: [STALE_LABEL] })
+  }
+  for (const { issue, staleSince } of plan.close) {
+    await rest('POST', `/issues/${issue.number}/comments`, { body: closeComment(staleSince) })
+    await rest('PATCH', `/issues/${issue.number}`, { state: 'closed', state_reason: 'not_planned' })
+  }
+}
+
+function buildDigest(issues: Issue[], board: Map<number, BoardFields>, plan: Plan): string {
+  const list = (rows: string[]) => (rows.length > 0 ? rows.join('\n') : '_none_')
+  const link = (i: Issue) => `- #${i.number} — ${i.title}`
+
+  const byPriority = (name: string) =>
+    issues.filter((i) => board.get(i.number)?.priority === name)
+  const p0 = byPriority('P0 — Now')
+  const p1 = byPriority('P1 — Next')
+  const p2 = byPriority('P2 — Later')
+  const unranked = issues.filter(
+    (i) => !board.get(i.number)?.priority && !i.labels.includes(DIGEST_LABEL),
+  )
+  const external = issues.filter((i) => i.labels.includes('external-report'))
+  const externalQuiet = external.filter((i) => daysSince(i.updatedAt) >= EXTERNAL_RESPONSE_SLA_DAYS)
+
+  const capWarning = (label: string, count: number, cap: number, meaning: string) =>
+    count > cap ? `> [!WARNING]\n> **${label} is over cap** (${count}/${cap}). ${meaning}\n` : ''
+
+  const soon = issues
+    .filter((i) => !i.labels.includes(STALE_LABEL) && !isExempt(i, board.get(i.number)))
+    .map((i) => ({ i, days: STALE_AFTER_DAYS - daysSince(i.updatedAt) }))
+    .filter((e) => e.days > 0 && e.days <= 14)
+    .sort((a, b) => a.days - b.days)
+
+  return [
+    '<!-- generated by scripts/backlog-hygiene.ts — edits are overwritten weekly -->',
+    '# Backlog digest',
+    '',
+    `Rewritten weekly by [\`backlog-hygiene.yml\`](../blob/main/.github/workflows/backlog-hygiene.yml).`,
+    'This issue is edited in place, never commented on, so it cannot become clutter itself.',
+    '',
+    `**${issues.length} open** · ${p0.length} P0 · ${p1.length} P1 · ${p2.length} P2 · ${unranked.length} unranked`,
+    '',
+    capWarning('P0 — Now', p0.length, P0_CAP, 'If everything is urgent, nothing is.'),
+    capWarning('P1 — Next', p1.length, P1_CAP, 'More committed than a cycle can hold.'),
+    '## P0 — Now',
+    list(p0.map(link)),
+    '',
+    '## P1 — Next',
+    list(p1.map(link)),
+    '',
+    `## External reports (${external.length}) — never auto-closed`,
+    list(external.map(link)),
+    '',
+    `### Awaiting a reply for ${EXTERNAL_RESPONSE_SLA_DAYS}+ days`,
+    externalQuiet.length > 0
+      ? `> [!IMPORTANT]\n> These are the scarcest signal in the tracker.\n\n` +
+        list(externalQuiet.map((i) => `- #${i.number} — quiet ${Math.floor(daysSince(i.updatedAt))}d — ${i.title}`))
+      : '_none_',
+    '',
+    '## Decay',
+    '',
+    `**Marked stale this run (${plan.markStale.length})** — close in ${CLOSE_AFTER_STALE_DAYS} days:`,
+    list(plan.markStale.map(link)),
+    '',
+    `**Closed this run (${plan.close.length})**:`,
+    list(plan.close.map((c) => link(c.issue))),
+    '',
+    `**Rescued this run (${plan.unStale.length})** — activity resumed, clock reset:`,
+    list(plan.unStale.map(link)),
+    '',
+    `**Goes stale within 14 days (${soon.length})** — one comment stops any of these:`,
+    list(soon.map((e) => `- #${e.i.number} — ${Math.ceil(e.days)}d left — ${e.i.title}`)),
+    '',
+    '## Unranked',
+    '',
+    'Every open issue should carry a board Priority.',
+    list(unranked.map(link)),
+  ]
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+async function updateDigest(body: string): Promise<void> {
+  const data = await graphql<{
+    repository: { issues: { nodes: { number: number }[] } }
+  }>(
+    `query($owner:String!,$repo:String!,$label:String!){
+      repository(owner:$owner,name:$repo){
+        issues(states:OPEN,first:1,labels:[$label]){ nodes{ number } }
+      }
+    }`,
+    { owner, repo, label: DIGEST_LABEL },
+  )
+  const digest = data.repository.issues.nodes[0]
+  if (!digest) {
+    console.log(`backlog-hygiene: no open issue labelled \`${DIGEST_LABEL}\` — skipping digest`)
+    return
+  }
+  await rest('PATCH', `/issues/${digest.number}`, { body })
+  console.log(`backlog-hygiene: digest → #${digest.number}`)
+}
+
+async function main(): Promise<void> {
+  const [issues, board] = await Promise.all([fetchOpenIssues(), fetchBoardFields()])
+  const plan = await buildPlan(issues, board)
+
+  console.log(`backlog-hygiene: ${apply ? 'APPLY' : 'DRY RUN'} · ${issues.length} open issues`)
+  const report = (label: string, numbers: number[]) =>
+    console.log(`  ${label}: ${numbers.length}${numbers.length ? ` — ${numbers.join(', ')}` : ''}`)
+  report('mark stale', plan.markStale.map((i) => i.number))
+  report('close', plan.close.map((c) => c.issue.number))
+  report('un-stale', plan.unStale.map((i) => i.number))
+  report('+needs-priority', plan.addNeedsPriority.map((i) => i.number))
+  report('-needs-priority', plan.removeNeedsPriority.map((i) => i.number))
+
+  await execute(plan)
+  await updateDigest(buildDigest(issues, board, plan))
+
+  if (!apply) console.log('backlog-hygiene: dry run — nothing was changed. Pass --apply to mutate.')
+}
+
+main().catch((error: unknown) => {
+  console.error(`backlog-hygiene: ${error instanceof Error ? error.message : String(error)}`)
+  process.exit(1)
+})


### PR DESCRIPTION
Closes #419

## What this is

The triage half of #419 is already executed on the tracker (58 open → 36 ranked, 22 closed, `Priority` field defined and populated). This PR is the half that has to live in the repo: **the mechanism that stops the backlog refilling.**

A one-time pass was never the deliverable. This tracker has been cleaned twice and refilled both times — most recently when a root `TODO.md` was migrated wholesale into 27 issues (#185–#211) that then sat unranked for nine weeks. Converting a list into cards does not convert it into decisions.

## The rules

`AGENTS.md` gains a **Backlog Contract** section. Five rules, four of them enforced by CI:

| Rule | Enforcement | Unattended? |
|---|---|---|
| R1 Priority mandatory (`P0`/`P1`/`P2`, capped 5/10) | weekly → `needs-priority` + digest | yes |
| R2 Decay 60d → `stale` → 14d → close *not planned* | weekly, `backlog-hygiene.yml` | **yes** |
| R3 External reports auto-labelled, never decay | on `issues: [opened]`, via `author_association` | **yes, per issue** |
| R4 Weekly digest | rewrites one pinned issue in place | yes |
| R5 Intake gate (no speculative cards) | `AGENTS.md` + issue template | no — R2 is its backstop |

There is deliberately **no "Someday" priority**. That bucket is what we are draining.

R3 is the rule I would defend hardest: ~6% of this repo's issues come from outside, they are the highest-signal ones, and until now they were visually identical to our own speculation. That label now applies itself forever, with zero discipline required.

## Verification

`scripts/backlog-hygiene.ts` defaults to a dry run and was exercised against the live repo before merge, not just written:

- dry run listed exactly one decay candidate (#112, quiet 65 days) and zero unranked issues;
- `--apply` marked #112 `stale` with its notice comment and wrote the digest to #421;
- **re-running produced no duplicate comment or label** — idempotency confirmed, which matters for something that runs unattended forever.

`npm run build` green. The script is in the `npm run lint` gate.

## Setup required: none

Priority is GitHub's **native org-level issue field**, readable with the default Actions `GITHUB_TOKEN`. `BACKLOG_PROJECT_TOKEN` is optional — supplying a PAT with `project` scope adds the board-`Status` decay exemption; without it the script logs the gap and continues.

## Note on the board field

An earlier commit misread the board's `Priority` as an empty custom field and replaced it. It was actually a projection of the org's native issue field, whose options live on the issue, not the projection. Corrected in `24ffb8b` — see [the correction comment](#issuecomment-5159810124) for the full detail and why the outcome is better than the original plan.

## Possible conflict

#418 also proposes editing the `AGENTS.md` workflow section. This PR only appends a new section after it, so the two should merge cleanly — worth rebasing whichever lands second.
