### PR TITLE
process: add a mechanically gated fast lane for small changes

### DIFF
--- a/.github/workflows/fast-lane-guard.yml
+++ b/.github/workflows/fast-lane-guard.yml
@@ -1,0 +1,31 @@
+name: Fast Lane Guard
+
+# Re-checks fast-lane eligibility (AGENTS.md, "Fast lane") on any PR carrying
+# the `fast-lane` label, so a mislabelled change cannot merge on a claim alone.
+#
+# Kept out of pr-check.yml on purpose: this needs the `labeled`/`unlabeled`
+# triggers, and adding those there would re-run the full build plus all three
+# e2e lanes every time a label changes. The job runs on every PR and exits 0
+# immediately when the label is absent, so it is safe as a required check.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  fast-lane-guard:
+    name: fast-lane-guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so `git merge-base origin/main HEAD` resolves.
+          fetch-depth: 0
+
+      - name: Check fast-lane eligibility
+        env:
+          FAST_LANE_LABELED: ${{ contains(github.event.pull_request.labels.*.name, 'fast-lane') }}
+        run: bash scripts/check-fast-lane.sh --ci --base origin/${{ github.event.pull_request.base.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,33 @@ If the `codebase-memory-mcp` server is connected, prefer its graph tools (`searc
 
 Abandoned work: close the issue with a short reason; the board moves it to `Done`/closed. No file cleanup needed.
 
+### Fast lane (waives steps 2–3 only)
+
+A change that provably cannot affect machine output, saved projects, or the gates themselves may skip **Plan** and **Approve**. Nothing else changes: still an issue first (the branch name needs its number), still a branch, still green `npm run build`, still a PR with `Closes #NN`, still the board. Every rule in **Build & Verify**, **Git & Branching**, and **Coding Standards** applies unchanged — license header, no `any`, unit tests for engine fixes, e2e when rendered DOM / menu wiring / dialog behavior changes.
+
+Eligibility is mechanical, never a judgment call:
+
+```bash
+npm run check:fast-lane   # before branching, and again before opening the PR
+```
+
+It measures the diff against `git merge-base origin/main HEAD` and fails unless both hold:
+
+- **Size:** ≤ 3 changed files and ≤ 25 changed lines (added + deleted). Test files (`**/*.test.ts(x)`, `e2e/**`) are exempt from both counts — never trim a test to fit the budget. Generated output (`public/icons.svg`, `package-lock.json`) is counted; if regenerating it blows the budget, take the full lane.
+- **No protected path is touched**, however small the diff: machine output and safety (`src/engine/toolpaths/**`, `src/engine/gcode/**`, `src/machine/**`, `src/utils/units.ts`), the `.camj` format and its migrations (`src/types/project.ts`, `src/store/helpers/projectFormat.ts`, `src/import/camj.ts`), the frozen `ProjectStore` contract (`src/store/types.ts`), and the process/gate machinery itself (`AGENTS.md`, `PROJECT.md`, `ARCHITECTURE.md`, `.github/**`, `.claude/**`, the gate scripts under `scripts/`, `package.json`, `tsconfig*.json`, `eslint.config.js`). [`scripts/check-fast-lane.sh`](scripts/check-fast-lane.sh) owns the authoritative list — add to it whenever a new gate lands.
+
+**Label the PR `fast-lane`.** The `fast-lane-guard` CI job ([`.github/workflows/fast-lane-guard.yml`](.github/workflows/fast-lane-guard.yml)) re-runs the check on every labeled PR, so a labeled PR that does not meet the criteria cannot merge.
+
+**Growing past the criteria converts the change to the full lane.** The check failing is the decision, not the author's read of it: stop before the next commit, write the plan into the issue, wait for explicit approval, drop the label. Never split a change across PRs to stay under the budget.
+
+**Audit, monthly.** Every merged PR since the last audit must have either the `fast-lane` label or an approval on its issue predating the branch's first commit — a PR with neither is a process escape.
+
+```bash
+gh pr list --state merged --limit 50 --json number,title,labels,mergedAt
+```
+
+Re-run the eligibility check against each labeled PR's merge base. If fast-lane PRs exceed a third of the window, the criteria are being stretched — tighten them.
+
 ## The Backlog Contract
 
 The workflow above governs how work *enters*. This section governs how it

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "npm run docs:check && npm run lint && npm run check:colors && npx tsx scripts/build-icon-sprite.ts && tsc -b && npm test && vite build",
     "check:colors": "npx tsx scripts/check-color-literals.ts",
+    "check:fast-lane": "bash scripts/check-fast-lane.sh",
     "docs:check": "npx tsx scripts/check-docs.test.ts && npx tsx scripts/check-docs.ts",
     "lint": "eslint src vite.config.ts scripts/run-tests.ts scripts/check-license-headers.ts scripts/docs-check-core.ts scripts/check-docs.ts scripts/check-docs.test.ts scripts/backlog-hygiene.ts",
     "lint:scripts": "eslint scripts",

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -7,6 +7,7 @@ available; do not treat one-off diagnostics as normal quality gates.
 
 - [`check-docs.ts`](check-docs.ts) and [`docs-check-core.ts`](docs-check-core.ts) — validate active-document links, planning metadata, and normalized agent entrypoints; covered by [`check-docs.test.ts`](check-docs.test.ts) and run through `npm run docs:check`.
 - [`check-license-headers.ts`](check-license-headers.ts) — enforce Apache 2.0 headers under `src/`.
+- [`check-fast-lane.sh`](check-fast-lane.sh) — decide fast-lane eligibility mechanically (size budget + protected paths) per the workflow section of [`AGENTS.md`](../AGENTS.md); run via `npm run check:fast-lane`, and by the `fast-lane-guard` CI job in `--ci` mode. Dependency-free bash, deliberately outside `npm run build` because it needs a fetched base ref.
 - [`run-tests.ts`](run-tests.ts) — discover and run structural `src/**/*.test.ts` files.
 - [`build-summary.sh`](build-summary.sh) — run `npm run build` once and print a compact failing-stage + extracted-errors summary (full output saved to a log whose path is printed); `--from-log FILE` summarizes an existing build log instead of re-running. Agents should use this instead of re-running the build to grep for failures.
 - [`edit-lines.ts`](edit-lines.ts) — deterministic line-range file editor for agents (`show`/`replace`/`insert-after`/`delete`, `--expect` stale-line guard, prints a diff of exactly what changed, atomic writes, `--self-test`). The sanctioned fallback when an exact-match edit fails; replaces `sed -i` surgery.

--- a/scripts/check-fast-lane.sh
+++ b/scripts/check-fast-lane.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Fast-lane eligibility gate (see AGENTS.md, "Fast lane").
+#
+# Decides mechanically whether a change may skip the Plan and Approve steps of
+# the workflow. Nothing here is a judgment call: a change is eligible only when
+# it stays inside the size budget AND touches no protected path.
+#
+# Deliberately dependency-free bash so CI can run it without `npm ci` and so it
+# works in a checkout that has never been built.
+#
+# Exit 0 = eligible (or, in --ci mode, not a fast-lane PR). Exit 1 = full lane.
+
+set -euo pipefail
+
+MAX_FILES=3
+MAX_LINES=25
+
+BASE_REF='origin/main'
+CI_MODE=0
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/check-fast-lane.sh [--base <ref>] [--ci]
+
+  (no args)      Check the working tree against origin/main. Run this before
+                 branching and again before opening the PR.
+  --base <ref>   Compare against something other than origin/main.
+  --ci           CI mode: no-op unless FAST_LANE_LABELED=true, so the job can
+                 run on every PR and still be a required check.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base) BASE_REF="${2:?--base needs a ref}"; shift 2 ;;
+    --base=*) BASE_REF="${1#--base=}"; shift ;;
+    --ci) CI_MODE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'check-fast-lane: unknown argument %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# The CI job runs on every PR so it can be a required check, but it only has an
+# opinion when the author actually claimed the fast lane.
+if [ "$CI_MODE" -eq 1 ] && [ "${FAST_LANE_LABELED:-false}" != 'true' ]; then
+  echo "No 'fast-lane' label on this PR — full lane assumed, nothing to check."
+  exit 0
+fi
+
+if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+  printf 'check-fast-lane: base ref %s not found (fetch it, or pass --base)\n' "$BASE_REF" >&2
+  exit 2
+fi
+MERGE_BASE=$(git merge-base "$BASE_REF" HEAD)
+
+# Protected paths: touching any of these is the full lane, however small the
+# diff. Patterns are matched with bash `case`, where * also spans '/'.
+protected_bucket() {
+  case "$1" in
+    src/engine/toolpaths/*|src/engine/gcode/*|src/machine/*|src/utils/units.ts)
+      echo 'machine output & safety' ;;
+    src/types/project.ts|src/store/helpers/projectFormat.ts|src/import/camj.ts)
+      echo '.camj format & migrations' ;;
+    src/store/types.ts)
+      echo 'frozen ProjectStore contract' ;;
+    AGENTS.md|PROJECT.md|ARCHITECTURE.md|.github/*|.claude/*|package.json|tsconfig*.json|eslint.config.js)
+      echo 'process & gate machinery' ;;
+    # Gate logic under scripts/. Anything whose corruption would silently weaken
+    # a gate belongs here — not just check-*. Add to this list when a new gate
+    # lands; scripts/backlog-hygiene.ts arrived after the first draft and was
+    # missed by the original `scripts/check-*` glob.
+    scripts/check-*|scripts/run-tests.ts|scripts/docs-check-core.ts|scripts/backlog-hygiene.ts)
+      echo 'process & gate machinery' ;;
+    *) return 1 ;;
+  esac
+}
+
+# Tests are exempt from both counts on purpose: charging a change for the tests
+# it adds is an incentive to skip them.
+is_test() {
+  case "$1" in
+    *.test.ts|*.test.tsx|e2e/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+counted_files=0
+counted_lines=0
+exempt_files=0
+violations=''
+counted_report=''
+exempt_report=''
+
+add_violation() {
+  violations="${violations}  - $1
+"
+}
+
+record() {
+  local added="$1" deleted="$2" path="$3" bucket lines
+
+  if bucket=$(protected_bucket "$path"); then
+    add_violation "protected path touched: $path ($bucket)"
+  fi
+
+  if is_test "$path"; then
+    exempt_files=$((exempt_files + 1))
+    exempt_report="${exempt_report}    ${path}
+"
+    return
+  fi
+
+  counted_files=$((counted_files + 1))
+
+  if [ "$added" = '-' ] || [ "$deleted" = '-' ]; then
+    add_violation "binary change, size not measurable: $path"
+    counted_report="${counted_report}    $(printf '%-50s %s' "$path" 'binary')
+"
+    return
+  fi
+
+  lines=$((added + deleted))
+  counted_lines=$((counted_lines + lines))
+  counted_report="${counted_report}    $(printf '%-50s +%-5s -%-5s = %s' "$path" "$added" "$deleted" "$lines")
+"
+}
+
+# Committed, staged and unstaged changes against the merge base. --no-renames
+# keeps paths unambiguous and makes a rename cost its full add+delete, which is
+# the conservative reading we want.
+while IFS=$'\t' read -r added deleted path; do
+  [ -n "${path:-}" ] || continue
+  record "$added" "$deleted" "$path"
+done <<EOF
+$(git diff --numstat --no-renames "$MERGE_BASE")
+EOF
+
+# Untracked files are part of the change too — a new file is the common case.
+# git itself counts the lines, so binary detection matches the tracked path.
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  stat=$(git diff --numstat --no-index -- /dev/null "$path" 2>/dev/null || true)
+  if [ -n "$stat" ]; then
+    record "$(printf '%s' "$stat" | cut -f1)" "$(printf '%s' "$stat" | cut -f2)" "$path"
+  else
+    record 0 0 "$path"
+  fi
+done <<EOF
+$(git ls-files --others --exclude-standard)
+EOF
+
+if [ "$counted_files" -gt "$MAX_FILES" ]; then
+  add_violation "$counted_files changed files, max $MAX_FILES (tests excluded)"
+fi
+if [ "$counted_lines" -gt "$MAX_LINES" ]; then
+  add_violation "$counted_lines changed lines, max $MAX_LINES (tests excluded)"
+fi
+
+echo 'Fast-lane eligibility check'
+printf '  base: %s (merge-base %s)\n\n' "$BASE_REF" "$(git rev-parse --short "$MERGE_BASE")"
+printf '  counted files: %s / %s\n' "$counted_files" "$MAX_FILES"
+if [ -n "$counted_report" ]; then printf '%s' "$counted_report"; fi
+printf '  counted lines: %s / %s\n' "$counted_lines" "$MAX_LINES"
+if [ "$exempt_files" -gt 0 ]; then
+  printf '  test files (exempt): %s\n' "$exempt_files"
+  printf '%s' "$exempt_report"
+fi
+echo
+
+if [ -n "$violations" ]; then
+  echo 'NOT ELIGIBLE — this change takes the full lane (issue -> plan -> explicit approval):'
+  printf '%s' "$violations"
+  echo
+  echo 'Do not split the change across PRs to fit the budget. Write the plan into the'
+  echo 'issue, wait for approval, and drop any fast-lane label.'
+  exit 1
+fi
+
+if [ "$counted_files" -eq 0 ] && [ "$exempt_files" -eq 0 ]; then
+  echo 'No changes against the base — nothing to check yet.'
+  exit 0
+fi
+
+echo 'ELIGIBLE — the fast lane may be used: skip Plan and Approve, nothing else.'
+echo 'Label the PR `fast-lane`. Re-run this before opening the PR.'


### PR DESCRIPTION
Closes #418

Adds a fast lane that waives **only** the Plan and Approve steps of the workflow, gated by a script and a CI job rather than by prose — so it cannot be rationalized into a cheating lane.

## What changed

| File | |
| --- | --- |
| `AGENTS.md` | New **Fast lane** subsection after the Workflow section (+30 lines): what it waives, the criteria, mid-flight conversion, the audit |
| `scripts/check-fast-lane.sh` | Dependency-free eligibility gate. `npm run check:fast-lane` |
| `.github/workflows/fast-lane-guard.yml` | Re-runs the check on any PR labeled `fast-lane` |
| `package.json`, `scripts/INDEX.md` | Script wiring and index entry |

## Why it is not a cheating lane

**Nothing about eligibility is a judgment call.** `check-fast-lane.sh` measures the diff against `git merge-base origin/main HEAD` (so merging `main` in cannot inflate it) and fails unless the change is ≤ 3 files / ≤ 25 lines *and* touches no protected path — CAM output and machine safety, the `.camj` format and its migrations, the frozen `ProjectStore` contract, and the process machinery itself. `--no-renames` makes a rename cost its full add+delete. Binary changes are unmeasurable, so they disqualify.

**Test files are exempt from both counts.** Charging a change for the tests it adds would create pressure to skip them — the opposite of what this repo wants. Generated output *is* counted, with no exclusion list, because an exclusion list is itself a cheat surface.

**Mislabelling fails CI.** `fast-lane-guard` re-runs the same script on every labeled PR, so claiming the lane for a large or protected change blocks the merge instead of sneaking through. The job runs on every PR and exits 0 immediately without the label, so it can be added to the required checks without skipped-check merge blocks.

**The audit catches what CI cannot see** — a PR with neither the label nor a pre-branch approval. Monthly, one `gh pr list` query, with a drift signal: if fast-lane PRs exceed a third of the window, tighten the criteria.

**Nothing is waived that was a gate before.** All seven items were verified against the current files rather than assumed: `npm run build`, no direct commits to `main`, PR + issue linkage, the Apache 2.0 header, unit tests for engine fixes, e2e for rendered-DOM changes, strict TS. Five are already enforced mechanically; this change touches none of them.

## Verification

`npm run build` green. The script was exercised against real temporary branches, not hand-fed input:

```
PASS  1 file / 2 lines -> eligible (exit 0)
PASS  + 400-line test -> still eligible (exit 0)
PASS  4 non-test files -> file cap (exit 1)
PASS  30 lines -> line cap (exit 1)
PASS  src/engine/gcode -> protected (exit 1)
PASS  --ci unlabeled -> no-op (exit 0)
PASS  --ci labeled -> still enforced (exit 1)
```

Calibrated against the last 40 merges, the lane would have covered roughly one merged PR in ten. That narrowness is the point — a wider lane is a weaker gate.

This PR takes the **full** lane, as its own rules require: it touches `AGENTS.md`, `.github/**`, `scripts/check-*`, and `package.json`.

## After merge

- [x] `fast-lane` label created.
- [ ] Add `fast-lane-guard` to the `main-requires-pr` required checks. Must be done **after** merge — before the workflow exists on `main` the check never reports and would block every PR.
