### PR TITLE
process: make the fast lane discoverable and self-authorizing

### DIFF
--- a/.clauderules
+++ b/.clauderules
@@ -3,5 +3,7 @@ for the assigned-task workflow, task router, coding rules, and verification.
 Read ARCHITECTURE.md only for technical contracts and the one matching
 planning/*.md document for a durable design reference.
 
-Every task plan and acceptance criteria live in an approved GitHub issue.
+Every task gets a GitHub issue; its plan and acceptance criteria live there and
+need approval before implementation. Small changes that pass the AGENTS.md
+fast-lane check skip the plan and approval, nothing else.
 planning/ contains durable design references, not implementation plans.

--- a/.clinerules
+++ b/.clinerules
@@ -3,5 +3,7 @@ for the assigned-task workflow, task router, coding rules, and verification.
 Read ARCHITECTURE.md only for technical contracts and the one matching
 planning/*.md document for a durable design reference.
 
-Every task plan and acceptance criteria live in an approved GitHub issue.
+Every task gets a GitHub issue; its plan and acceptance criteria live there and
+need approval before implementation. Small changes that pass the AGENTS.md
+fast-lane check skip the plan and approval, nothing else.
 planning/ contains durable design references, not implementation plans.

--- a/.cursorrules
+++ b/.cursorrules
@@ -3,5 +3,7 @@ for the assigned-task workflow, task router, coding rules, and verification.
 Read ARCHITECTURE.md only for technical contracts and the one matching
 planning/*.md document for a durable design reference.
 
-Every task plan and acceptance criteria live in an approved GitHub issue.
+Every task gets a GitHub issue; its plan and acceptance criteria live there and
+need approval before implementation. Small changes that pass the AGENTS.md
+fast-lane check skip the plan and approval, nothing else.
 planning/ contains durable design references, not implementation plans.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,5 +5,7 @@ Start with `INDEX.md`, then read `PROJECT.md` for the product contract and
 verification. Read `ARCHITECTURE.md` only for technical contracts and the one
 matching `planning/*.md` document for a durable design reference.
 
-Every task plan and acceptance criteria live in an approved GitHub issue.
+Every task gets a GitHub issue; its plan and acceptance criteria live there and
+need approval before implementation. Small changes that pass the `AGENTS.md`
+fast-lane check skip the plan and approval, nothing else.
 `planning/` contains durable design references, not implementation plans.

--- a/.roorules
+++ b/.roorules
@@ -1,3 +1,9 @@
-Read and follow `AGENTS.md` for project overview, build commands, coding standards, directory layout, and key conventions.
-Read `ARCHITECTURE.md` for deeper architectural detail.
-Consult `planning/` for feature-specific implementation plans before starting work.
+Start with INDEX.md, then read PROJECT.md for the product contract and AGENTS.md
+for the assigned-task workflow, task router, coding rules, and verification.
+Read ARCHITECTURE.md only for technical contracts and the one matching
+planning/*.md document for a durable design reference.
+
+Every task gets a GitHub issue; its plan and acceptance criteria live there and
+need approval before implementation. Small changes that pass the AGENTS.md
+fast-lane check skip the plan and approval, nothing else.
+planning/ contains durable design references, not implementation plans.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,3 +1,9 @@
-Read and follow `AGENTS.md` for project overview, build commands, coding standards, directory layout, and key conventions.
-Read `ARCHITECTURE.md` for deeper architectural detail.
-Consult `planning/` for feature-specific implementation plans before starting work.
+Start with INDEX.md, then read PROJECT.md for the product contract and AGENTS.md
+for the assigned-task workflow, task router, coding rules, and verification.
+Read ARCHITECTURE.md only for technical contracts and the one matching
+planning/*.md document for a durable design reference.
+
+Every task gets a GitHub issue; its plan and acceptance criteria live there and
+need approval before implementation. Small changes that pass the AGENTS.md
+fast-lane check skip the plan and approval, nothing else.
+planning/ contains durable design references, not implementation plans.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Eligibility is mechanical, never a judgment call. The two halves are answerable 
 
 **Before you write anything — protected paths.** You already know which files you will edit. If any is protected, it is the full lane; decided, no script needed. However small the diff: machine output and safety (`src/engine/toolpaths/**`, `src/engine/gcode/**`, `src/machine/**`, `src/utils/units.ts`), the `.camj` format and its migrations (`src/types/project.ts`, `src/store/helpers/projectFormat.ts`, `src/import/camj.ts`), the frozen `ProjectStore` contract (`src/store/types.ts`), and the process/gate machinery itself (`AGENTS.md`, `PROJECT.md`, `ARCHITECTURE.md`, `.github/**`, `.claude/**`, the gate scripts under `scripts/`, `package.json`, `tsconfig*.json`, `eslint.config.js`). [`scripts/check-fast-lane.sh`](scripts/check-fast-lane.sh) owns the authoritative list — add to it whenever a new gate lands.
 
-**After implementing, before you commit — size.** This needs a real diff, so it cannot be answered earlier:
+**After implementing, before you commit — size.** This needs a real diff, so it cannot be answered earlier. The script re-checks the paths too, so a file set that grew mid-implementation is still caught here:
 
 ```bash
 npm run check:fast-lane

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,11 @@ If the `codebase-memory-mcp` server is connected, prefer its graph tools (`searc
 
 ## Workflow: Issue → Plan → Approve → Implement → PR
 
-**Every task follows this loop. No exceptions — even a one-line bug fix gets an issue and a short plan.** The plan can be tiny if the task is tiny; the point is that intent is written down, agreed, and traceable. Tasks are tracked on the GitHub Project board ([PureCutCNC project #1](https://github.com/orgs/PureCutCNC/projects/1)), **not** in checked-in plan files.
+**Every task follows this loop, and every task gets an issue.** The only steps a change may skip are 2 and 3 (Plan and Approve), and only when the **Fast lane** below says so — nothing else here is optional. The plan can be tiny if the task is tiny; the point is that intent is written down, agreed, and traceable. Tasks are tracked on the GitHub Project board ([PureCutCNC project #1](https://github.com/orgs/PureCutCNC/projects/1)), **not** in checked-in plan files.
 
 1. **Issue.** Open a GitHub issue for the work (`gh issue create`). Add it to the Project board, set the area label and Size, and set Status to `Backlog` (or `Ready` once planned).
-2. **Plan.** Before changing any code, write the plan **in the issue** — in the body, or a follow-up comment if it grows. Do not create a `planning/*_Plan.md` file; the issue is the plan's home.
-3. **Approve.** Share the issue with the user and **wait for an explicit "approved" (or equivalent) signal**. Do not start implementation before approval. If the user asks for changes, edit the issue and re-confirm. On approval, set Status to `Ready`.
+2. **Plan.** Before changing any code, write the plan **in the issue** — in the body, or a follow-up comment if it grows. Do not create a `planning/*_Plan.md` file; the issue is the plan's home. **Fast lane: skipped — check below before you write a plan.**
+3. **Approve.** Share the issue with the user and **wait for an explicit "approved" (or equivalent) signal**. Do not start implementation before approval. If the user asks for changes, edit the issue and re-confirm. On approval, set Status to `Ready`. **Fast lane: skipped — do not ask.**
 4. **Implement.** Branch (`<type>/issue-<NN>-<slug>`), set the board Status to `In progress`, and implement against the plan in the issue. If the plan changes mid-flight, edit the issue so it stays the source of truth.
 5. **PR when done.** When work is complete and the build is green, open the PR with `Closes #NN` in the description. Move Status to `In review`. The PR is created at the **end** as the delivery — it is not where the plan lives.
 6. **Merge.** Merging auto-closes the issue and moves the card to `Done`.
@@ -33,16 +33,21 @@ Abandoned work: close the issue with a short reason; the board moves it to `Done
 
 A change that provably cannot affect machine output, saved projects, or the gates themselves may skip **Plan** and **Approve**. Nothing else changes: still an issue first (the branch name needs its number), still a branch, still green `npm run build`, still a PR with `Closes #NN`, still the board. Every rule in **Build & Verify**, **Git & Branching**, and **Coding Standards** applies unchanged — license header, no `any`, unit tests for engine fixes, e2e when rendered DOM / menu wiring / dialog behavior changes.
 
-Eligibility is mechanical, never a judgment call:
+Eligibility is mechanical, never a judgment call. The two halves are answerable at different times.
+
+**Before you write anything — protected paths.** You already know which files you will edit. If any is protected, it is the full lane; decided, no script needed. However small the diff: machine output and safety (`src/engine/toolpaths/**`, `src/engine/gcode/**`, `src/machine/**`, `src/utils/units.ts`), the `.camj` format and its migrations (`src/types/project.ts`, `src/store/helpers/projectFormat.ts`, `src/import/camj.ts`), the frozen `ProjectStore` contract (`src/store/types.ts`), and the process/gate machinery itself (`AGENTS.md`, `PROJECT.md`, `ARCHITECTURE.md`, `.github/**`, `.claude/**`, the gate scripts under `scripts/`, `package.json`, `tsconfig*.json`, `eslint.config.js`). [`scripts/check-fast-lane.sh`](scripts/check-fast-lane.sh) owns the authoritative list — add to it whenever a new gate lands.
+
+**After implementing, before you commit — size.** This needs a real diff, so it cannot be answered earlier:
 
 ```bash
-npm run check:fast-lane   # before branching, and again before opening the PR
+npm run check:fast-lane
 ```
 
-It measures the diff against `git merge-base origin/main HEAD` and fails unless both hold:
+It measures against `git merge-base origin/main HEAD` and passes at ≤ 3 changed files and ≤ 25 changed lines (added + deleted). Test files (`**/*.test.ts(x)`, `e2e/**`) are exempt from both counts — never trim a test to fit the budget. Generated output (`public/icons.svg`, `package-lock.json`) is counted; if regenerating it blows the budget, take the full lane.
 
-- **Size:** ≤ 3 changed files and ≤ 25 changed lines (added + deleted). Test files (`**/*.test.ts(x)`, `e2e/**`) are exempt from both counts — never trim a test to fit the budget. Generated output (`public/icons.svg`, `package-lock.json`) is counted; if regenerating it blows the budget, take the full lane.
-- **No protected path is touched**, however small the diff: machine output and safety (`src/engine/toolpaths/**`, `src/engine/gcode/**`, `src/machine/**`, `src/utils/units.ts`), the `.camj` format and its migrations (`src/types/project.ts`, `src/store/helpers/projectFormat.ts`, `src/import/camj.ts`), the frozen `ProjectStore` contract (`src/store/types.ts`), and the process/gate machinery itself (`AGENTS.md`, `PROJECT.md`, `ARCHITECTURE.md`, `.github/**`, `.claude/**`, the gate scripts under `scripts/`, `package.json`, `tsconfig*.json`, `eslint.config.js`). [`scripts/check-fast-lane.sh`](scripts/check-fast-lane.sh) owns the authoritative list — add to it whenever a new gate lands.
+Green → skip Plan and Approve. Red → full lane: write the plan into the issue and wait for approval.
+
+**Do not ask whether you may use the fast lane.** A green check is the authorization. Asking reintroduces exactly the round-trip the lane exists to remove.
 
 **Label the PR `fast-lane`.** The `fast-lane-guard` CI job ([`.github/workflows/fast-lane-guard.yml`](.github/workflows/fast-lane-guard.yml)) re-runs the check on every labeled PR, so a labeled PR that does not meet the criteria cannot merge.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,9 @@ Start with `INDEX.md`, then read `PROJECT.md` for the product contract and
 verification. Read `ARCHITECTURE.md` only for technical contracts and the one
 matching `planning/*.md` document for a durable design reference.
 
-Every task plan and acceptance criteria live in an approved GitHub issue.
+Every task gets a GitHub issue; its plan and acceptance criteria live there and
+need approval before implementation. Small changes that pass the `AGENTS.md`
+fast-lane check skip the plan and approval, nothing else.
 `planning/` contains durable design references, not implementation plans.
 
 Delegation to Codex or a project worker is optional, not the default. Use it

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -5,5 +5,7 @@ Start with `INDEX.md`, then read `PROJECT.md` for the product contract and
 verification. Read `ARCHITECTURE.md` only for technical contracts and the one
 matching `planning/*.md` document for a durable design reference.
 
-Every task plan and acceptance criteria live in an approved GitHub issue.
+Every task gets a GitHub issue; its plan and acceptance criteria live there and
+need approval before implementation. Small changes that pass the `AGENTS.md`
+fast-lane check skip the plan and approval, nothing else.
 `planning/` contains durable design references, not implementation plans.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,5 +5,7 @@ Start with `INDEX.md`, then read `PROJECT.md` for the product contract and
 verification. Read `ARCHITECTURE.md` only for technical contracts and the one
 matching `planning/*.md` document for a durable design reference.
 
-Every task plan and acceptance criteria live in an approved GitHub issue.
+Every task gets a GitHub issue; its plan and acceptance criteria live there and
+need approval before implementation. Small changes that pass the `AGENTS.md`
+fast-lane check skip the plan and approval, nothing else.
 `planning/` contains durable design references, not implementation plans.

--- a/scripts/docs-check-core.ts
+++ b/scripts/docs-check-core.ts
@@ -34,6 +34,8 @@ export const AGENT_ENTRYPOINTS = [
   '.clinerules',
   '.clauderules',
   '.github/copilot-instructions.md',
+  '.roorules',
+  '.windsurfrules',
 ] as const
 
 const REQUIRED_AGENT_MARKERS = [


### PR DESCRIPTION
Closes #432

The fast lane (#418) worked mechanically but agents would not take it, because
three higher-priority instructions told them to ask. This changes only wording —
no criteria, no thresholds, no CI logic.

## What changed

**`AGENTS.md`** (net +5 lines)

- The bolded gate no longer says "No exceptions". It names the fast lane as the
  one thing a change may skip, and only steps 2 and 3.
- Steps 2 and 3 each carry a forward reference, so an agent walking the numbered
  list meets the lane *before* it writes a plan or requests approval.
- The eligibility check is split into the two halves that are answerable at
  different times: protected paths before writing anything (no script needed,
  you already know the files), size after implementing and before committing
  (needs a real diff). This replaces `# before branching`, which could not be
  followed literally — with no diff yet, the script prints
  "No changes against the base — nothing to check yet."
- Adds the missing standing authority: **a green check is the authorization**,
  do not ask.

**Nine agent entrypoints**

`CLAUDE.md`, `GEMINI.md`, `CONVENTIONS.md`, `.cursorrules`, `.clinerules`,
`.clauderules`, `.github/copilot-instructions.md` — the unconditional sentence
"Every task plan and acceptance criteria live in an approved GitHub issue" now
carves out the lane. These load before `AGENTS.md`, so they were overriding it.

`.roorules` and `.windsurfrules` were stale in a second way, still pointing at
`planning/` for implementation plans. Both are rewritten to the standard body.

**`scripts/docs-check-core.ts`**

`.roorules` and `.windsurfrules` join `AGENT_ENTRYPOINTS`. They drifted precisely
because nothing checked them; rewording alone would have left that cause in
place. `npm run docs:check` now validates all nine.

## Verification

- `npm run build` — green (run as an independent gate, not self-reported).
- `docs:check` — `OK (53 active docs, 10 planning references, 9 agent entrypoints)`.
- Negative check on the newly-gated file: reverting `.roorules` to its previous
  body makes `docs:check` exit 1 with four missing markers
  (`INDEX.md`, `PROJECT.md`, `GitHub issue`, `durable design`); restoring it
  returns exit 0. A gate that has never rejected anything is not known to work.

  Note the check described in the issue — re-adding only the stale `planning/`
  line — cannot fail, because `validateAgentEntrypoint` reports *missing*
  markers and ignores extra lines. Reverting the whole body is the check that
  actually exercises the gate.

- No change to `scripts/check-fast-lane.sh`,
  `.github/workflows/fast-lane-guard.yml`, or the required-check wiring —
  visible in the diff.
- `AGENTS.md` net addition is +5 against the ≤ 10 budget.

## Not verified here, by design

The behavioural criteria in the issue stay open. They cannot be tested against
already-implemented work — a first-contact test cannot be re-run on a finished
task. They get checked against the next eligible change: red path (over budget →
implement, run the check, get red, *then* plan and ask) and green path (eligible
→ check, green, labelled PR, no approval request). If agents are still asking
after two or three eligible changes, reopen — the next lever is the entrypoint
files, not more prose in `AGENTS.md`.
