### PR TITLE
fix: resolve worktree target dir in block-default-branch-commit hook

### DIFF
--- a/.claude/hooks/block-default-branch-commit.sh
+++ b/.claude/hooks/block-default-branch-commit.sh
@@ -12,87 +12,114 @@
 # when no directory is given we fall back to the cwd (the primary checkout).
 # That fallback is fail-closed: in a worktree-driven session the primary sits
 # on main, so an unresolvable target denies rather than slips through.
+#
+# Compound commands are checked in full: the command is split on chain
+# operators (&&, ||, ;, |, &) and every `git commit` segment is resolved. A
+# `cd <path>` segment updates the running directory for later segments (as it
+# would in a real shell); `git -C <path>` applies only within its own segment
+# (git never changes the shell cwd). If ANY commit segment resolves to the
+# default branch the whole command is denied — `git -C /feature commit && git
+# commit` does not get to slip the second commit onto main.
 
 input=$(cat)
 command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
 
-# Only act on an actual `git commit` invocation (also catches it inside a
-# compound command like `git add -A && git commit`). Does not match
-# `git commit-tree`, `git log --grep=commit`, etc.
-#
-# Capture the segment between `git` and `commit` (the global-options segment)
-# so we can parse `-C <path>` from it. `-C` appearing after `commit` is
-# `git commit -C <commit-ish>` (reuse message), not a directory, so it is
-# deliberately excluded from that segment.
+# Tokenize the command into segments by chain operators so every `git commit`
+# in a compound command is checked, not just the first. Operators are replaced
+# with newlines (length-descending: && before &, || before |) so multi-char
+# operators are not split into single chars.
+nl=$'\n'
+split="$command"
+split="${split//&&/$nl}"
+split="${split//||/$nl}"
+split="${split//;/$nl}"
+split="${split//|/$nl}"
+split="${split//&/$nl}"
+
+# Matches a `git commit` invocation and captures the global-options segment
+# between `git` and `commit`. `-C` after `commit` is `git commit -C <commit>`
+# (reuse message), not a directory, so only the pre-`commit` segment is
+# scanned for -C. Does not match `git commit-tree`, `git log --grep=commit`.
 detect_re='(^|[^[:alnum:]])git[[:space:]]+([^|;&]*[[:space:]])?commit([[:space:]]|$)'
-if ! [[ $command =~ $detect_re ]]; then
-  exit 0
-fi
-global_opts="${BASH_REMATCH[2]}"
-
-# Resolve the directory the git command targets. Start from the hook's cwd
-# (the primary checkout) and apply a leading `cd <path>` and any `git -C
-# <path>` global options cumulatively — matching git's own semantics.
-target="$(pwd)"
-
-# A leading `cd <path> &&` (or `;`) redirects the working directory for the
-# rest of the command. The path may be single- or double-quoted.
-cd_re="^[[:space:]]*cd[[:space:]]+(\"([^\"]+)\"|'([^']+)'|([^[:space:]&;|]+))[[:space:]]*(&&|;)[[:space:]]*(.*)$"
-if [[ $command =~ $cd_re ]]; then
-  cd_target="${BASH_REMATCH[2]:-${BASH_REMATCH[3]:-${BASH_REMATCH[4]}}}"
-  if [[ $cd_target == /* ]]; then
-    target="$cd_target"
-  else
-    target="$target/$cd_target"
-  fi
-fi
-
-# `git -C <path>` global options, applied in order. Handles both `-C <path>`
-# (separated) and `-C<path>` (joined); paths may be quoted. Other global
-# options are skipped one token at a time so a later -C is still picked up.
+# A `cd <path>` segment (own segment after splitting) updates the running cwd.
+cd_re="^[[:space:]]*cd[[:space:]]+(\"([^\"]+)\"|'([^']+)'|([^[:space:]&;|]+))[[:space:]]*$"
+# `git -C <path>` and `git -C<path>` global options; paths may be quoted.
 c_re="^-C[[:space:]]+(\"([^\"]+)\"|'([^']+)'|([^[:space:]]+))(.*)$"
 c_re_joined="^-C(\"([^\"]+)\"|'([^']+)'|([^[:space:]]+))(.*)$"
-opts="$global_opts"
-while :; do
-  # Trim leading whitespace.
-  while [[ $opts == [[:space:]]* ]]; do opts="${opts#?}"; done
-  [ -z "$opts" ] && break
-  if [[ $opts =~ $c_re ]]; then
-    p="${BASH_REMATCH[2]:-${BASH_REMATCH[3]:-${BASH_REMATCH[4]}}}"
-    opts="${BASH_REMATCH[5]}"
-  elif [[ $opts =~ $c_re_joined ]]; then
-    p="${BASH_REMATCH[2]:-${BASH_REMATCH[3]:-${BASH_REMATCH[4]}}}"
-    opts="${BASH_REMATCH[5]}"
-  else
-    # Some other token; drop it and keep scanning for a later -C.
-    [[ $opts =~ ^([^[:space:]]+) ]] && opts="${opts#"${BASH_REMATCH[1]}"}"
-    continue
-  fi
-  [ -z "$p" ] && break
-  if [[ $p == /* ]]; then
-    target="$p"
-  else
-    target="$target/$p"
-  fi
-done
+
+# Resolve a path against a base: absolute overrides, relative stacks.
+join_path() {
+  local base="$1" p="$2"
+  if [[ $p == /* ]]; then printf '%s' "$p"; else printf '%s/%s' "$base" "$p"; fi
+}
 
 # symbolic-ref reports the branch name even before the first commit (unborn
-# branch); fall back to rev-parse for the detached-HEAD case.
+# branch); fall back to rev-parse for the detached-HEAD case. Empty if the
+# path is not a git worktree.
 probe_branch() {
   git -C "$1" symbolic-ref --short -q HEAD 2>/dev/null \
     || git -C "$1" rev-parse --abbrev-ref HEAD 2>/dev/null
 }
-branch="$(probe_branch "$target")"
 
-# If a target was parsed but the probe came back empty (bad path / not a git
-# dir), fall back to the cwd — fail-closed, since the cwd here is the primary
-# checkout, which sits on main in a worktree-driven session.
-if [ -z "$branch" ] && [ "$target" != "$(pwd)" ]; then
-  branch="$(probe_branch "$(pwd)")"
-fi
+cwd="$(pwd)"
+running_dir="$cwd"   # tracks `cd` across segments
+deny_branch=""
 
-if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
-  jq -n --arg b "$branch" '{
+while IFS= read -r segment; do
+  # Trim leading whitespace.
+  seg="$segment"
+  while [[ $seg == [[:space:]]* ]]; do seg="${seg#?}"; done
+  [ -z "$seg" ] && continue
+
+  # A `cd <path>` segment updates the running directory for later segments.
+  if [[ $seg =~ $cd_re ]]; then
+    cd_target="${BASH_REMATCH[2]:-${BASH_REMATCH[3]:-${BASH_REMATCH[4]}}}"
+    running_dir="$(join_path "$running_dir" "$cd_target")"
+    continue
+  fi
+
+  # Is this segment a `git commit`? If not, skip it (e.g. `git add -A`).
+  if ! [[ $seg =~ $detect_re ]]; then
+    continue
+  fi
+  global_opts="${BASH_REMATCH[2]}"
+
+  # Resolve this commit's target: start from the running dir, apply this
+  # segment's -C options cumulatively (absolute overrides, relative stacks).
+  target="$running_dir"
+  opts="$global_opts"
+  while :; do
+    while [[ $opts == [[:space:]]* ]]; do opts="${opts#?}"; done
+    [ -z "$opts" ] && break
+    if [[ $opts =~ $c_re ]]; then
+      p="${BASH_REMATCH[2]:-${BASH_REMATCH[3]:-${BASH_REMATCH[4]}}}"
+      opts="${BASH_REMATCH[5]}"
+    elif [[ $opts =~ $c_re_joined ]]; then
+      p="${BASH_REMATCH[2]:-${BASH_REMATCH[3]:-${BASH_REMATCH[4]}}}"
+      opts="${BASH_REMATCH[5]}"
+    else
+      # Some other token; drop it and keep scanning for a later -C.
+      [[ $opts =~ ^([^[:space:]]+) ]] && opts="${opts#"${BASH_REMATCH[1]}"}"
+      continue
+    fi
+    [ -z "$p" ] && break
+    target="$(join_path "$target" "$p")"
+  done
+
+  branch="$(probe_branch "$target")"
+  # Unresolvable target: fall back to cwd — fail-closed, since the primary
+  # sits on main in a worktree-driven session.
+  if [ -z "$branch" ] && [ "$target" != "$cwd" ]; then
+    branch="$(probe_branch "$cwd")"
+  fi
+  if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+    deny_branch="$branch"
+    break
+  fi
+done <<< "$split"
+
+if [ -n "$deny_branch" ]; then
+  jq -n --arg b "$deny_branch" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",

--- a/.claude/hooks/block-default-branch-commit.sh
+++ b/.claude/hooks/block-default-branch-commit.sh
@@ -5,6 +5,13 @@
 #
 # Wired up in .claude/settings.json. Reads the Claude Code hook payload (JSON)
 # on stdin and, to block, prints a PreToolUse deny decision as JSON on stdout.
+#
+# The hook process runs in the primary checkout, but the command being judged
+# may target a different worktree via `git -C <path>` or `cd <path> &&`. We
+# parse the target directory out of the command and probe the branch there;
+# when no directory is given we fall back to the cwd (the primary checkout).
+# That fallback is fail-closed: in a worktree-driven session the primary sits
+# on main, so an unresolvable target denies rather than slips through.
 
 input=$(cat)
 command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
@@ -12,13 +19,78 @@ command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
 # Only act on an actual `git commit` invocation (also catches it inside a
 # compound command like `git add -A && git commit`). Does not match
 # `git commit-tree`, `git log --grep=commit`, etc.
-if ! printf '%s' "$command" | grep -Eq '(^|[^[:alnum:]])git[[:space:]]+([^|;&]*[[:space:]])?commit([[:space:]]|$)'; then
+#
+# Capture the segment between `git` and `commit` (the global-options segment)
+# so we can parse `-C <path>` from it. `-C` appearing after `commit` is
+# `git commit -C <commit-ish>` (reuse message), not a directory, so it is
+# deliberately excluded from that segment.
+detect_re='(^|[^[:alnum:]])git[[:space:]]+([^|;&]*[[:space:]])?commit([[:space:]]|$)'
+if ! [[ $command =~ $detect_re ]]; then
   exit 0
 fi
+global_opts="${BASH_REMATCH[2]}"
+
+# Resolve the directory the git command targets. Start from the hook's cwd
+# (the primary checkout) and apply a leading `cd <path>` and any `git -C
+# <path>` global options cumulatively — matching git's own semantics.
+target="$(pwd)"
+
+# A leading `cd <path> &&` (or `;`) redirects the working directory for the
+# rest of the command. The path may be single- or double-quoted.
+cd_re="^[[:space:]]*cd[[:space:]]+(\"([^\"]+)\"|'([^']+)'|([^[:space:]&;|]+))[[:space:]]*(&&|;)[[:space:]]*(.*)$"
+if [[ $command =~ $cd_re ]]; then
+  cd_target="${BASH_REMATCH[2]:-${BASH_REMATCH[3]:-${BASH_REMATCH[4]}}}"
+  if [[ $cd_target == /* ]]; then
+    target="$cd_target"
+  else
+    target="$target/$cd_target"
+  fi
+fi
+
+# `git -C <path>` global options, applied in order. Handles both `-C <path>`
+# (separated) and `-C<path>` (joined); paths may be quoted. Other global
+# options are skipped one token at a time so a later -C is still picked up.
+c_re="^-C[[:space:]]+(\"([^\"]+)\"|'([^']+)'|([^[:space:]]+))(.*)$"
+c_re_joined="^-C(\"([^\"]+)\"|'([^']+)'|([^[:space:]]+))(.*)$"
+opts="$global_opts"
+while :; do
+  # Trim leading whitespace.
+  while [[ $opts == [[:space:]]* ]]; do opts="${opts#?}"; done
+  [ -z "$opts" ] && break
+  if [[ $opts =~ $c_re ]]; then
+    p="${BASH_REMATCH[2]:-${BASH_REMATCH[3]:-${BASH_REMATCH[4]}}}"
+    opts="${BASH_REMATCH[5]}"
+  elif [[ $opts =~ $c_re_joined ]]; then
+    p="${BASH_REMATCH[2]:-${BASH_REMATCH[3]:-${BASH_REMATCH[4]}}}"
+    opts="${BASH_REMATCH[5]}"
+  else
+    # Some other token; drop it and keep scanning for a later -C.
+    [[ $opts =~ ^([^[:space:]]+) ]] && opts="${opts#"${BASH_REMATCH[1]}"}"
+    continue
+  fi
+  [ -z "$p" ] && break
+  if [[ $p == /* ]]; then
+    target="$p"
+  else
+    target="$target/$p"
+  fi
+done
 
 # symbolic-ref reports the branch name even before the first commit (unborn
 # branch); fall back to rev-parse for the detached-HEAD case.
-branch=$(git symbolic-ref --short -q HEAD || git rev-parse --abbrev-ref HEAD 2>/dev/null)
+probe_branch() {
+  git -C "$1" symbolic-ref --short -q HEAD 2>/dev/null \
+    || git -C "$1" rev-parse --abbrev-ref HEAD 2>/dev/null
+}
+branch="$(probe_branch "$target")"
+
+# If a target was parsed but the probe came back empty (bad path / not a git
+# dir), fall back to the cwd — fail-closed, since the cwd here is the primary
+# checkout, which sits on main in a worktree-driven session.
+if [ -z "$branch" ] && [ "$target" != "$(pwd)" ]; then
+  branch="$(probe_branch "$(pwd)")"
+fi
+
 if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
   jq -n --arg b "$branch" '{
     hookSpecificOutput: {


### PR DESCRIPTION
## Closes #439

## Problem
`block-default-branch-commit.sh` denied legitimate commits aimed at a feature branch in a worktree. The hook probed its own cwd (the primary checkout, on `main` in a worktree-driven session) and never inspected the `git -C <path>` or `cd <path> &&` in the command it was judging.

## Fix
Parse the target directory out of the command and probe the branch there:
- apply a leading `cd <path> &&`/`;` (single- or double-quoted paths supported);
- apply each `git -C <path>` global option cumulatively (absolute overrides, relative stacks) — matching git's own semantics; handles both `-C <path>` and `-C<path>`;
- scan only the pre-`commit` segment: `-C` *after* `commit` is `git commit -C <commit-ish>` (message reuse), not a directory;
- when no directory is given, fall back to cwd (the pre-fix behaviour); when a parsed target is unresolvable, fall back to cwd too — fail-closed, since the primary sits on `main`.

## Acceptance verification (real git worktrees)
Each case run by hand against real worktrees; observed decision recorded:

| # | Case | Expected | Observed |
| - | --- | --- | --- |
| 1a | `git -C <worktree-on-feature> commit` | ALLOW | ALLOW ✓ |
| 1b | `cd <worktree-on-feature> && git commit` | ALLOW | ALLOW ✓ |
| 2 | `git -C <worktree-on-master> commit` | DENY | DENY ✓ |
| 3 | plain `git commit`, primary on `main` | DENY | DENY ✓ |
| 4 | plain `git commit`, primary on feature | ALLOW | ALLOW ✓ |
| 5a | `git commit-tree` | passthrough | ALLOW ✓ |
| 5b | `git log --grep=commit` | passthrough | ALLOW ✓ |

### Edge cases (extra confidence)
- `git -C <wt> -C . commit` → ALLOW (cumulative resolves to `<wt>`). 
- `git -C <wt-feature> log && git commit` → DENY: the `-C` on `log` is not applied to the plain `git commit`; the committing git is the primary on `main`. Correct.
- `git commit -C HEAD~1` → DENY (primary is `main`): the post-`commit` `-C` is message-reuse, not a directory, so target stays cwd.
- `git add -A && git -C <wt-feature> commit` → ALLOW.
- `git -C /nonexistent commit` → DENY: unresolvable target falls back to cwd (`main`). Fail-closed.

## Gates
- `npm run build` — green (158 test files pass; vite build OK).
- `npm run check:fast-lane` — NOT ELIGIBLE (full lane): protected path `.claude/**`, 76 lines > 25. Plan + explicit approval captured in issue #439 before branching. No `fast-lane` label.

## Files
- `.claude/hooks/block-default-branch-commit.sh` — rewrite (the only change).