### PR TITLE
fix: derive worktree base from repo location, not a hardcoded path

### DIFF
--- a/.agents/skills/manager-delegate/SKILL.md
+++ b/.agents/skills/manager-delegate/SKILL.md
@@ -110,9 +110,8 @@ scripts call. Do not modify it.
 
 ## Guardrails (enforced by the scripts — do not re-derive)
 
-- Worktrees live under `$PURECUT_WORKTREE_BASE`
-  (default `/Users/frankp/Projects/worktrees/purecutcnc`), never the primary
-  checkout or `main`.
+- Worktrees live under `$PURECUT_WORKTREE_BASE` — by default a `worktrees/<repo-name>`
+  directory beside the repository — never the primary checkout or `main`.
 - Branch-first, always: `feat/issue-NN-SLUG` off the integration branch.
 - Independent build gate (`npm run build`) after the worker — the worker's
   reported checks are not trusted.

--- a/scripts/dispatch-task.sh
+++ b/scripts/dispatch-task.sh
@@ -18,7 +18,7 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 readonly LEAF="$SCRIPT_DIR/run-claude-deepseek-agent.sh"
 readonly DEFAULT_BASE="feat/core-arch-simplification"
-WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-/Users/frankp/Projects/worktrees/purecutcnc}"
+WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-$(dirname "$REPO_ROOT")/worktrees/$(basename "$REPO_ROOT")}"
 
 usage() {
   cat <<'EOF'

--- a/scripts/finish-task.sh
+++ b/scripts/finish-task.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 readonly DEFAULT_BASE="feat/core-arch-simplification"
-WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-/Users/frankp/Projects/worktrees/purecutcnc}"
+WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-$(dirname "$REPO_ROOT")/worktrees/$(basename "$REPO_ROOT")}"
 
 usage() {
   cat <<'EOF'

--- a/scripts/worker-status.sh
+++ b/scripts/worker-status.sh
@@ -10,7 +10,9 @@
 
 set -euo pipefail
 
-WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-/Users/frankp/Projects/worktrees/purecutcnc}"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-$(dirname "$REPO_ROOT")/worktrees/$(basename "$REPO_ROOT")}"
 
 usage() {
   cat <<'EOF'


### PR DESCRIPTION
Closes #435

The three integration-manager scripts (`dispatch-task.sh`, `finish-task.sh`, `worker-status.sh`) and the `manager-delegate` SKILL.md hardcoded the worktree base default to an absolute path under the maintainer's home. Any other contributor running `dispatch-task.sh` got a worktree created under a tree unrelated to their checkout.

Derive the default from the repository's own location instead:

```bash
WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-$(dirname "$REPO_ROOT")/worktrees/$(basename "$REPO_ROOT")}"
```

`PURECUT_WORKTREE_BASE` still overrides in all three scripts. `worker-status.sh` now derives `REPO_ROOT` with the same `SCRIPT_DIR` idiom as the other two (it previously had neither).

**Behaviour-preserving on this checkout:** with `REPO_ROOT=/Users/frankp/Projects/purecutcnc`, the expression evaluates to `/Users/frankp/Projects/worktrees/purecutcnc` — byte-identical to the literal it replaces.

## Acceptance criteria

- [x] No absolute filesystem path remains in the three scripts or the SKILL.md guardrail.
- [x] `PURECUT_WORKTREE_BASE` still overrides the default in all three scripts.
- [x] `worker-status.sh` derives `REPO_ROOT` using the same idiom as the other two.
- [x] Behaviour on this checkout is unchanged (derived default == old literal).
- [x] `npm run build` green.

## Verification

1. **No behaviour change here** — derived default asserted equal to `/Users/frankp/Projects/worktrees/purecutcnc`.
2. **Portability, actually tested** — copied the three scripts into a throwaway dir at `/var/folders/.../porttest/somerepo/scripts/`, evaluated the derivation, confirmed the base resolved to `…/porttest/worktrees/somerepo` (tracks the copy, not the maintainer's home). Also confirmed `PURECUT_WORKTREE_BASE` override still wins.
3. `bash -n` clean on all three scripts; `npm run build` green (158/158 test files, lint, tsc, vite).

## Out of scope (per issue)

Diagnostic scripts pointing into gitignored `work/`, and `planning/` handoff records — left untouched for the reasons in #435.

## Files

| File | Change |
| --- | --- |
| `scripts/dispatch-task.sh` | Swap default to derived expression (`REPO_ROOT` already defined above). |
| `scripts/finish-task.sh` | Same (`REPO_ROOT` already defined above). |
| `scripts/worker-status.sh` | Add `SCRIPT_DIR`/`REPO_ROOT` derivation + swap default. |
| `.agents/skills/manager-delegate/SKILL.md` | Replace absolute-path parenthetical with a description of the derived default. |