### PR TITLE
Add Buy Me a Coffee sponsorship link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: zabooma
+buy_me_a_coffee: PureCutCNC


### PR DESCRIPTION
Closes #427

Adds `buy_me_a_coffee: PureCutCNC` to `.github/FUNDING.yml` so the Buy Me a Coffee link appears alongside GitHub Sponsors in the repository's Sponsor menu.

Note: this touches a protected path (`.github/**`), so the fast-lane guard rejects it. The `fast-lane` label was removed from the issue and the plan was recorded there per AGENTS.md.