### PR TITLE
docs: make the isolated worktree the default in Execution Modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,11 +209,22 @@ and delegated workers (Codex, opencode, the DeepSeek worker, etc.) alike.
 
 ## Execution Modes
 
-Delegation is optional. Use the simplest mode that fits the approved issue and
-the user's direction:
+Two independent choices: **where** the work happens, and **who** does it.
 
-- **Direct implementation (default):** one agent owns discovery, edits,
-  verification, and delivery on the issue branch.
+**Where — default to an isolated worktree.** New work starts in its own `git worktree` on its own branch unless the user says otherwise. This includes fast-lane changes: the reason is parallelism, not diff size. A worktree lets several branches be in flight at once without one agent's edits, build artifacts, or checkout state disturbing another's, and a one-line fix benefits from that as much as a large change does. Create it outside the repository directory, and do not commit the path.
+
+A fresh worktree has no `node_modules`. Symlinking the primary checkout's copy avoids a full install:
+
+```bash
+ln -s <primary-checkout>/node_modules node_modules
+```
+
+**Do not symlink when the branch changes `package.json` or `package-lock.json`.** A dependency change needs its own real install; a symlinked tree resolves against the primary checkout's dependency set and would build against the wrong one.
+
+**Who — delegation is optional. Use the simplest mode that fits the approved issue and the user's direction:**
+
+- **Direct implementation:** one agent owns discovery, edits, verification, and
+  delivery on the issue branch.
 - **Built-in subagents (in-process):** subagents provided by the agent's own
   harness (its built-in task/subagent mechanism — same model, same session) may
   be used proactively for parallel research and for bounded implementation
@@ -222,8 +233,6 @@ the user's direction:
   tree, so overlapping edits conflict. No explicit authorization needed — the
   explicit-authorization rule in **Delegated slices** applies only to the
   external worker harness.
-- **Isolated worktree:** use when the user requests isolation or concurrent work
-  would otherwise disturb the active checkout.
 - **Delegated slices (external worker):** use only when the user explicitly
   authorizes delegation and the task divides into bounded, independently
   reviewable slices. Follow


### PR DESCRIPTION
Closes #434

## What changed

`AGENTS.md` → **Execution Modes**, and nothing else.

- **Split into "where" and "who."** The section listed five options as siblings, conflating where the work happens (current checkout vs isolated worktree) with who does it (one agent, in-process subagents, an external worker).
- **The worktree is now the default for new work**, with parallelism given as the reason and fast-lane changes explicitly included — the argument is independent of diff size.
- **Added the `node_modules` symlink hint**, with the caveat not to symlink when the branch changes `package.json` or `package-lock.json`.
- **Dropped `(default)` from Direct implementation**, so exactly one "default" remains in the section.
- Removed the old `Isolated worktree` bullet, now superseded by the "where" statement.

## Acceptance criteria

| Criterion | Status |
| --- | --- |
| Split into a **where** statement and a **who** list | ✅ |
| Worktree is the stated default, parallelism as the reason, fast lane included | ✅ |
| Symlink hint present with the `package.json` / `package-lock.json` caveat | ✅ |
| `Direct implementation` no longer carries `(default)`; exactly one "default" in the section | ✅ |
| No absolute filesystem path in the added text | ✅ |
| Other mode bullets and the closing accountability paragraph byte-identical | ✅ — outside the diff hunks entirely |
| Net addition ≤ 15 lines | ✅ — **+9** (15 added / 6 deleted) |
| `npm run build` green | ✅ |

## Note on line wrapping

The issue's prose, wrapped at this section's ~78-column style, comes to roughly 24 added lines — net +20, which would break the ≤ 15 criterion. Written as single-line paragraphs it lands at +9, matching the line budget the issue was drafted against and the unwrapped style already used in **Workflow** and **Fast lane**. So the new prose is unwrapped while the bullets below it stay wrapped. Easy to rewrap if the consistency is worth the larger diff.

## Verification

`npm run build` — green. Runs `docs:check` (link and agent-entrypoint validation), lint, `check:colors`, `tsc -b`, 165 test files, and `vite build`. Diff read to confirm the untouched bullets really are untouched and no path leaked.

## Lane

Full lane — `AGENTS.md` is a protected path, so the fast lane does not apply regardless of diff size. Not labeled `fast-lane`.