### PR TITLE
Fix cut rejecting target when cutter endpoint is on boundary

### DIFF
--- a/src/components/canvas/draftGeometry.ts
+++ b/src/components/canvas/draftGeometry.ts
@@ -17,6 +17,7 @@
 import type { SnapMode } from '../../sketch/snapping'
 import type { SketchInsertTarget } from '../../store/types'
 import { bezierPoint, sampleProfilePoints } from '../../types/project'
+import { DEFAULT_FLATTEN_ARC_STEP } from '../../engine/toolpaths/geometry'
 import type { Point, Segment, SketchFeature, SketchProfile } from '../../types/project'
 import { anchorPointForIndex, arcControlPoint } from './profilePrimitives'
 import { distance2, pointInProfile, pointsEqual } from './hitTest'
@@ -171,7 +172,7 @@ export function sampleSegmentPolyline(start: Point, segment: Segment): Point[] {
     segments: [segment],
     closed: false,
   }
-  return sampleProfilePoints(profile, 12, Math.PI / 18)
+  return sampleProfilePoints(profile, 12, DEFAULT_FLATTEN_ARC_STEP)
 }
 
 export function nearestPointOnPolyline(point: Point, polyline: Point[]): Point {

--- a/src/store/helpers/polygonSplit.ts
+++ b/src/store/helpers/polygonSplit.ts
@@ -96,13 +96,32 @@ function pointInPolygon(p: Point, poly: Point[]): boolean {
   return inside
 }
 
-// Returns { j, u } if point p lies on edge poly[j]→poly[(j+1)%n], where
-// u is the parameter along that edge (0 at poly[j], 1 at poly[(j+1)%n]).
-// Returns null otherwise. If p coincides with a vertex, returns the edge
-// where it is the start vertex (u = 0).
-function pointOnPolygonBoundary(p: Point, poly: Point[]): { j: number; u: number } | null {
+// Scale-aware tolerance for "near boundary" classification. Curves (circles,
+// arcs) are flattened to inscribed polygons, so a point snapped to the
+// mathematical curve lands slightly inside the polygon — up to
+// r·(1 − cos(π/n)) for an n-gon. We use 5% of the shortest edge, which
+// comfortably exceeds that deviation while staying well below edge length.
+function polygonTolerance(poly: Point[]): number {
+  let minLen2 = Infinity
+  for (let j = 0; j < poly.length; j += 1) {
+    const a = poly[j]
+    const b = poly[(j + 1) % poly.length]
+    const len2 = (b.x - a.x) * (b.x - a.x) + (b.y - a.y) * (b.y - a.y)
+    if (len2 < minLen2) minLen2 = len2
+  }
+  if (minLen2 === Infinity) return EPSILON
+  return Math.max(EPSILON, 0.05 * Math.sqrt(minLen2))
+}
+
+// Returns { j, u, snapped } if point p lies on (or within `tol` of) edge
+// poly[j]→poly[(j+1)%n]. `u` is the parameter along that edge (0 at
+// poly[j], 1 at poly[(j+1)%n]); `snapped` is the projected point on the
+// edge. Returns null otherwise. If p coincides with a vertex, returns the
+// edge where it is the start vertex (u = 0).
+function pointOnPolygonBoundary(p: Point, poly: Point[], tol = EPSILON): { j: number; u: number; snapped: Point } | null {
   const n = poly.length
-  let best: { j: number; u: number } | null = null
+  const tol2 = tol * tol
+  let best: { j: number; u: number; snapped: Point } | null = null
   for (let j = 0; j < n; j += 1) {
     const a = poly[j]
     const b = poly[(j + 1) % n]
@@ -112,18 +131,17 @@ function pointOnPolygonBoundary(p: Point, poly: Point[]): { j: number; u: number
     if (len2 < EPSILON) continue
     const u = ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2
     if (u < -EPSILON || u > 1 + EPSILON) continue
-    const projX = a.x + u * dx
-    const projY = a.y + u * dy
-    const dist2 = (p.x - projX) * (p.x - projX) + (p.y - projY) * (p.y - projY)
-    if (dist2 < EPSILON * EPSILON) {
-      const clamped = Math.max(0, Math.min(1, u))
+    const clamped = Math.max(0, Math.min(1, u))
+    const snapped = { x: a.x + clamped * dx, y: a.y + clamped * dy }
+    const dist2 = (p.x - snapped.x) * (p.x - snapped.x) + (p.y - snapped.y) * (p.y - snapped.y)
+    if (dist2 < tol2) {
       // Prefer the edge where the point is the start vertex (u = 0).
-      if (clamped < EPSILON) return { j, u: 0 }
+      if (clamped < EPSILON) return { j, u: 0, snapped: { x: a.x, y: a.y } }
       if (clamped > 1 - EPSILON) {
-        best = { j: (j + 1) % n, u: 0 }
+        best = { j: (j + 1) % n, u: 0, snapped: { x: poly[(j + 1) % n].x, y: poly[(j + 1) % n].y } }
         continue
       }
-      return { j, u: clamped }
+      return { j, u: clamped, snapped }
     }
   }
   return best
@@ -204,23 +222,38 @@ export function openCrossesClosedFully(openProfile: SketchProfile, closedProfile
   const P = flattenToVertices(closedProfile).points
   if (L.length < 2 || P.length < 3) return false
 
-  // Endpoints strictly inside (but NOT on the boundary) are not allowed.
-  // Ray-casting can misclassify boundary points as inside; check boundary first.
-  if (!pointOnPolygonBoundary(L[0], P) && pointInPolygon(L[0], P)) return false
-  if (!pointOnPolygonBoundary(L[L.length - 1], P) && pointInPolygon(L[L.length - 1], P)) return false
+  const tol = polygonTolerance(P)
+  const startOnBnd = pointOnPolygonBoundary(L[0], P, tol)
+  const endOnBnd = pointOnPolygonBoundary(L[L.length - 1], P, tol)
+  // Endpoints strictly inside (not on/near the boundary) are not allowed.
+  if (!startOnBnd && pointInPolygon(L[0], P)) return false
+  if (!endOnBnd && pointInPolygon(L[L.length - 1], P)) return false
+
+  // If both endpoints are on/near the boundary, the cutter is a chord —
+  // it fully crosses.
+  if (startOnBnd && endOnBnd) return true
 
   let count = 0
+  let startFoundByIntersect = false
   for (let i = 0; i < L.length - 1; i += 1) {
     for (let j = 0; j < P.length; j += 1) {
       const hit = segmentIntersect(L[i], L[i + 1], P[j], P[(j + 1) % P.length])
-      if (hit !== null) count += 1
+      if (hit !== null) {
+        count += 1
+        // Track whether the start endpoint (t≈0 on first segment) was found
+        // by segmentIntersect — exact-boundary starts are found (t=0 is
+        // included), near-boundary starts are not.
+        if (i === 0 && hit.t < 1e-6) startFoundByIntersect = true
+      }
     }
   }
 
-  // Endpoints on the polygon boundary are valid entry/exit points.
-  // segmentIntersect uses [0,1): the start endpoint (t=0) is already caught
-  // by its first segment, but the end endpoint (t=1) is never reported.
-  if (pointOnPolygonBoundary(L[L.length - 1], P)) count += 1
+  // The end endpoint (t=1 on the last segment) is never reported by
+  // segmentIntersect (half-open [0,1)). Count it if on/near boundary.
+  if (endOnBnd) count += 1
+  // A near-boundary start is not an exact intersection — count it. An
+  // exact-boundary start was already counted by segmentIntersect.
+  if (startOnBnd && !startFoundByIntersect) count += 1
 
   return count >= 2 && count % 2 === 0
 }
@@ -436,10 +469,12 @@ export function splitClosedByOpen(
   const lPoints = flattenToVertices(openProfile).points
   if (pPoints.length < 3 || lPoints.length < 2) return null
 
-  // Endpoints of L must lie outside P (or on the boundary).
-  // Ray-casting can misclassify boundary points as inside; check boundary first.
-  if (!pointOnPolygonBoundary(lPoints[0], pPoints) && pointInPolygon(lPoints[0], pPoints)) return null
-  if (!pointOnPolygonBoundary(lPoints[lPoints.length - 1], pPoints) && pointInPolygon(lPoints[lPoints.length - 1], pPoints)) return null
+  const tol = polygonTolerance(pPoints)
+  // Endpoints of L must lie outside P (or on/near the boundary).
+  const startBnd = pointOnPolygonBoundary(lPoints[0], pPoints, tol)
+  const endBnd = pointOnPolygonBoundary(lPoints[lPoints.length - 1], pPoints, tol)
+  if (!startBnd && pointInPolygon(lPoints[0], pPoints)) return null
+  if (!endBnd && pointInPolygon(lPoints[lPoints.length - 1], pPoints)) return null
 
   // Compute all proper crossings of L segments with P segments.
   type RawCrossing = { point: Point, tP: number, tL: number }
@@ -456,22 +491,19 @@ export function splitClosedByOpen(
     }
   }
 
-  // Detect L endpoints that land on the polygon boundary and add them as
-  // crossings. segmentIntersect uses [0,1) on both parameters, so a cutter
-  // endpoint at t=1 on the last L segment is never reported.
-  const pointNearEqual = (a: Point, b: Point) => Math.abs(a.x - b.x) < EPSILON && Math.abs(a.y - b.y) < EPSILON
-  const endpointIndices = [0, lPoints.length - 1]
-  const endpointTL = [0, lPoints.length - 1]
-  for (let e = 0; e < endpointIndices.length; e += 1) {
-    const idx = endpointIndices[e]
-    const pt = lPoints[idx]
-    const bnd = pointOnPolygonBoundary(pt, pPoints)
-    if (!bnd) continue
-    const tP = bnd.j + bnd.u
-    const tL = endpointTL[e]
-    // Deduplicate against existing raw entries at the same point.
-    if (raw.some((r) => pointNearEqual(r.point, pt))) continue
-    raw.push({ point: { x: pt.x, y: pt.y }, tP, tL })
+  // Detect L endpoints that land on/near the polygon boundary and add them
+  // as crossings (using the snapped boundary point). segmentIntersect uses
+  // [0,1): the end endpoint (t=1) is never reported, and a near-boundary
+  // start (within tol but not exactly on an edge) is not an exact intersection.
+  const pointNearEqual = (a: Point, b: Point) => Math.abs(a.x - b.x) < tol && Math.abs(a.y - b.y) < tol
+  const endpointData: Array<{ idx: number; tL: number; bnd: { j: number; u: number; snapped: Point } }> = []
+  if (startBnd) endpointData.push({ idx: 0, tL: 0, bnd: startBnd })
+  if (endBnd) endpointData.push({ idx: lPoints.length - 1, tL: lPoints.length - 1, bnd: endBnd })
+  for (const ep of endpointData) {
+    const tP = ep.bnd.j + ep.bnd.u
+    // Deduplicate against existing raw entries near the snapped point.
+    if (raw.some((r) => pointNearEqual(r.point, ep.bnd.snapped))) continue
+    raw.push({ point: { x: ep.bnd.snapped.x, y: ep.bnd.snapped.y }, tP, tL: ep.tL })
   }
 
   if (raw.length < 2 || raw.length % 2 !== 0) return null

--- a/src/store/helpers/polygonSplit.ts
+++ b/src/store/helpers/polygonSplit.ts
@@ -96,6 +96,39 @@ function pointInPolygon(p: Point, poly: Point[]): boolean {
   return inside
 }
 
+// Returns { j, u } if point p lies on edge poly[j]→poly[(j+1)%n], where
+// u is the parameter along that edge (0 at poly[j], 1 at poly[(j+1)%n]).
+// Returns null otherwise. If p coincides with a vertex, returns the edge
+// where it is the start vertex (u = 0).
+function pointOnPolygonBoundary(p: Point, poly: Point[]): { j: number; u: number } | null {
+  const n = poly.length
+  let best: { j: number; u: number } | null = null
+  for (let j = 0; j < n; j += 1) {
+    const a = poly[j]
+    const b = poly[(j + 1) % n]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const len2 = dx * dx + dy * dy
+    if (len2 < EPSILON) continue
+    const u = ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2
+    if (u < -EPSILON || u > 1 + EPSILON) continue
+    const projX = a.x + u * dx
+    const projY = a.y + u * dy
+    const dist2 = (p.x - projX) * (p.x - projX) + (p.y - projY) * (p.y - projY)
+    if (dist2 < EPSILON * EPSILON) {
+      const clamped = Math.max(0, Math.min(1, u))
+      // Prefer the edge where the point is the start vertex (u = 0).
+      if (clamped < EPSILON) return { j, u: 0 }
+      if (clamped > 1 - EPSILON) {
+        best = { j: (j + 1) % n, u: 0 }
+        continue
+      }
+      return { j, u: clamped }
+    }
+  }
+  return best
+}
+
 // Segment-segment intersection treating each segment as a half-open interval
 // [start, end) on both parameters. This ensures intersections at shared
 // vertices are reported by exactly one segment (the one whose start vertex
@@ -171,8 +204,10 @@ export function openCrossesClosedFully(openProfile: SketchProfile, closedProfile
   const P = flattenToVertices(closedProfile).points
   if (L.length < 2 || P.length < 3) return false
 
-  if (pointInPolygon(L[0], P)) return false
-  if (pointInPolygon(L[L.length - 1], P)) return false
+  // Endpoints strictly inside (but NOT on the boundary) are not allowed.
+  // Ray-casting can misclassify boundary points as inside; check boundary first.
+  if (!pointOnPolygonBoundary(L[0], P) && pointInPolygon(L[0], P)) return false
+  if (!pointOnPolygonBoundary(L[L.length - 1], P) && pointInPolygon(L[L.length - 1], P)) return false
 
   let count = 0
   for (let i = 0; i < L.length - 1; i += 1) {
@@ -181,6 +216,12 @@ export function openCrossesClosedFully(openProfile: SketchProfile, closedProfile
       if (hit !== null) count += 1
     }
   }
+
+  // Endpoints on the polygon boundary are valid entry/exit points.
+  // segmentIntersect uses [0,1): the start endpoint (t=0) is already caught
+  // by its first segment, but the end endpoint (t=1) is never reported.
+  if (pointOnPolygonBoundary(L[L.length - 1], P)) count += 1
+
   return count >= 2 && count % 2 === 0
 }
 
@@ -395,9 +436,10 @@ export function splitClosedByOpen(
   const lPoints = flattenToVertices(openProfile).points
   if (pPoints.length < 3 || lPoints.length < 2) return null
 
-  // Endpoints of L must lie outside P.
-  if (pointInPolygon(lPoints[0], pPoints)) return null
-  if (pointInPolygon(lPoints[lPoints.length - 1], pPoints)) return null
+  // Endpoints of L must lie outside P (or on the boundary).
+  // Ray-casting can misclassify boundary points as inside; check boundary first.
+  if (!pointOnPolygonBoundary(lPoints[0], pPoints) && pointInPolygon(lPoints[0], pPoints)) return null
+  if (!pointOnPolygonBoundary(lPoints[lPoints.length - 1], pPoints) && pointInPolygon(lPoints[lPoints.length - 1], pPoints)) return null
 
   // Compute all proper crossings of L segments with P segments.
   type RawCrossing = { point: Point, tP: number, tL: number }
@@ -413,6 +455,25 @@ export function splitClosedByOpen(
       raw.push({ point: hit.point, tP: j + hit.u, tL: i + hit.t })
     }
   }
+
+  // Detect L endpoints that land on the polygon boundary and add them as
+  // crossings. segmentIntersect uses [0,1) on both parameters, so a cutter
+  // endpoint at t=1 on the last L segment is never reported.
+  const pointNearEqual = (a: Point, b: Point) => Math.abs(a.x - b.x) < EPSILON && Math.abs(a.y - b.y) < EPSILON
+  const endpointIndices = [0, lPoints.length - 1]
+  const endpointTL = [0, lPoints.length - 1]
+  for (let e = 0; e < endpointIndices.length; e += 1) {
+    const idx = endpointIndices[e]
+    const pt = lPoints[idx]
+    const bnd = pointOnPolygonBoundary(pt, pPoints)
+    if (!bnd) continue
+    const tP = bnd.j + bnd.u
+    const tL = endpointTL[e]
+    // Deduplicate against existing raw entries at the same point.
+    if (raw.some((r) => pointNearEqual(r.point, pt))) continue
+    raw.push({ point: { x: pt.x, y: pt.y }, tP, tL })
+  }
+
   if (raw.length < 2 || raw.length % 2 !== 0) return null
 
   // Pair crossings: sort by tL, then alternate entry/exit.

--- a/src/store/helpers/polygonSplit.ts
+++ b/src/store/helpers/polygonSplit.ts
@@ -96,32 +96,13 @@ function pointInPolygon(p: Point, poly: Point[]): boolean {
   return inside
 }
 
-// Scale-aware tolerance for "near boundary" classification. Curves (circles,
-// arcs) are flattened to inscribed polygons, so a point snapped to the
-// mathematical curve lands slightly inside the polygon — up to
-// r·(1 − cos(π/n)) for an n-gon. We use 5% of the shortest edge, which
-// comfortably exceeds that deviation while staying well below edge length.
-function polygonTolerance(poly: Point[]): number {
-  let minLen2 = Infinity
-  for (let j = 0; j < poly.length; j += 1) {
-    const a = poly[j]
-    const b = poly[(j + 1) % poly.length]
-    const len2 = (b.x - a.x) * (b.x - a.x) + (b.y - a.y) * (b.y - a.y)
-    if (len2 < minLen2) minLen2 = len2
-  }
-  if (minLen2 === Infinity) return EPSILON
-  return Math.max(EPSILON, 0.05 * Math.sqrt(minLen2))
-}
-
-// Returns { j, u, snapped } if point p lies on (or within `tol` of) edge
-// poly[j]→poly[(j+1)%n]. `u` is the parameter along that edge (0 at
-// poly[j], 1 at poly[(j+1)%n]); `snapped` is the projected point on the
-// edge. Returns null otherwise. If p coincides with a vertex, returns the
-// edge where it is the start vertex (u = 0).
-function pointOnPolygonBoundary(p: Point, poly: Point[], tol = EPSILON): { j: number; u: number; snapped: Point } | null {
+// Returns { j, u } if point p lies on edge poly[j]→poly[(j+1)%n], where
+// u is the parameter along that edge (0 at poly[j], 1 at poly[(j+1)%n]).
+// Returns null otherwise. If p coincides with a vertex, returns the edge
+// where it is the start vertex (u = 0).
+function pointOnPolygonBoundary(p: Point, poly: Point[]): { j: number; u: number } | null {
   const n = poly.length
-  const tol2 = tol * tol
-  let best: { j: number; u: number; snapped: Point } | null = null
+  let best: { j: number; u: number } | null = null
   for (let j = 0; j < n; j += 1) {
     const a = poly[j]
     const b = poly[(j + 1) % n]
@@ -131,17 +112,18 @@ function pointOnPolygonBoundary(p: Point, poly: Point[], tol = EPSILON): { j: nu
     if (len2 < EPSILON) continue
     const u = ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2
     if (u < -EPSILON || u > 1 + EPSILON) continue
-    const clamped = Math.max(0, Math.min(1, u))
-    const snapped = { x: a.x + clamped * dx, y: a.y + clamped * dy }
-    const dist2 = (p.x - snapped.x) * (p.x - snapped.x) + (p.y - snapped.y) * (p.y - snapped.y)
-    if (dist2 < tol2) {
+    const projX = a.x + u * dx
+    const projY = a.y + u * dy
+    const dist2 = (p.x - projX) * (p.x - projX) + (p.y - projY) * (p.y - projY)
+    if (dist2 < EPSILON * EPSILON) {
+      const clamped = Math.max(0, Math.min(1, u))
       // Prefer the edge where the point is the start vertex (u = 0).
-      if (clamped < EPSILON) return { j, u: 0, snapped: { x: a.x, y: a.y } }
+      if (clamped < EPSILON) return { j, u: 0 }
       if (clamped > 1 - EPSILON) {
-        best = { j: (j + 1) % n, u: 0, snapped: { x: poly[(j + 1) % n].x, y: poly[(j + 1) % n].y } }
+        best = { j: (j + 1) % n, u: 0 }
         continue
       }
-      return { j, u: clamped, snapped }
+      return { j, u: clamped }
     }
   }
   return best
@@ -222,38 +204,23 @@ export function openCrossesClosedFully(openProfile: SketchProfile, closedProfile
   const P = flattenToVertices(closedProfile).points
   if (L.length < 2 || P.length < 3) return false
 
-  const tol = polygonTolerance(P)
-  const startOnBnd = pointOnPolygonBoundary(L[0], P, tol)
-  const endOnBnd = pointOnPolygonBoundary(L[L.length - 1], P, tol)
-  // Endpoints strictly inside (not on/near the boundary) are not allowed.
-  if (!startOnBnd && pointInPolygon(L[0], P)) return false
-  if (!endOnBnd && pointInPolygon(L[L.length - 1], P)) return false
-
-  // If both endpoints are on/near the boundary, the cutter is a chord —
-  // it fully crosses.
-  if (startOnBnd && endOnBnd) return true
+  // Endpoints strictly inside (but NOT on the boundary) are not allowed.
+  // Ray-casting can misclassify boundary points as inside; check boundary first.
+  if (!pointOnPolygonBoundary(L[0], P) && pointInPolygon(L[0], P)) return false
+  if (!pointOnPolygonBoundary(L[L.length - 1], P) && pointInPolygon(L[L.length - 1], P)) return false
 
   let count = 0
-  let startFoundByIntersect = false
   for (let i = 0; i < L.length - 1; i += 1) {
     for (let j = 0; j < P.length; j += 1) {
       const hit = segmentIntersect(L[i], L[i + 1], P[j], P[(j + 1) % P.length])
-      if (hit !== null) {
-        count += 1
-        // Track whether the start endpoint (t≈0 on first segment) was found
-        // by segmentIntersect — exact-boundary starts are found (t=0 is
-        // included), near-boundary starts are not.
-        if (i === 0 && hit.t < 1e-6) startFoundByIntersect = true
-      }
+      if (hit !== null) count += 1
     }
   }
 
-  // The end endpoint (t=1 on the last segment) is never reported by
-  // segmentIntersect (half-open [0,1)). Count it if on/near boundary.
-  if (endOnBnd) count += 1
-  // A near-boundary start is not an exact intersection — count it. An
-  // exact-boundary start was already counted by segmentIntersect.
-  if (startOnBnd && !startFoundByIntersect) count += 1
+  // Endpoints on the polygon boundary are valid entry/exit points.
+  // segmentIntersect uses [0,1): the start endpoint (t=0) is already caught
+  // by its first segment, but the end endpoint (t=1) is never reported.
+  if (pointOnPolygonBoundary(L[L.length - 1], P)) count += 1
 
   return count >= 2 && count % 2 === 0
 }
@@ -469,12 +436,9 @@ export function splitClosedByOpen(
   const lPoints = flattenToVertices(openProfile).points
   if (pPoints.length < 3 || lPoints.length < 2) return null
 
-  const tol = polygonTolerance(pPoints)
-  // Endpoints of L must lie outside P (or on/near the boundary).
-  const startBnd = pointOnPolygonBoundary(lPoints[0], pPoints, tol)
-  const endBnd = pointOnPolygonBoundary(lPoints[lPoints.length - 1], pPoints, tol)
-  if (!startBnd && pointInPolygon(lPoints[0], pPoints)) return null
-  if (!endBnd && pointInPolygon(lPoints[lPoints.length - 1], pPoints)) return null
+  // Endpoints of L must lie outside P (or on the boundary).
+  if (!pointOnPolygonBoundary(lPoints[0], pPoints) && pointInPolygon(lPoints[0], pPoints)) return null
+  if (!pointOnPolygonBoundary(lPoints[lPoints.length - 1], pPoints) && pointInPolygon(lPoints[lPoints.length - 1], pPoints)) return null
 
   // Compute all proper crossings of L segments with P segments.
   type RawCrossing = { point: Point, tP: number, tL: number }
@@ -491,19 +455,22 @@ export function splitClosedByOpen(
     }
   }
 
-  // Detect L endpoints that land on/near the polygon boundary and add them
-  // as crossings (using the snapped boundary point). segmentIntersect uses
-  // [0,1): the end endpoint (t=1) is never reported, and a near-boundary
-  // start (within tol but not exactly on an edge) is not an exact intersection.
-  const pointNearEqual = (a: Point, b: Point) => Math.abs(a.x - b.x) < tol && Math.abs(a.y - b.y) < tol
-  const endpointData: Array<{ idx: number; tL: number; bnd: { j: number; u: number; snapped: Point } }> = []
-  if (startBnd) endpointData.push({ idx: 0, tL: 0, bnd: startBnd })
-  if (endBnd) endpointData.push({ idx: lPoints.length - 1, tL: lPoints.length - 1, bnd: endBnd })
-  for (const ep of endpointData) {
-    const tP = ep.bnd.j + ep.bnd.u
-    // Deduplicate against existing raw entries near the snapped point.
-    if (raw.some((r) => pointNearEqual(r.point, ep.bnd.snapped))) continue
-    raw.push({ point: { x: ep.bnd.snapped.x, y: ep.bnd.snapped.y }, tP, tL: ep.tL })
+  // Detect L endpoints that land on the polygon boundary and add them as
+  // crossings. segmentIntersect uses [0,1) on both parameters, so a cutter
+  // endpoint at t=1 on the last L segment is never reported.
+  const pointNearEqual = (a: Point, b: Point) => Math.abs(a.x - b.x) < EPSILON && Math.abs(a.y - b.y) < EPSILON
+  const endpointIndices = [0, lPoints.length - 1]
+  const endpointTL = [0, lPoints.length - 1]
+  for (let e = 0; e < endpointIndices.length; e += 1) {
+    const idx = endpointIndices[e]
+    const pt = lPoints[idx]
+    const bnd = pointOnPolygonBoundary(pt, pPoints)
+    if (!bnd) continue
+    const tP = bnd.j + bnd.u
+    const tL = endpointTL[e]
+    // Deduplicate against existing raw entries at the same point.
+    if (raw.some((r) => pointNearEqual(r.point, pt))) continue
+    raw.push({ point: { x: pt.x, y: pt.y }, tP, tL })
   }
 
   if (raw.length < 2 || raw.length % 2 !== 0) return null
@@ -518,6 +485,24 @@ export function splitClosedByOpen(
     const b = lSorted[i + 1]
     const mid = { x: (a.point.x + b.point.x) / 2, y: (a.point.y + b.point.y) / 2 }
     if (!pointInPolygon(mid, pPoints)) return null
+  }
+
+  // Subpath validation: every intermediate L vertex between a paired
+  // entry/exit must lie inside (or on) the polygon. If the cutter routes
+  // outside the target between two boundary crossings, the pairing is
+  // degenerate (e.g. a V-shaped cutter dipping out and back through the
+  // same edge) and the cut must be rejected.
+  for (let i = 0; i < lSorted.length; i += 2) {
+    const a = lSorted[i]
+    const b = lSorted[i + 1]
+    const lo = Math.min(a.tL, b.tL)
+    const hi = Math.max(a.tL, b.tL)
+    const firstIdx = Math.floor(lo) + 1
+    const lastIdx = Math.ceil(hi - EPSILON) - 1
+    for (let idx = firstIdx; idx <= lastIdx; idx += 1) {
+      const v = lPoints[idx]
+      if (!pointInPolygon(v, pPoints) && !pointOnPolygonBoundary(v, pPoints)) return null
+    }
   }
 
   // Now build Crossing entries with partner indices and directions.

--- a/src/store/polygonSplit.test.ts
+++ b/src/store/polygonSplit.test.ts
@@ -245,6 +245,38 @@ function test8() {
   console.log('test8 PASS')
 }
 
+// Test 9: near-boundary endpoints on a circle polygon (mimics the real
+// cutter-on-line.camj scenario). The cutter endpoints are snapped to the
+// mathematical circle but land slightly INSIDE the flattened polygon because
+// the polygon is inscribed in the circle. The tolerance must catch this.
+function test9() {
+  const cx = 2, cy = 1.5, r = 1.0
+  const n = 72
+  const circlePts: Point[] = []
+  for (let i = 0; i < n; i += 1) {
+    const a = -Math.PI / 2 + (i / n) * 2 * Math.PI
+    circlePts.push({ x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) })
+  }
+  const circle = polygonProfile(circlePts)
+
+  // Endpoints slightly inside the polygon (as happens when a user snaps to
+  // the circle curve, not the polygon edge).
+  const cutter = openPolyline([
+    { x: 1.0878, y: 1.0991 },
+    { x: 2.9149, y: 1.8952 },
+  ])
+
+  const crosses = openCrossesClosedFully(cutter, circle)
+  console.log('test9 openCrossesClosedFully:', crosses)
+  assert(crosses, 'near-boundary chord should fully cross')
+
+  const result = splitClosedByOpen(circle, cutter)
+  console.log('test9 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
+  assert(result !== null, 'result is non-null')
+  assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
+  console.log('test9 PASS')
+}
+
 try {
   test1()
   test2()
@@ -254,6 +286,7 @@ try {
   test6()
   test7()
   test8()
+  test9()
   console.log('\nAll tests PASS')
 } catch (e) {
   console.error(e)

--- a/src/store/polygonSplit.test.ts
+++ b/src/store/polygonSplit.test.ts
@@ -184,72 +184,10 @@ function test5() {
   console.log('test5 PASS')
 }
 
-// Test 6: cutter ends exactly on the top edge of the square.
-// Cutter from (2,-1) outside to (2,4) exactly on the boundary.
+// Test 6: circle endpoint snapped to a 72-gon vertex (exact boundary).
+// With canonical 5° flattening, a snapped curve endpoint lands exactly on
+// the splitter's 72-gon. This exercises the exact-endpoint fix on a curve.
 function test6() {
-  const square = polygonProfile([
-    { x: 0, y: 0 }, { x: 4, y: 0 }, { x: 4, y: 4 }, { x: 0, y: 4 },
-  ])
-  const cutter = openPolyline([{ x: 2, y: -1 }, { x: 2, y: 4 }])
-
-  const crosses = openCrossesClosedFully(cutter, square)
-  console.log('test6 openCrossesClosedFully:', crosses)
-  assert(crosses, 'cutter ending on boundary should fully cross')
-
-  const result = splitClosedByOpen(square, cutter)
-  console.log('test6 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
-  assert(result !== null, 'result is non-null')
-  assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
-  console.log('test6 PASS')
-}
-
-// Test 7: multi-segment cutter where only the last point lands on the boundary.
-// Cutter from (3,-1) outside through (3,2) interior to (2,4) on the top edge.
-function test7() {
-  const square = polygonProfile([
-    { x: 0, y: 0 }, { x: 4, y: 0 }, { x: 4, y: 4 }, { x: 0, y: 4 },
-  ])
-  const cutter = openPolyline([
-    { x: 3, y: -1 },
-    { x: 3, y: 2 },
-    { x: 2, y: 4 },
-  ])
-
-  const crosses = openCrossesClosedFully(cutter, square)
-  console.log('test7 openCrossesClosedFully:', crosses)
-  assert(crosses, 'multi-segment cutter ending on boundary should fully cross')
-
-  const result = splitClosedByOpen(square, cutter)
-  console.log('test7 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
-  assert(result !== null, 'result is non-null')
-  assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
-  console.log('test7 PASS')
-}
-
-// Test 8: both endpoints on the boundary — an interior chord.
-// Cutter from (2,0) to (2,4) — both on square edges, fully crossing.
-function test8() {
-  const square = polygonProfile([
-    { x: 0, y: 0 }, { x: 4, y: 0 }, { x: 4, y: 4 }, { x: 0, y: 4 },
-  ])
-  const cutter = openPolyline([{ x: 2, y: 0 }, { x: 2, y: 4 }])
-
-  const crosses = openCrossesClosedFully(cutter, square)
-  console.log('test8 openCrossesClosedFully:', crosses)
-  assert(crosses, 'interior chord should fully cross')
-
-  const result = splitClosedByOpen(square, cutter)
-  console.log('test8 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
-  assert(result !== null, 'result is non-null')
-  assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
-  console.log('test8 PASS')
-}
-
-// Test 9: near-boundary endpoints on a circle polygon (mimics the real
-// cutter-on-line.camj scenario). The cutter endpoints are snapped to the
-// mathematical circle but land slightly INSIDE the flattened polygon because
-// the polygon is inscribed in the circle. The tolerance must catch this.
-function test9() {
   const cx = 2, cy = 1.5, r = 1.0
   const n = 72
   const circlePts: Point[] = []
@@ -258,23 +196,95 @@ function test9() {
     circlePts.push({ x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) })
   }
   const circle = polygonProfile(circlePts)
-
-  // Endpoints slightly inside the polygon (as happens when a user snaps to
-  // the circle curve, not the polygon edge).
-  const cutter = openPolyline([
-    { x: 1.0878, y: 1.0991 },
-    { x: 2.9149, y: 1.8952 },
-  ])
-
+  // i=0 vertex (bottom) and i=18 vertex (right) — both exact 72-gon vertices.
+  const cutter = openPolyline([circlePts[0], circlePts[18]])
   const crosses = openCrossesClosedFully(cutter, circle)
-  console.log('test9 openCrossesClosedFully:', crosses)
-  assert(crosses, 'near-boundary chord should fully cross')
-
+  console.log('test6 openCrossesClosedFully:', crosses)
+  assert(crosses, 'chord between 72-gon vertices should fully cross')
   const result = splitClosedByOpen(circle, cutter)
-  console.log('test9 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
+  console.log('test6 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
   assert(result !== null, 'result is non-null')
   assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
+  console.log('test6 PASS')
+}
+
+// Test 7: analytic intersection snap on a circle. Endpoints on the
+// mathematical circle (slightly OUTSIDE the inscribed 72-gon) — the cutter
+// crosses the 72-gon boundary twice, no tolerance needed.
+function test7() {
+  const cx = 2, cy = 1.5, r = 1.0
+  const n = 72
+  const circlePts: Point[] = []
+  for (let i = 0; i < n; i += 1) {
+    const a = -Math.PI / 2 + (i / n) * 2 * Math.PI
+    circlePts.push({ x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) })
+  }
+  const circle = polygonProfile(circlePts)
+  // Points on the math circle at non-vertex angles (5° and 185° from -π/2).
+  const a0 = -Math.PI / 2 + (5 * Math.PI) / 180
+  const a1 = -Math.PI / 2 + (185 * Math.PI) / 180
+  const cutter = openPolyline([
+    { x: cx + r * Math.cos(a0), y: cy + r * Math.sin(a0) },
+    { x: cx + r * Math.cos(a1), y: cy + r * Math.sin(a1) },
+  ])
+  const crosses = openCrossesClosedFully(cutter, circle)
+  console.log('test7 openCrossesClosedFully:', crosses)
+  assert(crosses, 'analytic snap endpoints should fully cross')
+  const result = splitClosedByOpen(circle, cutter)
+  console.log('test7 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
+  assert(result !== null, 'result is non-null')
+  assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
+  console.log('test7 PASS')
+}
+
+// Test 8: straight-edge endpoint genuinely INSIDE the polygon is rejected.
+function test8() {
+  const square = polygonProfile([
+    { x: 0, y: 0 }, { x: 4, y: 0 }, { x: 4, y: 4 }, { x: 0, y: 4 },
+  ])
+  // Start strictly inside the square, end outside.
+  const cutter = openPolyline([{ x: 1, y: 1 }, { x: 5, y: 5 }])
+  const crosses = openCrossesClosedFully(cutter, square)
+  console.log('test8 openCrossesClosedFully:', crosses)
+  assert(!crosses, 'cutter starting strictly inside should be rejected')
+  const result = splitClosedByOpen(square, cutter)
+  console.log('test8 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
+  assert(result === null, 'strictly-inside endpoint must reject split')
+  console.log('test8 PASS')
+}
+
+// Test 9: boundary-to-boundary cutter routed OUTSIDE the target is rejected.
+// V-shaped cutter: both endpoints on the bottom edge, middle vertex below.
+function test9() {
+  const square = polygonProfile([
+    { x: 0, y: 0 }, { x: 4, y: 0 }, { x: 4, y: 4 }, { x: 0, y: 4 },
+  ])
+  const cutter = openPolyline([
+    { x: 1, y: 0 },
+    { x: 2, y: -1 },
+    { x: 3, y: 0 },
+  ])
+  const result = splitClosedByOpen(square, cutter)
+  console.log('test9 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
+  assert(result === null, 'cutter routed outside target must be rejected')
   console.log('test9 PASS')
+}
+
+// Test 10: original exact final-endpoint-on-boundary case → 2 pieces.
+function test10() {
+  const square = polygonProfile([
+    { x: 0, y: 0 }, { x: 4, y: 0 }, { x: 4, y: 4 }, { x: 0, y: 4 },
+  ])
+  // Cutter from outside ending exactly on the top edge.
+  const cutter = openPolyline([{ x: 2, y: -1 }, { x: 2, y: 4 }])
+  const crosses = openCrossesClosedFully(cutter, square)
+  console.log('test10 openCrossesClosedFully:', crosses)
+  assert(crosses, 'cutter ending on boundary should fully cross')
+  const result = splitClosedByOpen(square, cutter)
+  console.log('test10 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
+  assert(result !== null, 'result is non-null')
+  assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
+  console.log('test10 PASS')
 }
 
 try {
@@ -287,6 +297,7 @@ try {
   test7()
   test8()
   test9()
+  test10()
   console.log('\nAll tests PASS')
 } catch (e) {
   console.error(e)

--- a/src/store/polygonSplit.test.ts
+++ b/src/store/polygonSplit.test.ts
@@ -184,12 +184,76 @@ function test5() {
   console.log('test5 PASS')
 }
 
+// Test 6: cutter ends exactly on the top edge of the square.
+// Cutter from (2,-1) outside to (2,4) exactly on the boundary.
+function test6() {
+  const square = polygonProfile([
+    { x: 0, y: 0 }, { x: 4, y: 0 }, { x: 4, y: 4 }, { x: 0, y: 4 },
+  ])
+  const cutter = openPolyline([{ x: 2, y: -1 }, { x: 2, y: 4 }])
+
+  const crosses = openCrossesClosedFully(cutter, square)
+  console.log('test6 openCrossesClosedFully:', crosses)
+  assert(crosses, 'cutter ending on boundary should fully cross')
+
+  const result = splitClosedByOpen(square, cutter)
+  console.log('test6 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
+  assert(result !== null, 'result is non-null')
+  assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
+  console.log('test6 PASS')
+}
+
+// Test 7: multi-segment cutter where only the last point lands on the boundary.
+// Cutter from (3,-1) outside through (3,2) interior to (2,4) on the top edge.
+function test7() {
+  const square = polygonProfile([
+    { x: 0, y: 0 }, { x: 4, y: 0 }, { x: 4, y: 4 }, { x: 0, y: 4 },
+  ])
+  const cutter = openPolyline([
+    { x: 3, y: -1 },
+    { x: 3, y: 2 },
+    { x: 2, y: 4 },
+  ])
+
+  const crosses = openCrossesClosedFully(cutter, square)
+  console.log('test7 openCrossesClosedFully:', crosses)
+  assert(crosses, 'multi-segment cutter ending on boundary should fully cross')
+
+  const result = splitClosedByOpen(square, cutter)
+  console.log('test7 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
+  assert(result !== null, 'result is non-null')
+  assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
+  console.log('test7 PASS')
+}
+
+// Test 8: both endpoints on the boundary — an interior chord.
+// Cutter from (2,0) to (2,4) — both on square edges, fully crossing.
+function test8() {
+  const square = polygonProfile([
+    { x: 0, y: 0 }, { x: 4, y: 0 }, { x: 4, y: 4 }, { x: 0, y: 4 },
+  ])
+  const cutter = openPolyline([{ x: 2, y: 0 }, { x: 2, y: 4 }])
+
+  const crosses = openCrossesClosedFully(cutter, square)
+  console.log('test8 openCrossesClosedFully:', crosses)
+  assert(crosses, 'interior chord should fully cross')
+
+  const result = splitClosedByOpen(square, cutter)
+  console.log('test8 result:', result === null ? 'NULL' : `${result.pieces.length} pieces`)
+  assert(result !== null, 'result is non-null')
+  assert(result!.pieces.length === 2, `expected 2 pieces, got ${result!.pieces.length}`)
+  console.log('test8 PASS')
+}
+
 try {
   test1()
   test2()
   test3()
   test4()
   test5()
+  test6()
+  test7()
+  test8()
   console.log('\nAll tests PASS')
 } catch (e) {
   console.error(e)


### PR DESCRIPTION
Closes #431

## Root cause (revised per review — see plan v2 at https://github.com/PureCutCNC/purecutcnc/issues/431#issuecomment-5161287907)
Curve-snapping sampled circles at 10° (36-gon) while `flattenProfile` (used by the splitter and Clipper) uses 5° (72-gon). A cutter endpoint snapped to a circle landed on the 36-gon chord, slightly inside the 72-gon the splitter consumes (~0.003 units for a unit circle). The original exact-endpoint bug (`segmentIntersect` half-open `[0,1)` omitting `t=1`) was also real.

## Changes (plan v2)
1. **Canonical flattening (root-cause fix):** `sampleSegmentPolyline` in `src/components/canvas/draftGeometry.ts` now uses `DEFAULT_FLATTEN_ARC_STEP` (π/36, 5°) from `engine/toolpaths/geometry`, matching `flattenProfile`. Snapped curve endpoints land on the same 72-gon the splitter consumes.
2. **Removed the broad `polygonTolerance`** (5% of shortest edge from the first revision) — it misclassified genuinely interior endpoints on straight polygons. `pointOnPolygonBoundary` is back to exact `EPSILON` matching; straight boundaries stay strict.
3. **Kept the exact final-endpoint fix** (`pointOnPolygonBoundary` helper + endpoint-as-crossing logic) for endpoints landing exactly on the boundary.
4. **Added subpath validation** in `splitClosedByOpen`: every intermediate L vertex between a paired entry/exit must lie inside (or on) the polygon. Rejects cutters that route outside the target between two boundary crossings (e.g. a V-shaped cutter `(1,0)→(2,-1)→(3,0)` dipping out and back through the same edge), which previously produced the unchanged target plus an outside triangle.

## Tests (`src/store/polygonSplit.test.ts`)
- `test6`: 72-gon vertex chord (canonical snap consumed by the splitter) → 2 pieces
- `test7`: analytic intersection on a circle (endpoints on the math circle, outside the inscribed 72-gon) → 2 pieces
- `test8`: straight-edge endpoint genuinely inside the polygon → rejected
- `test9`: boundary-to-boundary cutter routed outside the target → rejected
- `test10`: original exact final-endpoint-on-boundary case → 2 pieces
- `test1`–`test5` unchanged

## Verification
- `npx tsx src/store/polygonSplit.test.ts` — all 10 tests pass
- `npm run build` — green (lint + tsc + 158 test files + vite)
- `npm run test:e2e` — 85 passed (canvas-side snapping change verified not to regress)

## Note on stale files
Files saved with the old 10° snapping (e.g. `work/cutter-on-line.camj`) have cutter endpoints baked at 36-gon positions, slightly inside the 72-gon, so they remain rejected under exact matching. This is accepted per plan v2 — the fix applies to new projects where 5° snapping lands endpoints on the 72-gon. Curve-edge provenance tolerance for stale files is deferred to a follow-up if needed.

## Scope
Three files, ~91 non-test changed lines. Not eligible for fast-lane (91 > 25), so full lane: plan v2 approved on issue #431.