### PR TITLE
fix(tabs): stop tabs swallowing the final pass on small circles

### DIFF
--- a/src/app/useToolpathGeneration.ts
+++ b/src/app/useToolpathGeneration.ts
@@ -229,18 +229,21 @@ export function useToolpathGeneration(project: Project, selectedOperation: Opera
       } else if (operation.kind === 'v_carve_medial') {
         result = applyClampWarnings(project, optimizeAndCapture(generateVCarveMedialToolpath(project, operation)), operation)
       } else if (operation.kind === 'edge_route_inside' || operation.kind === 'edge_route_outside') {
-        const tabAware = applyTabsToEdgeRoute(project, operation, generateEdgeRouteToolpath(project, operation))
-        result = applyClampWarnings(project, optimizeAndCapture(applyTabWarnings(project, operation, tabAware)), operation)
+        // Warnings first: applyTabWarnings judges each tab against the cut Z range, and
+        // applyTabsToEdgeRoute raises that range to the tab tops. Run it on the adjusted
+        // moves and every applied tab reports as lying outside the range it just created.
+        const warned = applyTabWarnings(project, operation, generateEdgeRouteToolpath(project, operation))
+        result = applyClampWarnings(project, optimizeAndCapture(applyTabsToEdgeRoute(project, operation, warned)), operation)
       } else if (operation.kind === 'surface_clean') {
         result = applyClampWarnings(project, optimizeAndCapture(applyTabWarnings(project, operation, generateSurfaceCleanToolpath(project, operation))), operation)
       } else if (operation.kind === 'rough_surface') {
         result = applyClampWarnings(project, optimizeAndCapture(applyTabWarnings(project, operation, generateRoughSurfaceToolpath(project, operation))), operation)
       } else if (operation.kind === 'finish_surface') {
-        const tabAware = applyTabsToEdgeRoute(project, operation, generateFinishSurfaceToolpath(project, operation))
-        result = applyClampWarnings(project, optimizeAndCapture(applyTabWarnings(project, operation, tabAware)), operation)
+        const warned = applyTabWarnings(project, operation, generateFinishSurfaceToolpath(project, operation))
+        result = applyClampWarnings(project, optimizeAndCapture(applyTabsToEdgeRoute(project, operation, warned)), operation)
       } else if (operation.kind === 'finish_surface_cleanup') {
-        const tabAware = applyTabsToEdgeRoute(project, operation, generateFinishSurfaceCleanupToolpath(project, operation))
-        result = applyClampWarnings(project, optimizeAndCapture(applyTabWarnings(project, operation, tabAware)), operation)
+        const warned = applyTabWarnings(project, operation, generateFinishSurfaceCleanupToolpath(project, operation))
+        result = applyClampWarnings(project, optimizeAndCapture(applyTabsToEdgeRoute(project, operation, warned)), operation)
       } else if (operation.kind === 'follow_line') {
         result = applyClampWarnings(project, optimizeAndCapture(generateFollowLineToolpath(project, operation)), operation)
       } else if (operation.kind === 'drilling') {

--- a/src/engine/toolpaths/tabs.test.ts
+++ b/src/engine/toolpaths/tabs.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tab application tests — issue #445.
+ *
+ * Covers the three engine-side halves of that fix: the tab obstacle is the
+ * tool's round swept envelope (not a square), a fully covered final pass is
+ * reported rather than emitted silently, and tab spacing is measurable against
+ * the real tool-centre path.
+ *
+ * Run with: npx tsx src/engine/toolpaths/tabs.test.ts
+ */
+
+import { circleProfile, defaultTool, newProject, rectProfile, type Operation, type Project, type Tab } from '../../types/project'
+import { projectWithFeatures } from '../../test/projectFixtures'
+import { flattenProfile } from './geometry'
+import { generateEdgeRouteToolpath } from './edge'
+import { applyTabsToEdgeRoute, applyTabWarnings, tabLayoutFreeFraction, toolCentreContours } from './tabs'
+import type { ToolpathResult } from './types'
+
+// ── Harness ──────────────────────────────────────────────────────────
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+let passed = 0
+let failed = 0
+
+function test(name: string, fn: () => void): void {
+  try {
+    fn()
+    passed += 1
+    console.log(`   ✓ ${name}`)
+  } catch (err: unknown) {
+    failed += 1
+    console.log(`   ✗ ${name}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const TOOL_DIAMETER = 6
+const TOOL_RADIUS = TOOL_DIAMETER / 2
+
+function baseProject(): Project {
+  const base = newProject()
+  return {
+    ...base,
+    meta: { ...base.meta, units: 'mm' },
+    stock: { ...base.stock, thickness: 12 },
+    tools: [{ ...defaultTool('mm', 1), id: 't1', name: 'em6', diameter: TOOL_DIAMETER, units: 'mm' }],
+  }
+}
+
+function edgeOperation(featureId: string, kind: Operation['kind'] = 'edge_route_inside'): Operation {
+  return {
+    id: 'op1',
+    name: 'Edge',
+    kind,
+    pass: 'rough',
+    enabled: true,
+    showToolpath: true,
+    debugToolpath: false,
+    target: { source: 'features', featureIds: [featureId] },
+    toolRef: 't1',
+    stepdown: 4,
+    stepover: 0.4,
+    feed: 800,
+    plungeFeed: 300,
+    rpm: 18000,
+    pocketPattern: 'offset',
+    pocketAngle: 0,
+    roundOutsideCorners: false,
+    stockToLeaveRadial: 0,
+    stockToLeaveAxial: 0,
+    finishWalls: true,
+    finishFloor: true,
+    carveDepth: 1,
+    maxCarveDepth: 1,
+    cutDirection: 'conventional',
+    machiningOrder: 'level_first',
+  }
+}
+
+function tab(id: string, x: number, y: number, size: number, zTop = 3): Tab {
+  return { id, name: `Tab ${id}`, x, y, w: size, h: size, z_top: zTop, z_bottom: 0, visible: true }
+}
+
+/** Circle feature of the given diameter centred at (60, 60), cut as a hole. */
+function circleProject(diameter: number, tabs: Tab[]): { project: Project; operation: Operation } {
+  const project = projectWithFeatures(baseProject(), [
+    {
+      id: 'f1',
+      name: 'Hole',
+      kind: 'circle',
+      folderId: null,
+      sketch: {
+        profile: circleProfile(60, 60, diameter / 2),
+        origin: { x: 0, y: 0 },
+        orientationAngle: 0,
+        dimensions: [],
+        constraints: [],
+      },
+      operation: 'subtract',
+      z_top: 12,
+      z_bottom: 0,
+      visible: true,
+      locked: false,
+    },
+  ] as never)
+  return { project: { ...project, tabs }, operation: edgeOperation('f1') }
+}
+
+function run(project: Project, operation: Operation): ToolpathResult {
+  // Shipped pipeline order: warnings judge the pre-tab toolpath, tabs adjust it after.
+  const warned = applyTabWarnings(project, operation, generateEdgeRouteToolpath(project, operation))
+  return applyTabsToEdgeRoute(project, operation, warned)
+}
+
+function deepestCutZ(result: ToolpathResult): number {
+  return result.moves
+    .filter((move) => move.kind === 'cut')
+    .reduce((min, move) => Math.min(min, move.from.z, move.to.z), Number.POSITIVE_INFINITY)
+}
+
+// ── Step 1: the raised zone is the tool's round envelope, not a square ──
+
+console.log('\nTab obstacle uses the tool\'s round swept envelope')
+
+test('path in the miter-only corner band is left free', () => {
+  // Tab corner at (10, 10), tool radius 3. A path 3.6 away along the diagonal is
+  // outside the tool's disc (3) but inside the square a miter join would produce
+  // (radius * sqrt(2) = 4.243 along the diagonal), so a miter expansion would
+  // wrongly claim it. Kept tiny so the whole loop stays inside that band.
+  const diagonal = 3.6 / Math.SQRT2
+  const centre = 10 + diagonal
+  const half = 0.1
+  const loop = [
+    { x: centre - half, y: centre - half },
+    { x: centre + half, y: centre - half },
+    { x: centre + half, y: centre + half },
+    { x: centre - half, y: centre + half },
+  ]
+
+  const nearest = Math.hypot(centre - half - 10, centre - half - 10)
+  const furthest = Math.hypot(centre + half - 10, centre + half - 10)
+  assert(nearest > 3, `loop clears the round envelope, nearest corner at ${nearest.toFixed(3)}`)
+  assert(furthest < 3 * Math.SQRT2, `loop stays inside the miter square, furthest corner at ${furthest.toFixed(3)}`)
+
+  const free = tabLayoutFreeFraction([loop], [{ x: 0, y: 0, w: 10, h: 10 }], 3)
+  assert(free > 0.999, `path is fully free of the tab, got free fraction ${free.toFixed(3)}`)
+})
+
+test('path within the tool radius of a tab is still claimed', () => {
+  // Same corner, but 2.4 away along the diagonal — inside the tool's disc.
+  const diagonal = 2.4 / Math.SQRT2
+  const centre = 10 + diagonal
+  const half = 0.1
+  const loop = [
+    { x: centre - half, y: centre - half },
+    { x: centre + half, y: centre - half },
+    { x: centre + half, y: centre + half },
+    { x: centre - half, y: centre + half },
+  ]
+
+  const free = tabLayoutFreeFraction([loop], [{ x: 0, y: 0, w: 10, h: 10 }], 3)
+  assert(free < 0.001, `path is fully covered by the tab, got free fraction ${free.toFixed(3)}`)
+})
+
+test('a tab still raises the path it genuinely covers', () => {
+  const { project, operation } = circleProject(40, [tab('tb1', 56, 36, 8)])
+  const result = run(project, operation)
+  const raised = result.moves.filter((move) => move.kind === 'cut' && Math.abs(move.from.z - 3) < 1e-6)
+  assert(raised.length > 0, `tab raises part of the path, got ${raised.length} raised cut moves`)
+  assert(Math.abs(deepestCutZ(result)) < 1e-9, 'the rest of the pass still reaches final depth')
+})
+
+// ── Step 2: warnings are judged against the pre-tab toolpath ──
+
+console.log('\nTab warnings judge the pre-tab cut range')
+
+test('an applied tab is not reported as outside the cut Z range', () => {
+  const { project, operation } = circleProject(40, [tab('tb1', 56, 36, 8)])
+  const codes = run(project, operation).warnings.map((warning) => warning.code)
+  assert(
+    !codes.some((code) => code === 'tabOutsideCutZ' || code.startsWith('tabsOutsideCutZ')),
+    `no outside-cut-Z warning, got [${codes.join(', ')}]`,
+  )
+})
+
+test('a tab genuinely above the cut range is still reported', () => {
+  // Cut spans z 12 -> 0; a tab from z 20 to 24 never meets it.
+  const { project, operation } = circleProject(40, [{ ...tab('tb1', 56, 36, 8), z_bottom: 20, z_top: 24 }])
+  const codes = run(project, operation).warnings.map((warning) => warning.code)
+  assert(
+    codes.some((code) => code === 'tabOutsideCutZ' || code.startsWith('tabsOutsideCutZ')),
+    `outside-cut-Z warning still fires, got [${codes.join(', ')}]`,
+  )
+})
+
+// ── Step 3: total coverage is reported ──
+
+console.log('\nTabs that swallow the final pass are reported')
+
+test('full coverage raises tabsBlockFinalDepth', () => {
+  // Four oversized tabs on a small circle cover the whole tool-centre path.
+  const { project, operation } = circleProject(24, [
+    tab('tb1', 54, 42, 12),
+    tab('tb2', 54, 66, 12),
+    tab('tb3', 42, 54, 12),
+    tab('tb4', 66, 54, 12),
+  ])
+  const result = run(project, operation)
+  assert(deepestCutZ(result) > 1e-9, `final pass never reaches z=0, got ${deepestCutZ(result)}`)
+  assert(
+    result.warnings.some((warning) => warning.code === 'tabsBlockFinalDepth'),
+    `tabsBlockFinalDepth is raised, got [${result.warnings.map((w) => w.code).join(', ')}]`,
+  )
+})
+
+test('partial coverage does not raise tabsBlockFinalDepth', () => {
+  const { project, operation } = circleProject(40, [tab('tb1', 56, 36, 8), tab('tb2', 56, 76, 8)])
+  const result = run(project, operation)
+  assert(Math.abs(deepestCutZ(result)) < 1e-9, 'the pass still reaches final depth')
+  assert(
+    !result.warnings.some((warning) => warning.code === 'tabsBlockFinalDepth'),
+    'tabsBlockFinalDepth is not raised when the part is cut free',
+  )
+})
+
+// ── Step 4: coverage measurement against the real tool-centre path ──
+
+console.log('\nTab coverage is measured on the tool-centre path')
+
+test('a circle\'s inside path is shorter than its bounding box suggests', () => {
+  const points = flattenProfile(circleProfile(60, 60, 12.7)).points
+  const contours = toolCentreContours(points, -TOOL_RADIUS)
+  assert(contours.length === 1, `one inside contour, got ${contours.length}`)
+  let length = 0
+  const contour = contours[0]
+  for (let index = 0; index < contour.length; index += 1) {
+    const start = contour[index]
+    const end = contour[(index + 1) % contour.length]
+    length += Math.hypot(end.x - start.x, end.y - start.y)
+  }
+  const expected = Math.PI * (25.4 - TOOL_DIAMETER)
+  assert(Math.abs(length - expected) / expected < 0.01, `path length ~${expected.toFixed(2)}, got ${length.toFixed(2)}`)
+})
+
+test('four tabs cover a circle that the same four leave open on a square', () => {
+  const rects = [
+    { x: 60 - 3.96875, y: 60 - 12.7 - 3.96875, w: 7.9375, h: 7.9375 },
+    { x: 60 - 3.96875, y: 60 + 12.7 - 3.96875, w: 7.9375, h: 7.9375 },
+    { x: 60 - 12.7 - 3.96875, y: 60 - 3.96875, w: 7.9375, h: 7.9375 },
+    { x: 60 + 12.7 - 3.96875, y: 60 - 3.96875, w: 7.9375, h: 7.9375 },
+  ]
+  const radius = 6.35 / 2
+  const circle = toolCentreContours(flattenProfile(circleProfile(60, 60, 12.7)).points, -radius)
+  const square = toolCentreContours(flattenProfile(rectProfile(60 - 12.7, 60 - 12.7, 25.4, 25.4)).points, -radius)
+
+  const circleFree = tabLayoutFreeFraction(circle, rects, radius)
+  const squareFree = tabLayoutFreeFraction(square, rects, radius)
+  assert(circleFree < 0.05, `circle is all but covered, free fraction ${circleFree.toFixed(3)}`)
+  assert(squareFree > 0.2, `square keeps real cut-through, free fraction ${squareFree.toFixed(3)}`)
+})
+
+test('two tabs leave a small circle usable', () => {
+  const radius = 6.35 / 2
+  const circle = toolCentreContours(flattenProfile(circleProfile(60, 60, 12.7)).points, -radius)
+  const rects = [
+    { x: 60 - 3.96875, y: 60 - 12.7 - 3.96875, w: 7.9375, h: 7.9375 },
+    { x: 60 - 3.96875, y: 60 + 12.7 - 3.96875, w: 7.9375, h: 7.9375 },
+  ]
+  const free = tabLayoutFreeFraction(circle, rects, radius)
+  assert(free > 0.4, `two tabs leave most of the path free, got ${free.toFixed(3)}`)
+})
+
+// ── Summary ──────────────────────────────────────────────────────────
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  throw new Error(`${failed} tab test(s) failed`)
+}

--- a/src/engine/toolpaths/tabs.ts
+++ b/src/engine/toolpaths/tabs.ts
@@ -28,19 +28,32 @@ interface PreservedObstacle {
   zBottom: number
 }
 
+const MAX_ROUND_JOIN_ARC_TOLERANCE = DEFAULT_CLIPPER_SCALE * 0.01
+const ROUND_JOIN_ARC_TOLERANCE_RATIO = 0.01
+
 function offsetObstaclePoints(points: Point[], delta: number): Point[] {
   if (!(delta > 1e-9) || points.length < 3) {
     return points
   }
 
+  const scaledDelta = delta * DEFAULT_CLIPPER_SCALE
   const offset = new ClipperLib.ClipperOffset()
+  // Round join, not miter: the raised zone is the set of tool-centre positions whose
+  // swept disc would touch the tab, i.e. the Minkowski sum of the tab rect with a
+  // circle of the tool radius. A miter join grows the rect by a *square* instead,
+  // overshooting each corner by up to (sqrt(2)-1)*radius and raising the toolpath
+  // where the cutter would never have reached the tab.
+  offset.ArcTolerance = Math.max(
+    1,
+    Math.min(MAX_ROUND_JOIN_ARC_TOLERANCE, scaledDelta * ROUND_JOIN_ARC_TOLERANCE_RATIO),
+  )
   offset.AddPaths(
     [toClipperPath(normalizeWinding(points, false), DEFAULT_CLIPPER_SCALE)],
-    ClipperLib.JoinType.jtMiter,
+    ClipperLib.JoinType.jtRound,
     ClipperLib.EndType.etClosedPolygon,
   )
   const solution = new ClipperLib.Paths()
-  offset.Execute(solution, delta * DEFAULT_CLIPPER_SCALE)
+  offset.Execute(solution, scaledDelta)
   const expanded = (solution as unknown as { X: number; Y: number }[][])[0]
   return expanded ? fromClipperPath(expanded, DEFAULT_CLIPPER_SCALE) : points
 }
@@ -413,11 +426,152 @@ export function applyTabsToEdgeRoute(project: Project, operation: Operation, res
     return result
   }
 
+  const warnings = [...result.warnings]
+  if (finalDepthIsBlocked(result.moves, adjustedMoves)) {
+    warnings.push({ code: 'tabsBlockFinalDepth', params: { name: operation.name } })
+  }
+
   return {
     ...result,
     moves: adjustedMoves,
+    warnings,
     bounds: computeBounds(adjustedMoves),
   }
+}
+
+/**
+ * True when every cut move that reached the deepest level before tabs were applied
+ * has been raised off it. The operation then never severs the part: the final pass
+ * rides the tab tops for its whole length. Tabs are meant to interrupt that pass,
+ * not replace it, so full coverage is always a mistake in the tab layout.
+ */
+function finalDepthIsBlocked(originalMoves: ToolpathMove[], adjustedMoves: ToolpathMove[]): boolean {
+  let deepestZ = Number.POSITIVE_INFINITY
+  for (const move of originalMoves) {
+    if (move.kind !== 'cut') continue
+    deepestZ = Math.min(deepestZ, move.from.z, move.to.z)
+  }
+
+  if (!Number.isFinite(deepestZ)) {
+    return false
+  }
+
+  return !adjustedMoves.some(
+    (move) => move.kind === 'cut'
+      && (move.from.z <= deepestZ + 1e-9 || move.to.z <= deepestZ + 1e-9),
+  )
+}
+
+/** A candidate tab footprint, before it becomes a `Tab` record. */
+export interface TabRect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+/**
+ * Tool-centre contours for a closed feature outline, offset the way an edge route
+ * offsets it: inward by the tool radius for an inside cut, outward for an outside cut.
+ * This is the path tabs actually interrupt, and it is what tab spacing has to be
+ * measured against — a feature's bounding box says nothing useful about it, least of
+ * all for a circle, whose offset path is `pi/4` of the box perimeter.
+ */
+export function toolCentreContours(profilePoints: Point[], offsetDelta: number): Point[][] {
+  if (profilePoints.length < 3) {
+    return []
+  }
+
+  if (Math.abs(offsetDelta) <= 1e-9) {
+    return [profilePoints]
+  }
+
+  const scaledDelta = offsetDelta * DEFAULT_CLIPPER_SCALE
+  const offset = new ClipperLib.ClipperOffset()
+  offset.ArcTolerance = Math.max(
+    1,
+    Math.min(MAX_ROUND_JOIN_ARC_TOLERANCE, Math.abs(scaledDelta) * ROUND_JOIN_ARC_TOLERANCE_RATIO),
+  )
+  offset.AddPaths(
+    [toClipperPath(normalizeWinding(profilePoints, true), DEFAULT_CLIPPER_SCALE)],
+    ClipperLib.JoinType.jtRound,
+    ClipperLib.EndType.etClosedPolygon,
+  )
+  const solution = new ClipperLib.Paths()
+  offset.Execute(solution, scaledDelta)
+
+  return (solution as unknown as { X: number; Y: number }[][])
+    .map((path) => fromClipperPath(path, DEFAULT_CLIPPER_SCALE))
+    .filter((points) => points.length >= 3)
+}
+
+/**
+ * Fraction of `contours` that the given tabs would leave free to cut, once each tab is
+ * grown by the tool radius exactly as `applyTabsToEdgeRoute` grows it. Returns 0 when
+ * there is no path to cut. A tab spanning a curve consumes arc length, which exceeds
+ * its own width, so this has to be measured rather than inferred from tab sizes.
+ */
+export function tabLayoutFreeFraction(
+  contours: Point[][],
+  tabRects: TabRect[],
+  toolRadius: number,
+): number {
+  const obstacles = tabRects.map((rect) =>
+    offsetObstaclePoints(sampleProfilePoints(rectProfile(rect.x, rect.y, rect.w, rect.h)), Math.max(0, toolRadius)),
+  )
+
+  let pathLength = 0
+  let coveredLength = 0
+
+  for (const contour of contours) {
+    for (let index = 0; index < contour.length; index += 1) {
+      const start = contour[index]
+      const end = contour[(index + 1) % contour.length]
+      const segmentLength = Math.hypot(end.x - start.x, end.y - start.y)
+      if (!(segmentLength > 0)) {
+        continue
+      }
+
+      pathLength += segmentLength
+
+      const intervals: Array<[number, number]> = []
+      for (const obstacle of obstacles) {
+        const interval = clipSegmentPolygon2D(start.x, start.y, end.x, end.y, obstacle)
+        if (interval) {
+          intervals.push(interval)
+        }
+      }
+
+      coveredLength += segmentLength * unionLength(intervals)
+    }
+  }
+
+  return pathLength > 0 ? Math.max(0, (pathLength - coveredLength) / pathLength) : 0
+}
+
+/** Total length of a union of [start, end] sub-intervals of [0, 1]. */
+function unionLength(intervals: Array<[number, number]>): number {
+  if (intervals.length === 0) {
+    return 0
+  }
+
+  const sorted = [...intervals].sort((left, right) => left[0] - right[0])
+  let total = 0
+  let currentStart = sorted[0][0]
+  let currentEnd = sorted[0][1]
+
+  for (let index = 1; index < sorted.length; index += 1) {
+    const [start, end] = sorted[index]
+    if (start > currentEnd) {
+      total += currentEnd - currentStart
+      currentStart = start
+      currentEnd = end
+      continue
+    }
+    currentEnd = Math.max(currentEnd, end)
+  }
+
+  return Math.min(1, total + (currentEnd - currentStart))
 }
 
 export function applyTabWarnings(project: Project, operation: Operation, result: ToolpathResult): ToolpathResult {

--- a/src/engine/toolpaths/warningCodes.ts
+++ b/src/engine/toolpaths/warningCodes.ts
@@ -91,6 +91,7 @@ export type ToolpathWarningCode =
   | 'tabsOutsideCutZ'
   | 'tabsOutsideCutZList'
   | 'tabsOutsideCutZListMore'
+  | 'tabsBlockFinalDepth'
   // surface clean / finish bands
   | 'surfaceNoCleanupRegion'
   | 'surfaceNoCleanupSegments'

--- a/src/i18n/locales/de/warnings.ts
+++ b/src/i18n/locales/de/warnings.ts
@@ -97,6 +97,7 @@ export const warningsDe: Record<keyof typeof warningsEn, string> = {
   'warnings.tabsOutsideCutZ': '{count} nahe Haltestege überlappen die Werkzeugweg-Grundfläche, liegen aber außerhalb des Schnitt-Z-Bereichs ({minZ} -> {maxZ}).',
   'warnings.tabsOutsideCutZList': '{count} nahe Haltestege überlappen die Werkzeugweg-Grundfläche, liegen aber außerhalb des Schnitt-Z-Bereichs ({minZ} -> {maxZ}): {names}.',
   'warnings.tabsOutsideCutZListMore': '{count} nahe Haltestege überlappen die Werkzeugweg-Grundfläche, liegen aber außerhalb des Schnitt-Z-Bereichs ({minZ} -> {maxZ}): {names} und {more} weitere.',
+  'warnings.tabsBlockFinalDepth': 'Haltestege bedecken den gesamten letzten Durchgang von „{name}", daher wird die volle Tiefe nie erreicht und das Teil wird nicht freigeschnitten. Verwenden Sie weniger oder schmalere Haltestege.',
   // surface clean / finish bands
   'warnings.surfaceNoCleanupRegion': 'Kein bearbeitbarer paralleler Säuberungsbereich für Band {topZ} -> {bottomZ}',
   'warnings.surfaceNoCleanupSegments': 'Keine bearbeitbaren parallelen Säuberungssegmente für Band {topZ} -> {bottomZ}',

--- a/src/i18n/locales/en/warnings.ts
+++ b/src/i18n/locales/en/warnings.ts
@@ -97,6 +97,7 @@ export const warningsEn = {
   'warnings.tabsOutsideCutZ': '{count} nearby tabs overlap the toolpath footprint but are outside the cut Z range ({minZ} -> {maxZ}).',
   'warnings.tabsOutsideCutZList': '{count} nearby tabs overlap the toolpath footprint but are outside the cut Z range ({minZ} -> {maxZ}): {names}.',
   'warnings.tabsOutsideCutZListMore': '{count} nearby tabs overlap the toolpath footprint but are outside the cut Z range ({minZ} -> {maxZ}): {names}, and {more} more.',
+  'warnings.tabsBlockFinalDepth': 'Tabs cover the whole final pass of "{name}", so it never reaches full depth and the part will not be cut free. Use fewer or narrower tabs.',
   // surface clean / finish bands
   'warnings.surfaceNoCleanupRegion': 'No machinable parallel cleanup region for band {topZ} -> {bottomZ}',
   'warnings.surfaceNoCleanupSegments': 'No machinable parallel cleanup segments for band {topZ} -> {bottomZ}',

--- a/src/i18n/locales/es/warnings.ts
+++ b/src/i18n/locales/es/warnings.ts
@@ -85,6 +85,7 @@ export const warningsEs: Record<keyof typeof warningsEn, string> = {
   "warnings.tabsOutsideCutZ": "{count} Las pestañas cercanas se superponen a la huella de la trayectoria de la herramienta, pero están fuera del rango de corte Z ({minZ} -> {maxZ}).",
   "warnings.tabsOutsideCutZList": "{count} Las pestañas cercanas se superponen a la huella de la trayectoria de la herramienta, pero están fuera del rango de corte Z ({minZ} -> {maxZ}): {names}.",
   "warnings.tabsOutsideCutZListMore": "Las pestañas cercanas a {count} se superponen a la huella de la trayectoria de la herramienta, pero están fuera del rango de corte Z ({minZ} -> {maxZ}): {names} y {more} más.",
+  "warnings.tabsBlockFinalDepth": "Las pestañas cubren toda la pasada final de \"{name}\", por lo que nunca alcanza la profundidad final y la pieza no quedará separada. Use menos pestañas o pestañas más estrechas.",
   "warnings.surfaceNoCleanupRegion": "No hay región de limpieza paralela mecanizable para la banda {topZ} -> {bottomZ}",
   "warnings.surfaceNoCleanupSegments": "No hay segmentos de limpieza paralela mecanizables para la banda {topZ} -> {bottomZ}",
   "warnings.surfaceNoOffsetContours": "No hay contornos de desfase mecanizables para la banda {topZ} -> {bottomZ}",

--- a/src/i18n/locales/fr/warnings.ts
+++ b/src/i18n/locales/fr/warnings.ts
@@ -85,6 +85,7 @@ export const warningsFr: Record<keyof typeof warningsEn, string> = {
   'warnings.tabsOutsideCutZ': '{count} attaches proches recouvrent l’empreinte du parcours d’outil mais se trouvent hors de la plage Z de coupe ({minZ} -> {maxZ}).',
   'warnings.tabsOutsideCutZList': '{count} attaches proches recouvrent l’empreinte du parcours d’outil mais se trouvent hors de la plage Z de coupe ({minZ} -> {maxZ}) : {names}.',
   'warnings.tabsOutsideCutZListMore': '{count} attaches proches recouvrent l’empreinte du parcours d’outil mais se trouvent hors de la plage Z de coupe ({minZ} -> {maxZ}) : {names} et {more} autres.',
+  'warnings.tabsBlockFinalDepth': 'Les attaches couvrent toute la dernière passe de « {name} » : elle n’atteint jamais la profondeur finale et la pièce ne sera pas détachée. Utilisez moins d’attaches ou des attaches plus étroites.',
   'warnings.surfaceNoCleanupRegion': 'Aucune région de nettoyage parallèle usinable pour la bande {topZ} -> {bottomZ}',
   'warnings.surfaceNoCleanupSegments': 'Aucun segment de nettoyage parallèle usinable pour la bande {topZ} -> {bottomZ}',
   'warnings.surfaceNoOffsetContours': 'Aucun contour décalé usinable pour la bande {topZ} -> {bottomZ}',

--- a/src/i18n/locales/zh-CN/warnings.ts
+++ b/src/i18n/locales/zh-CN/warnings.ts
@@ -89,6 +89,7 @@ export const warningsZhCN: Record<keyof typeof warningsEn, string> = {
   'warnings.tabsOutsideCutZ': '{count} 个附近凸台与刀路覆盖范围重叠，但在切削Z范围（{minZ} -> {maxZ}）之外。',
   'warnings.tabsOutsideCutZList': '{count} 个附近凸台与刀路覆盖范围重叠，但在切削Z范围（{minZ} -> {maxZ}）之外：{names}。',
   'warnings.tabsOutsideCutZListMore': '{count} 个附近凸台与刀路覆盖范围重叠，但在切削Z范围（{minZ} -> {maxZ}）之外：{names}，另有 {more} 个。',
+  'warnings.tabsBlockFinalDepth': '凸台覆盖了“{name}”的整个最后一刀，因此始终未切到最终深度，工件不会被切离。请减少凸台数量或缩小凸台宽度。',
   'warnings.surfaceNoCleanupRegion': '深度带 {topZ} -> {bottomZ} 没有可加工的平行清理区域',
   'warnings.surfaceNoCleanupSegments': '深度带 {topZ} -> {bottomZ} 没有可加工的平行清理段',
   'warnings.surfaceNoOffsetContours': '深度带 {topZ} -> {bottomZ} 没有可加工的偏置轮廓',

--- a/src/i18n/warningsCoverage.test.ts
+++ b/src/i18n/warningsCoverage.test.ts
@@ -45,6 +45,7 @@ const ALL_CODES = [
   'surface3dFloorCollapsed', 'surface3dNoLevels',
   'tabOnlyEdgeRoute', 'tabsOverlapAmbiguous', 'tabNoIntersect', 'tabAboveStockTop', 'tabBelowStockBottom',
   'tabInvalidZRange', 'tabOutsideCutZ', 'tabsOutsideCutZ', 'tabsOutsideCutZList', 'tabsOutsideCutZListMore',
+  'tabsBlockFinalDepth',
   'surfaceNoCleanupRegion', 'surfaceNoCleanupSegments', 'surfaceNoOffsetContours', 'surfaceFinishBothDisabled',
   'surfaceCleanWrongKind', 'surfaceCleanNoTargets', 'surfaceCleanNoValidTargets',
   'surfaceBandNoFinishDepth', 'surfaceBandNoRoughDepth', 'surfaceNoFinishContours',

--- a/src/store/featureLifecycleOps.test.ts
+++ b/src/store/featureLifecycleOps.test.ts
@@ -35,6 +35,8 @@ import { useProjectStore } from './projectStore'
 import { resolveFeatureInstance, resolvedProjectFeatures } from './helpers/resolveFeatures'
 import type { ProjectStore } from './types'
 import { getProfileBounds } from '../types/project'
+import { flattenProfile } from '../engine/toolpaths/geometry'
+import { tabLayoutFreeFraction, toolCentreContours } from '../engine/toolpaths/tabs'
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -367,6 +369,68 @@ test('autoPlaceTabsForOperation creates tabs for edge_route_outside', () => {
   for (const tab of tabs) {
     assert(tab.w > 0 && tab.h > 0, `tab should have positive dimensions, got w=${tab.w}, h=${tab.h}`)
   }
+})
+
+// Issue #445: tab spacing has to be judged against the tool-centre path, not the
+// feature's bounding box. A circle's inside path is pi/4 of the box perimeter and
+// each tab consumes arc rather than chord, so four tabs that leave a same-sized
+// square well open can swallow the circle's final pass whole.
+test('autoPlaceTabsForOperation measures a circle against its real toolpath', () => {
+  function placeOn(shape: 'circle' | 'square'): { count: number; size: number; free: number } {
+    resetStore()
+    const base = newProject()
+    useProjectStore.setState({
+      project: { ...base, meta: { ...base.meta, units: 'mm' }, stock: { ...base.stock, thickness: 12 } },
+    } as unknown as Partial<ProjectStore>)
+
+    const store = useProjectStore.getState()
+    if (shape === 'circle') store.addCircleFeature('C', 60, 60, 12.7, 12)
+    else store.addRectFeature('C', 47.3, 47.3, 25.4, 25.4, 12)
+    const feat = getFeatures()[0]
+
+    const tool = { ...defaultTool('mm', 1), id: 't1', name: '6.35mm endmill', diameter: 6.35 }
+    const withTool = getProject()
+    useProjectStore.setState({
+      project: {
+        ...withTool,
+        tools: [tool],
+        featureDefinitions: Object.fromEntries(
+          Object.entries(withTool.featureDefinitions).map(([key, value]) => [key, { ...value, operation: 'subtract' }]),
+        ),
+      },
+    } as unknown as Partial<ProjectStore>)
+
+    const opId = useProjectStore.getState().addOperation('edge_route_inside', 'rough', {
+      source: 'features',
+      featureIds: [feat.id],
+    })
+    const withOp = getProject()
+    useProjectStore.setState({
+      project: {
+        ...withOp,
+        operations: withOp.operations.map((op) => (op.id === opId ? { ...op, toolRef: 't1', stepdown: 4 } : op)),
+      },
+    } as unknown as Partial<ProjectStore>)
+
+    useProjectStore.getState().autoPlaceTabsForOperation(opId!)
+
+    const project = getProject()
+    const resolved = resolveFeatureInstance(project, feat.id)!
+    const contours = toolCentreContours(flattenProfile(resolved.sketch.profile).points, -6.35 / 2)
+    return {
+      count: project.tabs.length,
+      size: project.tabs[0]?.w ?? 0,
+      free: tabLayoutFreeFraction(contours, project.tabs, 6.35 / 2),
+    }
+  }
+
+  const circle = placeOn('circle')
+  const square = placeOn('square')
+
+  assert(square.count === 4, `square of the same extents still gets 4 tabs, got ${square.count}`)
+  assert(square.free > 0.2, `square keeps real cut-through, free fraction ${square.free.toFixed(3)}`)
+  assert(circle.count === 2, `circle drops to 2 tabs, got ${circle.count}`)
+  assert(circle.free > 0.15, `circle keeps real cut-through, free fraction ${circle.free.toFixed(3)}`)
 })
 
 test('updateTab modifies tab geometry', () => {

--- a/src/store/slices/tabsSlice.ts
+++ b/src/store/slices/tabsSlice.ts
@@ -18,6 +18,8 @@ import type { StateCreator } from 'zustand'
 import type { Tab, Project, SketchFeature, Operation } from '../../types/project'
 import type { ProjectStore } from '../types'
 import { getProfileBounds } from '../../types/project'
+import { flattenProfile } from '../../engine/toolpaths/geometry'
+import { tabLayoutFreeFraction, toolCentreContours, type TabRect } from '../../engine/toolpaths/tabs'
 import { convertLength } from '../../utils/units'
 import { nextUniqueGeneratedId } from '../helpers/ids'
 import { emptySelection, sanitizeSelection } from './selectionSlice'
@@ -65,6 +67,41 @@ function resolveToolDiameterInProjectUnits(project: Project, operation: Operatio
     : convertLength(tool.diameter, tool.units, project.meta.units)
 }
 
+/**
+ * Share of the tool-centre path a tab layout must leave uncovered to be usable. Below
+ * this the part is barely attached — and at zero the operation never reaches final
+ * depth at all, which `tabsBlockFinalDepth` reports.
+ */
+const MIN_FREE_PATH_FRACTION = 0.15
+
+function tabRectsAt(
+  count: 2 | 4,
+  size: number,
+  bounds: { minX: number; maxX: number; minY: number; maxY: number },
+  cx: number,
+  cy: number,
+  widthIsLongest: boolean,
+): TabRect[] {
+  if (count === 2) {
+    return widthIsLongest
+      ? [
+          { x: cx - size / 2, y: bounds.minY - size / 2, w: size, h: size },
+          { x: cx - size / 2, y: bounds.maxY - size / 2, w: size, h: size },
+        ]
+      : [
+          { x: bounds.minX - size / 2, y: cy - size / 2, w: size, h: size },
+          { x: bounds.maxX - size / 2, y: cy - size / 2, w: size, h: size },
+        ]
+  }
+
+  return [
+    { x: cx - size / 2, y: bounds.minY - size / 2, w: size, h: size },
+    { x: cx - size / 2, y: bounds.maxY - size / 2, w: size, h: size },
+    { x: bounds.minX - size / 2, y: cy - size / 2, w: size, h: size },
+    { x: bounds.maxX - size / 2, y: cy - size / 2, w: size, h: size },
+  ]
+}
+
 function buildAutoTabsForFeature(
   feature: SketchFeature,
   project: Project,
@@ -83,25 +120,32 @@ function buildAutoTabsForFeature(
   const zTop = defaultAutoTabZTop(project)
   const zBottom = 0
 
-  const entries: Array<Pick<Tab, 'x' | 'y' | 'w' | 'h'>> =
-    Math.min(width, height) < size * 3
-      ? (
-          width >= height
-            ? [
-                { x: cx - size / 2, y: bounds.minY - size / 2, w: size, h: size },
-                { x: cx - size / 2, y: bounds.maxY - size / 2, w: size, h: size },
-              ]
-            : [
-                { x: bounds.minX - size / 2, y: cy - size / 2, w: size, h: size },
-                { x: bounds.maxX - size / 2, y: cy - size / 2, w: size, h: size },
-              ]
-        )
-      : [
-          { x: cx - size / 2, y: bounds.minY - size / 2, w: size, h: size },
-          { x: cx - size / 2, y: bounds.maxY - size / 2, w: size, h: size },
-          { x: bounds.minX - size / 2, y: cy - size / 2, w: size, h: size },
-          { x: bounds.maxX - size / 2, y: cy - size / 2, w: size, h: size },
-        ]
+  // Measure candidate layouts against the real tool-centre path rather than the
+  // bounding box. A circle's inside path is pi/4 of the box perimeter and each tab
+  // eats arc, not chord, so four tabs that fit a square of the same extents can
+  // swallow the circle's final pass whole.
+  const toolRadius = (toolDiameter ?? 0) / 2
+  const insideCut = operation.kind === 'edge_route_inside'
+  const contours = toolCentreContours(
+    flattenProfile(feature.sketch.profile).points,
+    insideCut ? -toolRadius : toolRadius,
+  )
+  const widthIsLongest = width >= height
+
+  const candidates: Array<{ count: 2 | 4; size: number }> = [
+    { count: 4, size },
+    { count: 2, size },
+  ]
+  if (size > minSize + 1e-9) {
+    candidates.push({ count: 4, size: minSize }, { count: 2, size: minSize })
+  }
+
+  const fallback = tabRectsAt(2, minSize, bounds, cx, cy, widthIsLongest)
+  const entries =
+    candidates
+      .map((candidate) => tabRectsAt(candidate.count, candidate.size, bounds, cx, cy, widthIsLongest))
+      .find((rects) => tabLayoutFreeFraction(contours, rects, toolRadius) >= MIN_FREE_PATH_FRACTION)
+    ?? fallback
 
   const created: Tab[] = []
   for (const entry of entries) {


### PR DESCRIPTION
Closes #445

Four auto-placed tabs on a small circle consumed the **entire** final pass of an edge
route — the toolpath rode the tab tops for the whole last loop and the part was never
cut free. Reproduced with `work/circle-with-tabs-issue.camj` (Ø1″ circle, ¼″ endmill,
`edge_route_inside`); a same-sized square in the same file cut through fine.

Three defects stacked. Only the third is shape-dependent; the other two are universal
and simply do not usually reach total coverage on their own.

## Changes

**1. The tab obstacle is the tool's round swept envelope** — `tabs.ts`

`offsetObstaclePoints` grew each tab rect with `jtMiter`, a Minkowski sum with a
*square* of side 2r rather than the tool's disc, overshooting each corner by up to
`(√2−1)·r` ≈ 41%. Now `jtRound` with an explicit `ArcTolerance`. Every tab on every
shape was being over-raised around its corners. (Also fixed `delta` being scaled twice
in the same function.)

**2. Tab warnings judge the pre-tab toolpath** — `useToolpathGeneration.ts`

`applyTabWarnings` ran on the *already tab-adjusted* result, so applied tabs raised the
cut floor to their own `z_top` and were then reported as lying outside the cut range
they had just created:

```
before:  tabsOutsideCutZListMore — "4 nearby tabs … are outside the cut Z range
                                    (0.118 -> 0.625)"    ← the tabs made that range
after:   (no warnings)
```

Reordered at all three paired call sites (`edge_route_*`, `finish_surface`,
`finish_surface_cleanup`). `applyTabWarnings` itself is unchanged — the inversion was
purely call ordering.

**3. Total coverage is reported** — new `tabsBlockFinalDepth`

Raised from `applyTabsToEdgeRoute` when no cut move survives at the pre-tab deepest Z.
Added to the code union, the coverage test's `ALL_CODES`, and all **five** locales (the
issue said four; `zh-CN` exists too).

**4. Tab placement measures the real toolpath** — `tabsSlice.ts`

`buildAutoTabsForFeature` chose 2 vs 4 tabs with `min(width, height) < size * 3` — a
fair proxy for a rectangle, wrong for a circle, whose inside path is `π/4` of the box
perimeter and whose tabs consume *arc* rather than chord:

| | available toolpath | consumed per tab | total |
|---|---|---|---|
| Square 1″×1″ | 4 × 0.75 = 3.000″ | 0.5625″ (straight) | 2.250″ → 75%, cuts through |
| Circle Ø1″ | π × 0.75 = 2.356″ | 0.636″ (arc) | 2.544″ → **108%, never cuts** |

Candidate layouts are now measured against the tool-centre path via two new engine
exports, `toolCentreContours` and `tabLayoutFreeFraction`, trying 4-at-size →
2-at-size → 4-at-min → 2-at-min and taking the first that leaves ≥15% of the path free.
Keeping the measurement in `tabs.ts` means the placer and the toolpath agree on one
definition of "covered".

## Results

- The reported project: all three operations reach `z = 0`, no warnings.
- Fresh auto-place, Ø1″ circle + ¼″ tool: **2 tabs, 51.6% of path free** (was 4 tabs, 0%).
- Rectangles unchanged — 40 / 25.4 / 80 mm squares still get 4 tabs at identical sizes.
- 1661-configuration sweep (diameter × tool diameter), inside-route circles:
  **168 → 118** configurations that never reach final depth, now level with the square
  baseline of 118.

The residual 118 are parts barely larger than the tool, where the `toolDia × 1.25` tab
floor cannot shrink further. Those are physically impossible rather than mis-planned,
and `tabsBlockFinalDepth` now reports them instead of failing silently. I left that
floor alone deliberately — overriding it would produce tabs too thin to survive.

## Tests

New `src/engine/toolpaths/tabs.test.ts` (10 assertions) covering all four steps:
round-envelope vs miter corner band, tabs still claiming what they genuinely cover,
warning ordering both ways, total coverage raising the new code and partial coverage
not, and coverage measurement on circle vs square. Plus a placer test in
`featureLifecycleOps.test.ts` asserting the circle drops to 2 tabs while the
same-extents square keeps 4.

The round-join test was confirmed to fail against `jtMiter` and pass on restore.

`npm run build` green — 160/160 test files.
