### PR TITLE
fix(gcode): emit arcs the controller will accept

### DIFF
--- a/src/engine/gcode/arcFitting.test.ts
+++ b/src/engine/gcode/arcFitting.test.ts
@@ -20,8 +20,18 @@
  * Run with: npx tsx src/engine/gcode/arcFitting.test.ts
  */
 
-import { fitArcsInMachineMoves } from './arcFitting'
-import type { ArcMoveDescriptor } from './arcFitting'
+import {
+  fitArcsInMachineMoves,
+  resolveEmittedArc,
+  applyEmittedArcFallback,
+  ARC_RADIUS_CONSISTENCY_TOLERANCE_MM,
+} from './arcFitting'
+import type {
+  ArcMoveDescriptor,
+  FittedMoveDescriptor,
+  LinearMoveDescriptor,
+  EmittedArcOptions,
+} from './arcFitting'
 import type { ToolpathMove, ToolpathPoint } from '../toolpaths/types'
 
 function assert(condition: boolean, message: string): void {
@@ -732,6 +742,391 @@ function pointsEq(a: ToolpathPoint, b: ToolpathPoint, eps = 1e-6): boolean {
     && Math.abs(a.z - b.z) <= eps
 }
 
+// ── issue #447: emitted arcs must survive number formatting ─────
+
+/** Three-decimal millimetre formatting, as GRBL-family definitions use. */
+function mm3(value: number): number {
+  return Number(value.toFixed(3))
+}
+
+/** Emit options for a 3-decimal millimetre, I/J-format machine. */
+const MM3_IJ: EmittedArcOptions = {
+  format: mm3, arcFormat: 'ij', mmPerOutputUnit: 1, quantum: 1e-3,
+}
+
+/**
+ * Reproduce the controller's own arc check on a formatted block:
+ * r_start = |I,J|, r_end = |target − (start + I,J)|.
+ */
+function controllerRadiusDelta(
+  start: { x: number; y: number },
+  target: { x: number; y: number },
+  i: number,
+  j: number,
+): number {
+  const centerX = start.x + i
+  const centerY = start.y + j
+  return Math.abs(
+    Math.hypot(target.x - centerX, target.y - centerY) - Math.hypot(i, j),
+  )
+}
+
+/**
+ * Walk a descriptor sequence exactly as the postprocessor does — formatted
+ * position chained from block to block — and return the worst radius
+ * disagreement any emitted arc would present to the controller.
+ */
+function worstEmittedRadiusDelta(descriptors: FittedMoveDescriptor[]): number {
+  let position: { x: number; y: number } | null = null
+  let worst = 0
+  for (const d of descriptors) {
+    if (d.kind === 'linear') {
+      position = { x: mm3(d.point.x), y: mm3(d.point.y) }
+      continue
+    }
+    const start = position ?? { x: mm3(d.startPoint.x), y: mm3(d.startPoint.y) }
+    const emitted = resolveEmittedArc(d, start, MM3_IJ)
+    worst = Math.max(worst, controllerRadiusDelta(
+      start,
+      { x: mm3(d.endPoint.x), y: mm3(d.endPoint.y) },
+      mm3(emitted.i),
+      mm3(emitted.j),
+    ))
+    position = { x: mm3(d.endPoint.x), y: mm3(d.endPoint.y) }
+  }
+  return worst
+}
+
+/** The 14 contiguous cut moves from the issue #447 report. */
+function issue447Moves(): ToolpathMove[] {
+  const xy: Array<[number, number]> = [
+    [122.3941767939508, 167.17278330912177],
+    [122.37556680190744, 167.10332987328752],
+    [122.36930000002496, 167.0317],
+    [122.36677898139465, 166.96007012671248],
+    [122.37660115292522, 166.89061669087823],
+    [122.3982010594255, 166.82545000000005],
+    [122.43065538518721, 166.76655011100434],
+    [122.4727110084653, 166.71570666721345],
+    [122.52282307694827, 166.67446452093895],
+    [122.57920194731366, 166.6440767939257],
+    [122.63986756263506, 166.62546680188257],
+    [122.7027096154099, 166.6192000000001],
+    [122.76555166818474, 166.62546680188257],
+    [122.82621728350614, 166.6440767939257],
+    [122.88259615387153, 166.67446452093895],
+  ]
+  const points = xy.map(([x, y]) => pt(x, y, -10.5))
+  const moves: ToolpathMove[] = []
+  for (let i = 0; i < points.length - 1; i++) {
+    moves.push(cut(points[i], points[i + 1]))
+  }
+  return moves
+}
+
+function testIssue447MinimalReproduction(): void {
+  console.log('Testing issue #447 minimal reproduction (small-radius trochoidal span)...')
+
+  const result = fitArcsInMachineMoves(issue447Moves(), TOL, MAX_DEG)
+  const arcs = result.filter(d => d.kind === 'arc')
+  assert(arcs.length > 0, 'reproduction should still fit arcs, not degrade to all-linear')
+
+  // Radii here are ~0.32-0.43 mm: below 5 mm the GRBL relative allowance is
+  // smaller than the 0.005 mm floor, so the floor is the whole budget.
+  for (const arc of arcs as ArcMoveDescriptor[]) {
+    const radius = Math.hypot(arc.centerOffsets.i, arc.centerOffsets.j)
+    assert(radius > 0.3 && radius < 0.5,
+      `fixture should exercise small-radius arcs, got r=${radius}`)
+  }
+
+  const worst = worstEmittedRadiusDelta(result)
+  assert(worst <= ARC_RADIUS_CONSISTENCY_TOLERANCE_MM,
+    `every emitted block must pass the GRBL radius check; worst delta ${worst.toFixed(6)} mm`)
+}
+
+function testAdjacentRunsShareEndpointsExactly(): void {
+  console.log('Testing endpoint continuity between adjacent fitted runs...')
+
+  const result = fitArcsInMachineMoves(issue447Moves(), TOL, MAX_DEG)
+  const runIds = new Set(
+    result.filter((d): d is ArcMoveDescriptor => d.kind === 'arc').map(d => d.runId),
+  )
+  assert(runIds.size >= 2,
+    `fixture must produce adjacent independently fitted runs, got ${runIds.size}`)
+
+  // Every descriptor must begin exactly where the previous one ended —
+  // this is what the pre-fix code violated by 0.0153 mm.
+  let previousEnd: ToolpathPoint | null = null
+  for (const d of result) {
+    const start = d.kind === 'arc' ? d.startPoint : null
+    if (previousEnd && start) {
+      assert(Math.hypot(start.x - previousEnd.x, start.y - previousEnd.y) === 0,
+        `arc start must equal the previous emitted endpoint exactly, gap ` +
+        `${Math.hypot(start.x - previousEnd.x, start.y - previousEnd.y)}`)
+    }
+    previousEnd = d.kind === 'arc' ? d.endPoint : d.point
+  }
+}
+
+function testFittedArcsPassThroughSourceEndpoints(): void {
+  console.log('Testing that fitted runs land on their source points...')
+
+  const moves = issue447Moves()
+  const result = fitArcsInMachineMoves(moves, TOL, MAX_DEG)
+
+  // The last descriptor's endpoint must be the last source point exactly:
+  // no radial projection drift is allowed to accumulate across runs.
+  const last = result[result.length - 1]
+  const end = last.kind === 'arc' ? last.endPoint : last.point
+  const target = moves[moves.length - 1].to
+  assert(Math.hypot(end.x - target.x, end.y - target.y) < 1e-9,
+    `emitted span must end on the source point, off by ${Math.hypot(end.x - target.x, end.y - target.y)}`)
+}
+
+function testIJDerivedFromPreviousEmittedPoint(): void {
+  console.log('Testing that I/J are relative to the emitted position, not the declared start...')
+
+  const arc: ArcMoveDescriptor = {
+    kind: 'arc',
+    startPoint: pt(10.0004, 0, 0),      // exporter's un-rounded idea of the start
+    endPoint: pt(0, 10, 0),
+    centerOffsets: { i: -10.0004, j: 0 },  // centre at the origin
+    clockwise: false,
+    runId: 0,
+    runFallback: [{ kind: 'linear', point: pt(0, 10, 0), moveKind: 'cut' }],
+  }
+  // The controller is at the *formatted* 10.000, not at 10.0004.
+  const emitted = resolveEmittedArc(arc, { x: 10, y: 0 }, MM3_IJ)
+  assert(Math.abs(emitted.i - -10) < 1e-9,
+    `I must be measured from the emitted position (expected -10, got ${emitted.i})`)
+  assert(emitted.accepted, 'a centred arc measured from the emitted position must be accepted')
+}
+
+/**
+ * A run the controller must reject: the endpoint sits 0.02 mm off the circle
+ * its own I/J declares — the exact failure shape issue #447 produced. Built by
+ * hand rather than fitted, so the test pins the fallback behaviour itself and
+ * not the fitter's choice of run boundaries.
+ */
+function inconsistentRun(): { arcs: ArcMoveDescriptor[]; fallback: LinearMoveDescriptor[] } {
+  const fallback: LinearMoveDescriptor[] = [
+    { kind: 'linear', point: pt(7.07, 7.07, 0), moveKind: 'cut' },
+    { kind: 'linear', point: pt(0, 10.02, 0), moveKind: 'cut' },
+  ]
+  return {
+    arcs: [{
+      kind: 'arc',
+      startPoint: pt(10, 0, 0),
+      endPoint: pt(0, 10.02, 0),
+      centerOffsets: { i: -10, j: 0 },   // declares r = 10, lands at r = 10.02
+      clockwise: false,
+      runId: 99,
+      runFallback: fallback,
+    }],
+    fallback,
+  }
+}
+
+function testInvalidRunFallsBackToOriginalMoves(): void {
+  console.log('Testing whole-run fallback to original G1 moves...')
+
+  const { arcs, fallback } = inconsistentRun()
+  const entry: LinearMoveDescriptor = { kind: 'linear', point: pt(10, 0, 0), moveKind: 'rapid' }
+  const resolved = applyEmittedArcFallback([entry, ...arcs], MM3_IJ)
+
+  assert(resolved.fallbackRuns === 1,
+    `expected exactly 1 rejected run, got ${resolved.fallbackRuns}`)
+  assert(!resolved.descriptors.some(d => d.kind === 'arc'),
+    'a rejected run must leave no arcs behind')
+  assert(resolved.descriptors.length === 1 + fallback.length,
+    'fallback must emit the run’s original moves, one for one')
+
+  // The span must still end exactly where the original moves ended.
+  const last = resolved.descriptors[resolved.descriptors.length - 1]
+  if (last.kind !== 'linear') throw new Error('fallback output must be linear')
+  assert(last.point.x === 0 && last.point.y === 10.02,
+    'fallback must end on the original final source point')
+}
+
+function testFallbackLeavesValidRunsAlone(): void {
+  console.log('Testing that fallback is scoped to the offending run...')
+
+  // A clean 10 mm circle plus the issue #447 span: neither may be rewritten.
+  const r = 10
+  const circle: ToolpathPoint[] = []
+  for (let i = 0; i <= 16; i++) {
+    const angle = (Math.PI * 2 * i) / 16
+    circle.push(pt(r * Math.cos(angle), r * Math.sin(angle), -10.5))
+  }
+  const moves: ToolpathMove[] = []
+  for (let i = 0; i < 16; i++) moves.push(cut(circle[i], circle[i + 1]))
+  moves.push(rapid(circle[16], pt(122.3941767939508, 167.17278330912177, -10.5)))
+  moves.push(...issue447Moves())
+
+  const fitted = fitArcsInMachineMoves(moves, TOL, MAX_DEG)
+  const goodArcs = fitted.filter(d => d.kind === 'arc').length
+  assert(goodArcs > 0, 'fixture must fit arcs to be meaningful')
+
+  const clean = applyEmittedArcFallback(fitted, MM3_IJ)
+  assert(clean.fallbackRuns === 0,
+    `well-formed spans must not fall back, got ${clean.fallbackRuns}`)
+  assert(worstEmittedRadiusDelta(clean.descriptors) <= ARC_RADIUS_CONSISTENCY_TOLERANCE_MM,
+    'every emitted arc across both spans must pass the radius check')
+
+  // Now append a run that must fail: only it may be rewritten.
+  const { arcs } = inconsistentRun()
+  const mixed = applyEmittedArcFallback(
+    [...fitted, { kind: 'linear', point: pt(10, 0, 0), moveKind: 'rapid' }, ...arcs],
+    MM3_IJ,
+  )
+  assert(mixed.fallbackRuns === 1,
+    `only the offending run may fall back, got ${mixed.fallbackRuns}`)
+  assert(mixed.descriptors.filter(d => d.kind === 'arc').length === goodArcs,
+    'valid runs must survive untouched alongside a rejected one')
+}
+
+function testRFormatRejectsUnrepresentableChord(): void {
+  console.log('Testing R-format chord validation...')
+
+  // Chord longer than the diameter: GRBL derives the centre itself in R mode
+  // and cannot, so this must be rejected rather than emitted.
+  const arc: ArcMoveDescriptor = {
+    kind: 'arc',
+    startPoint: pt(0, 0, 0),
+    endPoint: pt(10, 0, 0),
+    centerOffsets: { i: 1, j: 0 },   // radius 1, chord 10
+    clockwise: false,
+    runId: 0,
+    runFallback: [{ kind: 'linear', point: pt(10, 0, 0), moveKind: 'cut' }],
+  }
+  const bad = resolveEmittedArc(arc, { x: 0, y: 0 }, { ...MM3_IJ, arcFormat: 'r' })
+  assert(!bad.accepted, 'a chord longer than the diameter must be rejected in R format')
+
+  // The issue #447 span must be emittable in R format too.
+  const fitted = fitArcsInMachineMoves(issue447Moves(), TOL, MAX_DEG)
+  const resolved = applyEmittedArcFallback(fitted, { ...MM3_IJ, arcFormat: 'r' })
+  assert(resolved.fallbackRuns === 0,
+    `R-format output must also be representable, got ${resolved.fallbackRuns} fallback(s)`)
+}
+
+function testInchOutputUsesMillimetreBudget(): void {
+  console.log('Testing that inch output is judged against the millimetre threshold...')
+
+  // 0.004" of radius disagreement is 0.1016 mm — comfortably legal in inches
+  // if the threshold were applied naively, but far past GRBL's 0.005 mm.
+  const arc: ArcMoveDescriptor = {
+    kind: 'arc',
+    startPoint: pt(1, 0, 0),
+    endPoint: pt(0, 1.004, 0),
+    centerOffsets: { i: -1, j: 0 },
+    clockwise: false,
+    runId: 0,
+    runFallback: [{ kind: 'linear', point: pt(0, 1.004, 0), moveKind: 'cut' }],
+  }
+  const inch4 = (v: number): number => Number(v.toFixed(4))
+  const asInch = resolveEmittedArc(arc, { x: 1, y: 0 }, { format: inch4, arcFormat: 'ij', mmPerOutputUnit: 25.4, quantum: 1e-4 })
+  assert(!asInch.accepted,
+    `inch output must face the same 0.005 mm budget (delta ${asInch.deltaRmm.toFixed(4)} mm)`)
+}
+
+function testSnappingNeverWorsensAgreement(): void {
+  console.log('Testing that I/J snapping beats naive rounding...')
+
+  // I/J are ours to choose: the emitted pair must agree at least as well as
+  // the naively rounded one, on every arc, in both unit systems.
+  for (const [label, opts] of [
+    ['mm @3dp', MM3_IJ],
+    ['inch @4dp', {
+      format: (v: number) => Number(v.toFixed(4)),
+      arcFormat: 'ij' as const,
+      mmPerOutputUnit: 25.4,
+      quantum: 1e-4,
+    }],
+  ] as const) {
+    const scale = opts.mmPerOutputUnit === 1 ? 1 : 1 / 25.4
+    const moves = issue447Moves().map((m) => ({
+      ...m,
+      from: pt(m.from.x * scale, m.from.y * scale, m.from.z * scale),
+      to: pt(m.to.x * scale, m.to.y * scale, m.to.z * scale),
+    }))
+    const fitted = fitArcsInMachineMoves(moves, TOL * scale, MAX_DEG)
+
+    let position: { x: number; y: number } | null = null
+    let improved = false
+    for (const d of fitted) {
+      if (d.kind !== 'arc') {
+        position = { x: opts.format(d.point.x), y: opts.format(d.point.y) }
+        continue
+      }
+      const start = position ?? { x: opts.format(d.startPoint.x), y: opts.format(d.startPoint.y) }
+      const resolved = resolveEmittedArc(d, start, opts)
+
+      // What plain rounding would have produced for the same block.
+      const centerX = d.startPoint.x + d.centerOffsets.i
+      const centerY = d.startPoint.y + d.centerOffsets.j
+      const naiveI = opts.format(centerX - start.x)
+      const naiveJ = opts.format(centerY - start.y)
+      const targetX = opts.format(d.endPoint.x)
+      const targetY = opts.format(d.endPoint.y)
+      const naiveDelta = Math.abs(
+        Math.hypot(targetX - (start.x + naiveI), targetY - (start.y + naiveJ))
+        - Math.hypot(naiveI, naiveJ),
+      ) * opts.mmPerOutputUnit
+
+      assert(resolved.deltaRmm <= naiveDelta + 1e-12,
+        `${label}: snapped delta ${resolved.deltaRmm} must not exceed naive ${naiveDelta}`)
+      if (resolved.deltaRmm < naiveDelta - 1e-12) improved = true
+
+      position = { x: targetX, y: targetY }
+    }
+    assert(improved, `${label}: snapping should strictly improve at least one arc`)
+  }
+}
+
+function testRFormatRepairsRoundingShortfallOnly(): void {
+  console.log('Testing that R format repairs rounding, not geometry...')
+
+  // Chord a hair longer than the rounded diameter — a pure rounding artifact.
+  // Nudging R up one grid step is the right repair.
+  const nudge: ArcMoveDescriptor = {
+    kind: 'arc',
+    startPoint: pt(0, 0, 0),
+    endPoint: pt(1.0004, 0, 0),
+    centerOffsets: { i: 0.5002, j: 0 },
+    clockwise: false,
+    runId: 0,
+    runFallback: [{ kind: 'linear', point: pt(1.0004, 0, 0), moveKind: 'cut' }],
+  }
+  const repaired = resolveEmittedArc(nudge, { x: 0, y: 0 }, { ...MM3_IJ, arcFormat: 'r' })
+  assert(repaired.accepted, 'a rounding-sized shortfall must be repaired, not rejected')
+  assert(repaired.radius >= 0.5,
+    `repaired radius must span the chord, got ${repaired.radius}`)
+  assert(repaired.radius < 0.51,
+    `repair must stay within rounding distance, got ${repaired.radius}`)
+
+  // A genuinely inconsistent descriptor must still be rejected: widening R to
+  // fit would swap the intended arc for a much larger one.
+  const { arcs } = inconsistentRunForR()
+  const rejected = resolveEmittedArc(arcs[0], { x: 0, y: 0 }, { ...MM3_IJ, arcFormat: 'r' })
+  assert(!rejected.accepted,
+    'a chord far longer than the diameter must be rejected, not silently reshaped')
+}
+
+/** Radius 1, chord 10 — inconsistent by a factor of five, not by rounding. */
+function inconsistentRunForR(): { arcs: ArcMoveDescriptor[] } {
+  return {
+    arcs: [{
+      kind: 'arc',
+      startPoint: pt(0, 0, 0),
+      endPoint: pt(10, 0, 0),
+      centerOffsets: { i: 1, j: 0 },
+      clockwise: false,
+      runId: 0,
+      runFallback: [{ kind: 'linear', point: pt(10, 0, 0), moveKind: 'cut' }],
+    }],
+  }
+}
+
 // ── run all ─────────────────────────────────────────────────────
 
 testAcceptedCircularRun()
@@ -759,5 +1154,16 @@ testRejectsLongStraightWithCornerFragment()
 testAcceptsOrdinaryCircularArcAfterCollinearGate()
 testFullCircularChordLoop()
 testPartialArcWithStraightLeads()
+
+testIssue447MinimalReproduction()
+testAdjacentRunsShareEndpointsExactly()
+testFittedArcsPassThroughSourceEndpoints()
+testIJDerivedFromPreviousEmittedPoint()
+testInvalidRunFallsBackToOriginalMoves()
+testFallbackLeavesValidRunsAlone()
+testRFormatRejectsUnrepresentableChord()
+testInchOutputUsesMillimetreBudget()
+testSnappingNeverWorsensAgreement()
+testRFormatRepairsRoundingShortfallOnly()
 
 console.log('arcFitting tests passed')

--- a/src/engine/gcode/arcFitting.ts
+++ b/src/engine/gcode/arcFitting.ts
@@ -57,6 +57,17 @@ export interface ArcMoveDescriptor {
   source?: string
   /** Feed-scale carried from the original moves (may be undefined). */
   feedScale?: number
+  /** Identifier shared by every sub-arc split out of one fitted run.
+   *  Validation and fallback are per *run*, never per sub-arc. */
+  runId: number
+  /** The original linear moves this run replaced, in order.  Emitted
+   *  verbatim when post-format validation rejects any sub-arc of the run.
+   *  Shared by reference across the run's sub-arcs.
+   *
+   *  Fallback must be whole-run: sub-arc boundaries are synthesised points
+   *  on the fitted circle that match no source point, so a partial fallback
+   *  would strand the controller somewhere no original G1 move reaches. */
+  runFallback: readonly LinearMoveDescriptor[]
 }
 
 export interface LinearMoveDescriptor {
@@ -147,6 +158,7 @@ function splitArc(
   clockwise: boolean,
   maxSweepDeg: number,
 ): Array<{ endPt: ToolpathPoint; centerOffsets: { i: number; j: number } }> {
+  const radius = Math.hypot(start.x - center.x, start.y - center.y)
   const maxSweep = (maxSweepDeg * Math.PI) / 180
   const rawSweep = signedSweep(start, end, center)
 
@@ -172,11 +184,17 @@ function splitArc(
   let segStart = start
   for (let s = 1; s <= segments; s++) {
     const angle = a0 + step * s
-    const ep: ToolpathPoint = {
-      x: center.x + Math.cos(angle) * Math.hypot(start.x - center.x, start.y - center.y),
-      y: center.y + Math.sin(angle) * Math.hypot(start.x - center.x, start.y - center.y),
-      z: start.z,
-    }
+    // The final sub-arc lands on the caller's end point exactly. With an
+    // endpoint-constrained fit the projected point already equals it to
+    // floating-point precision; using `end` verbatim removes the last path
+    // by which an emitted run could drift off its source geometry.
+    const ep: ToolpathPoint = s === segments
+      ? { x: end.x, y: end.y, z: start.z }
+      : {
+        x: center.x + Math.cos(angle) * radius,
+        y: center.y + Math.sin(angle) * radius,
+        z: start.z,
+      }
     segments_out.push({
       endPt: ep,
       centerOffsets: {
@@ -188,6 +206,285 @@ function splitArc(
   }
 
   return segments_out
+}
+
+// ── emitted-arc self-consistency ─────────────────────────────
+
+/**
+ * An arc block is over-determined: start (modal), end (X/Y) and centre (I/J)
+ * supply one more constraint than a circular arc needs, so the numbers can
+ * contradict each other.  Controllers absorb a little contradiction as
+ * rounding noise and reject the rest — a large disagreement means a spiral,
+ * and cutting one because the file was wrong gouges the part.
+ *
+ * These are *export invariants*, not a dialect gate: they apply to every
+ * machine definition, and no controller benefits from receiving an arc that
+ * fails them.  The values are GRBL's published limits (`gcode.c`), which are
+ * the tightest among the controllers shipped in `definitions/`; satisfying
+ * them satisfies the more permissive ones.  Snapping (below) keeps emitted
+ * arcs one to two orders of magnitude inside this budget, so the exact
+ * numbers do not change any real outcome — if a stricter controller ever
+ * turns up, tightening them here is the whole change.
+ */
+export const ARC_RADIUS_CONSISTENCY_TOLERANCE_MM = 0.005
+
+/** Above this absolute disagreement no relative allowance applies. */
+export const ARC_RADIUS_GROSS_MM = 0.5
+
+/** Relative allowance between the floor and the gross limit (0.1 % of radius). */
+export const ARC_RADIUS_RELATIVE_TOLERANCE = 0.001
+
+/** How far around the naively rounded I/J the snap search looks, in grid steps. */
+const SNAP_SEARCH_STEPS = 2
+
+export interface EmittedArcOptions {
+  /** Formats a value exactly as the postprocessor will, parsed back to a
+   *  number, so the values judged here are the values written to the file. */
+  format: (value: number) => number
+  arcFormat: 'ij' | 'r'
+  /** 1 for millimetre output, 25.4 for inch.  Controllers convert to
+   *  millimetres before checking, so an inch program faces the same budget —
+   *  and inch at 4 dp has a *coarser* grid in millimetres (0.00254) than
+   *  millimetre output at 3 dp (0.001). */
+  mmPerOutputUnit: number
+  /** Output grid step in output units (10^-decimalPlaces).  Enables I/J
+   *  snapping; pass 0 to disable it. */
+  quantum: number
+}
+
+export interface EmittedArcGeometry {
+  /** I offset to emit, relative to the *previously emitted* position. */
+  i: number
+  /** J offset to emit, relative to the *previously emitted* position. */
+  j: number
+  /** Radius to emit in R-format dialects. */
+  radius: number
+  /** False when the controller would reject the formatted block. */
+  accepted: boolean
+  /** Radius disagreement the controller would compute, in millimetres. */
+  deltaRmm: number
+}
+
+/** The radius disagreement a controller computes from a formatted I/J block. */
+function radiusDisagreement(
+  startX: number, startY: number,
+  targetX: number, targetY: number,
+  i: number, j: number,
+): number {
+  return Math.abs(
+    Math.hypot(targetX - (startX + i), targetY - (startY + j)) - Math.hypot(i, j),
+  )
+}
+
+/**
+ * Choose the I/J the file should carry.
+ *
+ * I and J are *ours to pick*: the only hard requirement is that the emitted
+ * block be self-consistent. Naive rounding takes whatever the grid happens to
+ * give and can land the two radii further apart than necessary, so instead we
+ * search the grid neighbourhood and keep the pair that agrees best. Ties go to
+ * the smaller displacement, which bounds the centre shift to at most
+ * {@link SNAP_SEARCH_STEPS} output quanta — the same rounding that already
+ * constrains every number in the file.
+ */
+function snapOffsets(
+  startX: number, startY: number,
+  targetX: number, targetY: number,
+  rawI: number, rawJ: number,
+  format: (value: number) => number,
+  quantum: number,
+): { i: number; j: number } {
+  const baseI = format(rawI)
+  const baseJ = format(rawJ)
+  if (!(quantum > 0)) return { i: baseI, j: baseJ }
+
+  let best = { i: baseI, j: baseJ }
+  let bestDelta = radiusDisagreement(startX, startY, targetX, targetY, baseI, baseJ)
+  let bestSteps = 0
+
+  for (let di = -SNAP_SEARCH_STEPS; di <= SNAP_SEARCH_STEPS; di++) {
+    for (let dj = -SNAP_SEARCH_STEPS; dj <= SNAP_SEARCH_STEPS; dj++) {
+      if (di === 0 && dj === 0) continue
+      // Re-format so the candidate is exactly on the output grid rather than
+      // a float a hair off it.
+      const i = format(baseI + di * quantum)
+      const j = format(baseJ + dj * quantum)
+      const delta = radiusDisagreement(startX, startY, targetX, targetY, i, j)
+      const steps = Math.abs(di) + Math.abs(dj)
+      if (delta < bestDelta - 1e-12
+        || (delta <= bestDelta + 1e-12 && steps < bestSteps)) {
+        best = { i, j }
+        bestDelta = delta
+        bestSteps = steps
+      }
+    }
+  }
+
+  return best
+}
+
+/**
+ * Resolve the words an arc will emit, and decide whether the controller will
+ * accept them — by reproducing its arithmetic on the *formatted* values.
+ *
+ * Both halves live here so they cannot diverge: the postprocessor emits the
+ * values returned, formatted with the same `format` used to judge them.
+ *
+ * @param previousEmitted  Where the controller actually is — the formatted
+ *                         endpoint of the preceding block, not the arc's own
+ *                         declared start.  This distinction is the defect in
+ *                         issue #447.
+ */
+export function resolveEmittedArc(
+  arc: ArcMoveDescriptor,
+  previousEmitted: { x: number; y: number },
+  opts: EmittedArcOptions,
+): EmittedArcGeometry {
+  const { format, arcFormat, mmPerOutputUnit, quantum } = opts
+  const center = {
+    x: arc.startPoint.x + arc.centerOffsets.i,
+    y: arc.startPoint.y + arc.centerOffsets.j,
+  }
+  const rawI = center.x - previousEmitted.x
+  const rawJ = center.y - previousEmitted.y
+
+  // What the controller reads off the line.
+  const startX = format(previousEmitted.x)
+  const startY = format(previousEmitted.y)
+  const targetX = format(arc.endPoint.x)
+  const targetY = format(arc.endPoint.y)
+
+  if (arcFormat === 'r') {
+    // In R mode the controller derives the centre itself, and cannot when the
+    // chord is longer than the diameter. Rounding the radius *down* can cause
+    // that on its own, so nudge up to the smallest grid radius spanning the
+    // chord — but only when the shortfall is rounding-sized. A larger gap
+    // means the descriptor is genuinely inconsistent, and widening R there
+    // would silently swap the intended arc for a different, larger one.
+    const chord = Math.hypot(targetX - startX, targetY - startY)
+    const rounded = format(Math.hypot(rawI, rawJ))
+    const spanning = quantum > 0
+      ? Math.ceil((chord / 2) / quantum) * quantum
+      : chord / 2
+    const repairable = quantum > 0 && spanning - rounded <= SNAP_SEARCH_STEPS * quantum
+    const radius = repairable ? Math.max(rounded, spanning) : rounded
+    const overshoot = (chord - 2 * format(radius)) * mmPerOutputUnit
+    return {
+      i: rawI,
+      j: rawJ,
+      radius,
+      accepted: overshoot <= 0,
+      deltaRmm: Math.max(0, overshoot),
+    }
+  }
+
+  const { i, j } = snapOffsets(
+    startX, startY, targetX, targetY, rawI, rawJ, format, quantum,
+  )
+  const startRadius = Math.hypot(i, j)
+  const deltaRmm = radiusDisagreement(startX, startY, targetX, targetY, i, j) * mmPerOutputUnit
+
+  let accepted: boolean
+  if (deltaRmm <= ARC_RADIUS_CONSISTENCY_TOLERANCE_MM) {
+    accepted = true
+  } else if (deltaRmm > ARC_RADIUS_GROSS_MM) {
+    accepted = false
+  } else {
+    accepted = deltaRmm <= ARC_RADIUS_RELATIVE_TOLERANCE * startRadius * mmPerOutputUnit
+  }
+
+  return { i, j, radius: Math.hypot(rawI, rawJ), accepted, deltaRmm }
+}
+
+/**
+ * Walk a run's sub-arcs from a known emitted position and report whether every
+ * one of them survives formatting.  Rejecting the run as a whole keeps the
+ * fallback aligned to real source points — see {@link ArcMoveDescriptor.runFallback}.
+ */
+export function runSurvivesFormatting(
+  runArcs: readonly ArcMoveDescriptor[],
+  previousEmitted: { x: number; y: number },
+  opts: EmittedArcOptions,
+): boolean {
+  let position = previousEmitted
+  for (const arc of runArcs) {
+    if (!resolveEmittedArc(arc, position, opts).accepted) return false
+    position = { x: opts.format(arc.endPoint.x), y: opts.format(arc.endPoint.y) }
+  }
+  return true
+}
+
+export interface ArcFallbackResult {
+  /** Descriptors as they will actually be emitted: runs the controller would
+   *  reject are replaced by the original linear moves they had fitted. */
+  descriptors: FittedMoveDescriptor[]
+  /** How many fitted runs were replaced. */
+  fallbackRuns: number
+}
+
+/**
+ * Resolve a fitted descriptor sequence into the sequence that can safely be
+ * emitted, replacing any run whose formatted output the controller would
+ * reject with the original G1 moves for that span.
+ *
+ * Both the emission path and the exported-motion debug trace call this, so the
+ * debug view can never show an arc on a span that was emitted as G1.
+ */
+export function applyEmittedArcFallback(
+  descriptors: readonly FittedMoveDescriptor[],
+  opts: EmittedArcOptions,
+  /** Where the controller already is when this sequence begins — the emitted
+   *  position carried over from earlier operations.  Omitting it would judge
+   *  a leading arc from its own declared start, the very conflation this
+   *  function exists to prevent. */
+  startPosition?: { x: number; y: number } | null,
+): ArcFallbackResult {
+  const { format } = opts
+  const out: FittedMoveDescriptor[] = []
+  let fallbackRuns = 0
+  // Where the controller believes it is, tracked in formatted values.
+  let position: { x: number; y: number } | null = startPosition ?? null
+  let index = 0
+
+  while (index < descriptors.length) {
+    const descriptor = descriptors[index]
+
+    if (descriptor.kind === 'linear') {
+      out.push(descriptor)
+      position = { x: format(descriptor.point.x), y: format(descriptor.point.y) }
+      index += 1
+      continue
+    }
+
+    // Gather the whole fitted run — validation and fallback are per run.
+    const runId = descriptor.runId
+    const runArcs: ArcMoveDescriptor[] = []
+    while (index < descriptors.length) {
+      const next = descriptors[index]
+      if (next.kind !== 'arc' || next.runId !== runId) break
+      runArcs.push(next)
+      index += 1
+    }
+
+    const start = position ?? {
+      x: format(runArcs[0].startPoint.x),
+      y: format(runArcs[0].startPoint.y),
+    }
+
+    if (runSurvivesFormatting(runArcs, start, opts)) {
+      out.push(...runArcs)
+    } else {
+      fallbackRuns += 1
+      out.push(...runArcs[0].runFallback)
+    }
+
+    const last = out[out.length - 1]
+    position = last.kind === 'arc'
+      ? { x: format(last.endPoint.x), y: format(last.endPoint.y) }
+      : { x: format(last.point.x), y: format(last.point.y) }
+  }
+
+  return { descriptors: out, fallbackRuns }
 }
 
 // ── public API ────────────────────────────────────────────────
@@ -213,6 +510,7 @@ export function fitArcsInMachineMoves(
   const result: FittedMoveDescriptor[] = []
   const n = machineMoves.length
   let i = 0
+  let nextRunId = 0
 
   while (i < n) {
     const move = machineMoves[i]
@@ -266,6 +564,7 @@ export function fitArcsInMachineMoves(
       minChordRatio: 0.15,       // reject tiny-chord fits
       minTotalSweepRad: MIN_TOTAL_SWEEP_RAD,
       maxAngularStepRatio: 4,    // never blend a long G1 with tiny corner chords
+      endpointConstrained: true, // arcs must pass through their source endpoints
     })
 
     const source = run[0].source
@@ -298,6 +597,13 @@ export function fitArcsInMachineMoves(
         maxSweepDeg,
       )
 
+      // Original moves this run replaces — move k spans points k → k+1, so the
+      // point range [startIndex, endIndex] is covered by moves
+      // [startIndex, endIndex).  Shared by reference across the run's sub-arcs.
+      const runFallback: readonly LinearMoveDescriptor[] =
+        run.slice(arcRun.startIndex, arcRun.endIndex).map(toLinear)
+      const runId = nextRunId++
+
       let prevEnd = arcStart
       for (const seg of subArcs) {
         result.push({
@@ -308,6 +614,8 @@ export function fitArcsInMachineMoves(
           clockwise: arcRun.clockwise,
           source,
           feedScale,
+          runId,
+          runFallback,
         })
         prevEnd = seg.endPt
       }

--- a/src/engine/gcode/motionDebug.test.ts
+++ b/src/engine/gcode/motionDebug.test.ts
@@ -342,6 +342,8 @@ function testFittedArcOverCoarseChordsVerifies(): void {
         endPoint: pt(0, -radius, z),
         centerOffsets: { i: -radius, j: 0 },
         clockwise: true,
+        runId: 0,
+        runFallback: [{ kind: 'linear', point: pt(0, -radius, z), moveKind: 'cut' }],
       },
     ],
     tryFit: true,

--- a/src/engine/gcode/postprocessor.test.ts
+++ b/src/engine/gcode/postprocessor.test.ts
@@ -1003,6 +1003,7 @@ function circularCutMoves(): ToolpathMove[] {
 function runArcFixture(
   definition: MachineDefinition,
   operationOverrides?: Partial<Operation>,
+  movesOverride?: ToolpathMove[],
 ): { gcode: string; warnings: ToolpathWarning[]; stats: { moveCount: number } } {
   const project = newProject('Arc Test', 'mm')
   const toolRecord = { ...defaultTool('mm', 1), id: 't1', name: '6 mm Endmill' }
@@ -1037,7 +1038,7 @@ function runArcFixture(
     operationId: operation.id,
     warnings: [],
     bounds: null,
-    moves: circularCutMoves(),
+    moves: movesOverride ?? circularCutMoves(),
   }
   return runPostProcessor({
     project,
@@ -1098,6 +1099,125 @@ function testArcDisabledLinearFallback(): void {
   const arcWarnings = warnings.filter((w) => w.code === 'postArcNoCapability')
   assert(arcWarnings.length === 0, `expected no arc capability warning when disabled, got ${arcWarnings.length}`)
   assert(stats.moveCount === 8, `linear fallback should emit all 8 source moves, got ${stats.moveCount}`)
+}
+
+// ── issue #447: emitted arcs must satisfy the controller ───────
+
+/** The 14 contiguous cut moves from the issue #447 report. */
+function issue447CutMoves(): ToolpathMove[] {
+  const xy: Array<[number, number]> = [
+    [122.3941767939508, 167.17278330912177],
+    [122.37556680190744, 167.10332987328752],
+    [122.36930000002496, 167.0317],
+    [122.36677898139465, 166.96007012671248],
+    [122.37660115292522, 166.89061669087823],
+    [122.3982010594255, 166.82545000000005],
+    [122.43065538518721, 166.76655011100434],
+    [122.4727110084653, 166.71570666721345],
+    [122.52282307694827, 166.67446452093895],
+    [122.57920194731366, 166.6440767939257],
+    [122.63986756263506, 166.62546680188257],
+    [122.7027096154099, 166.6192000000001],
+    [122.76555166818474, 166.62546680188257],
+    [122.82621728350614, 166.6440767939257],
+    [122.88259615387153, 166.67446452093895],
+  ]
+  const points = xy.map(([x, y]) => ({ x, y, z: -1 }))
+  // Lead in with a rapid, as any real toolpath does: the arc chain is only
+  // meaningful relative to a position the controller has actually been given.
+  const moves: ToolpathMove[] = [
+    { kind: 'rapid', from: { x: 0, y: 0, z: 5 }, to: { ...points[0], z: 5 } },
+    { kind: 'plunge', from: { ...points[0], z: 5 }, to: { ...points[0] } },
+  ]
+  for (let i = 0; i < points.length - 1; i++) {
+    moves.push({ kind: 'cut', from: { ...points[i] }, to: { ...points[i + 1] } })
+  }
+  return moves
+}
+
+/**
+ * Re-derive GRBL's arc check from the emitted text alone — modal motion,
+ * modal position, formatted words. Deliberately independent of the exporter's
+ * own parser so the assertion tests the file, not our model of it.
+ */
+function assertEmittedArcsAreValid(gcode: string): number {
+  let modal = ''
+  let x = 0
+  let y = 0
+  let checked = 0
+
+  for (const raw of gcode.split('\n')) {
+    const line = raw.trim()
+    const motion = line.match(/\bG(0|1|2|3)\b/)
+    if (motion) modal = motion[1]
+
+    const wordX = line.match(/X(-?[\d.]+)/)
+    const wordY = line.match(/Y(-?[\d.]+)/)
+    const wordI = line.match(/I(-?[\d.]+)/)
+    const wordJ = line.match(/J(-?[\d.]+)/)
+
+    if ((modal === '2' || modal === '3') && wordX && wordY && wordI && wordJ) {
+      const i = parseFloat(wordI[1])
+      const j = parseFloat(wordJ[1])
+      const targetX = parseFloat(wordX[1])
+      const targetY = parseFloat(wordY[1])
+      const startRadius = Math.hypot(i, j)
+      const endRadius = Math.hypot(targetX - (x + i), targetY - (y + j))
+      const delta = Math.abs(endRadius - startRadius)
+      // GRBL: pass under 0.005 mm, else fail past 0.5 mm or 0.1 % of radius.
+      const accepted = delta <= 0.005
+        || (delta <= 0.5 && delta <= 0.001 * startRadius)
+      assert(accepted,
+        `controller would reject "${line}" from ${x},${y}: radius delta ${delta.toFixed(6)} mm`)
+      checked += 1
+    }
+
+    if (wordX) x = parseFloat(wordX[1])
+    if (wordY) y = parseFloat(wordY[1])
+  }
+
+  return checked
+}
+
+function testIssue447EmittedArcsPassControllerCheck(): void {
+  console.log('Testing issue #447 span exports arcs the controller accepts...')
+
+  const def = arcTestDefinition({ motion: { ...arcTestDefinition().motion, arcFormat: 'ij' } })
+  const { gcode, warnings } = runArcFixture(def, undefined, issue447CutMoves())
+
+  const checked = assertEmittedArcsAreValid(gcode)
+  assert(checked > 0, 'fixture must emit at least one I/J arc to be meaningful')
+  const fallbacks = warnings.filter((w) => w.code === 'postArcFallbackLinear')
+  assert(fallbacks.length === 0,
+    `span should export as arcs without falling back, got ${JSON.stringify(fallbacks)}`)
+}
+
+function testIssue447RFormatExport(): void {
+  console.log('Testing issue #447 span in R format...')
+
+  const def = arcTestDefinition({ motion: { ...arcTestDefinition().motion, arcFormat: 'r' } })
+  const { gcode, warnings } = runArcFixture(def, undefined, issue447CutMoves())
+
+  assert(/\bG[23]\b/.test(gcode), 'R-format export should still emit arcs')
+  assert(!/\bI-?[\d.]/.test(gcode), 'should not contain I when using R format')
+  const fallbacks = warnings.filter((w) => w.code === 'postArcFallbackLinear')
+  assert(fallbacks.length === 0,
+    `R-format span should not fall back, got ${JSON.stringify(fallbacks)}`)
+}
+
+function testArcOutputPassesControllerCheck(): void {
+  console.log('Testing that the standard arc fixture also satisfies the controller...')
+  const def = arcTestDefinition({ motion: { ...arcTestDefinition().motion, arcFormat: 'ij' } })
+  // Same circle as the other arc tests, led into by a rapid so the emitted
+  // arcs can be checked against a position the controller actually holds.
+  const circle = circularCutMoves()
+  const { gcode } = runArcFixture(def, undefined, [
+    { kind: 'rapid', from: { x: 0, y: 0, z: 5 }, to: { ...circle[0].from, z: 5 } },
+    { kind: 'plunge', from: { ...circle[0].from, z: 5 }, to: { ...circle[0].from } },
+    ...circle,
+  ])
+  const checked = assertEmittedArcsAreValid(gcode)
+  assert(checked > 0, 'standard fixture must emit I/J arcs')
 }
 
 // ── Unsupported machine fallback + warning ─────────────────────
@@ -1316,6 +1436,9 @@ testArcOutputIJ()
 testArcOutputR()
 testArcDisabledLinearFallback()
 testArcUnsupportedMachineWarning()
+testIssue447EmittedArcsPassControllerCheck()
+testIssue447RFormatExport()
+testArcOutputPassesControllerCheck()
 testArcNoRegressionLinear()
 testArcMixedRapidAndCut()
 testArcMoveCountReflectsFittedOutput()

--- a/src/engine/gcode/postprocessor.ts
+++ b/src/engine/gcode/postprocessor.ts
@@ -25,9 +25,9 @@ import type { ToolpathPoint, ToolpathMove } from '../toolpaths/types'
 import { effectiveFeed } from '../toolpaths/feed'
 import type { FedMoveKind } from '../toolpaths/feed'
 import type { OperationTarget } from '../../types/project'
-import { exportGeometryTolerance } from '../../utils/units'
-import { fitArcsInMachineMoves } from './arcFitting'
-import type { ArcMoveDescriptor, FittedMoveDescriptor } from './arcFitting'
+import { exportGeometryTolerance, MM_PER_INCH } from '../../utils/units'
+import { fitArcsInMachineMoves, applyEmittedArcFallback, resolveEmittedArc } from './arcFitting'
+import type { ArcMoveDescriptor, FittedMoveDescriptor, EmittedArcOptions } from './arcFitting'
 
 interface ModalState {
   motionCommand: string | null   // last G0/G1/G2/G3
@@ -84,6 +84,30 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
   let moveCount = 0
   const captureTrace = options.captureMotionTrace === true
   const motionTraces: OperationMotionTrace[] = []
+
+  // Formats a value exactly as it will be written, parsed back to a number.
+  // Arc validation must judge the numbers the controller reads, not ours.
+  const formatValue = (value: number): number =>
+    Number(formatGCodeNumber(value, definition, outputUnits))
+
+  // Everything the emitted-arc resolver needs to reproduce, and satisfy, what
+  // the controller will compute from the formatted words.
+  const arcEmitOptions: EmittedArcOptions = {
+    format: formatValue,
+    arcFormat: definition.motion.arcFormat,
+    // Controllers convert to millimetres before checking, so an inch program
+    // faces the same absolute budget.
+    mmPerOutputUnit: outputUnits === 'mm' ? 1 : MM_PER_INCH,
+    // The output grid I/J can be snapped onto. `decimalPlaces` is normalised
+    // to a per-unit object by the definition schema.
+    quantum: Math.pow(10, -definition.numberFormat.decimalPlaces[outputUnits]),
+  }
+
+  // Where the *controller* believes the tool is: every emitted coordinate
+  // after number formatting. Arc I/J offsets are relative to this, not to the
+  // exporter's un-rounded position (`state.currentPosition`) — conflating the
+  // two is the defect behind issue #447.
+  let emittedPosition: { x: number; y: number } | null = null
 
   const emitLine = (content: string) => {
     if (definition.program.lineNumbers) {
@@ -161,6 +185,11 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
       x: axes.x ?? state.currentPosition?.x ?? 0,
       y: axes.y ?? state.currentPosition?.y ?? 0,
       z: axes.z ?? state.currentPosition?.z ?? 0,
+    }
+
+    emittedPosition = {
+      x: axes.x !== undefined ? formatValue(axes.x) : emittedPosition?.x ?? 0,
+      y: axes.y !== undefined ? formatValue(axes.y) : emittedPosition?.y ?? 0,
     }
   }
 
@@ -433,18 +462,22 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
           state.motionCommand = motionCmd
         }
 
+        // I/J are relative to where the controller actually is — the formatted
+        // endpoint of the preceding block — not to the arc's declared start.
+        const start = emittedPosition ?? {
+          x: formatValue(arc.startPoint.x),
+          y: formatValue(arc.startPoint.y),
+        }
+        const emitted = resolveEmittedArc(arc, start, arcEmitOptions)
+
         lineSegments.push(`X${formatGCodeNumber(arc.endPoint.x, definition, outputUnits)}`)
         lineSegments.push(`Y${formatGCodeNumber(arc.endPoint.y, definition, outputUnits)}`)
 
         if (definition.motion.arcFormat === 'ij') {
-          lineSegments.push(`I${formatGCodeNumber(arc.centerOffsets.i, definition, outputUnits)}`)
-          lineSegments.push(`J${formatGCodeNumber(arc.centerOffsets.j, definition, outputUnits)}`)
+          lineSegments.push(`I${formatGCodeNumber(emitted.i, definition, outputUnits)}`)
+          lineSegments.push(`J${formatGCodeNumber(emitted.j, definition, outputUnits)}`)
         } else {
-          const radius = Math.sqrt(
-            arc.centerOffsets.i * arc.centerOffsets.i +
-            arc.centerOffsets.j * arc.centerOffsets.j,
-          )
-          lineSegments.push(`R${formatGCodeNumber(radius, definition, outputUnits)}`)
+          lineSegments.push(`R${formatGCodeNumber(emitted.radius, definition, outputUnits)}`)
         }
 
         if (feed !== undefined && motionCmd !== definition.motion.rapidCommand) {
@@ -470,6 +503,11 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
           y: arc.endPoint.y,
           z: state.currentPosition?.z ?? 0,
         }
+
+        emittedPosition = {
+          x: formatValue(arc.endPoint.x),
+          y: formatValue(arc.endPoint.y),
+        }
       }
 
       // ── Arc fitting (export-stage) ──
@@ -477,6 +515,10 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
       const arcEnabled = operation.arcFittingEnabled ?? true
       const machineHasArcs = definition.motion.arcInterpolation === true
       const tryFit = arcEnabled && machineHasArcs
+
+      // Captured before emission so the debug trace below can replay the same
+      // decisions from the same starting point.
+      const operationStartPosition = emittedPosition
 
       // Transform every move into machine coordinates once.
       const transformMoves = (): ToolpathMove[] =>
@@ -487,12 +529,23 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
         }))
 
       if (tryFit) {
-        // Fit arcs and emit the mixed sequence.
+        // Fit arcs, drop any run the controller would reject once formatted,
+        // then emit the mixed sequence.
         const machineMoves = transformMoves()
         const tolerance = exportGeometryTolerance(project.meta.units)
-        const descriptors = fitArcsInMachineMoves(machineMoves, tolerance, 90)
+        const fitted = fitArcsInMachineMoves(machineMoves, tolerance, 90)
+        const resolved = applyEmittedArcFallback(
+          fitted, arcEmitOptions, operationStartPosition,
+        )
 
-        for (const d of descriptors) {
+        if (resolved.fallbackRuns > 0) {
+          warnings.push({
+            code: 'postArcFallbackLinear',
+            params: { operation: operation.name, count: resolved.fallbackRuns },
+          })
+        }
+
+        for (const d of resolved.descriptors) {
           if (d.kind === 'linear') {
             if (d.moveKind === 'rapid') {
               emitRapid(d.point)
@@ -543,7 +596,12 @@ export function runPostProcessor(input: PostProcessorInput): PostProcessorResult
         let traceDescriptors: FittedMoveDescriptor[] = []
         if (tryFit) {
           const tolerance = exportGeometryTolerance(project.meta.units)
-          traceDescriptors = fitArcsInMachineMoves(traceMachineMoves, tolerance, 90)
+          // Same fallback resolution as the emission path above, so the debug
+          // view never draws an arc on a span that was emitted as G1.
+          traceDescriptors = applyEmittedArcFallback(
+            fitArcsInMachineMoves(traceMachineMoves, tolerance, 90),
+            arcEmitOptions, operationStartPosition,
+          ).descriptors
         }
         motionTraces.push({
           operationId: operation.id,

--- a/src/engine/toolpaths/arcReconstruction.ts
+++ b/src/engine/toolpaths/arcReconstruction.ts
@@ -592,6 +592,19 @@ export interface PartialArcFitOptions {
    *  min(0.01, radius×0.001) from any source center is rejected.
    *  Pass an empty array to skip this check (export does this). */
   sourceCenters?: Point[]
+  /** When true, each candidate's fitted centre is moved onto the
+   *  perpendicular bisector of its first and last point, so the accepted
+   *  circle passes *exactly* through both run endpoints.  Every gate then
+   *  validates that constrained circle, so the search naturally shortens a
+   *  run until the constrained fit is within tolerance.
+   *
+   *  The export path (issue #447) needs this: it emits one arc run per
+   *  fitted run, and adjacent runs share an endpoint index.  Without the
+   *  constraint each run projects that shared point radially onto its own
+   *  circle, so the two disagree about it by up to twice the residual
+   *  tolerance — which the controller then rejects as an invalid target.
+   *  The editor offset path re-fits whole profiles and leaves this off. */
+  endpointConstrained?: boolean
 }
 
 /** One contiguous arc sub-run found within a point sequence. */
@@ -617,6 +630,34 @@ const MAX_ARC_FIT_CANDIDATE_POINTS = 128
 
 function dist2D(a: Point, b: Point): number {
   return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+/**
+ * Move a fitted circle onto the perpendicular bisector of `start`→`end`,
+ * returning the closest such circle to the original fit.  Both endpoints are
+ * then exactly equidistant from the centre, so an arc drawn on this circle
+ * passes through them rather than through radial projections of them.
+ *
+ * Returns null when the endpoints coincide (a closed run / full circle): the
+ * bisector is undefined there, and the unconstrained fit is already endpoint-
+ * continuous because start and end are the same point.
+ */
+function constrainCircleToEndpoints(
+  fit: { center: Point; radius: number },
+  start: Point,
+  end: Point,
+): { center: Point; radius: number } | null {
+  const dx = end.x - start.x
+  const dy = end.y - start.y
+  const chord2 = dx * dx + dy * dy
+  if (chord2 <= (fit.radius * 1e-6) ** 2) return null
+
+  // Bisector: point (mx, my) + t·(-dy, dx). Project the fitted centre onto it.
+  const mx = (start.x + end.x) / 2
+  const my = (start.y + end.y) / 2
+  const t = ((fit.center.x - mx) * -dy + (fit.center.y - my) * dx) / chord2
+  const center = { x: mx - dy * t, y: my + dx * t }
+  return { center, radius: dist2D(start, center) }
 }
 
 /**
@@ -650,8 +691,15 @@ export function findArcRunsInPoints(
     // Try the longest qualifying sub-run in the bounded window first (greedy).
     for (let end = maxEnd; end >= minEnd; end -= 1) {
       const sub = points.slice(i, end + 1)
-      const fit = fitCircleLeastSquares(sub)
+      let fit = fitCircleLeastSquares(sub)
       if (!fit) continue
+
+      // Constrain before validating, so every gate — residual, chord ratio,
+      // segment angle, sweep — judges the circle that will actually be
+      // emitted rather than the looser unconstrained fit.
+      if (opts.endpointConstrained) {
+        fit = constrainCircleToEndpoints(fit, sub[0], sub[sub.length - 1]) ?? fit
+      }
 
       if (!validateArcFitPoints(sub, fit, opts)) continue
 

--- a/src/engine/toolpaths/warningCodes.ts
+++ b/src/engine/toolpaths/warningCodes.ts
@@ -166,6 +166,7 @@ export type ToolpathWarningCode =
   | 'postNoCoolantCommands'
   | 'postCannedCycleUnsupported'
   | 'postArcNoCapability'
+  | 'postArcFallbackLinear'
   // simulation replay / booklet report
   | 'replayNoTool'
   | 'bookletNoTool'

--- a/src/i18n/locales/de/warnings.ts
+++ b/src/i18n/locales/de/warnings.ts
@@ -164,6 +164,7 @@ export const warningsDe: Record<keyof typeof warningsEn, string> = {
   'warnings.postNoCoolantCommands': 'Kühlmittelausgabe angefordert, aber die Maschinendefinition hat keine Kühlmittelbefehle.',
   'warnings.postCannedCycleUnsupported': 'Operation „{operation}": {drillType}-Festzyklus wird von Maschine „{machine}" nicht unterstützt; erweiterte Bewegungen werden ausgegeben.',
   'warnings.postArcNoCapability': 'Operation „{operation}" enthält lineare Bewegungen, die als Bögen ausgegeben werden könnten, aber die ausgewählte Maschine unterstützt keine Kreisinterpolation (G2/G3). Stattdessen werden lineare Bewegungen ausgegeben.',
+  'warnings.postArcFallbackLinear': 'Bei Operation „{operation}" hätte die ausgewählte Steuerung {count} angepasste Bogenabschnitt(e) nach der Zahlenrundung abgelehnt. Diese Abschnitte wurden stattdessen als lineare Bewegungen ausgegeben.',
   // simulation replay / booklet report
   'warnings.replayNoTool': 'Der ausgewählten Operation ist kein Werkzeug zugewiesen.',
   'warnings.bookletNoTool': 'Für diese Operation ist kein Werkzeug ausgewählt.',

--- a/src/i18n/locales/en/warnings.ts
+++ b/src/i18n/locales/en/warnings.ts
@@ -164,6 +164,7 @@ export const warningsEn = {
   'warnings.postNoCoolantCommands': 'Coolant emission requested but machine definition has no coolant commands.',
   'warnings.postCannedCycleUnsupported': 'Operation "{operation}": {drillType} canned cycle not supported by machine "{machine}"; emitting expanded moves.',
   'warnings.postArcNoCapability': 'Operation "{operation}" contains linear moves that could be fitted as arcs, but the selected machine does not support arc interpolation (G2/G3). Emitting linear moves instead.',
+  'warnings.postArcFallbackLinear': 'Operation "{operation}" had {count} fitted arc run(s) that the selected controller would reject after number rounding. Those spans were emitted as linear moves instead.',
   // simulation replay / booklet report
   'warnings.replayNoTool': 'No tool assigned to the selected operation.',
   'warnings.bookletNoTool': 'No tool is selected for this operation.',

--- a/src/i18n/locales/es/warnings.ts
+++ b/src/i18n/locales/es/warnings.ts
@@ -144,6 +144,7 @@ export const warningsEs: Record<keyof typeof warningsEn, string> = {
   "warnings.postNoCoolantCommands": "Se solicitó la emisión de refrigerante, pero la definición de la máquina no tiene comandos de refrigerante.",
   "warnings.postCannedCycleUnsupported": "Operación \"{operation}\": el ciclo encapsulado {drillType} no es compatible con la máquina \"{machine}\"; se emiten movimientos expandidos.",
   "warnings.postArcNoCapability": "La operación \"{operation}\" contiene movimientos lineales que podrían ajustarse como arcos, pero la máquina seleccionada no admite interpolación circular (G2/G3). Se emiten movimientos lineales en su lugar.",
+  "warnings.postArcFallbackLinear": "La operación \"{operation}\" tenía {count} tramo(s) de arco ajustado(s) que el controlador seleccionado habría rechazado tras el redondeo numérico. Esos tramos se emitieron como movimientos lineales.",
   "warnings.replayNoTool": "No se ha asignado ninguna herramienta a la operación seleccionada.",
   "warnings.bookletNoTool": "No se ha seleccionado ninguna herramienta para esta operación.",
   "warnings.bookletNoToolpath": "No se pudo generar la trayectoria de la herramienta para esta operación.",

--- a/src/i18n/locales/fr/warnings.ts
+++ b/src/i18n/locales/fr/warnings.ts
@@ -144,6 +144,7 @@ export const warningsFr: Record<keyof typeof warningsEn, string> = {
   'warnings.postNoCoolantCommands': 'L’émission de liquide de refroidissement est demandée, mais la définition de machine ne contient aucune commande correspondante.',
   'warnings.postCannedCycleUnsupported': 'Opération « {operation} » : cycle fixe {drillType} non pris en charge par la machine « {machine} » ; émission des mouvements développés.',
   'warnings.postArcNoCapability': 'L\'opération « {operation} » contient des mouvements linéaires qui pourraient être ajustés en arcs, mais la machine sélectionnée ne prend pas en charge l\'interpolation circulaire (G2/G3). Émission de mouvements linéaires à la place.',
+  'warnings.postArcFallbackLinear': 'L\'opération « {operation} » comportait {count} section(s) d\'arc ajustée(s) que le contrôleur sélectionné aurait rejetée(s) après l\'arrondi des nombres. Ces sections ont été émises sous forme de mouvements linéaires.',
   'warnings.replayNoTool': 'Aucun outil n’est affecté à l’opération sélectionnée.',
   'warnings.bookletNoTool': 'Aucun outil n’est sélectionné pour cette opération.',
   'warnings.bookletNoToolpath': 'Le parcours d’outil n’a pas pu être généré pour cette opération.',

--- a/src/i18n/locales/zh-CN/warnings.ts
+++ b/src/i18n/locales/zh-CN/warnings.ts
@@ -148,6 +148,7 @@ export const warningsZhCN: Record<keyof typeof warningsEn, string> = {
   'warnings.postNoCoolantCommands': '已请求冷却液输出，但机床定义没有冷却液指令。',
   'warnings.postCannedCycleUnsupported': '加工操作“{operation}”：机床“{machine}”不支持 {drillType} 固定循环；已输出展开的移动。',
   'warnings.postArcNoCapability': '加工操作”{operation}”包含可拟合为圆弧的直线移动，但所选机床不支持圆弧插补（G2/G3）。已改用直线移动输出。',
+  'warnings.postArcFallbackLinear': '加工操作”{operation}”中有 {count} 段拟合圆弧在数字舍入后会被所选控制器拒绝。这些区段已改用直线移动输出。',
   'warnings.replayNoTool': '所选加工操作未指定刀具。',
   'warnings.bookletNoTool': '此加工操作未选择刀具。',
   'warnings.bookletNoToolpath': '无法为此加工操作生成刀路。',

--- a/src/i18n/warningsCoverage.test.ts
+++ b/src/i18n/warningsCoverage.test.ts
@@ -61,7 +61,7 @@ const ALL_CODES = [
   'surfaceHeightMapReduced', 'surfaceSilhouetteDegenerate', 'cleanupStockToLeaveOffsets', 'cleanupNoContours',
   'pocketNoFloorRegion', 'pocketNoFloorSegments',
   'postWcsNullSelect', 'postToolChangesDisabled', 'postNoCoolantCommands', 'postCannedCycleUnsupported',
-  'postArcNoCapability',
+  'postArcNoCapability', 'postArcFallbackLinear',
   'replayNoTool', 'bookletNoTool', 'bookletNoToolpath',
   'restOperationNotFound', 'restOnlyPocketEdgeTargets',
 ] as const satisfies readonly ToolpathWarningCode[]

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -42,7 +42,7 @@ import type {
 
 export type Units = ProjectMeta['units']
 
-const MM_PER_INCH = 25.4
+export const MM_PER_INCH = 25.4
 
 /**
  * Geometric tolerance, in millimetres, shared by export-stage arc fitting and


### PR DESCRIPTION
Closes #447

Arc fitting could emit G2/G3 blocks that GRBL-family controllers reject with error 33 (`Gcode invalid target`), aborting the job mid-cut. Reported from the field against FluidNC and reproduced here exactly — the minimal 14-move repro produces the reporter's numbers to the digit.

## Root cause

Two mechanisms, both in `fitArcsInMachineMoves`:

1. **`splitArc` discarded the fitted radius.** Sub-arc endpoints were built at `hypot(start − centre)`, so a run's final endpoint was a *radial projection* of its source point, not the point itself.
2. **The next run started from the un-projected source point.** `findArcRunsInPoints` advances with `i = best.endIndex`, so adjacent runs share that index — and disagreed about it by up to twice the residual tolerance.

The postprocessor then derived I/J from the descriptor's declared start while the controller sat at the previous *formatted* endpoint, and nothing validated the emitted block.

Measured on the reported span: a **0.0153 mm** continuity gap producing a **0.010565 mm** radius disagreement against the 0.005 mm budget. Number formatting contributed ~0.002 mm — an aggravating factor, not the cause.

## Fix

**Endpoint continuity is now structural.** Fitted circles are constrained to pass exactly through their run's source endpoints (Kasa centre projected onto the perpendicular bisector), applied *before* validation so the greedy search picks a run length that satisfies it. Recentring only after fitting was tried and rejected — it pushes residuals past tolerance and forces needless G1 fallback.

**Post-format validation** reproduces the controller's arithmetic on the emitted values, using the actual previous emitted endpoint.

**I/J are chosen, not merely rounded.** The offsets are ours to pick; the emitter searches the output grid for the pair whose two radii agree best.

| | before | after |
|---|---|---|
| fitted runs (repro) | 3 | 2 |
| chords kept as arcs | 14/14 | 14/14 |
| worst radius delta, mm @3dp | 0.010565 mm | **0.000111 mm** (45× margin) |
| worst radius delta, inch @4dp | — | **0.000273 mm** (18× margin) |

Runs that still fail fall back **whole** to their original G1 moves — sub-arc boundaries are synthesised points matching no source point, so a partial fallback would strand the controller. R-format output nudges the radius up only when the chord shortfall is rounding-sized; a larger gap is rejected rather than silently reshaped into a different, larger arc.

## Design notes

- The check is an **export invariant applied to every machine definition**, not a dialect gate. A per-definition tolerance field was considered and dropped: it would need a schema change, a form control, and a docs paragraph, to configure something that snapping makes non-load-bearing. If a stricter controller ever turns up, tightening the constant is the whole change.
- `EXPORT_GEOMETRY_TOLERANCE_MM` stays at 0.01 mm — with the endpoint constraint, residual tolerance no longer leaks into endpoint error.
- The endpoint constraint is opt-in (`endpointConstrained`); the editor offset path is untouched.
- The exported-motion debug view shares the same resolution pass, so it cannot draw an arc on a span that exported as G1.
- New `postArcFallbackLinear` warning, translated across all five locales.

## Verification

- `npm run build` green — docs check, lint, colour check, tsc, **160 test files**, vite build
- `gcodeExport` + `motionDebug` e2e 3/3 (dedicated port so no stale dev server could hijack the run)
- All pre-existing arc tests pass **unchanged** — existing fixtures are exact circles, where the constrained fit equals the unconstrained one
- New coverage: the minimal repro as a regression test, endpoint continuity, I/J measured from the emitted position, whole-run fallback, fallback scoping, R-format repair-vs-reject, inch judged against the mm budget, and snapping never doing worse than naive rounding

**Not yet hardware-tested** — @zerg32's original failing file would be the real confirmation.
