### PR TITLE
fix(post-converter): handle nested properties and OR'd capabilities in the Autodesk .cps adapter

### DIFF
--- a/src/postProcessorConverter/__fixtures__/autodeskCps/carbide3d.cps
+++ b/src/postProcessorConverter/__fixtures__/autodeskCps/carbide3d.cps
@@ -1,0 +1,1671 @@
+/**
+  Copyright (C) 2012-2026 by Autodesk, Inc.
+  All rights reserved.
+
+  Carbide 3D Grbl post processor configuration.
+
+  $Revision: 44229 e780fd31175d3ecc1f0eb61106a1f48cbb5c06bf $
+  $Date: 2026-06-12 11:32:13 $
+
+  FORKID {D897E9AA-349A-4011-AA01-06B6CCC181EB}
+*/
+
+description = "Carbide 3D (Grbl)";
+vendor = "Carbide 3D";
+vendorUrl = "http://www.carbide3d.com";
+legal = "Copyright (C) 2012-2026 by Autodesk, Inc.";
+certificationLevel = 2;
+minimumRevision = 45917;
+
+longDescription = "Generic milling post for Carbide 3D (Grbl).";
+
+extension = "nc";
+setCodePage("ascii");
+
+capabilities = CAPABILITY_MILLING | CAPABILITY_MACHINE_SIMULATION;
+tolerance = spatial(0.002, MM);
+
+minimumChordLength = spatial(0.25, MM);
+minimumCircularRadius = spatial(0.1, MM);
+maximumCircularRadius = spatial(1000, MM);
+minimumCircularSweep = toRad(0.01);
+maximumCircularSweep = toRad(180);
+allowHelicalMoves = true;
+allowedCircularPlanes = undefined; // allow any circular motion
+highFeedrate = (unit == MM) ? 5000 : 200;
+
+// user-defined properties
+properties = {
+  showSequenceNumbers: {
+    title      : "Use sequence numbers",
+    description: "'Yes' outputs sequence numbers on each block, 'Only on tool change' outputs sequence numbers on tool change blocks only, and 'No' disables the output of sequence numbers.",
+    group      : "formats",
+    type       : "enum",
+    values     : [
+      {title:"Yes", id:"true"},
+      {title:"No", id:"false"},
+      {title:"Only on tool change", id:"toolChange"}
+    ],
+    value: "false",
+    order: 1,
+    scope: "post"
+  },
+  sequenceNumberStart: {
+    title      : "Start sequence number",
+    description: "The number at which to start the sequence numbers.",
+    group      : "formats",
+    type       : "integer",
+    value      : 10,
+    order      : 2,
+    scope      : "post"
+  },
+  sequenceNumberIncrement: {
+    title      : "Sequence number increment",
+    description: "The amount by which the sequence number is incremented by in each block.",
+    group      : "formats",
+    type       : "integer",
+    value      : 1,
+    order      : 3,
+    scope      : "post"
+  },
+  separateWordsWithSpace: {
+    title      : "Separate words with space",
+    description: "Adds spaces between words if 'yes' is selected.",
+    group      : "formats",
+    type       : "boolean",
+    value      : true,
+    scope      : "post"
+  },
+  safePositionMethod: {
+    title      : "Safe Retracts",
+    description: "Select your desired retract option. 'Clearance Height' retracts to the operation clearance height.",
+    group      : "homePositions",
+    type       : "enum",
+    values     : [
+      {title:"G28", id:"G28"},
+      // {title:"G53", id: "G53"},
+      {title:"Clearance Height", id:"clearanceHeight"}
+    ],
+    value: "G28",
+    scope: "post"
+  }
+};
+
+// wcs definiton
+wcsDefinitions = {
+  useZeroOffset: false,
+  wcs          : [
+    {name:"Standard", format:"G", range:[54, 59]}
+  ]
+};
+
+var gFormat = createFormat({prefix:"G", decimals:0});
+var mFormat = createFormat({prefix:"M", decimals:0});
+
+var xyzFormat = createFormat({decimals:(unit == MM ? 3 : 4)});
+var feedFormat = createFormat({decimals:(unit == MM ? 2 : 3)});
+var toolFormat = createFormat({decimals:0});
+var rpmFormat = createFormat({decimals:0});
+var secFormat = createFormat({decimals:3, type:FORMAT_REAL}); // seconds - range 0.001-1000
+var taperFormat = createFormat({decimals:1, scale:DEG});
+
+var xOutput = createOutputVariable({onchange:function() {state.retractedX = false;}, prefix:"X"}, xyzFormat);
+var yOutput = createOutputVariable({onchange:function() {state.retractedY = false;}, prefix:"Y"}, xyzFormat);
+var zOutput = createOutputVariable({onchange:function() {state.retractedZ = false;}, prefix:"Z"}, xyzFormat);
+var feedOutput = createOutputVariable({prefix:"F"}, feedFormat);
+var sOutput = createOutputVariable({prefix:"S", control:CONTROL_FORCE}, rpmFormat);
+
+// circular output
+var iOutput = createOutputVariable({prefix:"I", control:CONTROL_FORCE}, xyzFormat);
+var jOutput = createOutputVariable({prefix:"J", control:CONTROL_FORCE}, xyzFormat);
+var kOutput = createOutputVariable({prefix:"K", control:CONTROL_FORCE}, xyzFormat);
+
+var gMotionModal = createOutputVariable({}, gFormat); // modal group 1 // G0-G3, ...
+var gPlaneModal = createOutputVariable({onchange:function () {gMotionModal.reset();}}, gFormat); // modal group 2 // G17-19
+var gAbsIncModal = createOutputVariable({}, gFormat); // modal group 3 // G90-91
+var gUnitModal = createOutputVariable({}, gFormat); // modal group 6 // G20-21
+
+var settings = {
+  coolant: {
+    // samples:
+    // {id: COOLANT_THROUGH_TOOL, on: 88, off: 89}
+    // {id: COOLANT_THROUGH_TOOL, on: [8, 88], off: [9, 89]}
+    // {id: COOLANT_THROUGH_TOOL, on: "M88 P3 (myComment)", off: "M89"}
+    coolants: [
+      {id:COOLANT_FLOOD, on:7},
+      {id:COOLANT_MIST},
+      {id:COOLANT_THROUGH_TOOL},
+      {id:COOLANT_AIR},
+      {id:COOLANT_AIR_THROUGH_TOOL},
+      {id:COOLANT_SUCTION},
+      {id:COOLANT_FLOOD_MIST},
+      {id:COOLANT_FLOOD_THROUGH_TOOL},
+      {id:COOLANT_OFF, off:9}
+    ],
+    singleLineCoolant: false, // specifies to output multiple coolant codes in one line rather than in separate lines
+  },
+  retract: {
+    cancelRotationOnRetracting: false, // specifies that rotations (G68) need to be canceled prior to retracting
+    methodXY                  : undefined, // special condition, overwrite retract behavior per axis
+    methodZ                   : undefined, // special condition, overwrite retract behavior per axis
+    useZeroValues             : ["G28", "G30"], // enter property value id(s) for using "0" value instead of machineConfiguration axes home position values (ie G30 Z0)
+    homeXY                    : {onIndexing:false, onToolChange:false, onProgramEnd:{axes:[X, Y]}} // Specifies when the machine should be homed in X/Y. Sample: onIndexing:{axes:[X, Y], singleLine:false}
+  },
+  comments: {
+    permittedCommentChars: " abcdefghijklmnopqrstuvwxyz0123456789.,=_-", // letters are not case sensitive, use option 'outputFormat' below. Set to 'undefined' to allow any character
+    prefix               : "(", // specifies the prefix for the comment
+    suffix               : ")", // specifies the suffix for the comment
+    outputFormat         : "ignoreCase", // can be set to "upperCase", "lowerCase" and "ignoreCase". Set to "ignoreCase" to write comments without upper/lower case formatting
+    maximumLineLength    : 80 // the maximum number of characters allowed in a line, set to 0 to disable comment output
+  },
+  maximumSequenceNumber       : undefined, // the maximum sequence number (Nxxx), use 'undefined' for unlimited
+  outputToolLengthCompensation: false, // specifies if tool length compensation code should be output (G43)
+  outputToolLengthOffset      : false, // specifies if tool length offset code should be output (Hxx)
+  // fixed settings below, do not modify
+  supportsTCP                 : false, // this postprocessor does not support TCP
+  supportsRadiusCompensation  : false // this postprocessor does not support tool radius compensation
+};
+
+function onOpen() {
+  if (machineConfiguration.isMultiAxisConfiguration()) {
+    error(localize("This postprocessor does not support multi axis machine configurations."));
+  }
+  if (!getProperty("separateWordsWithSpace")) {
+    setWordSeparator("");
+  }
+
+  writeln("%");
+  writeComment(programName);
+  writeComment(programComment);
+  writeProgramHeader();
+
+  // absolute coordinates and feed per min
+  writeBlock(gAbsIncModal.format(90));
+  writeBlock(gPlaneModal.format(17));
+  writeBlock(gUnitModal.format(unit == MM ? 21 : 20));
+  validateCommonParameters();
+}
+
+function onSection() {
+  var forceSectionRestart = optionalSection && !currentSection.isOptional();
+  optionalSection = currentSection.isOptional();
+  var insertToolCall = isToolChangeNeeded("number") || forceSectionRestart;
+  var newWorkOffset = isNewWorkOffset() || forceSectionRestart;
+  var newWorkPlane = isNewWorkPlane() || forceSectionRestart || (typeof defineWorkPlane == "function" &&
+    Vector.diff(defineWorkPlane(getPreviousSection(), false), defineWorkPlane(currentSection, false)).length > 1e-4);
+
+  if (insertToolCall || newWorkOffset || newWorkPlane) {
+    if (insertToolCall && !isFirstSection()) {
+      onCommand(COMMAND_COOLANT_OFF); // turn off coolant before retract during tool change
+      onCommand(COMMAND_STOP_SPINDLE); // stop spindle before retract during tool change
+    }
+    writeRetract(Z); // retract
+  }
+
+  writeln("");
+  writeComment(getParameter("operation-comment", ""));
+
+  // tool change
+  writeToolCall(tool, insertToolCall);
+  startSpindle(tool, insertToolCall);
+
+  // Output modal commands here
+  writeBlock(gPlaneModal.format(17), gAbsIncModal.format(90));
+
+  // wcs
+  if (insertToolCall) { // force work offset when changing tool
+    currentWorkOffset = undefined;
+  }
+  writeWCS(currentSection, true);
+
+  forceXYZ();
+
+  { // pure 3D
+    var remaining = currentSection.workPlane;
+    if (!isSameDirection(remaining.forward, new Vector(0, 0, 1))) {
+      error(localize("Tool orientation is not supported."));
+      return;
+    }
+    setRotation(remaining);
+  }
+
+  setCoolant(tool.coolant); // writes the required coolant codes
+
+  forceXYZ();
+  forceFeed();
+
+  // prepositioning
+  var initialPosition = getFramePosition(currentSection.getInitialPosition());
+  var isRequired = insertToolCall || state.retractedZ || !state.lengthCompensationActive || (!isFirstSection() && getPreviousSection().isMultiAxis());
+  writeInitialPositioning(initialPosition, isRequired);
+}
+
+function onDwell(seconds) {
+  var maxValue = 99999.999;
+  if (seconds > maxValue) {
+    warning(subst(localize("Dwelling time of '%1' exceeds the maximum value of '%2' in operation '%3'"), seconds, maxValue, getParameter("operation-comment", "")));
+  }
+  seconds = clamp(0.001, seconds, 99999.999);
+  writeBlock(gFormat.format(4), "P" + secFormat.format(seconds));
+}
+
+function onSpindleSpeed(spindleSpeed) {
+  writeBlock(sOutput.format(spindleSpeed));
+}
+
+/** Adjust final point to lie exactly on circle. */
+function CircularData(_plane, _center, _end) {
+  // use Output variables, since last point could have been adjusted if previous move was circular
+  var start = new Vector(xOutput.getCurrent(), yOutput.getCurrent(), zOutput.getCurrent());
+  var saveStart = new Vector(start.x, start.y, start.z);
+  var center = new Vector(
+    xyzFormat.getResultingValue(_center.x),
+    xyzFormat.getResultingValue(_center.y),
+    xyzFormat.getResultingValue(_center.z)
+  );
+  var end = new Vector(_end.x, _end.y, _end.z);
+  switch (_plane) {
+  case PLANE_XY:
+    start.setZ(center.z);
+    end.setZ(center.z);
+    break;
+  case PLANE_ZX:
+    start.setY(center.y);
+    end.setY(center.y);
+    break;
+  case PLANE_YZ:
+    start.setX(center.x);
+    end.setX(center.x);
+    break;
+  default:
+    this.center = new Vector(_center.x, _center.y, _center.z);
+    this.start = new Vector(start.x, start.y, start.z);
+    this.end = new Vector(_end.x, _end.y, _end.z);
+    this.offset = Vector.diff(center, start);
+    this.radius = this.offset.length;
+  }
+  this.start = new Vector(
+    xyzFormat.getResultingValue(start.x),
+    xyzFormat.getResultingValue(start.y),
+    xyzFormat.getResultingValue(start.z)
+  );
+  var temp = Vector.diff(center, start);
+  this.offset = new Vector(
+    xyzFormat.getResultingValue(temp.x),
+    xyzFormat.getResultingValue(temp.y),
+    xyzFormat.getResultingValue(temp.z)
+  );
+  this.center = Vector.sum(this.start, this.offset);
+  this.radius = this.offset.length;
+
+  temp = Vector.diff(end, center).normalized;
+  this.end = new Vector(
+    xyzFormat.getResultingValue(this.center.x + temp.x * this.radius),
+    xyzFormat.getResultingValue(this.center.y + temp.y * this.radius),
+    xyzFormat.getResultingValue(this.center.z + temp.z * this.radius)
+  );
+
+  switch (_plane) {
+  case PLANE_XY:
+    this.start.setZ(saveStart.z);
+    this.end.setZ(_end.z);
+    this.offset.setZ(0);
+    break;
+  case PLANE_ZX:
+    this.start.setY(saveStart.y);
+    this.end.setY(_end.y);
+    this.offset.setY(0);
+    break;
+  case PLANE_YZ:
+    this.start.setX(saveStart.x);
+    this.end.setX(_end.x);
+    this.offset.setX(0);
+    break;
+  }
+}
+
+function onCircular(clockwise, cx, cy, cz, x, y, z, feed) {
+  // one of X/Y and I/J are required and likewise
+
+  if (pendingRadiusCompensation >= 0) {
+    error(localize("Radius compensation cannot be activated/deactivated for a circular move."));
+    return;
+  }
+
+  circle = new CircularData(getCircularPlane(), new Vector(cx, cy, cz), new Vector(x, y, z));
+
+  if (isFullCircle()) {
+    if (isHelical()) {
+      linearize(tolerance);
+      return;
+    }
+    // TAG: are 360deg arcs supported
+    switch (getCircularPlane()) {
+    case PLANE_XY:
+      writeBlock(gPlaneModal.format(17), gMotionModal.format(clockwise ? 2 : 3), xOutput.format(circle.end.x), iOutput.format(circle.offset.x), jOutput.format(circle.offset.y), feedOutput.format(feed));
+      break;
+    case PLANE_ZX:
+      writeBlock(gPlaneModal.format(18), gMotionModal.format(clockwise ? 2 : 3), zOutput.format(circle.end.z), iOutput.format(circle.offset.x), kOutput.format(circle.offset.z), feedOutput.format(feed));
+      break;
+    case PLANE_YZ:
+      writeBlock(gPlaneModal.format(19), gMotionModal.format(clockwise ? 2 : 3), yOutput.format(circle.end.y), jOutput.format(circle.offset.y), kOutput.format(circle.offset.z), feedOutput.format(feed));
+      break;
+    default:
+      linearize(tolerance);
+    }
+  } else {
+    switch (getCircularPlane()) {
+    case PLANE_XY:
+      writeBlock(gPlaneModal.format(17), gMotionModal.format(clockwise ? 2 : 3),
+        xOutput.format(circle.end.x), yOutput.format(circle.end.y), zOutput.format(circle.end.z),
+        iOutput.format(circle.offset.x), jOutput.format(circle.offset.y), feedOutput.format(feed));
+      break;
+    case PLANE_ZX:
+      writeBlock(gPlaneModal.format(18), gMotionModal.format(clockwise ? 2 : 3),
+        xOutput.format(circle.end.x), yOutput.format(circle.end.y), zOutput.format(circle.end.z),
+        iOutput.format(circle.offset.x), kOutput.format(circle.offset.z), feedOutput.format(feed));
+      break;
+    case PLANE_YZ:
+      writeBlock(gPlaneModal.format(19), gMotionModal.format(clockwise ? 2 : 3),
+        xOutput.format(circle.end.x), yOutput.format(circle.end.y), zOutput.format(circle.end.z),
+        jOutput.format(circle.offset.y), kOutput.format(circle.offset.z), feedOutput.format(feed));
+      break;
+    default:
+      linearize(tolerance);
+    }
+  }
+}
+
+var mapCommand = {
+  COMMAND_END         : 2,
+  COMMAND_STOP_SPINDLE: 5
+};
+
+function onCommand(command) {
+  switch (command) {
+  case COMMAND_COOLANT_OFF:
+    setCoolant(COOLANT_OFF);
+    return;
+  case COMMAND_COOLANT_ON:
+    setCoolant(tool.coolant);
+    return;
+  case COMMAND_STOP:
+    writeBlock(mFormat.format(0));
+    forceSpindleSpeed = true;
+    forceCoolant = true;
+    return;
+  case COMMAND_START_SPINDLE:
+    forceSpindleSpeed = false;
+    writeBlock(sOutput.format(spindleSpeed), mFormat.format(tool.clockwise ? 3 : 4));
+    return;
+  case COMMAND_LOAD_TOOL:
+    writeToolBlock("T" + toolFormat.format(tool.number), mFormat.format(6));
+    writeComment(tool.comment);
+    return;
+  case COMMAND_LOCK_MULTI_AXIS:
+    return;
+  case COMMAND_UNLOCK_MULTI_AXIS:
+    return;
+  case COMMAND_BREAK_CONTROL:
+    return;
+  case COMMAND_TOOL_MEASURE:
+    return;
+  }
+
+  var stringId = getCommandStringId(command);
+  var mcode = mapCommand[stringId];
+  if (mcode != undefined) {
+    writeBlock(mFormat.format(mcode));
+  } else {
+    onUnsupportedCommand(command);
+  }
+}
+
+function onSectionEnd() {
+  writeBlock(gPlaneModal.format(17));
+  if (!isLastSection()) {
+    if (getNextSection().getTool().coolant != tool.coolant) {
+      setCoolant(COOLANT_OFF);
+    }
+    if (tool.breakControl && isToolChangeNeeded(getNextSection(), getProperty("toolAsName") ? "description" : "number")) {
+      onCommand(COMMAND_BREAK_CONTROL);
+    }
+  }
+  forceXYZ();
+  forceFeed();
+}
+
+function onClose() {
+  optionalSection = false;
+  setCoolant(COOLANT_OFF);
+  writeRetract(Z); // retract
+  if (getSetting("retract.homeXY.onProgramEnd", false)) {
+    writeRetract(settings.retract.homeXY.onProgramEnd);
+  }
+  writeBlock(mFormat.format(30)); // stop program, spindle stop, coolant off
+  writeln("%");
+}
+
+// >>>>> INCLUDED FROM include_files/commonFunctions.cpi
+// internal variables, do not change
+var receivedMachineConfiguration;
+var tcp = {isSupportedByControl:getSetting("supportsTCP", true), isSupportedByMachine:false, isSupportedByOperation:false};
+var state = {
+  retractedX              : false, // specifies that the machine has been retracted in X
+  retractedY              : false, // specifies that the machine has been retracted in Y
+  retractedZ              : false, // specifies that the machine has been retracted in Z
+  tcpIsActive             : false, // specifies that TCP is currently active
+  twpIsActive             : false, // specifies that TWP is currently active
+  lengthCompensationActive: !getSetting("outputToolLengthCompensation", true), // specifies that tool length compensation is active
+  mainState               : true // specifies the current context of the state (true = main, false = optional)
+};
+var validateLengthCompensation = getSetting("outputToolLengthCompensation", true); // disable validation when outputToolLengthCompensation is disabled
+var multiAxisFeedrate;
+var sequenceNumber;
+var optionalSection = false;
+var currentWorkOffset;
+var forceSpindleSpeed = false;
+var operationNeedsSafeStart = false; // used to convert blocks to optional for safeStartAllOperations
+
+function activateMachine() {
+  // disable unsupported rotary axes output
+  if (!machineConfiguration.isMachineCoordinate(0) && (typeof aOutput != "undefined")) {
+    aOutput.disable();
+  }
+  if (!machineConfiguration.isMachineCoordinate(1) && (typeof bOutput != "undefined")) {
+    bOutput.disable();
+  }
+  if (!machineConfiguration.isMachineCoordinate(2) && (typeof cOutput != "undefined")) {
+    cOutput.disable();
+  }
+
+  // setup usage of useTiltedWorkplane
+  settings.workPlaneMethod.useTiltedWorkplane = getProperty("useTiltedWorkplane") != undefined ? getProperty("useTiltedWorkplane") :
+    getSetting("workPlaneMethod.useTiltedWorkplane", false);
+  settings.workPlaneMethod.useABCPrepositioning = getSetting("workPlaneMethod.useABCPrepositioning", true);
+
+  if (!machineConfiguration.isMultiAxisConfiguration()) {
+    return; // don't need to modify any settings for 3-axis machines
+  }
+
+  // identify if any of the rotary axes has TCP enabled
+  var axes = [machineConfiguration.getAxisU(), machineConfiguration.getAxisV(), machineConfiguration.getAxisW()];
+  tcp.isSupportedByMachine = axes.some(function(axis) {return axis.isEnabled() && axis.isTCPEnabled();}); // true if TCP is enabled on any rotary axis
+  if (tcp.isSupportedByMachine) {
+    bufferRotaryMoves = false; // disable bufferRotaryMoves if TCP is enabled on any rotary axis
+  }
+
+  // save multi-axis feedrate settings from machine configuration
+  var mode = machineConfiguration.getMultiAxisFeedrateMode();
+  var type = mode == FEED_INVERSE_TIME ? machineConfiguration.getMultiAxisFeedrateInverseTimeUnits() :
+    (mode == FEED_DPM ? machineConfiguration.getMultiAxisFeedrateDPMType() : DPM_STANDARD);
+  multiAxisFeedrate = {
+    mode     : mode,
+    maximum  : machineConfiguration.getMultiAxisFeedrateMaximum(),
+    type     : type,
+    tolerance: mode == FEED_DPM ? machineConfiguration.getMultiAxisFeedrateOutputTolerance() : 0,
+    bpwRatio : mode == FEED_DPM ? machineConfiguration.getMultiAxisFeedrateBpwRatio() : 1
+  };
+
+  // setup of retract/reconfigure  TAG: Only needed until post kernel supports these machine config settings
+  if (receivedMachineConfiguration && machineConfiguration.performRewinds()) {
+    safeRetractDistance = machineConfiguration.getSafeRetractDistance();
+    safePlungeFeed = machineConfiguration.getSafePlungeFeedrate();
+    safeRetractFeed = machineConfiguration.getSafeRetractFeedrate();
+  }
+  if (typeof safeRetractDistance == "number" && getProperty("safeRetractDistance") != undefined && getProperty("safeRetractDistance") != 0) {
+    safeRetractDistance = getProperty("safeRetractDistance");
+  }
+
+  if (revision >= 50294) {
+    activateAutoPolarMode({tolerance:tolerance / 2, optimizeType:OPTIMIZE_AXIS, expandCycles:getSetting("polarCycleExpandMode", EXPAND_ALL)});
+  }
+
+  if (machineConfiguration.isHeadConfiguration() && getSetting("workPlaneMethod.compensateToolLength", false)) {
+    for (var i = 0; i < getNumberOfSections(); ++i) {
+      var section = getSection(i);
+      if (section.isMultiAxis()) {
+        machineConfiguration.setToolLength(getBodyLength(section.getTool())); // define the tool length for head adjustments
+        section.optimizeMachineAnglesByMachine(machineConfiguration, OPTIMIZE_AXIS);
+      }
+    }
+  } else {
+    optimizeMachineAngles2(OPTIMIZE_AXIS);
+  }
+}
+
+function getBodyLength(tool) {
+  for (var i = 0; i < getNumberOfSections(); ++i) {
+    var section = getSection(i);
+    if (tool.number == section.getTool().number) {
+      if (section.hasParameter("operation:tool_assemblyGaugeLength")) { // For Fusion
+        return section.getParameter("operation:tool_assemblyGaugeLength", tool.bodyLength + tool.holderLength);
+      } else { // Legacy products
+        return section.getParameter("operation:tool_overallLength", tool.bodyLength + tool.holderLength);
+      }
+    }
+  }
+  return tool.bodyLength + tool.holderLength;
+}
+
+function getFeed(f) {
+  if (getProperty("useG95")) {
+    return feedOutput.format(f / spindleSpeed); // use feed value
+  }
+  if (typeof activeMovements != "undefined" && activeMovements) {
+    var feedContext = activeMovements[movement];
+    if (feedContext != undefined) {
+      if (!feedFormat.areDifferent(feedContext.feed, f)) {
+        if (feedContext.id == currentFeedId) {
+          return ""; // nothing has changed
+        }
+        forceFeed();
+        currentFeedId = feedContext.id;
+        return settings.parametricFeeds.feedOutputVariable + (settings.parametricFeeds.firstFeedParameter + feedContext.id);
+      }
+    }
+    currentFeedId = undefined; // force parametric feed next time
+  }
+  return feedOutput.format(f); // use feed value
+}
+
+function validateCommonParameters() {
+  validateToolData();
+  for (var i = 0; i < getNumberOfSections(); ++i) {
+    var section = getSection(i);
+    if (getSection(0).workOffset == 0 && section.workOffset > 0) {
+      if (!(typeof wcsDefinitions != "undefined" && wcsDefinitions.useZeroOffset)) {
+        error(localize("Using multiple work offsets is not possible if the initial work offset is 0."));
+      }
+    }
+    if (section.isMultiAxis()) {
+      if (!section.isOptimizedForMachine() &&
+        (!getSetting("workPlaneMethod.useTiltedWorkplane", false) || !getSetting("supportsToolVectorOutput", false))) {
+        error(localize("This postprocessor requires a machine configuration for 5-axis simultaneous toolpath."));
+      }
+      if (machineConfiguration.getMultiAxisFeedrateMode() == FEED_INVERSE_TIME && !getSetting("supportsInverseTimeFeed", true)) {
+        error(localize("This postprocessor does not support inverse time feedrates."));
+      }
+      if (getSetting("supportsToolVectorOutput", false) && !tcp.isSupportedByControl) {
+        error(localize("Incompatible postprocessor settings detected." + EOL +
+        "Setting 'supportsToolVectorOutput' requires setting 'supportsTCP' to be enabled as well."));
+      }
+    }
+  }
+  if (!tcp.isSupportedByControl && tcp.isSupportedByMachine) {
+    error(localize("The machine configuration has TCP enabled which is not supported by this postprocessor."));
+  }
+  if (getProperty("safePositionMethod") == "clearanceHeight") {
+    var msg = "-Attention- Property 'Safe Retracts' is set to 'Clearance Height'." + EOL +
+      "Ensure the clearance height will clear the part and or fixtures." + EOL +
+      "Raise the Z-axis to a safe height before starting the program.";
+    warning(msg);
+    writeComment(msg);
+  }
+}
+
+function validateToolData() {
+  var _default = 99999;
+  var _maximumSpindleRPM = machineConfiguration.getMaximumSpindleSpeed() > 0 ? machineConfiguration.getMaximumSpindleSpeed() :
+    settings.maximumSpindleRPM == undefined ? _default : settings.maximumSpindleRPM;
+  var _maximumToolNumber = machineConfiguration.isReceived() && machineConfiguration.getNumberOfTools() > 0 ? machineConfiguration.getNumberOfTools() :
+    settings.maximumToolNumber == undefined ? _default : settings.maximumToolNumber;
+  var _maximumToolLengthOffset = settings.maximumToolLengthOffset == undefined ? _default : settings.maximumToolLengthOffset;
+  var _maximumToolDiameterOffset = settings.maximumToolDiameterOffset == undefined ? _default : settings.maximumToolDiameterOffset;
+
+  var header = ["Detected maximum values are out of range.", "Maximum values:"];
+  var warnings = {
+    toolNumber    : {msg:"Tool number value exceeds the maximum value for tool: " + EOL, max:" Tool number: " + _maximumToolNumber, values:[]},
+    lengthOffset  : {msg:"Tool length offset value exceeds the maximum value for tool: " + EOL, max:" Tool length offset: " + _maximumToolLengthOffset, values:[]},
+    diameterOffset: {msg:"Tool diameter offset value exceeds the maximum value for tool: " + EOL, max:" Tool diameter offset: " + _maximumToolDiameterOffset, values:[]},
+    spindleSpeed  : {msg:"Spindle speed exceeds the maximum value for operation: " + EOL, max:" Spindle speed: " + _maximumSpindleRPM, values:[]}
+  };
+
+  var toolIds = [];
+  for (var i = 0; i < getNumberOfSections(); ++i) {
+    var section = getSection(i);
+    if (toolIds.indexOf(section.getTool().getToolId()) === -1) { // loops only through sections which have a different tool ID
+      var toolNumber = section.getTool().number;
+      var lengthOffset = section.getTool().lengthOffset;
+      var diameterOffset = section.getTool().diameterOffset;
+      var comment = section.getParameter("operation-comment", "");
+
+      if (toolNumber > _maximumToolNumber && !getProperty("toolAsName")) {
+        warnings.toolNumber.values.push(SP + toolNumber + EOL);
+      }
+      if (lengthOffset > _maximumToolLengthOffset) {
+        warnings.lengthOffset.values.push(SP + "Tool " + toolNumber + " (" + comment + "," + " Length offset: " + lengthOffset + ")" + EOL);
+      }
+      if (diameterOffset > _maximumToolDiameterOffset) {
+        warnings.diameterOffset.values.push(SP + "Tool " + toolNumber + " (" + comment + "," + " Diameter offset: " + diameterOffset + ")" + EOL);
+      }
+      toolIds.push(section.getTool().getToolId());
+    }
+    // loop through all sections regardless of tool id for idenitfying spindle speeds
+
+    // identify if movement ramp is used in current toolpath, use ramp spindle speed for comparisons
+    var ramp = section.getMovements() & ((1 << MOVEMENT_RAMP) | (1 << MOVEMENT_RAMP_ZIG_ZAG) | (1 << MOVEMENT_RAMP_PROFILE) | (1 << MOVEMENT_RAMP_HELIX));
+    var _sectionSpindleSpeed = Math.max(section.getTool().spindleRPM, ramp ? section.getTool().rampingSpindleRPM : 0, 0);
+    if (_sectionSpindleSpeed > _maximumSpindleRPM) {
+      warnings.spindleSpeed.values.push(SP + section.getParameter("operation-comment", "") + " (" + _sectionSpindleSpeed + " RPM" + ")" + EOL);
+    }
+  }
+
+  // sort lists by tool number
+  warnings.toolNumber.values.sort(function(a, b) {return a - b;});
+  warnings.lengthOffset.values.sort(function(a, b) {return a.localeCompare(b);});
+  warnings.diameterOffset.values.sort(function(a, b) {return a.localeCompare(b);});
+
+  var warningMessages = [];
+  for (var key in warnings) {
+    if (warnings[key].values != "") {
+      header.push(warnings[key].max); // add affected max values to the header
+      warningMessages.push(warnings[key].msg + warnings[key].values.join(""));
+    }
+  }
+  if (warningMessages.length != 0) {
+    warningMessages.unshift(header.join(EOL) + EOL);
+    warning(warningMessages.join(EOL));
+  }
+}
+
+function forceFeed() {
+  currentFeedId = undefined;
+  feedOutput.reset();
+}
+
+/** Force output of X, Y, and Z. */
+function forceXYZ() {
+  xOutput.reset();
+  yOutput.reset();
+  zOutput.reset();
+}
+
+/** Force output of A, B, and C. */
+function forceABC() {
+  aOutput.reset();
+  bOutput.reset();
+  cOutput.reset();
+}
+
+/** Force output of X, Y, Z, A, B, C, and F on next output. */
+function forceAny() {
+  forceXYZ();
+  forceABC();
+  forceFeed();
+}
+
+/**
+  Writes the specified block.
+*/
+function writeBlock() {
+  var text = formatWords(arguments);
+  if (!text) {
+    return;
+  }
+  var prefix = getSetting("sequenceNumberPrefix", "N");
+  var suffix = getSetting("writeBlockSuffix", "");
+  if ((optionalSection || skipBlocks) && !getSetting("supportsOptionalBlocks", true)) {
+    error(localize("Optional blocks are not supported by this post."));
+  }
+  if (getProperty("showSequenceNumbers") == "true") {
+    if (sequenceNumber == undefined || sequenceNumber >= settings.maximumSequenceNumber) {
+      sequenceNumber = getProperty("sequenceNumberStart");
+    }
+    if (optionalSection || skipBlocks) {
+      writeWords2("/", prefix + sequenceNumber, text + suffix);
+    } else {
+      writeWords2(prefix + sequenceNumber, text + suffix);
+    }
+    sequenceNumber += getProperty("sequenceNumberIncrement");
+  } else {
+    if (optionalSection || skipBlocks) {
+      writeWords2("/", text + suffix);
+    } else {
+      writeWords(text + suffix);
+    }
+  }
+}
+
+validate(settings.comments, "Setting 'comments' is required but not defined.");
+function formatComment(text) {
+  var prefix = settings.comments.prefix;
+  var suffix = settings.comments.suffix;
+  var _permittedCommentChars = settings.comments.permittedCommentChars == undefined ? "" : settings.comments.permittedCommentChars;
+  switch (settings.comments.outputFormat) {
+  case "upperCase":
+    text = text.toUpperCase();
+    _permittedCommentChars = _permittedCommentChars.toUpperCase();
+    break;
+  case "lowerCase":
+    text = text.toLowerCase();
+    _permittedCommentChars = _permittedCommentChars.toLowerCase();
+    break;
+  case "ignoreCase":
+    _permittedCommentChars = _permittedCommentChars.toUpperCase() + _permittedCommentChars.toLowerCase();
+    break;
+  default:
+    error(localize("Unsupported option specified for setting 'comments.outputFormat'."));
+  }
+  if (_permittedCommentChars != "") {
+    text = filterText(String(text), _permittedCommentChars);
+  }
+  text = String(text).substring(0, settings.comments.maximumLineLength - prefix.length - suffix.length);
+  return text != "" ? prefix + text + suffix : "";
+}
+
+/**
+  Output a comment.
+*/
+function writeComment(text) {
+  if (!text) {
+    return;
+  }
+  var comments = String(text).split(/\r?\n/);
+  for (comment in comments) {
+    var _comment = formatComment(comments[comment]);
+    if (_comment) {
+      if (getSetting("comments.showSequenceNumbers", false)) {
+        writeBlock(_comment);
+      } else {
+        writeln(_comment);
+      }
+    }
+  }
+}
+
+function onComment(text) {
+  writeComment(text);
+}
+
+/**
+  Writes the specified block - used for tool changes only.
+*/
+function writeToolBlock() {
+  var show = getProperty("showSequenceNumbers");
+  setProperty("showSequenceNumbers", (show == "true" || show == "toolChange") ? "true" : "false");
+  writeBlock(arguments);
+  setProperty("showSequenceNumbers", show);
+  machineSimulation({/*x:toPreciseUnit(200, MM), y:toPreciseUnit(200, MM), coordinates:MACHINE,*/ mode:TOOLCHANGE}); // move machineSimulation to a tool change position
+}
+
+var skipBlocks = false;
+var initialState = JSON.parse(JSON.stringify(state)); // save initial state
+var optionalState = JSON.parse(JSON.stringify(state));
+var saveCurrentSectionId = undefined;
+function writeStartBlocks(isRequired, code) {
+  var saveSkipBlocks = skipBlocks;
+  var saveMainState = state; // save main state
+
+  if (!isRequired) {
+    if (!getProperty("safeStartAllOperations", false)) {
+      return; // when safeStartAllOperations is disabled, dont output code and return
+    }
+    if (saveCurrentSectionId != getCurrentSectionId()) {
+      saveCurrentSectionId = getCurrentSectionId();
+      forceModals(); // force all modal variables when entering a new section
+      optionalState = Object.create(initialState); // reset optionalState to initialState when entering a new section
+    }
+    skipBlocks = true; // if values are not required, but safeStartAllOperations is enabled - write following blocks as optional
+    state = optionalState; // set state to optionalState if skipBlocks is true
+    state.mainState = false;
+  }
+  code(); // writes out the code which is passed to this function as an argument
+
+  state = saveMainState; // restore main state
+  skipBlocks = saveSkipBlocks; // restore skipBlocks value
+}
+
+var pendingRadiusCompensation = -1;
+function onRadiusCompensation() {
+  pendingRadiusCompensation = radiusCompensation;
+  if (pendingRadiusCompensation >= 0 && !getSetting("supportsRadiusCompensation", true)) {
+    error(localize("Radius compensation mode is not supported."));
+    return;
+  }
+}
+
+function onPassThrough(text) {
+  var commands = String(text).split(",");
+  for (text in commands) {
+    writeBlock(commands[text]);
+  }
+}
+
+function forceModals() {
+  if (arguments.length == 0) { // reset all modal variables listed below
+    var modals = [
+      "gMotionModal",
+      "gPlaneModal",
+      "gAbsIncModal",
+      "gFeedModeModal",
+      "feedOutput"
+    ];
+    if (operationNeedsSafeStart && (typeof currentSection != "undefined" && currentSection.isMultiAxis())) {
+      modals.push("fourthAxisClamp", "fifthAxisClamp", "sixthAxisClamp");
+    }
+    for (var i = 0; i < modals.length; ++i) {
+      if (typeof this[modals[i]] != "undefined") {
+        this[modals[i]].reset();
+      }
+    }
+  } else {
+    for (var i in arguments) {
+      arguments[i].reset(); // only reset the modal variable passed to this function
+    }
+  }
+}
+
+/** Helper function to be able to use a default value for settings which do not exist. */
+function getSetting(setting, defaultValue) {
+  var result = defaultValue;
+  var keys = setting.split(".");
+  var obj = settings;
+  for (var i in keys) {
+    if (obj[keys[i]] != undefined) { // setting does exist
+      result = obj[keys[i]];
+      if (typeof [keys[i]] === "object") {
+        obj = obj[keys[i]];
+        continue;
+      }
+    } else { // setting does not exist, use default value
+      if (defaultValue != undefined) {
+        result = defaultValue;
+      } else {
+        error("Setting '" + keys[i] + "' has no default value and/or does not exist.");
+        return undefined;
+      }
+    }
+  }
+  return result;
+}
+
+function getForwardDirection(_section) {
+  var forward = undefined;
+  var _optimizeType = settings.workPlaneMethod && settings.workPlaneMethod.optimizeType;
+  if (_section.isMultiAxis()) {
+    forward = _section.workPlane.forward;
+  } else if (!getSetting("workPlaneMethod.useTiltedWorkplane", false) && machineConfiguration.isMultiAxisConfiguration()) {
+    if (_optimizeType == undefined) {
+      var saveRotation = getRotation();
+      getWorkPlaneMachineABC(_section, true);
+      forward = getRotation().forward;
+      setRotation(saveRotation); // reset rotation
+    } else {
+      var abc = getWorkPlaneMachineABC(_section, false);
+      var forceAdjustment = settings.workPlaneMethod.optimizeType == OPTIMIZE_TABLES || settings.workPlaneMethod.optimizeType == OPTIMIZE_BOTH;
+      forward = machineConfiguration.getOptimizedDirection(_section.workPlane.forward, abc, false, forceAdjustment);
+    }
+  } else {
+    forward = getRotation().forward;
+  }
+  return forward;
+}
+
+function getRetractParameters() {
+  var _arguments = typeof arguments[0] === "object" ? arguments[0].axes : arguments;
+  var singleLine = arguments[0].singleLine == undefined ? true : arguments[0].singleLine;
+  var words = []; // store all retracted axes in an array
+  var retractAxes = new Array(false, false, false);
+  var method = getProperty("safePositionMethod", "undefined");
+  if (method == "clearanceHeight") {
+    if (!is3D()) {
+      error(localize("Safe retract option 'Clearance Height' is only supported when all operations are along the setup Z-axis."));
+    }
+    return undefined;
+  }
+  validate(settings.retract, "Setting 'retract' is required but not defined.");
+  validate(_arguments.length != 0, "No axis specified for getRetractParameters().");
+  for (i in _arguments) {
+    retractAxes[_arguments[i]] = true;
+  }
+  if ((retractAxes[0] || retractAxes[1]) && !state.retractedZ) { // retract Z first before moving to X/Y home
+    error(localize("Retracting in X/Y is not possible without being retracted in Z."));
+    return undefined;
+  }
+  // special conditions
+  if (retractAxes[0] || retractAxes[1]) {
+    method = getSetting("retract.methodXY", method);
+  }
+  if (retractAxes[2]) {
+    method = getSetting("retract.methodZ", method);
+  }
+  // define home positions
+  var useZeroValues = (settings.retract.useZeroValues && settings.retract.useZeroValues.indexOf(method) != -1);
+  var _xHome = machineConfiguration.hasHomePositionX() && !useZeroValues ? machineConfiguration.getHomePositionX() : toPreciseUnit(0, MM);
+  var _yHome = machineConfiguration.hasHomePositionY() && !useZeroValues ? machineConfiguration.getHomePositionY() : toPreciseUnit(0, MM);
+  var _zHome = machineConfiguration.getRetractPlane() != 0 && !useZeroValues ? machineConfiguration.getRetractPlane() : toPreciseUnit(0, MM);
+  for (var i = 0; i < _arguments.length; ++i) {
+    switch (_arguments[i]) {
+    case X:
+      if (!state.retractedX) {
+        words.push("X" + xyzFormat.format(_xHome));
+        xOutput.reset();
+        state.retractedX = true;
+      }
+      break;
+    case Y:
+      if (!state.retractedY) {
+        words.push("Y" + xyzFormat.format(_yHome));
+        yOutput.reset();
+        state.retractedY = true;
+      }
+      break;
+    case Z:
+      if (!state.retractedZ) {
+        words.push("Z" + xyzFormat.format(_zHome));
+        zOutput.reset();
+        state.retractedZ = true;
+      }
+      break;
+    default:
+      error(localize("Unsupported axis specified for getRetractParameters()."));
+      return undefined;
+    }
+  }
+  return {
+    method     : method,
+    retractAxes: retractAxes,
+    words      : words,
+    positions  : {
+      x: retractAxes[0] ? _xHome : undefined,
+      y: retractAxes[1] ? _yHome : undefined,
+      z: retractAxes[2] ? _zHome : undefined},
+    singleLine: singleLine};
+}
+
+/** Returns true when subprogram logic does exist into the post. */
+function subprogramsAreSupported() {
+  return typeof subprogramState != "undefined";
+}
+
+// Start of machine simulation connection move support
+var debugSimulation = false; // enable to output debug information for connection move support in the NC program
+var TCPON = "TCP ON";
+var TCPOFF = "TCP OFF";
+var TWPON = "TWP ON";
+var TWPOFF = "TWP OFF";
+var TOOLCHANGE = "TOOL CHANGE";
+var RETRACTTOOLAXIS = "RETRACT TOOLAXIS";
+var WORK = "WORK CS";
+var MACHINE = "MACHINE CS";
+var MIN = "MIN";
+var MAX = "MAX";
+var SHORTEST = "SHORTEST";
+var PROGRAMMED = "PROGRAMMED";
+var WARNING_NON_RANGE = [0, 1, 2];
+var isTwpOn;
+var isTcpOn;
+/**
+ * Helper function for connection moves in machine simulation.
+ * @param {Object} parameters An object containing the desired options for machine simulation.
+ * @note Available properties are:
+ * @param {Number} x X axis position, alternatively use MIN or MAX to move to the axis limit
+ * @param {Number} y Y axis position, alternatively use MIN or MAX to move to the axis limit
+ * @param {Number} z Z axis position, alternatively use MIN or MAX to move to the axis limit
+ * @param {Number} a A axis position (in radians)
+ * @param {Number} b B axis position (in radians)
+ * @param {Number} c C axis position (in radians)
+ * @param {Number} feed desired feedrate, automatically set to high/current feedrate if not specified
+ * @param {String} mode mode TCPON | TCPOFF | TWPON | TWPOFF | TOOLCHANGE | RETRACTTOOLAXIS
+ * @param {String} coordinates WORK | MACHINE - if undefined, work coordinates will be used by default
+ * @param {Number} eulerAngles the calculated Euler angles for the workplane
+ * @param {String} rotaryMode SHORTEST | PROGRAMMED - if undefined, the default rotary mode will be used
+ * @example
+  machineSimulation({a:abc.x, b:abc.y, c:abc.z, coordinates:MACHINE});
+  machineSimulation({x:toPreciseUnit(200, MM), y:toPreciseUnit(200, MM), coordinates:MACHINE, mode:TOOLCHANGE});
+  machineSimulation({a:abc.x, b:abc.y, c:abc.z, coordinates:MACHINE, rotaryMode:SHORTEST});
+*/
+function machineSimulation(parameters) {
+  if (revision < 50198 || skipBlocks || (getSimulationStreamPath() == "" && !debugSimulation)) {
+    return; // return when post kernel revision is lower than 50198 or when skipBlocks is enabled
+  }
+  getAxisLimit = function(axis, limit) {
+    validate(limit == MIN || limit == MAX, subst(localize("Invalid argument \"%1\" passed to the machineSimulation function."), limit));
+    var range = axis.getRange();
+    if (range.isNonRange()) {
+      var axisLetters = ["X", "Y", "Z"];
+      var warningMessage = subst(localize("An attempt was made to move the \"%1\" axis to its MIN/MAX limits during machine simulation, but its range is set to \"unlimited\"." + EOL +
+        "A limited range must be set for the \"%1\" axis in the machine definition, or these motions will not be shown in machine simulation."), axisLetters[axis.getCoordinate()]);
+      warningOnce(warningMessage, WARNING_NON_RANGE[axis.getCoordinate()]);
+      return undefined;
+    }
+    return limit == MIN ? range.minimum : range.maximum;
+  };
+  var x = (isNaN(parameters.x) && parameters.x) ? getAxisLimit(machineConfiguration.getAxisX(), parameters.x) : parameters.x;
+  var y = (isNaN(parameters.y) && parameters.y) ? getAxisLimit(machineConfiguration.getAxisY(), parameters.y) : parameters.y;
+  var z = (isNaN(parameters.z) && parameters.z) ? getAxisLimit(machineConfiguration.getAxisZ(), parameters.z) : parameters.z;
+  var rotaryAxesErrorMessage = localize("Invalid argument for rotary axes passed to the machineSimulation function. Only numerical values are supported.");
+  var a = (isNaN(parameters.a) && parameters.a) ? error(rotaryAxesErrorMessage) : parameters.a;
+  var b = (isNaN(parameters.b) && parameters.b) ? error(rotaryAxesErrorMessage) : parameters.b;
+  var c = (isNaN(parameters.c) && parameters.c) ? error(rotaryAxesErrorMessage) : parameters.c;
+  var coordinates = parameters.coordinates;
+  var eulerAngles = parameters.eulerAngles;
+  var rotaryMode = parameters.rotaryMode;
+  var feed = parameters.feed;
+  if (feed === undefined && typeof gMotionModal !== "undefined") {
+    feed = gMotionModal.getCurrent() !== 0;
+  }
+  var mode = parameters.mode;
+  var performToolChange = mode == TOOLCHANGE;
+  if (mode !== undefined && ![TCPON, TCPOFF, TWPON, TWPOFF, TOOLCHANGE, RETRACTTOOLAXIS].includes(mode)) {
+    error(subst("Mode '%1' is not supported.", mode));
+  }
+  if (rotaryMode !== undefined && ![SHORTEST, PROGRAMMED].includes(rotaryMode)) {
+    error(subst(localize("Rotary mode '%1' is not supported."), rotaryMode));
+  }
+
+  // mode takes precedence over TCP/TWP states
+  var enableTCP = isTcpOn;
+  var enableTWP = isTwpOn;
+  if (mode === TCPON || mode === TCPOFF) {
+    enableTCP = mode === TCPON;
+  } else if (mode === TWPON || mode === TWPOFF) {
+    enableTWP = mode === TWPON;
+  } else {
+    enableTCP = typeof state !== "undefined" && state.tcpIsActive;
+    enableTWP = typeof state !== "undefined" && state.twpIsActive;
+  }
+  var disableTCP = !enableTCP;
+  var disableTWP = !enableTWP;
+  if (disableTWP) {
+    simulation.setTWPModeOff();
+    isTwpOn = false;
+  }
+  if (disableTCP) {
+    simulation.setTCPModeOff();
+    isTcpOn = false;
+  }
+  if (enableTCP) {
+    simulation.setTCPModeOn();
+    isTcpOn = true;
+  }
+  if (enableTWP) {
+    if (settings.workPlaneMethod.eulerConvention == undefined) {
+      simulation.setTWPModeAlignToCurrentPose();
+    } else if (eulerAngles) {
+      simulation.setTWPModeByEulerAngles(settings.workPlaneMethod.eulerConvention, eulerAngles.x, eulerAngles.y, eulerAngles.z);
+    }
+    isTwpOn = true;
+  }
+  if (mode == RETRACTTOOLAXIS) {
+    simulation.retractAlongToolAxisToLimit();
+  }
+
+  if (debugSimulation) {
+    writeln("  DEBUG" + JSON.stringify(parameters));
+    writeln("  DEBUG" + JSON.stringify({isTwpOn:isTwpOn, isTcpOn:isTcpOn, feed:feed}));
+  }
+
+  if (x !== undefined || y !== undefined || z !== undefined || a !== undefined || b !== undefined || c !== undefined) {
+    if (x !== undefined) {simulation.setTargetX(x);}
+    if (y !== undefined) {simulation.setTargetY(y);}
+    if (z !== undefined) {simulation.setTargetZ(z);}
+    if (a !== undefined) {simulation.setTargetA(a);}
+    if (b !== undefined) {simulation.setTargetB(b);}
+    if (c !== undefined) {simulation.setTargetC(c);}
+
+    if (feed != undefined && feed) {
+      simulation.setMotionToLinear();
+      simulation.setFeedrate(typeof feed == "number" ? feed : feedOutput.getCurrent() == 0 ? highFeedrate : feedOutput.getCurrent());
+    } else {
+      simulation.setMotionToRapid();
+    }
+
+    var supportsRotaryMode = rotaryMode !== undefined && revision >= 50338;
+    var saveRotaryDirection = supportsRotaryMode ? simulation.getRotaryDirection() : undefined;
+    if (supportsRotaryMode) {
+      if (rotaryMode === SHORTEST) {
+        simulation.setRotaryToGoShortestDirection();
+      } else if (rotaryMode === PROGRAMMED) {
+        simulation.setRotaryToGoProgrammedDirection();
+      }
+    }
+
+    if (coordinates != undefined && coordinates == MACHINE) {
+      simulation.moveToTargetInMachineCoords();
+    } else {
+      simulation.moveToTargetInWorkCoords();
+    }
+
+    if (supportsRotaryMode) {
+      if (saveRotaryDirection === ROTARY_DIRECTION_AS_PROGRAMMED) {
+        simulation.setRotaryToGoProgrammedDirection();
+      } else {
+        simulation.setRotaryToGoShortestDirection();
+      }
+    }
+  }
+  if (performToolChange) {
+    simulation.performToolChangeCycle();
+    simulation.moveToTargetInMachineCoords();
+  }
+}
+// <<<<< INCLUDED FROM include_files/commonFunctions.cpi
+// >>>>> INCLUDED FROM include_files/writeWCS.cpi
+function writeWCS(section, wcsIsRequired) {
+  if (section.workOffset != currentWorkOffset) {
+    if (getSetting("workPlaneMethod.cancelTiltFirst", false) && wcsIsRequired) {
+      cancelWorkPlane();
+    }
+    if (typeof forceWorkPlane == "function" && wcsIsRequired) {
+      forceWorkPlane();
+    }
+    writeStartBlocks(wcsIsRequired, function () {
+      writeBlock(section.wcs);
+    });
+    currentWorkOffset = section.workOffset;
+    if (revision >= 50338 && getCurrentSectionId() > 0 && section.workOffset != getPreviousSection().workOffset) {
+      simulation.activateWorkCoordsForNextOperation();
+    }
+  }
+}
+// <<<<< INCLUDED FROM include_files/writeWCS.cpi
+// >>>>> INCLUDED FROM include_files/writeToolCall.cpi
+function writeToolCall(tool, insertToolCall) {
+  if (!isFirstSection()) {
+    writeStartBlocks(!getProperty("safeStartAllOperations") && insertToolCall, function () {
+      writeRetract(Z); // write optional Z retract before tool change if safeStartAllOperations is enabled
+    });
+  }
+  writeStartBlocks(insertToolCall, function () {
+    writeRetract(Z);
+    if (getSetting("retract.homeXY.onToolChange", false)) {
+      writeRetract(settings.retract.homeXY.onToolChange);
+    }
+    if (!isFirstSection() && insertToolCall) {
+      if (typeof forceWorkPlane == "function") {
+        forceWorkPlane();
+      }
+      onCommand(COMMAND_COOLANT_OFF); // turn off coolant on tool change
+    }
+
+    if (tool.manualToolChange) {
+      onCommand(COMMAND_STOP);
+      writeComment("MANUAL TOOL CHANGE TO T" + toolFormat.format(tool.number));
+    } else {
+      if (!isFirstSection() && getProperty("optionalStop") && insertToolCall) {
+        onCommand(COMMAND_OPTIONAL_STOP);
+      }
+      onCommand(COMMAND_LOAD_TOOL);
+    }
+  });
+  if (typeof forceModals == "function" && (insertToolCall || getProperty("safeStartAllOperations"))) {
+    forceModals();
+  }
+}
+// <<<<< INCLUDED FROM include_files/writeToolCall.cpi
+// >>>>> INCLUDED FROM include_files/startSpindle.cpi
+function startSpindle(tool, insertToolCall) {
+  if (tool.type != TOOL_PROBE) {
+    var spindleSpeedIsRequired = insertToolCall || forceSpindleSpeed || isFirstSection() ||
+      rpmFormat.areDifferent(spindleSpeed, sOutput.getCurrent()) ||
+      (tool.clockwise != getPreviousSection().getTool().clockwise);
+
+    writeStartBlocks(spindleSpeedIsRequired, function () {
+      if (spindleSpeedIsRequired || operationNeedsSafeStart) {
+        onCommand(COMMAND_START_SPINDLE);
+      }
+    });
+  }
+}
+// <<<<< INCLUDED FROM include_files/startSpindle.cpi
+// >>>>> INCLUDED FROM include_files/coolant.cpi
+var currentCoolantMode = COOLANT_OFF;
+var coolantOff = undefined;
+var isOptionalCoolant = false;
+var forceCoolant = false;
+
+function setCoolant(coolant) {
+  var coolantCodes = getCoolantCodes(coolant);
+  if (Array.isArray(coolantCodes)) {
+    writeStartBlocks(!isOptionalCoolant, function () {
+      if (settings.coolant.singleLineCoolant) {
+        writeBlock(coolantCodes.join(getWordSeparator()));
+      } else {
+        for (var c in coolantCodes) {
+          writeBlock(coolantCodes[c]);
+        }
+      }
+    });
+    return undefined;
+  }
+  return coolantCodes;
+}
+
+function getCoolantCodes(coolant, format) {
+  if (!getProperty("useCoolant", true)) {
+    return undefined; // coolant output is disabled by property if it exists
+  }
+  isOptionalCoolant = false;
+  if (typeof operationNeedsSafeStart == "undefined") {
+    operationNeedsSafeStart = false;
+  }
+  var multipleCoolantBlocks = new Array(); // create a formatted array to be passed into the outputted line
+  var coolants = settings.coolant.coolants;
+  if (!coolants) {
+    error(localize("Coolants have not been defined."));
+  }
+  if (tool.type && tool.type == TOOL_PROBE) { // avoid coolant output for probing
+    coolant = COOLANT_OFF;
+  }
+  if (coolant == currentCoolantMode) {
+    if (operationNeedsSafeStart && coolant != COOLANT_OFF) {
+      isOptionalCoolant = true;
+    } else if (!forceCoolant || coolant == COOLANT_OFF) {
+      return undefined; // coolant is already active
+    }
+  }
+  if ((coolant != COOLANT_OFF) && (currentCoolantMode != COOLANT_OFF) && (coolantOff != undefined) && !forceCoolant && !isOptionalCoolant) {
+    if (Array.isArray(coolantOff)) {
+      for (var i in coolantOff) {
+        multipleCoolantBlocks.push(coolantOff[i]);
+      }
+    } else {
+      multipleCoolantBlocks.push(coolantOff);
+    }
+  }
+  forceCoolant = false;
+
+  var m;
+  var coolantCodes = {};
+  for (var c in coolants) { // find required coolant codes into the coolants array
+    if (coolants[c].id == coolant) {
+      coolantCodes.on = coolants[c].on;
+      if (coolants[c].off != undefined) {
+        coolantCodes.off = coolants[c].off;
+        break;
+      } else {
+        for (var i in coolants) {
+          if (coolants[i].id == COOLANT_OFF) {
+            coolantCodes.off = coolants[i].off;
+            break;
+          }
+        }
+      }
+    }
+  }
+  if (coolant == COOLANT_OFF) {
+    m = !coolantOff ? coolantCodes.off : coolantOff; // use the default coolant off command when an 'off' value is not specified
+  } else {
+    coolantOff = coolantCodes.off;
+    m = coolantCodes.on;
+  }
+
+  if (!m) {
+    onUnsupportedCoolant(coolant);
+    m = 9;
+  } else {
+    if (Array.isArray(m)) {
+      for (var i in m) {
+        multipleCoolantBlocks.push(m[i]);
+      }
+    } else {
+      multipleCoolantBlocks.push(m);
+    }
+    currentCoolantMode = coolant;
+    for (var i in multipleCoolantBlocks) {
+      if (typeof multipleCoolantBlocks[i] == "number") {
+        multipleCoolantBlocks[i] = mFormat.format(multipleCoolantBlocks[i]);
+      }
+    }
+    if (format == undefined || format) {
+      return multipleCoolantBlocks; // return the single formatted coolant value
+    } else {
+      return m; // return unformatted coolant value
+    }
+  }
+  return undefined;
+}
+// <<<<< INCLUDED FROM include_files/coolant.cpi
+// >>>>> INCLUDED FROM include_files/writeProgramHeader.cpi
+properties.writeMachine = {
+  title      : "Write machine",
+  description: "Output the machine settings in the header of the program.",
+  group      : "formats",
+  type       : "boolean",
+  value      : true,
+  scope      : "post"
+};
+properties.writeTools = {
+  title      : "Write tool list",
+  description: "Output a tool list in the header of the program.",
+  group      : "formats",
+  type       : "boolean",
+  value      : true,
+  scope      : "post"
+};
+function writeProgramHeader() {
+  // dump machine configuration
+  var vendor = machineConfiguration.getVendor();
+  var model = machineConfiguration.getModel();
+  var mDescription = machineConfiguration.getDescription();
+  if (getProperty("writeMachine") && (vendor || model || mDescription)) {
+    writeComment(localize("Machine"));
+    if (vendor) {
+      writeComment("  " + localize("vendor") + ": " + vendor);
+    }
+    if (model) {
+      writeComment("  " + localize("model") + ": " + model);
+    }
+    if (mDescription) {
+      writeComment("  " + localize("description") + ": " + mDescription);
+    }
+  }
+
+  // dump tool information
+  if (getProperty("writeTools")) {
+    if (false) { // set to true to use the post kernel version of the tool list
+      writeToolTable(TOOL_NUMBER_COL);
+    } else {
+      var zRanges = {};
+      if (is3D()) {
+        var numberOfSections = getNumberOfSections();
+        for (var i = 0; i < numberOfSections; ++i) {
+          var section = getSection(i);
+          var zRange = section.getGlobalZRange();
+          var tool = section.getTool();
+          if (zRanges[tool.number]) {
+            zRanges[tool.number].expandToRange(zRange);
+          } else {
+            zRanges[tool.number] = zRange;
+          }
+        }
+      }
+      var tools = getToolTable();
+      if (tools.getNumberOfTools() > 0) {
+        for (var i = 0; i < tools.getNumberOfTools(); ++i) {
+          var tool = tools.getTool(i);
+          var comment = (getProperty("toolAsName") ? "\"" + tool.description.toUpperCase() + "\"" : "T" + toolFormat.format(tool.number)) + " " +
+          "D=" + xyzFormat.format(tool.diameter) + " " +
+          localize("CR") + "=" + xyzFormat.format(tool.cornerRadius);
+          if ((tool.taperAngle > 0) && (tool.taperAngle < Math.PI)) {
+            comment += " " + localize("TAPER") + "=" + taperFormat.format(tool.taperAngle) + localize("deg");
+          }
+          if (zRanges[tool.number]) {
+            comment += " - " + localize("ZMIN") + "=" + xyzFormat.format(zRanges[tool.number].getMinimum());
+          }
+          comment += " - " + getToolTypeName(tool.type);
+          writeComment(comment);
+        }
+      }
+    }
+  }
+}
+// <<<<< INCLUDED FROM include_files/writeProgramHeader.cpi
+
+// >>>>> INCLUDED FROM include_files/onRapid_fanuc.cpi
+function onRapid(_x, _y, _z) {
+  var x = xOutput.format(_x);
+  var y = yOutput.format(_y);
+  var z = zOutput.format(_z);
+  if (x || y || z) {
+    if (pendingRadiusCompensation >= 0) {
+      error(localize("Radius compensation mode cannot be changed at rapid traversal."));
+      return;
+    }
+    writeBlock(gMotionModal.format(0), x, y, z);
+    forceFeed();
+  }
+}
+// <<<<< INCLUDED FROM include_files/onRapid_fanuc.cpi
+// >>>>> INCLUDED FROM include_files/onLinear_fanuc.cpi
+function onLinear(_x, _y, _z, feed) {
+  if (pendingRadiusCompensation >= 0) {
+    xOutput.reset();
+    yOutput.reset();
+  }
+  var x = xOutput.format(_x);
+  var y = yOutput.format(_y);
+  var z = zOutput.format(_z);
+  var f = getFeed(feed);
+  if (x || y || z) {
+    if (pendingRadiusCompensation >= 0) {
+      pendingRadiusCompensation = -1;
+      var d = getSetting("outputToolDiameterOffset", true) ? diameterOffsetFormat.format(tool.diameterOffset) : "";
+      writeBlock(gPlaneModal.format(17));
+      switch (radiusCompensation) {
+      case RADIUS_COMPENSATION_LEFT:
+        writeBlock(gMotionModal.format(1), gFormat.format(41), x, y, z, d, f);
+        break;
+      case RADIUS_COMPENSATION_RIGHT:
+        writeBlock(gMotionModal.format(1), gFormat.format(42), x, y, z, d, f);
+        break;
+      default:
+        writeBlock(gMotionModal.format(1), gFormat.format(40), x, y, z, f);
+      }
+    } else {
+      writeBlock(gMotionModal.format(1), x, y, z, f);
+    }
+  } else if (f) {
+    if (getNextRecord().isMotion()) { // try not to output feed without motion
+      forceFeed(); // force feed on next line
+    } else {
+      writeBlock(gMotionModal.format(1), f);
+    }
+  }
+}
+// <<<<< INCLUDED FROM include_files/onLinear_fanuc.cpi
+// >>>>> INCLUDED FROM include_files/writeRetract_fanuc.cpi
+function writeRetract() {
+  var retract = getRetractParameters.apply(this, arguments);
+  if (retract && retract.words.length > 0) {
+    if (typeof cancelWCSRotation == "function" && getSetting("retract.cancelRotationOnRetracting", false)) { // cancel rotation before retracting
+      cancelWCSRotation();
+    }
+    if (typeof setTCP == "function" && getSetting("allowCancelTCPBeforeRetracting", false)) {
+      setTCP(false); // cancel TCP before retracting
+    }
+    for (var i in retract.words) {
+      var words = retract.singleLine ? retract.words : retract.words[i];
+      switch (retract.method) {
+      case "G28":
+        forceModals(gMotionModal, gAbsIncModal);
+        writeBlock(gFormat.format(28), gAbsIncModal.format(91), words);
+        writeBlock(gAbsIncModal.format(90));
+        break;
+      case "G30":
+        forceModals(gMotionModal, gAbsIncModal);
+        writeBlock(gFormat.format(30), gAbsIncModal.format(91), words);
+        writeBlock(gAbsIncModal.format(90));
+        break;
+      case "G53":
+        forceModals(gMotionModal);
+        writeBlock(gAbsIncModal.format(90), gFormat.format(53), gMotionModal.format(0), words);
+        break;
+      default:
+        if (typeof writeRetractCustom == "function") {
+          writeRetractCustom(retract);
+          return;
+        } else {
+          error(subst(localize("Unsupported safe position method '%1'"), retract.method));
+        }
+      }
+      machineSimulation({
+        x          : retract.singleLine || words.indexOf("X") != -1 ? retract.positions.x : undefined,
+        y          : retract.singleLine || words.indexOf("Y") != -1 ? retract.positions.y : undefined,
+        z          : retract.singleLine || words.indexOf("Z") != -1 ? retract.positions.z : undefined,
+        coordinates: MACHINE
+      });
+      if (retract.singleLine) {
+        break;
+      }
+    }
+  }
+}
+// <<<<< INCLUDED FROM include_files/writeRetract_fanuc.cpi
+// >>>>> INCLUDED FROM include_files/lengthCompFunctions_fanuc.cpi
+if (typeof lengthCompCodes === "undefined") {
+  var lengthCompCodes = {tool:43, tcp:43.4, tcpVector:43.5, cancel:49};
+}
+var lengthCompOutput = createOutputVariable({control : CONTROL_FORCE,
+  onchange: function() {
+    state.tcpIsActive = lengthCompOutput.getCurrent() == lengthCompCodes.tcp || lengthCompOutput.getCurrent() == lengthCompCodes.tcpVector;
+    state.lengthCompensationActive = lengthCompOutput.getCurrent() != lengthCompCodes.cancel;
+    machineSimulation({}); // update machine simulation TCP state
+  }
+}, gFormat);
+
+function getLengthCompCode(forceTCP) {
+  if (!getSetting("outputToolLengthCompensation", true) && lengthCompOutput.isEnabled()) {
+    state.lengthCompensationActive = true; // always assume that length compensation is active
+    lengthCompOutput.disable();
+  }
+  var lengthCompCode = lengthCompCodes.tool;
+  if (tcp.isSupportedByOperation || forceTCP) {
+    lengthCompCode = machineConfiguration.isMultiAxisConfiguration() ? lengthCompCodes.tcp : lengthCompCodes.tcpVector;
+  }
+  return lengthCompOutput.format(lengthCompCode);
+}
+
+function setTCP(_tcp, force) {
+  if (!force && state.tcpIsActive === _tcp) {
+    return;
+  }
+  cancelLengthCompensation();
+  if (_tcp) {
+    var hOffset = getSetting("outputToolLengthOffset", true) ? hFormat.format(tool.lengthOffset) : "";
+    writeBlock(getLengthCompCode(force), hOffset);
+    forceXYZ();
+  }
+}
+// <<<<< INCLUDED FROM include_files/lengthCompFunctions_fanuc.cpi
+// >>>>> INCLUDED FROM include_files/initialPositioning_fanuc.cpi
+/**
+ * Writes the initial positioning procedure for a section to get to the start position of the toolpath.
+ * @param {Vector} position The initial position to move to
+ * @param {boolean} isRequired true: Output full positioning, false: Output full positioning in optional state or output simple positioning only
+ * @param {String} codes1 Allows to add additional code to the first positioning line
+ * @param {String} codes2 Allows to add additional code to the second positioning line (if applicable)
+ * @example
+  var myVar1 = formatWords("T" + tool.number, currentSection.wcs);
+  var myVar2 = getCoolantCodes(tool.coolant);
+  writeInitialPositioning(initialPosition, isRequired, myVar1, myVar2);
+*/
+function writeInitialPositioning(position, isRequired, codes1, codes2) {
+  var motionCode = {single:0, multi:0};
+  switch (highFeedMapping) {
+  case HIGH_FEED_MAP_ANY:
+    motionCode = {single:1, multi:1}; // map all rapid traversals to high feed
+    break;
+  case HIGH_FEED_MAP_MULTI:
+    motionCode = {single:0, multi:1}; // map rapid traversal along more than one axis to high feed
+    break;
+  }
+  var feed = (highFeedMapping != HIGH_FEED_NO_MAPPING) ? getFeed(highFeedrate) : "";
+  var hOffset = getSetting("outputToolLengthOffset", true) ? hFormat.format(tool.lengthOffset) : "";
+  var additionalCodes = [formatWords(codes1), formatWords(codes2)];
+
+  forceModals(gMotionModal);
+  writeStartBlocks(isRequired, function() {
+    var modalCodes = formatWords(gAbsIncModal.format(90), gPlaneModal.format(17));
+    if (typeof cancelLengthCompensation == "function") {
+      cancelLengthCompensation(!isRequired); // cancel tool length compensation prior to enabling it, required when switching G43/G43.4 modes
+    }
+
+    if (machineConfiguration.isHeadConfiguration()) { // head/head head/table kinematics
+      cancelTransformation();
+      var machineABC = currentSection.isMultiAxis() ? defineWorkPlane(currentSection, false) : getWorkPlaneMachineABC(currentSection, false);
+      machineConfiguration.setToolLength(getSetting("workPlaneMethod.compensateToolLength", false) ? getBodyLength(currentSection.getTool()) : 0); // define the tool length for head adjustments
+      var mode = currentSection.isOptimizedForMachine() ? TCP_XYZ_OPTIMIZED : TCP_XYZ;
+      var globalPosition = getGlobalPosition(currentSection.getInitialPosition());
+      var machinePosition = machineConfiguration.getOptimizedPosition(globalPosition, machineABC, mode, OPTIMIZE_BOTH, true);
+      var prePosition = (currentSection.isOptimizedForMachine() || currentSection.isMultiAxis()) ? position :
+        (settings.workPlaneMethod.useTiltedWorkplane && !tcp.isSupportedByMachine) ? machinePosition : globalPosition;
+
+      cancelWorkPlane();
+      positionABC(machineABC);
+      if ((getSetting("workPlaneMethod.useTiltedWorkplane", false) && tcp.isSupportedByMachine && getCurrentDirection().isNonZero()) || tcp.isSupportedByOperation) {
+        setTCP(true, true); // force TCP for prepositioning although the operation may not require it
+      }
+      writeBlock(modalCodes, gMotionModal.format(motionCode.multi), xOutput.format(prePosition.x), yOutput.format(prePosition.y), feed, additionalCodes[0]);
+      machineSimulation({x:prePosition.x, y:prePosition.y});
+      if (currentSection.isMultiAxis() || getSetting("headPositioningMethod", 0) == 1) {
+        var lengthComp = state.lengthCompensationActive ? {code:undefined, hOffset:undefined} : {code:getLengthCompCode(), hOffset:hOffset};
+        writeBlock(modalCodes, gMotionModal.format(motionCode.single), lengthComp.code, zOutput.format(prePosition.z), lengthComp.hOffset, additionalCodes[1]);
+        machineSimulation({z:prePosition.z});
+      }
+
+      if (!currentSection.isMultiAxis()) {
+        if (state.tcpIsActive && !tcp.isSupportedByOperation && typeof setTCP == "function") {
+          setTCP(false);
+        }
+        if (getSetting("workPlaneMethod.useTiltedWorkplane", false) && getCurrentDirection().isNonZero()) {
+          var saveRetractedState = [state.retractedX, state.retractedY, state.retractedZ];
+          state.retractedX = state.retractedY = state.retractedZ = true; // set retracted states to true to avoid retraction
+          defineWorkPlane(currentSection, true); // apply workplane for the operation if TWP is supported
+          [state.retractedX, state.retractedY, state.retractedZ] = saveRetractedState; // restore retracted states
+        }
+        if (!state.lengthCompensationActive) {
+          if (state.twpIsActive) {
+            forceXYZ();
+          }
+          if (getSetting("headPositioningMethod", 0) == 1) {
+            writeBlock(modalCodes, gMotionModal.format(motionCode.multi), xOutput.format(position.x), yOutput.format(position.y));
+            machineSimulation({x:position.x, y:position.y});
+            writeBlock(modalCodes, gMotionModal.format(motionCode.single), getLengthCompCode(), zOutput.format(position.z), hOffset);
+            machineSimulation({z:position.z});
+          } else {
+            writeBlock(modalCodes, getLengthCompCode(), gMotionModal.format(motionCode.single), xOutput.format(position.x), yOutput.format(position.y), zOutput.format(position.z), hOffset);
+            machineSimulation({x:position.x, y:position.y, z:position.z});
+          }
+        }
+      }
+      forceFeed();
+    } else {
+      // multi axis prepositioning with TWP
+      if (currentSection.isMultiAxis() && getSetting("workPlaneMethod.prepositionWithTWP", true) && getSetting("workPlaneMethod.useTiltedWorkplane", false) &&
+        tcp.isSupportedByOperation && getCurrentDirection().isNonZero()) {
+        var W = machineConfiguration.isMultiAxisConfiguration() ? machineConfiguration.getOrientation(getCurrentDirection()) :
+          Matrix.getOrientationFromDirection(getCurrentDirection());
+        var prePosition = W.getTransposed().multiply(position);
+        var angles = W.getEuler2(settings.workPlaneMethod.eulerConvention);
+        setWorkPlane(angles);
+        writeBlock(modalCodes, gMotionModal.format(motionCode.multi), xOutput.format(prePosition.x), yOutput.format(prePosition.y), feed, additionalCodes);
+        machineSimulation({x:prePosition.x, y:prePosition.y});
+        cancelWorkPlane();
+        setTCP(true); // omit Z-axis output is desired
+        forceAny(); // required to output XYZ coordinates in the following line
+      } else {
+        writeBlock(modalCodes, gMotionModal.format(motionCode.multi), xOutput.format(position.x), yOutput.format(position.y), feed, additionalCodes[0]);
+        machineSimulation({x:position.x, y:position.y});
+        writeBlock(gMotionModal.format(motionCode.single), getLengthCompCode(), zOutput.format(position.z), hOffset, additionalCodes[1]);
+        machineSimulation(tcp.isSupportedByOperation ? {x:position.x, y:position.y, z:position.z} : {z:position.z});
+      }
+    }
+    forceModals(gMotionModal);
+    if (isRequired) {
+      additionalCodes = []; // clear additionalCodes buffer
+    }
+  });
+
+  validate(!validateLengthCompensation || state.lengthCompensationActive, "Tool length compensation is not active."); // make sure that lenght compensation is enabled
+  if (!isRequired) { // simple positioning
+    var modalCodes = formatWords(gAbsIncModal.format(90), gPlaneModal.format(17));
+    forceXYZ();
+    if (!state.retractedZ && xyzFormat.getResultingValue(getCurrentPosition().z) < xyzFormat.getResultingValue(position.z)) {
+      writeBlock(modalCodes, gMotionModal.format(motionCode.single), zOutput.format(position.z), feed);
+      machineSimulation({z:position.z});
+    }
+    writeBlock(modalCodes, gMotionModal.format(motionCode.multi), xOutput.format(position.x), yOutput.format(position.y), feed, additionalCodes);
+    machineSimulation({x:position.x, y:position.y});
+  }
+  if (machineConfiguration.isMultiAxisConfiguration() && !currentSection.isMultiAxis()) {
+    onCommand(COMMAND_LOCK_MULTI_AXIS);
+  }
+}
+
+Matrix.getOrientationFromDirection = function (ijk) {
+  var forward = ijk;
+  var unitZ = new Vector(0, 0, 1);
+  var W;
+  if (Math.abs(Vector.dot(forward, unitZ)) < 0.5) {
+    var imX = Vector.cross(forward, unitZ).getNormalized();
+    W = new Matrix(imX, Vector.cross(forward, imX), forward);
+  } else {
+    var imX = Vector.cross(new Vector(0, 1, 0), forward).getNormalized();
+    W = new Matrix(imX, Vector.cross(forward, imX), forward);
+  }
+  return W;
+};
+// <<<<< INCLUDED FROM include_files/initialPositioning_fanuc.cpi

--- a/src/postProcessorConverter/adapters/autodeskCps.test.ts
+++ b/src/postProcessorConverter/adapters/autodeskCps.test.ts
@@ -238,14 +238,17 @@ assert(autodeskCpsAdapter.staticAnalysisOnly === true, 'staticAnalysisOnly shoul
 // --- inline: expression-valued nested property resolves to null ---
 // Per the #402 no-evaluation contract: an expression value must be reported, never computed.
 {
+  // Deliberately on sequenceNumberIncrement — a property the adapter actually
+  // consumes. An expression on a property nobody reads cannot fail, so it would
+  // not test the null path at all.
   const inlineSource = [
     'capabilities = CAPABILITY_MILLING;',
     'extension = "nc";',
     'properties = {',
-    '  maximumSpindleSpeed: {',
-    '    title      : "Maximum spindle speed",',
+    '  sequenceNumberIncrement: {',
+    '    title      : "Sequence number increment",',
     '    description: "Test.",',
-    '    group      : "spindle",',
+    '    group      : "formats",',
     '    type       : "integer",',
     '    value: 100 * 60,',
     '    scope: "post"',
@@ -254,18 +257,25 @@ assert(autodeskCpsAdapter.staticAnalysisOnly === true, 'staticAnalysisOnly shoul
   ].join('\n')
 
   const result = autodeskCpsAdapter.convert(inlineSource, 'inline-expression.cps')
-  // The conversion must succeed — no crash trying to compute 100 * 60.
-  // The generic default for maximumSpindleSpeed is left untouched; no expression evaluation happened.
   const definition = buildMachineDefinition(result.overrides, {
     id: 'test-inline-expression',
     name: 'Test',
     description: 'Inline expression test',
   })
-  // The adapter does not look up maximumSpindleSpeed; the property resolves to null in the map
-  // but is never consumed. The key invariant is that the conversion completes without error
-  // and never evaluates the expression (it did not compute 6000).
-  assert(typeof definition.feedSpeed.spindleOnCW === 'string', 'spindleOnCW must stay the generic default — no crash, no expression evaluation')
-  assert(result.findings.length > 0, 'expected findings from the inline expression source')
+
+  // Never computed: 6000 is what evaluating `100 * 60` would have produced, and
+  // NaN is what Number() on the raw text produces. Both must be absent — the
+  // generic baseline default (10) survives instead.
+  assert(
+    definition.program.lineNumberIncrement === 10,
+    `lineNumberIncrement: ${definition.program.lineNumberIncrement} (expected the generic default 10 — the expression must not be evaluated to 6000 or coerced to NaN)`,
+  )
+
+  // ...and the refusal is reported rather than silently dropped (#402 contract).
+  const finding = result.findings.find((f) => f.sourceField === 'properties.sequenceNumberIncrement')
+  assert(finding !== undefined, 'expected a findings entry for the expression-valued sequenceNumberIncrement')
+  assert(finding?.status === 'omitted', `expression finding status: ${finding?.status} (expected omitted)`)
+  assert(/expression/.test(finding?.message ?? ''), `expected the finding to say the value is an expression; got: ${finding?.message}`)
   console.log('autodeskCps.test: inline expression-valued property assertion passed')
 }
 

--- a/src/postProcessorConverter/adapters/autodeskCps.test.ts
+++ b/src/postProcessorConverter/adapters/autodeskCps.test.ts
@@ -167,3 +167,121 @@ assert(autodeskCpsAdapter.staticAnalysisOnly === true, 'staticAnalysisOnly shoul
 
   console.log('autodeskCps.test: edingcnc-turning.cps (lathe, refused) assertions passed')
 }
+
+// --- carbide3d.cps: nested-format properties (current Autodesk shape) ---
+{
+  const text = loadFixture('carbide3d.cps')
+  const result = autodeskCpsAdapter.convert(text, 'carbide3d.cps')
+  const definition = buildMachineDefinition(result.overrides, {
+    id: 'test-autodesk-cps-carbide3d',
+    name: 'Test Carbide3D (Grbl)',
+    description: 'Converted from carbide3d.cps',
+  })
+
+  // A1 — the reported bug: lineNumberIncrement must be the real nested value 1, not NaN or the generic default.
+  assert(definition.program.lineNumberIncrement === 1, `lineNumberIncrement: ${definition.program.lineNumberIncrement} (expected 1 — the real nested value)`)
+
+  // A2 — showSequenceNumbers: the real nested value "false".
+  assert(definition.program.lineNumbers === false, `lineNumbers: ${definition.program.lineNumbers} (expected false — the real nested value)`)
+
+  // B — capabilities gate: CAPABILITY_MILLING | CAPABILITY_MACHINE_SIMULATION must be mapped, non-blocking.
+  const capFinding = result.findings.find((f) => f.sourceField === 'capabilities')
+  assert(capFinding !== undefined, 'expected a findings entry for capabilities')
+  assert(capFinding?.status === 'mapped', `capabilities status: ${capFinding?.status} (expected mapped)`)
+  assert(capFinding?.blocksStrict === false, `capabilities blocksStrict: ${capFinding?.blocksStrict} (expected false)`)
+  assert(/CAPABILITY_MACHINE_SIMULATION/.test(capFinding?.message ?? ''), 'expected the ignored CAPABILITY_MACHINE_SIMULATION flag to appear in the message')
+
+  for (const finding of result.findings) {
+    assert(finding.message.length > 0, `finding for ${finding.sourceField} has an empty message`)
+    if (finding.status === 'unsupported' || finding.status === 'conflicting') {
+      assert(typeof finding.blocksStrict === 'boolean', `finding for ${finding.sourceField} (${finding.status}) must have a blocksStrict decision`)
+    }
+  }
+
+  console.log('autodeskCps.test: carbide3d.cps (nested format) assertions passed')
+}
+
+// --- inline: showSequenceNumbers with nested value "true" ---
+// Guards A2: without this, lineNumbers === false could pass even if the parser
+// still returns `{` and falls through to false (the bug that hides behind the NaN crash).
+{
+  const inlineSource = [
+    'capabilities = CAPABILITY_MILLING;',
+    'extension = "nc";',
+    'properties = {',
+    '  showSequenceNumbers: {',
+    '    title      : "Use sequence numbers",',
+    '    description: "Test.",',
+    '    group      : "formats",',
+    '    type       : "enum",',
+    '    values     : [',
+    '      {title:"Yes", id:"true"},',
+    '      {title:"No", id:"false"}',
+    '    ],',
+    '    value: "true",',
+    '    scope: "post"',
+    '  }',
+    '};',
+  ].join('\n')
+
+  const result = autodeskCpsAdapter.convert(inlineSource, 'inline-showseq-true.cps')
+  const definition = buildMachineDefinition(result.overrides, {
+    id: 'test-inline-showseq-true',
+    name: 'Test',
+    description: 'Inline test',
+  })
+
+  assert(definition.program.lineNumbers === true, `lineNumbers: ${definition.program.lineNumbers} (expected true — nested value "true")`)
+  console.log('autodeskCps.test: inline showSequenceNumbers "true" assertion passed')
+}
+
+// --- inline: expression-valued nested property resolves to null ---
+// Per the #402 no-evaluation contract: an expression value must be reported, never computed.
+{
+  const inlineSource = [
+    'capabilities = CAPABILITY_MILLING;',
+    'extension = "nc";',
+    'properties = {',
+    '  maximumSpindleSpeed: {',
+    '    title      : "Maximum spindle speed",',
+    '    description: "Test.",',
+    '    group      : "spindle",',
+    '    type       : "integer",',
+    '    value: 100 * 60,',
+    '    scope: "post"',
+    '  }',
+    '};',
+  ].join('\n')
+
+  const result = autodeskCpsAdapter.convert(inlineSource, 'inline-expression.cps')
+  // The conversion must succeed — no crash trying to compute 100 * 60.
+  // The generic default for maximumSpindleSpeed is left untouched; no expression evaluation happened.
+  const definition = buildMachineDefinition(result.overrides, {
+    id: 'test-inline-expression',
+    name: 'Test',
+    description: 'Inline expression test',
+  })
+  // The adapter does not look up maximumSpindleSpeed; the property resolves to null in the map
+  // but is never consumed. The key invariant is that the conversion completes without error
+  // and never evaluates the expression (it did not compute 6000).
+  assert(typeof definition.feedSpeed.spindleOnCW === 'string', 'spindleOnCW must stay the generic default — no crash, no expression evaluation')
+  assert(result.findings.length > 0, 'expected findings from the inline expression source')
+  console.log('autodeskCps.test: inline expression-valued property assertion passed')
+}
+
+// --- inline: capabilities = CAPABILITY_MILLING | CAPABILITY_JET yields conflicting + blocksStrict true ---
+{
+  const inlineSource = [
+    'capabilities = CAPABILITY_MILLING | CAPABILITY_JET;',
+    'extension = "nc";',
+    'properties = {};',
+  ].join('\n')
+
+  const result = autodeskCpsAdapter.convert(inlineSource, 'inline-milling-jet.cps')
+  const capFinding = result.findings.find((f) => f.sourceField === 'capabilities')
+  assert(capFinding !== undefined, 'expected a findings entry for capabilities')
+  assert(capFinding?.status === 'conflicting', `capabilities status: ${capFinding?.status} (expected conflicting)`)
+  assert(capFinding?.blocksStrict === true, `capabilities blocksStrict: ${capFinding?.blocksStrict} (expected true)`)
+  assert(/CAPABILITY_JET/.test(capFinding?.message ?? ''), 'expected CAPABILITY_JET to appear in the conflicting message')
+  console.log('autodeskCps.test: inline CAPABILITY_MILLING | CAPABILITY_JET assertion passed')
+}

--- a/src/postProcessorConverter/adapters/autodeskCps.ts
+++ b/src/postProcessorConverter/adapters/autodeskCps.ts
@@ -24,8 +24,10 @@ import { normalizeLineEndings } from './textFormat'
  * same well-known idioms across every vendor's Autodesk post. Per issue #402,
  * this source is NEVER executed, `eval`'d, `require`'d, or run as JS in any
  * way: everything below is plain text pattern matching against a handful of
- * specific, well-documented call-site idioms and a flat `properties = {...}`
- * object literal. Anything not matched by one of these narrow patterns is
+ * specific, well-documented call-site idioms and a `properties = {...}`
+ * object literal whose values are either simple literals (flat legacy
+ * format) or nested `{title, description, value, ...}` objects (current
+ * Autodesk format). Anything not matched by one of these narrow patterns is
  * left at the generic default and reported `omitted` rather than guessed.
  */
 
@@ -56,19 +58,41 @@ function findCallSite(text: string, snippet: string): TextMatch | null {
 }
 
 interface CpsProperty {
-  value: string
+  value: string | null
   line: number
 }
 
 const PROPERTY_LINE = /^\s*(\w+):\s*(.+?),?\s*(\/\/.*)?$/
+const NESTED_VALUE_LINE = /^\s*value\s*:\s*(.+?),?\s*(\/\/.*)?$/
+
+/** Returns true when `raw` is a JS literal (quoted string, boolean/null keyword, or number). */
+function isLiteralValue(raw: string): boolean {
+  const t = raw.trim()
+  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) return true
+  if (t === 'true' || t === 'false' || t === 'null') return true
+  return /^-?\d+(\.\d+)?$/.test(t)
+}
+
+/** Strips one pair of matching outer quotes. Returns the input unchanged when not quoted. */
+function unquote(s: string): string {
+  const t = s.trim()
+  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) return t.slice(1, -1)
+  return t
+}
 
 /**
- * Extracts `properties = { key: value, // comment ... };` into a flat
- * key->value map. Deliberately line-oriented — never a general JS
- * object-literal parser — since every real-world .cps properties block is
- * one simple boolean/number/string literal per line. Lines that don't fit
- * that shape (e.g. an expression value, or `key :` with a space before the
- * colon) are silently skipped rather than mis-parsed.
+ * Extracts `properties = { key: value, ... };` into a key->value map.
+ * Handles two shapes:
+ *
+ * 1. Flat legacy format  — `key: literal,` (one literal per line).
+ * 2. Nested current format — `key: { title, description, value: literal, ... },`
+ *    where the `value` field is column-aligned (whitespace before the colon
+ *    tolerated). Inner fields (title/description/group/type/values/order/scope)
+ *    never leak into the returned map.
+ *
+ * A nested property whose `value` is an expression (e.g. `eFirmware.GRBL`,
+ * `100 * 60`) resolves to `null` — per the #402 no-evaluation contract it is
+ * never computed.
  */
 function extractProperties(text: string): Map<string, CpsProperty> {
   const properties = new Map<string, CpsProperty>()
@@ -79,12 +103,52 @@ function extractProperties(text: string): Map<string, CpsProperty> {
   if (bodyEnd === -1) return properties
   const body = text.slice(bodyStart, bodyEnd)
   const bodyStartLine = lineAt(text, bodyStart)
-  body.split('\n').forEach((rawLine, offset) => {
-    const match = PROPERTY_LINE.exec(rawLine)
-    if (!match) return
-    const [, key, value] = match
-    properties.set(key, { value: value.trim(), line: bodyStartLine + offset })
-  })
+  const lines = body.split('\n')
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = PROPERTY_LINE.exec(lines[i])
+    if (!match) continue
+
+    const [, key, rawValue] = match
+    const trimmed = rawValue.trim()
+
+    if (trimmed === '{') {
+      // Nested format: brace-match to find the closing }, find the `value` field inside.
+      let depth = 0
+      let closeIdx = -1
+      for (let j = i; j < lines.length; j++) {
+        for (let k = 0; k < lines[j].length; k++) {
+          if (lines[j][k] === '{') depth++
+          else if (lines[j][k] === '}') {
+            depth--
+            if (depth === 0) { closeIdx = j; break }
+          }
+        }
+        if (closeIdx !== -1) break
+      }
+
+      if (closeIdx === -1) continue // malformed — skip this property
+
+      for (let j = i + 1; j < closeIdx; j++) {
+        const valueMatch = NESTED_VALUE_LINE.exec(lines[j])
+        if (!valueMatch) continue
+
+        const innerValue = valueMatch[1].trim()
+        if (isLiteralValue(innerValue)) {
+          properties.set(key, { value: unquote(innerValue), line: bodyStartLine + i })
+        } else {
+          properties.set(key, { value: null, line: bodyStartLine + i })
+        }
+        break
+      }
+
+      i = closeIdx // skip past this nested block
+    } else {
+      // Flat legacy format (unchanged).
+      properties.set(key, { value: trimmed, line: bodyStartLine + i })
+    }
+  }
+
   return properties
 }
 
@@ -185,24 +249,57 @@ export const autodeskCpsAdapter: SourceAdapter = {
       )
     }
 
-    const capabilities = findAssignment(fileText, 'capabilities')
-    if (!capabilities) {
+    const capabilitiesRe = /^capabilities\s*=\s*(.+?);/m
+    const capabilitiesMatch = capabilitiesRe.exec(fileText)
+    if (!capabilitiesMatch) {
       findings.push({
         status: 'conflicting',
         sourceField: 'capabilities',
         message: 'No top-level "capabilities = CAPABILITY_...;" assignment found; cannot confirm this post targets a 3-axis mill, so it cannot be treated as safe.',
         blocksStrict: true,
       })
-    } else if (capabilities.value !== 'CAPABILITY_MILLING') {
-      findings.push({
-        status: 'unsupported',
-        sourceField: 'capabilities',
-        message: `capabilities = ${capabilities.value} — this post targets a machine type other than 3-axis milling (e.g. turning/lathe, or a mill-turn combination). PureCutCNC is mill-only; diameter-mode axes, turret/live-tooling macros, and lathe-specific canned cycles are out of scope. Fields below were still extracted where literally present, for transparency, but this definition should not be used as-is.`,
-        blocksStrict: true,
-        sourceLocation: { line: capabilities.line },
-      })
     } else {
-      mapped('capabilities', undefined, 'capabilities = CAPABILITY_MILLING — confirms this post targets a 3-axis mill, the only PureCutCNC-supported machine type.', capabilities.line)
+      const capabilitiesLine = lineAt(fileText, capabilitiesMatch.index)
+      const flags = capabilitiesMatch[1].split('|').map((f) => f.trim()).filter(Boolean)
+      if (flags.length === 0) {
+        findings.push({
+          status: 'conflicting',
+          sourceField: 'capabilities',
+          message: 'No top-level "capabilities = CAPABILITY_...;" assignment found; cannot confirm this post targets a 3-axis mill, so it cannot be treated as safe.',
+          blocksStrict: true,
+        })
+      } else if (flags.length === 1 && flags[0] === 'CAPABILITY_TURNING') {
+        findings.push({
+          status: 'unsupported',
+          sourceField: 'capabilities',
+          message: `capabilities = ${flags[0]} — this post targets a machine type other than 3-axis milling (e.g. turning/lathe, or a mill-turn combination). PureCutCNC is mill-only; diameter-mode axes, turret/live-tooling macros, and lathe-specific canned cycles are out of scope. Fields below were still extracted where literally present, for transparency, but this definition should not be used as-is.`,
+          blocksStrict: true,
+          sourceLocation: { line: capabilitiesLine },
+        })
+      } else if (flags.includes('CAPABILITY_MILLING')) {
+        const otherMachineModes = flags.filter((f) => f !== 'CAPABILITY_MILLING' && f !== 'CAPABILITY_MACHINE_SIMULATION')
+        const ignoredFlags = flags.filter((f) => f === 'CAPABILITY_MACHINE_SIMULATION')
+        if (otherMachineModes.length > 0) {
+          findings.push({
+            status: 'conflicting',
+            sourceField: 'capabilities',
+            message: `capabilities = ${capabilitiesMatch[1].trim()} — CAPABILITY_MILLING is present but so are other machine-mode flags (${otherMachineModes.join(', ')}). This post serves multiple machine modes behind a machineMode switch, and static extraction cannot tell which branch a given idiom belongs to.`,
+            blocksStrict: true,
+            sourceLocation: { line: capabilitiesLine },
+          })
+        } else {
+          const extra = ignoredFlags.length > 0 ? ` (non-G-code flag${ignoredFlags.length > 1 ? 's' : ''} ${ignoredFlags.join(', ')} ignored)` : ''
+          mapped('capabilities', undefined, `capabilities = ${capabilitiesMatch[1].trim()} — confirms this post targets a 3-axis mill, the only PureCutCNC-supported machine type.${extra}`, capabilitiesLine)
+        }
+      } else {
+        findings.push({
+          status: 'unsupported',
+          sourceField: 'capabilities',
+          message: `capabilities = ${capabilitiesMatch[1].trim()} — this post does not declare CAPABILITY_MILLING. PureCutCNC is mill-only; this definition should not be used as-is.`,
+          blocksStrict: true,
+          sourceLocation: { line: capabilitiesLine },
+        })
+      }
     }
 
     // --- 2. properties = { ... } ---
@@ -219,16 +316,36 @@ export const autodeskCpsAdapter: SourceAdapter = {
 
     const showSequenceNumbers = properties.get('showSequenceNumbers')
     if (showSequenceNumbers) {
-      overrides.program!.lineNumbers = showSequenceNumbers.value === 'true'
-      mapped('properties.showSequenceNumbers', 'program.lineNumbers', `showSequenceNumbers: ${showSequenceNumbers.value} — writeBlock() only prefixes "N" + sequenceNumber when this is true.`, showSequenceNumbers.line)
+      if (showSequenceNumbers.value === null) {
+        omitted('properties.showSequenceNumbers', 'program.lineNumbers', 'showSequenceNumbers value is an expression this adapter refuses to evaluate; kept the generic default.')
+      } else if (showSequenceNumbers.value === 'toolChange') {
+        findings.push({
+          status: 'unsupported',
+          sourceField: 'properties.showSequenceNumbers',
+          targetField: 'program.lineNumbers',
+          message: 'showSequenceNumbers is "toolChange" — line numbers on tool-change blocks only. PureCutCNC has no per-block-type line-number toggle; kept the generic default.',
+          blocksStrict: false,
+          sourceLocation: { line: showSequenceNumbers.line },
+        })
+      } else {
+        overrides.program!.lineNumbers = showSequenceNumbers.value === 'true'
+        mapped('properties.showSequenceNumbers', 'program.lineNumbers', `showSequenceNumbers: ${showSequenceNumbers.value} — writeBlock() only prefixes "N" + sequenceNumber when this is true.`, showSequenceNumbers.line)
+      }
     } else {
       omitted('properties.showSequenceNumbers', 'program.lineNumbers', 'No showSequenceNumbers property found; kept the generic default.')
     }
 
     const sequenceNumberIncrement = properties.get('sequenceNumberIncrement')
-    if (sequenceNumberIncrement) {
-      overrides.program!.lineNumberIncrement = Number(sequenceNumberIncrement.value)
-      mapped('properties.sequenceNumberIncrement', 'program.lineNumberIncrement', `sequenceNumberIncrement: ${sequenceNumberIncrement.value}.`, sequenceNumberIncrement.line)
+    if (sequenceNumberIncrement && sequenceNumberIncrement.value !== null) {
+      const n = Number(sequenceNumberIncrement.value)
+      if (Number.isFinite(n)) {
+        overrides.program!.lineNumberIncrement = n
+        mapped('properties.sequenceNumberIncrement', 'program.lineNumberIncrement', `sequenceNumberIncrement: ${sequenceNumberIncrement.value}.`, sequenceNumberIncrement.line)
+      } else {
+        omitted('properties.sequenceNumberIncrement', 'program.lineNumberIncrement', `sequenceNumberIncrement value "${sequenceNumberIncrement.value}" could not be parsed as a finite number; kept the generic default.`)
+      }
+    } else if (sequenceNumberIncrement) {
+      omitted('properties.sequenceNumberIncrement', 'program.lineNumberIncrement', 'sequenceNumberIncrement value is an expression this adapter refuses to evaluate; kept the generic default.')
     } else {
       omitted('properties.sequenceNumberIncrement', 'program.lineNumberIncrement', 'No sequenceNumberIncrement property found; kept the generic default.')
     }


### PR DESCRIPTION
Closes #456

The `autodesk-cps` adapter crashed with `lineNumberIncrement = NaN` on the official Carbide3D GRBL post. Two defects were involved; the reported crash was hiding the second.

## A — nested `properties` were parsed as `{`

`extractProperties()` was line-oriented and only understood the flat legacy shape (`key: literal,`). Current Autodesk posts nest each property as an object.

The reporter's diagnosis pointed at the right function, but by a different mechanism than described: the regex requires the colon to touch the key, and vendor files column-align their nested fields (`value      : 1`), so the inner lines never matched at all. What matched was the **outer** line, capturing `{` as the value — `Number('{')` → `NaN`.

**The crash was the safe half.** One line up, `showSequenceNumbers` also captured `{`, and `'{' === 'true'` is `false`, so `program.lineNumbers` was silently set to `false` for *any* nested-format post regardless of its real setting — no error, just a wrong machine definition. On this file that happened to be correct by coincidence.

`extractProperties()` now handles both shapes: nested blocks are brace-matched, the inner `value` field is read tolerating whitespace before the colon, and inner fields (`title`/`description`/`group`/`type`/`values`/`order`/`scope`) no longer leak into the map as top-level property names.

`CpsProperty.value` becomes `string | null`, where `null` means the source assigned an expression (`eFirmware.GRBL`, `100 * 60`). Per the #402 no-evaluation contract those are reported, never computed. `sequenceNumberIncrement` additionally guards on `Number.isFinite`, so no NaN can reach the schema even if the null path is later broken — the two defenses are independent.

`showSequenceNumbers` in the nested format is an enum (`"true"` / `"false"` / `"toolChange"`), not the legacy boolean. `"toolChange"` — line numbers on tool-change blocks only — has no PureCutCNC equivalent, so it is reported `unsupported` and keeps the default rather than being coerced to either boolean. Non-blocking for `--strict`, per the `ConversionFinding` contract's cosmetic-gap carve-out: line numbers change emitted text, not motion or safety.

## B — the capabilities gate misfired on a bitwise-OR RHS

```
capabilities = CAPABILITY_MILLING | CAPABILITY_MACHINE_SIMULATION;
```

The gate accepted only a bare identifier, so this matched nothing and tripped the `blocksStrict` branch — *"cannot confirm this post targets a 3-axis mill"* — on a post that declares `CAPABILITY_MILLING` on its face. Not in the original report; it was blocked behind the crash.

The RHS is now parsed as a `|`-separated flag list:

| Flags | Result |
|---|---|
| `MILLING`, other flags G-code-irrelevant (`MACHINE_SIMULATION`) | `mapped`, non-blocking |
| `MILLING` + another machine mode (e.g. `JET`) | `conflicting`, blocking — the post serves multiple modes behind a `machineMode` switch and static extraction cannot tell which branch an idiom belongs to |
| `TURNING` alone | unchanged: `unsupported`, blocking |
| no assignment | unchanged: `conflicting`, blocking |

This is not a single-vendor quirk: `MPCNC_v4.0_Beta2.cps` uses the nested format too and is `CAPABILITY_MILLING | CAPABILITY_JET`.

## Tests

`carbide3d.cps` is added as a fixture (verbatim vendor file, alongside the existing eding posts).

- `lineNumberIncrement === 1` — the real nested value, asserted exactly so a fallback-to-default regression fails. The baseline default is `10`.
- A companion inline source whose nested `showSequenceNumbers` is `"true"` must yield `lineNumbers === true`. Without it, asserting `false` on the Carbide file passes even if the parser is still returning `{` and falling through — the silent bug above.
- The expression case targets `sequenceNumberIncrement`, a property the adapter actually consumes, and asserts the default `10` survives — neither `6000` (the evaluated expression) nor `NaN` — plus an `omitted` finding naming the value as an expression. Mutation-checked: forcing `isLiteralValue` to accept everything fails this test.
- `CAPABILITY_MILLING | CAPABILITY_JET` yields `conflicting` + blocking.
- Existing eding mill and turning assertions are untouched, including the turning post staying refused.

## Verification

- `npx tsx src/postProcessorConverter/adapters/autodeskCps.test.ts` — 6 blocks pass
- `crossFormatAgreement.test.ts`, `cli.test.ts` — pass
- `npm run build` — green
- End-to-end on the reporter's file with `--strict` now writes a definition where it previously produced no output: `lineNumberIncrement: 1`, 0 blocking findings
