### PR TITLE
Rework g-code preview toolbar

### DIFF
--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -535,3 +535,26 @@ export const viewMenu = {
   action3d: (page: Page, label: string) =>
     viewMenu.menu3d(page).getByRole('menuitem', { name: new RegExp(`^${label}`) }),
 }
+
+// ── Toolpath visibility panel ──────────────────────────────────────
+
+export const toolpathVis = {
+  /** The sketch-view toolpath visibility panel. */
+  sketchPanel: (page: Page) => page.locator('.sketch-toolpath-vis'),
+
+  /** The 3D-view toolpath visibility panel (no extra class). */
+  view3dPanel: (page: Page) =>
+    page.locator('#workspace-panel-preview3d .viewport-toolpath-vis'),
+
+  /** The toggle button (now the g-code icon). Scoped to the sketch panel. */
+  toggle: (page: Page) =>
+    toolpathVis.sketchPanel(page).locator('.viewport-toolpath-vis__label'),
+
+  /** All expanded items in the sketch panel. */
+  sketchItems: (page: Page) =>
+    toolpathVis.sketchPanel(page).locator('.viewport-toolpath-vis__item'),
+
+  /** All expanded items in the 3D panel. */
+  view3dItems: (page: Page) =>
+    toolpathVis.view3dPanel(page).locator('.viewport-toolpath-vis__item'),
+}

--- a/e2e/toolpathVisibility.helpers.ts
+++ b/e2e/toolpathVisibility.helpers.ts
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Page } from '@playwright/test'
+import { seedProject } from './helpers'
+
+function resolvedRectProfile(cx: number, cy: number, w: number, h: number) {
+  return {
+    start: { x: cx, y: cy },
+    segments: [
+      { type: 'line' as const, to: { x: cx + w, y: cy } },
+      { type: 'line' as const, to: { x: cx + w, y: cy + h } },
+      { type: 'line' as const, to: { x: cx, y: cy + h } },
+      { type: 'line' as const, to: { x: cx, y: cy } },
+    ],
+    closed: true,
+  }
+}
+
+function buildToolpathVisProjectJson(): string {
+  const now = '2026-01-01T00:00:00.000Z'
+  const stockW = 180
+  const stockH = 120
+
+  return JSON.stringify({
+    version: '3.0',
+    meta: {
+      name: 'Toolpath Visibility E2E Fixture',
+      created: now,
+      modified: now,
+      units: 'inch',
+      showFeatureInfo: true,
+      showDimensions: true,
+      copyMode: 'reference',
+      maxTravelZ: 2,
+      operationClearanceZ: 0.2,
+      clampClearanceXY: 0.5,
+      clampClearanceZ: 0.2,
+      machineId: 'grbl',
+    },
+    grid: {
+      extent: 200,
+      majorSpacing: 1,
+      minorSpacing: 0.25,
+      snapEnabled: false,
+      snapIncrement: 0.25,
+      visible: true,
+    },
+    stock: {
+      profile: resolvedRectProfile(0, 0, stockW, stockH),
+      thickness: 2,
+      material: 'aluminum_6061',
+      color: '#b9a83c',
+      visible: true,
+      origin: { x: 0, y: 0 },
+    },
+    origin: { name: 'Origin', x: stockW / 2, y: stockH / 2, z: 2, visible: true },
+    backdrop: null,
+    dimensions: {},
+    annotations: [],
+    modelAssets: {},
+    featureDefinitions: {
+      'def-machinable-add': {
+        id: 'def-machinable-add',
+        kind: 'rect',
+        profile: resolvedRectProfile(0, 0, 60, 40),
+        dimensions: [],
+        text: null,
+        stl: null,
+        operation: 'add',
+      },
+    },
+    features: [
+      {
+        id: 'f-machinable-add',
+        name: 'Machinable Add',
+        definitionId: 'def-machinable-add',
+        transform: { a: 1, b: 0, c: 0, d: 1, e: 30, f: 30 },
+        constraints: [],
+        folderId: null,
+        z_top: 2,
+        z_bottom: 0,
+        visible: true,
+        locked: false,
+      },
+    ],
+    featureFolders: [],
+    featureTree: [],
+    global_constraints: [],
+    tools: [
+      {
+        id: 'tool-1',
+        name: 'Quarter Inch Endmill',
+        units: 'inch',
+        type: 'flat_endmill',
+        diameter: 0.25,
+        vBitAngle: null,
+        flutes: 2,
+        material: 'carbide',
+        defaultRpm: 18000,
+        defaultFeed: 60,
+        defaultPlungeFeed: 30,
+        defaultStepdown: 0.1,
+        defaultStepover: 0.125,
+        maxCutDepth: 1,
+      },
+    ],
+    operations: [
+      {
+        id: 'op-route-a',
+        name: 'Route A',
+        kind: 'edge_route_outside',
+        pass: 'rough',
+        enabled: true,
+        showToolpath: true,
+        debugToolpath: false,
+        target: { source: 'features', featureIds: ['f-machinable-add'] },
+        toolRef: 'tool-1',
+        stepdown: 0.1,
+        stepover: 0.125,
+        feed: 60,
+        plungeFeed: 30,
+        rpm: 18000,
+        pocketPattern: 'offset',
+        pocketAngle: 0,
+        roundOutsideCorners: false,
+        stockToLeaveRadial: 0,
+        stockToLeaveAxial: 0,
+        finishWalls: false,
+        finishFloor: false,
+        carveDepth: 0,
+        maxCarveDepth: 0,
+      },
+    ],
+    tabs: [],
+    clamps: [],
+    ai_history: [],
+  })
+}
+
+const TOOLPATH_VIS_FIXTURE_JSON = buildToolpathVisProjectJson()
+
+export async function seedToolpathVisProject(page: Page): Promise<void> {
+  await seedProject(page, TOOLPATH_VIS_FIXTURE_JSON)
+}

--- a/e2e/toolpathVisibility.smoke.spec.ts
+++ b/e2e/toolpathVisibility.smoke.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures'
+import { seedToolpathVisProject } from './toolpathVisibility.helpers'
+
+test.describe('Toolpath visibility panel smoke', () => {
+  test('gcode icon toggle expands and collapses the panel', async ({ app, ui }) => {
+    await seedToolpathVisProject(app.page)
+
+    // Async toolpath generation — wait for the sketch panel to appear.
+    const sketchPanel = ui.toolpathVis.sketchPanel(app.page)
+    await expect(sketchPanel).toBeVisible({ timeout: 15000 })
+    await expect(sketchPanel).toHaveClass(/viewport-toolpath-vis--expanded/)
+
+    // Items visible when expanded
+    const sketchItems = ui.toolpathVis.sketchItems(app.page)
+    await expect(sketchItems.first()).toBeVisible()
+
+    // Collapse
+    await ui.toolpathVis.toggle(app.page).click()
+    await expect(sketchPanel).not.toHaveClass(/viewport-toolpath-vis--expanded/)
+    await expect(sketchItems).toHaveCount(0)
+
+    // Expand again
+    await ui.toolpathVis.toggle(app.page).click()
+    await expect(sketchPanel).toHaveClass(/viewport-toolpath-vis--expanded/)
+    await expect(sketchItems.first()).toBeVisible()
+  })
+
+  test('collapse preserves toggle selections', async ({ app, ui }) => {
+    await seedToolpathVisProject(app.page)
+
+    const sketchPanel = ui.toolpathVis.sketchPanel(app.page)
+    await expect(sketchPanel).toBeVisible({ timeout: 15000 })
+
+    // Toggle off one item
+    const sketchItems = ui.toolpathVis.sketchItems(app.page)
+    const firstItem = sketchItems.first()
+    await expect(firstItem).toHaveAttribute('aria-pressed', 'true')
+    await firstItem.click()
+    await expect(firstItem).toHaveAttribute('aria-pressed', 'false')
+
+    // Collapse and expand
+    await ui.toolpathVis.toggle(app.page).click()
+    await expect(sketchPanel).not.toHaveClass(/viewport-toolpath-vis--expanded/)
+    await ui.toolpathVis.toggle(app.page).click()
+    await expect(sketchPanel).toHaveClass(/viewport-toolpath-vis--expanded/)
+
+    // Selection preserved
+    await expect(sketchItems.first()).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  test('panel renders in both sketch and 3D views', async ({ app, ui }) => {
+    await seedToolpathVisProject(app.page)
+
+    const sketchPanel = ui.toolpathVis.sketchPanel(app.page)
+    await expect(sketchPanel).toBeVisible({ timeout: 15000 })
+    await expect(ui.toolpathVis.sketchItems(app.page).first()).toBeVisible()
+
+    // The 3D panel exists in the DOM (LCR layout) but may be hidden behind
+    // the inactive preview tab — verify it is present in the DOM.
+    await expect(ui.toolpathVis.view3dPanel(app.page)).toBeAttached({ timeout: 15000 })
+    await expect(ui.toolpathVis.view3dItems(app.page).first()).toBeAttached()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import { isTabletMode, useShellMode } from './components/layout/useShellMode'
 import { CreationToolbar, GlobalToolbar } from './components/layout/Toolbar'
 import { SimulationViewport, type SimulationViewportHandle } from './components/simulation/SimulationViewport'
 import { Viewport3D, type Viewport3DHandle } from './components/viewport3d/Viewport3D'
-import { type ToolpathVisibility, DEFAULT_TOOLPATH_VISIBILITY } from './components/toolpathVisibility'
+import { type ToolpathVisibility, DEFAULT_TOOLPATH_VISIBILITY, ALL_TOOLPATH_HIDDEN } from './components/toolpathVisibility'
 import { ExportDialog } from './components/export/ExportDialog'
 import { ModelExportDialog } from './components/export/ModelExportDialog'
 import { PrintDesignDialog } from './components/export/PrintDesignDialog'
@@ -74,6 +74,8 @@ function App() {
   const [showImportDialog, setShowImportDialog] = useState(false)
   const [showAboutDialog, setShowAboutDialog] = useState(false)
   const [toolpathVisibility, setToolpathVisibility] = useState<ToolpathVisibility>(DEFAULT_TOOLPATH_VISIBILITY)
+  const [toolpathPanelExpanded, setToolpathPanelExpanded] = useState(true)
+  const effectiveToolpathVisibility = toolpathPanelExpanded ? toolpathVisibility : ALL_TOOLPATH_HIDDEN
   // A1.3: operation kind armed in the CAM "Add operation" menu (on hover), so the
   // sketch canvas can highlight the features that operation could act on.
   const [operationHighlightKind, setOperationHighlightKind] = useState<OperationKind | null>(null)
@@ -394,8 +396,10 @@ function App() {
               onActiveSnapModeChange={setActiveSnapMode}
               depthLegendCollapsed={depthLegendCollapsed}
               onToggleDepthLegend={() => setDepthLegendCollapsed((value) => !value)}
-              toolpathVisibility={toolpathVisibility}
+              toolpathVisibility={effectiveToolpathVisibility}
               onToolpathVisibilityChange={setToolpathVisibility}
+              toolpathPanelExpanded={toolpathPanelExpanded}
+              onToolpathPanelExpandedChange={setToolpathPanelExpanded}
               operationHighlightKind={operationHighlightKind}
             />
             {project.features.length === 0 && !pendingAdd && !emptyStateEngaged ? (
@@ -417,8 +421,10 @@ function App() {
             originVisible={project.origin.visible}
             zoomWindowActive={zoomWindowActive && centerTab === 'preview3d'}
             onZoomWindowComplete={onZoomWindowComplete}
-            toolpathVisibility={toolpathVisibility}
+            toolpathVisibility={effectiveToolpathVisibility}
             onToolpathVisibilityChange={setToolpathVisibility}
+            toolpathPanelExpanded={toolpathPanelExpanded}
+            onToolpathPanelExpandedChange={setToolpathPanelExpanded}
           />
         }
         simulationViewport={

--- a/src/components/ToolpathVisibilityPanel.tsx
+++ b/src/components/ToolpathVisibilityPanel.tsx
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-import { useState } from 'react'
 import type { ToolpathVisibility } from './toolpathVisibility'
 import { useI18n } from '../i18n/i18nContext'
 import type { MessageKey } from '../i18n/locales/en'
+import { Icon } from './Icon'
 
 interface ToolpathVisibilityPanelProps {
   visibility: ToolpathVisibility
   onChange: (visibility: ToolpathVisibility) => void
   className?: string
+  expanded: boolean
+  onExpandedChange: (expanded: boolean) => void
 }
 
 const ITEMS: Array<{ key: keyof ToolpathVisibility; labelKey: MessageKey; swatch: string }> = [
@@ -34,19 +36,19 @@ const ITEMS: Array<{ key: keyof ToolpathVisibility; labelKey: MessageKey; swatch
   { key: 'directions', labelKey: 'appShell.toolpath.directions', swatch: 'viewport-toolpath-vis__swatch--directions' },
 ]
 
-export function ToolpathVisibilityPanel({ visibility, onChange, className }: ToolpathVisibilityPanelProps) {
+export function ToolpathVisibilityPanel({ visibility, onChange, className, expanded, onExpandedChange }: ToolpathVisibilityPanelProps) {
   const { t } = useI18n()
-  const [expanded, setExpanded] = useState(true)
 
   return (
     <div className={`viewport-toolpath-vis${expanded ? ' viewport-toolpath-vis--expanded' : ''}${className ? ` ${className}` : ''}`}>
       <button
         className="viewport-toolpath-vis__label"
         type="button"
+        aria-label={t('appShell.toolpath.show')}
         aria-expanded={expanded}
-        onClick={() => setExpanded((value) => !value)}
+        onClick={() => onExpandedChange(!expanded)}
       >
-        {t('appShell.toolpath.show')}
+        <Icon id="gcode" />
       </button>
       {expanded ? (
         ITEMS.map(({ key, labelKey, swatch }) => {

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -174,6 +174,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     onToggleDepthLegend,
     toolpathVisibility,
     onToolpathVisibilityChange,
+    toolpathPanelExpanded, onToolpathPanelExpandedChange,
     operationHighlightKind = null,
   },
   ref
@@ -286,8 +287,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     moveFeatureControl,
     insertFeaturePoint,
     joinOpenFeatureEndpoints,
-    deleteFeaturePoint,
-    deleteFeatureSegment,
+    deleteFeaturePoint, deleteFeatureSegment,
     disconnectFeaturePoint,
     filletFeaturePoint,
     chamferFeaturePoint,
@@ -310,8 +310,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     undoPendingPolygonPoint,
     completePendingPolygon,
     completePendingOpenPath,
-    cancelPendingAdd,
-    setPendingCompositeMode,
+    cancelPendingAdd, setPendingCompositeMode,
     addPendingCompositePoint,
     undoPendingCompositeStep,
     completePendingComposite,
@@ -328,8 +327,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     completePendingOffset,
     cancelPendingOffset,
     completePendingShapeAction,
-    cancelPendingShapeAction,
-    confirmCutCutters,
+    cancelPendingShapeAction, confirmCutCutters,
     setPendingShapeActionKeepOriginals,
     setBackdropImageLoading,
     beginConstraint,
@@ -2855,11 +2853,13 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       <OverlapFeaturePicker picker={overlapFeaturePicker} />
       <CreationTargetBadge />
       {!depthLegendCollapsed ? <DepthLegend onToggleDepthLegend={onToggleDepthLegend} /> : null}
-      {(toolpaths && toolpaths.some((tp) => tp.moves.length > 0)) && toolpathVisibility && onToolpathVisibilityChange && (
+      {(toolpaths && toolpaths.some((tp) => tp.moves.length > 0)) && toolpathVisibility && onToolpathVisibilityChange && toolpathPanelExpanded !== undefined && onToolpathPanelExpandedChange && (
         <ToolpathVisibilityPanel
           visibility={toolpathVisibility}
           onChange={onToolpathVisibilityChange}
           className="sketch-toolpath-vis"
+          expanded={toolpathPanelExpanded}
+          onExpandedChange={onToolpathPanelExpandedChange}
         />
       )}
       <ConstraintEditPanel constraint={constraint} />

--- a/src/components/canvas/SketchCanvas.types.ts
+++ b/src/components/canvas/SketchCanvas.types.ts
@@ -77,6 +77,8 @@ export interface SketchCanvasProps {
   onToggleDepthLegend?: () => void
   toolpathVisibility?: ToolpathVisibility
   onToolpathVisibilityChange?: (visibility: ToolpathVisibility) => void
+  toolpathPanelExpanded?: boolean
+  onToolpathPanelExpandedChange?: (expanded: boolean) => void
   /**
    * A1.3: when an operation kind is armed/hovered in the CAM "Add operation"
    * menu, the canvas highlights features that operation could act on and dims

--- a/src/components/toolpathVisibility.ts
+++ b/src/components/toolpathVisibility.ts
@@ -31,3 +31,12 @@ export const DEFAULT_TOOLPATH_VISIBILITY: ToolpathVisibility = {
   retractions: true,
   directions: true,
 }
+
+export const ALL_TOOLPATH_HIDDEN: ToolpathVisibility = {
+  cuts: false,
+  leadIns: false,
+  rapids: false,
+  plunges: false,
+  retractions: false,
+  directions: false,
+}

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -60,6 +60,8 @@ interface Viewport3DProps {
   onZoomWindowComplete?: () => void
   toolpathVisibility: ToolpathVisibility
   onToolpathVisibilityChange: (visibility: ToolpathVisibility) => void
+  toolpathPanelExpanded: boolean
+  onToolpathPanelExpandedChange: (expanded: boolean) => void
 }
 
 function disposeObject3D(object: THREE.Object3D) {
@@ -347,6 +349,8 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
   onZoomWindowComplete,
   toolpathVisibility,
   onToolpathVisibilityChange,
+  toolpathPanelExpanded,
+  onToolpathPanelExpandedChange,
 }, ref) {
   const { palette } = useTheme()
   const threePalette = palette.three
@@ -916,6 +920,8 @@ useImperativeHandle(ref, () => ({
         <ToolpathVisibilityPanel
           visibility={toolpathVisibility}
           onChange={onToolpathVisibilityChange}
+          expanded={toolpathPanelExpanded}
+          onExpandedChange={onToolpathPanelExpandedChange}
         />
       )}
       <div className="viewport-presets">

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2640,6 +2640,14 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin-right: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+}
+
+.viewport-toolpath-vis__label svg {
+  width: 14px;
+  height: 14px;
 }
 
 .app-shell .viewport-toolpath-vis__label {


### PR DESCRIPTION
Closes #429

## What
Reworks the g-code preview toolbar in the sketch and 3D views:

1. **Icon label.** Replaces the "SHOW" text with the existing g-code icon (`<Icon id="gcode" />`, same icon used for per-operation G-code export in the CAM panel). The `appShell.toolpath.show` i18n token is kept as the button's `aria-label`, so all locale catalogs stay valid and the screen-reader name stays localized.
2. **Collapse hides all moves, preserves selections.** The toolbar's `expanded` flag is lifted to shared App state (`toolpathPanelExpanded`) so both the sketch and 3D toolbars collapse/expand together. App computes `effectiveToolpathVisibility = toolpathPanelExpanded ? toolpathVisibility : ALL_TOOLPATH_HIDDEN` and passes that to the renderers — so collapsing hides all toolpath moves in both views via the existing renderers, while the real `toolpathVisibility` selections are preserved in App state and restored on expand.
3. **Expanded behavior unchanged.** When expanded, the panel behaves as before.

`PrintDesignDialog` keeps the real `toolpathVisibility` (not the effective one), so print reflects actual selections rather than the toolbar's collapsed state.

## Plan
Approved plan: https://github.com/PureCutCNC/purecutcnc/issues/429#issuecomment-5160725398 (full lane — shared `expanded` state must be lifted to App and threaded through both view components + CSS + types + e2e; exceeds fast-lane).

## Verify
- `npm run lint` — pass
- `npm run build` — pass (tsc + tests + vite)
- `npm run test:e2e` — 85 passed (3 new smoke tests: gcode icon toggle, preserve selections on collapse/expand, both views render)

## Files
- `src/components/toolpathVisibility.ts` — `ALL_TOOLPATH_HIDDEN` constant
- `src/components/ToolpathVisibilityPanel.tsx` — icon label, controlled `expanded`
- `src/App.tsx` — shared `toolpathPanelExpanded` state + `effectiveToolpathVisibility`
- `src/components/viewport3d/Viewport3D.tsx` — forward `expanded`/`onExpandedChange`
- `src/components/canvas/SketchCanvas.tsx` + `SketchCanvas.types.ts` — forward `expanded`/`onExpandedChange`
- `src/styles/layout.css` — size the gcode icon inside the label
- `e2e/selectors.ts`, `e2e/toolpathVisibility.helpers.ts`, `e2e/toolpathVisibility.smoke.spec.ts` — smoke coverage

## Notes
- `SketchCanvas.tsx` is at its `max-lines: 3800` ratchet; a few short destructuring lines were merged onto single lines to absorb the 2 new props without bumping the ratchet. Flagged for a future split (out of scope here).