### PR TITLE
feat: add lead-ins as their own toolpath view filter

### DIFF
--- a/src/components/ToolpathVisibilityPanel.tsx
+++ b/src/components/ToolpathVisibilityPanel.tsx
@@ -27,6 +27,7 @@ interface ToolpathVisibilityPanelProps {
 
 const ITEMS: Array<{ key: keyof ToolpathVisibility; labelKey: MessageKey; swatch: string }> = [
   { key: 'cuts', labelKey: 'appShell.toolpath.cuts', swatch: 'viewport-toolpath-vis__swatch--cuts' },
+  { key: 'leadIns', labelKey: 'appShell.toolpath.leadIns', swatch: 'viewport-toolpath-vis__swatch--lead-ins' },
   { key: 'rapids', labelKey: 'appShell.toolpath.rapids', swatch: 'viewport-toolpath-vis__swatch--rapids' },
   { key: 'plunges', labelKey: 'appShell.toolpath.plunges', swatch: 'viewport-toolpath-vis__swatch--plunges' },
   { key: 'retractions', labelKey: 'appShell.toolpath.retractions', swatch: 'viewport-toolpath-vis__swatch--retractions' },

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -1161,7 +1161,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
     for (const toolpath of toolpaths) {
       if (toolpath.moves.length > 0) {
-        drawToolpath(ctx, toolpath, vt, toolpath.operationId === selectedOperationId, toolpathVisibility ?? { cuts: true, rapids: true, plunges: true, retractions: true, directions: true })
+        drawToolpath(ctx, toolpath, vt, toolpath.operationId === selectedOperationId, toolpathVisibility ?? { cuts: true, leadIns: true, rapids: true, plunges: true, retractions: true, directions: true })
       }
     }
 

--- a/src/components/canvas/operationSnapshot.ts
+++ b/src/components/canvas/operationSnapshot.ts
@@ -47,6 +47,7 @@ const MAX_PIXEL_RATIO = 2
 
 const SNAPSHOT_TOOLPATH_VISIBILITY: ToolpathVisibility = {
   cuts: true,
+  leadIns: true,
   rapids: true,
   plunges: true,
   retractions: true,

--- a/src/components/canvas/previewPrimitives.test.ts
+++ b/src/components/canvas/previewPrimitives.test.ts
@@ -16,7 +16,10 @@
 
 import { rectProfile } from '../../types/project'
 import type { SketchFeature } from '../../types/project'
-import { drawLineFeatureBatch, featureUsesSketchFill } from './previewPrimitives'
+import { drawLineFeatureBatch, drawToolpath, featureUsesSketchFill } from './previewPrimitives'
+import type { ToolpathVisibility } from '../toolpathVisibility'
+import type { ToolpathResult } from '../../engine/toolpaths/types'
+import type { ViewTransform } from './viewTransform'
 
 function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
@@ -66,5 +69,65 @@ drawLineFeatureBatch(ctx, [lineFeature('a', 0), lineFeature('b', 20)], {
 })
 assert(beginPathCount === 1, 'Line batch starts one canvas path')
 assert(strokeCount === 1, 'Line batch issues one stroke for multiple features')
+
+// --- drawToolpath: lead-ins are in their own layer, gated by leadIns ---
+
+function testDrawToolpathLayerSplit(): void {
+  console.log('Testing drawToolpath separates lead_in moves into a leadIns layer...')
+
+  const segments: Array<{ fromX: number; fromY: number; toX: number; toY: number }> = []
+  const mockCtx = {
+    beginPath: () => undefined,
+    moveTo: (x: number, y: number) => { segments.push({ fromX: x, fromY: y, toX: -1, toY: -1 }) },
+    lineTo: (x: number, y: number) => {
+      const last = segments[segments.length - 1]
+      if (last) { last.toX = x; last.toY = y }
+    },
+    stroke: () => undefined,
+    setLineDash: () => undefined,
+    strokeStyle: '',
+    lineWidth: 0,
+    globalAlpha: 1,
+  } as unknown as CanvasRenderingContext2D
+
+  const toolpath: ToolpathResult = {
+    operationId: 'test-op',
+    moves: [
+      { kind: 'cut', from: { x: 0, y: 0, z: 0 }, to: { x: 10, y: 0, z: 0 } },
+      { kind: 'lead_in', from: { x: 20, y: 0, z: 0 }, to: { x: 30, y: 0, z: 0 } },
+    ],
+    warnings: [],
+    bounds: null,
+  }
+
+  const vt: ViewTransform = { scale: 1, offsetX: 0, offsetY: 0 }
+
+  // Visible: cuts only. Lead-in should NOT appear.
+  segments.length = 0
+  const cutsOnly: ToolpathVisibility = { cuts: true, leadIns: false, rapids: false, plunges: false, retractions: false, directions: false }
+  drawToolpath(mockCtx, toolpath, vt, false, cutsOnly)
+  const cutSegmentIndex = segments.findIndex((s) => s.fromX === 0 && s.toX === 10)
+  const leadInSegmentIndex = segments.findIndex((s) => s.fromX === 20 && s.toX === 30)
+  assert(cutSegmentIndex !== -1, 'cut move renders when cuts visible and leadIns hidden')
+  assert(leadInSegmentIndex === -1, 'lead_in move does NOT render when leadIns hidden')
+
+  // Visible: leadIns only. Cut should NOT appear.
+  segments.length = 0
+  const leadInsOnly: ToolpathVisibility = { cuts: false, leadIns: true, rapids: false, plunges: false, retractions: false, directions: false }
+  drawToolpath(mockCtx, toolpath, vt, false, leadInsOnly)
+  const cutIndex2 = segments.findIndex((s) => s.fromX === 0 && s.toX === 10)
+  const leadInIndex2 = segments.findIndex((s) => s.fromX === 20 && s.toX === 30)
+  assert(cutIndex2 === -1, 'cut move does NOT render when cuts hidden and leadIns visible')
+  assert(leadInIndex2 !== -1, 'lead_in move renders when leadIns visible and cuts hidden')
+
+  // Both visible: both should render.
+  segments.length = 0
+  const bothOn: ToolpathVisibility = { cuts: true, leadIns: true, rapids: false, plunges: false, retractions: false, directions: false }
+  drawToolpath(mockCtx, toolpath, vt, false, bothOn)
+  assert(segments.findIndex((s) => s.fromX === 0 && s.toX === 10) !== -1, 'cut move renders when both visible')
+  assert(segments.findIndex((s) => s.fromX === 20 && s.toX === 30) !== -1, 'lead_in move renders when both visible')
+}
+
+testDrawToolpathLayerSplit()
 
 console.log('previewPrimitives.test.ts passed')

--- a/src/components/canvas/previewPrimitives.ts
+++ b/src/components/canvas/previewPrimitives.ts
@@ -592,7 +592,8 @@ export function drawToolpath(
     horizontalOnly?: boolean
     retractOnly?: boolean
   }> = [
-    { kinds: ['cut', 'lead_in', 'lead_out'], stroke: canvasColors().toolpathCut, lineWidth: 2.1, dash: [], visible: visibility.cuts },
+    { kinds: ['cut'], stroke: canvasColors().toolpathCut, lineWidth: 2.1, dash: [], visible: visibility.cuts },
+    { kinds: ['lead_in', 'lead_out'], stroke: canvasColors().toolpathCut, lineWidth: 2.1, dash: [], visible: visibility.leadIns },
     { kinds: ['rapid'], stroke: canvasColors().toolpathRapid, lineWidth: 1.3, dash: [8, 6], visible: visibility.rapids, horizontalOnly: true },
     { kinds: ['plunge'], stroke: canvasColors().toolpathPlunge, lineWidth: 1.5, dash: [3, 4], visible: visibility.plunges },
     { kinds: ['rapid'], stroke: canvasColors().toolpathRapid, lineWidth: 1.3, dash: [8, 6], visible: visibility.retractions, retractOnly: true },

--- a/src/components/toolpathVisibility.ts
+++ b/src/components/toolpathVisibility.ts
@@ -16,6 +16,7 @@
 
 export interface ToolpathVisibility {
   cuts: boolean
+  leadIns: boolean
   rapids: boolean
   plunges: boolean
   retractions: boolean
@@ -24,6 +25,7 @@ export interface ToolpathVisibility {
 
 export const DEFAULT_TOOLPATH_VISIBILITY: ToolpathVisibility = {
   cuts: true,
+  leadIns: true,
   rapids: true,
   plunges: true,
   retractions: true,

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -26,7 +26,7 @@ import { applyClampHighlight, applyTabHighlight, buildOriginTriad, buildScene } 
 import { getStockBounds, rectProfile } from '../../types/project'
 import { getFeaturesWorldBounds } from '../canvas/scenePrimitives'
 import { getFeatureGeometryProfiles } from '../../text'
-import { buildToolpathLinePositionChunks, toolpathPointToWorldTuple } from './toolpathOverlay'
+import { buildToolpathLinePositionChunks, buildToolpathOverlayLayers, toolpathPointToWorldTuple } from './toolpathOverlay'
 import { useTheme } from '../../theme/themeContext'
 import type { ThreeThemePalette } from '../../theme/palette'
 import { createOrbitControls, type OrbitControls } from './orbitControls'
@@ -265,6 +265,7 @@ function buildToolpathOverlay(
   visibility: ToolpathVisibility,
   palette: ThreeThemePalette,
 ): THREE.Object3D[] {
+  const schemaLayers = buildToolpathOverlayLayers(visibility)
   const layers: Array<{
     kinds: ToolpathResult['moves'][number]['kind'][]
     color: number
@@ -272,12 +273,17 @@ function buildToolpathOverlay(
     visible: boolean
     horizontalOnly?: boolean
     retractOnly?: boolean
-  }> = [
-    { kinds: ['cut', 'lead_in', 'lead_out'], color: palette.toolpathCut, opacity: 0.98, visible: visibility.cuts },
-    { kinds: ['rapid'], color: palette.toolpathRapid, opacity: 0.75, visible: visibility.rapids, horizontalOnly: true },
-    { kinds: ['plunge'], color: palette.toolpathPlunge, opacity: 0.9, visible: visibility.plunges },
-    { kinds: ['rapid'], color: palette.toolpathRapid, opacity: 0.75, visible: visibility.retractions, retractOnly: true },
-  ]
+  }> = schemaLayers.map((layer) => {
+    const color =
+      layer.key === 'cuts' || layer.key === 'leadIns' ? palette.toolpathCut
+      : layer.key === 'rapids' || layer.key === 'retractions' ? palette.toolpathRapid
+      : palette.toolpathPlunge
+    const opacity =
+      layer.key === 'cuts' || layer.key === 'leadIns' ? 0.98
+      : layer.key === 'rapids' || layer.key === 'retractions' ? 0.75
+      : 0.9
+    return { kinds: layer.kinds, color, opacity, visible: layer.visible, horizontalOnly: layer.horizontalOnly, retractOnly: layer.retractOnly }
+  })
 
   const objects: THREE.Object3D[] = []
   for (const layer of layers) {

--- a/src/components/viewport3d/toolpathOverlay.test.ts
+++ b/src/components/viewport3d/toolpathOverlay.test.ts
@@ -21,8 +21,10 @@
  */
 
 import type { ToolpathMove } from '../../engine/toolpaths/types'
+import type { ToolpathVisibility } from '../toolpathVisibility'
 import {
   buildToolpathLinePositionChunks,
+  buildToolpathOverlayLayers,
   toolpathPointToWorldTuple,
 } from './toolpathOverlay'
 
@@ -85,5 +87,60 @@ function testEmptyMovesDoNotAllocateChunks(): void {
 testPointMapping()
 testChunkedLinePositions()
 testEmptyMovesDoNotAllocateChunks()
+
+// --- buildToolpathOverlayLayers: layer kind membership and visibility gating ---
+
+function testOverlayLayersKinds(): void {
+  console.log('Testing buildToolpathOverlayLayers kind membership...')
+
+  const vis: ToolpathVisibility = { cuts: true, leadIns: true, rapids: true, plunges: true, retractions: true, directions: true }
+  const layers = buildToolpathOverlayLayers(vis)
+  const byKey = new Map(layers.map((l) => [l.key, l]))
+
+  // cuts layer
+  const cutsLayer = byKey.get('cuts')
+  assert(!!cutsLayer, 'cuts layer exists')
+  assert(cutsLayer!.kinds.length === 1 && cutsLayer!.kinds[0] === 'cut', 'cuts layer kinds === [\'cut\']')
+  assert(!cutsLayer!.kinds.includes('lead_in'), 'cuts layer does NOT include lead_in')
+  assert(!cutsLayer!.kinds.includes('lead_out'), 'cuts layer does NOT include lead_out')
+
+  // leadIns layer
+  const leadInsLayer = byKey.get('leadIns')
+  assert(!!leadInsLayer, 'leadIns layer exists')
+  assert(leadInsLayer!.kinds.includes('lead_in'), 'leadIns layer includes lead_in')
+  assert(leadInsLayer!.kinds.includes('lead_out'), 'leadIns layer includes lead_out')
+  assert(!leadInsLayer!.kinds.includes('cut'), 'leadIns layer does NOT include cut')
+}
+
+function testOverlayLayersVisibilityGating(): void {
+  console.log('Testing buildToolpathOverlayLayers visibility gating...')
+
+  const visDefault: ToolpathVisibility = { cuts: true, leadIns: true, rapids: true, plunges: true, retractions: true, directions: true }
+  function layerVis(vis: ToolpathVisibility, key: string): boolean {
+    return buildToolpathOverlayLayers(vis).find((l) => l.key === key)?.visible ?? false
+  }
+
+  assert(layerVis(visDefault, 'cuts') === true, 'cuts visible when cuts=true')
+  assert(layerVis({ ...visDefault, cuts: false }, 'cuts') === false, 'cuts hidden when cuts=false')
+  assert(layerVis(visDefault, 'leadIns') === true, 'leadIns visible when leadIns=true')
+  assert(layerVis({ ...visDefault, leadIns: false }, 'leadIns') === false, 'leadIns hidden when leadIns=false')
+
+  // leadIns visible independent of cuts
+  assert(
+    layerVis({ ...visDefault, cuts: false, leadIns: true }, 'leadIns') === true,
+    'leadIns visible when cuts=false,leadIns=true',
+  )
+  assert(
+    layerVis({ ...visDefault, cuts: true, leadIns: false }, 'leadIns') === false,
+    'leadIns hidden when cuts=true,leadIns=false',
+  )
+  assert(
+    layerVis({ ...visDefault, cuts: false, leadIns: true }, 'cuts') === false,
+    'cuts hidden when cuts=false,leadIns=true',
+  )
+}
+
+testOverlayLayersKinds()
+testOverlayLayersVisibilityGating()
 
 console.log('toolpathOverlay tests passed')

--- a/src/components/viewport3d/toolpathOverlay.ts
+++ b/src/components/viewport3d/toolpathOverlay.ts
@@ -14,9 +14,30 @@
  * limitations under the License.
  */
 
-import type { ToolpathMove, ToolpathPoint } from '../../engine/toolpaths/types'
+import type { ToolpathMove, ToolpathMoveKind, ToolpathPoint } from '../../engine/toolpaths/types'
+import type { ToolpathVisibility } from '../toolpathVisibility'
 
 export const DEFAULT_TOOLPATH_LINE_SEGMENTS_PER_CHUNK = 16384
+
+export type ToolpathOverlayLayerKey = 'cuts' | 'leadIns' | 'rapids' | 'plunges' | 'retractions'
+
+export interface ToolpathOverlayLayer {
+  key: ToolpathOverlayLayerKey
+  kinds: ToolpathMoveKind[]
+  visible: boolean
+  horizontalOnly?: boolean
+  retractOnly?: boolean
+}
+
+export function buildToolpathOverlayLayers(visibility: ToolpathVisibility): ToolpathOverlayLayer[] {
+  return [
+    { key: 'cuts', kinds: ['cut'], visible: visibility.cuts },
+    { key: 'leadIns', kinds: ['lead_in', 'lead_out'], visible: visibility.leadIns },
+    { key: 'rapids', kinds: ['rapid'], visible: visibility.rapids, horizontalOnly: true },
+    { key: 'plunges', kinds: ['plunge'], visible: visibility.plunges },
+    { key: 'retractions', kinds: ['rapid'], visible: visibility.retractions, retractOnly: true },
+  ]
+}
 
 export interface ToolpathLinePositionChunk {
   positions: Float32Array

--- a/src/engine/designPrint/svg.ts
+++ b/src/engine/designPrint/svg.ts
@@ -530,7 +530,7 @@ function buildToolpaths(ctx: WorldContext, extras: DesignPrintSvgExtras): string
   const toolpaths = extras.toolpaths ?? []
   if (toolpaths.length === 0) return []
   const visibility: PrintToolpathVisibility =
-    extras.toolpathVisibility ?? { cuts: true, rapids: true, plunges: true, retractions: true }
+    extras.toolpathVisibility ?? { cuts: true, leadIns: true, rapids: true, plunges: true, retractions: true }
 
   const layers: Array<{
     className: string
@@ -544,8 +544,15 @@ function buildToolpaths(ctx: WorldContext, extras: DesignPrintSvgExtras): string
       stroke: ctx.palette.cutToolpath,
       widthMm: STROKE_CUT_MM,
       dashed: false,
+      filter: (move) => visibility.cuts && move.kind === 'cut',
+    },
+    {
+      className: 'pc-toolpath-lead-in',
+      stroke: ctx.palette.cutToolpath,
+      widthMm: STROKE_CUT_MM,
+      dashed: false,
       filter: (move) =>
-        visibility.cuts && (move.kind === 'cut' || move.kind === 'lead_in' || move.kind === 'lead_out'),
+        visibility.leadIns && (move.kind === 'lead_in' || move.kind === 'lead_out'),
     },
     {
       className: 'pc-toolpath-rapid',

--- a/src/engine/designPrint/types.ts
+++ b/src/engine/designPrint/types.ts
@@ -118,6 +118,7 @@ export interface DesignPrintLayout {
  */
 export interface PrintToolpathVisibility {
   cuts: boolean
+  leadIns: boolean
   rapids: boolean
   plunges: boolean
   retractions: boolean

--- a/src/i18n/locales/de/appShell.ts
+++ b/src/i18n/locales/de/appShell.ts
@@ -124,6 +124,7 @@ export const appShellDe: Record<keyof typeof appShellEn, string> = {
   // ── Toolpath visibility ──
   'appShell.toolpath.show': 'Anzeigen',
   'appShell.toolpath.cuts': 'Schnitte',
+  'appShell.toolpath.leadIns': 'Anfahrten',
   'appShell.toolpath.rapids': 'Eilgänge',
   'appShell.toolpath.plunges': 'Eintauchbewegungen',
   'appShell.toolpath.retractions': 'Rückzüge',

--- a/src/i18n/locales/en/appShell.ts
+++ b/src/i18n/locales/en/appShell.ts
@@ -129,6 +129,7 @@ export const appShellEn = {
   // ── Toolpath visibility ──
   'appShell.toolpath.show': 'Show',
   'appShell.toolpath.cuts': 'Cuts',
+  'appShell.toolpath.leadIns': 'Lead-ins',
   'appShell.toolpath.rapids': 'Rapids',
   'appShell.toolpath.plunges': 'Plunges',
   'appShell.toolpath.retractions': 'Retractions',

--- a/src/i18n/locales/es/appShell.ts
+++ b/src/i18n/locales/es/appShell.ts
@@ -83,6 +83,7 @@ export const appShellEs: Record<keyof typeof appShellEn, string> = {
   "appShell.empty.camPanel": "Las operaciones CAM y las trayectorias de herramientas están programadas para la Fase 4.",
   "appShell.toolpath.show": "Mostrar",
   "appShell.toolpath.cuts": "cortes",
+  "appShell.toolpath.leadIns": "Entradas",
   "appShell.toolpath.rapids": "Rápidos",
   "appShell.toolpath.plunges": "penetraciones",
   "appShell.toolpath.retractions": "Retracciones",

--- a/src/i18n/locales/fr/appShell.ts
+++ b/src/i18n/locales/fr/appShell.ts
@@ -83,6 +83,7 @@ export const appShellFr: Record<keyof typeof appShellEn, string> = {
   'appShell.empty.camPanel': 'Les opérations FAO et les parcours d’outil sont prévus pour la phase 4.',
   'appShell.toolpath.show': 'Afficher',
   'appShell.toolpath.cuts': 'Coupes',
+  'appShell.toolpath.leadIns': 'Entrées',
   'appShell.toolpath.rapids': 'Rapides',
   'appShell.toolpath.plunges': 'Plongées',
   'appShell.toolpath.retractions': 'Retraits',

--- a/src/i18n/locales/zh-CN/appShell.ts
+++ b/src/i18n/locales/zh-CN/appShell.ts
@@ -130,6 +130,7 @@ export const appShellZhCN: Record<keyof typeof appShellEn, string> = {
   // ── Toolpath visibility ──
   'appShell.toolpath.show': '显示',
   'appShell.toolpath.cuts': '切削',
+  'appShell.toolpath.leadIns': '导入',
   'appShell.toolpath.rapids': '快速移动',
   'appShell.toolpath.plunges': '下刀',
   'appShell.toolpath.retractions': '抬刀',

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2721,6 +2721,9 @@
 .viewport-toolpath-vis__swatch--cuts {
   background: var(--toolpath-cut);
 }
+.viewport-toolpath-vis__swatch--lead-ins {
+  background: var(--toolpath-cut);
+}
 
 .viewport-toolpath-vis__swatch--rapids {
   background: var(--toolpath-rapid);


### PR DESCRIPTION
Closes #416

## What

Lead-in moves already exist as a distinct `lead_in` move kind (first emitted by #412's `entry.ts`), but both viewports rendered them inside the cuts layer, so there was no way to see an entry on its own. This adds a `leadIns` toggle to the toolpath view filters, splitting lead-in/lead-out moves out of the cuts layer in the sketch renderer, the 3D renderer, and the design-print SVG exporter.

## Decisions

- **Default on, reusing the cut color** — so shipping the toggle is a visual no-op. The toggle's job is to *isolate* entry moves (turn Cuts off, leave Lead-ins on), not to recolor them. The panel swatch uses `--toolpath-cut` (precedent: retractions already shares the rapids swatch color). No new palette color or theme token.
- **`lead_out` joins `lead_in` in the new layer** — unemitted today, so harmless and semantically correct.
- **`PrintToolpathVisibility` tracks the new field** — the print dialog passes the live sketch `ToolpathVisibility` straight through (no separate print-visibility UI), so the SVG export must honor `leadIns` to stay WYSIWYG. Omitting it would silently ignore the user's lead-in toggle in the export. This pulls `svg.ts` into the change set beyond the issue's literal file list; the issue flagged `types.ts` and warned against drift, and `svg.ts` is the consumer.
- **Direction arrows unchanged** — direction-marker builders still filter on `cut`/`rapid` only; lead-ins do not get arrows. Out of scope.

## 3D testability

`buildToolpathOverlay` lived inside `Viewport3D.tsx` (not exported, React/three imports) so it could not be tested from a node test. The layer *schema* (kinds + visibility gating + horizontalOnly/retractOnly, no THREE styling) is now a pure exported `buildToolpathOverlayLayers(visibility)` in `toolpathOverlay.ts`, consumed by `buildToolpathOverlay`. This matches the existing `toolpathOverlay.ts` / `toolpathOverlay.test.ts` pairing and avoids importing the `.tsx` in a node test. No behavior change to the 3D overlay.

## Tests

- `previewPrimitives.test.ts` — mock-ctx test of `drawToolpath`: a toolpath with one `cut` + one `lead_in` move. With `cuts:on, leadIns:off` the cut is drawn and the lead-in is not; with `cuts:off, leadIns:on` the lead-in is drawn and the cut is not. Proves `lead_in` is in the lead-in layer, gated by `leadIns`, not `cuts`.
- `toolpathOverlay.test.ts` — `buildToolpathOverlayLayers` assertions: cut layer kinds === `['cut']`; lead-in layer kinds include `lead_in`/`lead_out` and not `cut`; visibility gating is independent (`cuts` and `leadIns` don't affect each other).

## Verification

- `scripts/build-summary.sh` (full gate: docs:check + lint + tsc + tests + vite) — passed, run independently by the dispatch harness on the worktree. tsc clean (enforces i18n completeness across all five locales and the `ToolpathVisibility` literal completeness).
- No e2e added — pure structural/layering change; the only rendered-DOM delta is one toggle button in the existing `ToolpathVisibilityPanel`, covered by the layering tests.

## Out of scope

Per the issue: no `lead_out` emission, no engine/toolpath-generation changes, no direction-arrow changes.