### PR TITLE
fix(booklet): resolve trochoidal edge settings against the tool

### DIFF
--- a/src/engine/operationBooklet/operationBooklet.test.ts
+++ b/src/engine/operationBooklet/operationBooklet.test.ts
@@ -195,6 +195,87 @@ function testReportIncludesTrochoidalSettings(): void {
   assert(report.settingRows.some((row) => row.label === translate('booklet.label.machiningOrder') && row.value === translate('booklet.machiningOrder.featureFirst')), 'trochoidal routing honours machining order, so the booklet must report it')
 }
 
+function testReportIncludesTrochoidalEdgeSettingsResolvedFromTool(): void {
+  console.log('Testing operation booklet resolves unset trochoidal edge settings from the tool...')
+  const { project, operation, toolpath } = fixture()
+  const tool = normalizeToolForProject(project.tools[0], project)
+  const trochoidalEdge: Operation = {
+    ...operation,
+    kind: 'edge_route_inside',
+    pass: 'rough',
+    edgeStrategy: 'trochoidal',
+  }
+
+  // Both fields deliberately left unset — the common case, since the derived
+  // defaults are good. They track the tool until edited, and the printout must
+  // show the channel that will actually be cut.
+  const derived = buildOperationBookletReport({
+    project,
+    operation: trochoidalEdge,
+    tool,
+    toolpath,
+    generatedAt: new Date('2026-06-04T12:00:00Z'),
+  })
+
+  const expectedWidth = `${tool.diameter * 1.5} mm`
+  assert(
+    derived.settingRows.some((row) => row.label === translate('booklet.label.trochoidalCutWidth') && row.value === expectedWidth),
+    `unset cut width must resolve against the tool (expected ${expectedWidth})`,
+  )
+  assert(
+    derived.settingRows.some((row) => row.label === translate('booklet.label.trochoidalAdvance') && row.value === '0.1 × D'),
+    'unset advance must resolve to the 0.1 x D default rather than reporting zero',
+  )
+  assert(
+    !derived.settingRows.some((row) => row.label === translate('booklet.label.trochoidalCutWidth') && row.value === '0 mm'),
+    'a zero cut width contradicts the toolpath on the shop-floor document',
+  )
+  assert(
+    !derived.settingRows.some((row) => row.label === translate('booklet.label.trochoidalAdvance') && row.value === '0 × D'),
+    'a zero advance contradicts the toolpath on the shop-floor document',
+  )
+
+  // The counterpart direction: an explicit edit pins the value, so it must win
+  // over the derived one. Both values are chosen to differ from what the 6 mm
+  // fixture tool would derive (9 mm and 0.1), or the assertions prove nothing.
+  const pinned = buildOperationBookletReport({
+    project,
+    operation: { ...trochoidalEdge, trochoidalCutWidth: 11, trochoidalAdvance: 0.25 },
+    tool,
+    toolpath,
+    generatedAt: new Date('2026-06-04T12:00:00Z'),
+  })
+
+  assert(
+    pinned.settingRows.some((row) => row.label === translate('booklet.label.trochoidalCutWidth') && row.value === '11 mm'),
+    'an explicitly edited cut width must be reported as edited, not re-derived from the tool',
+  )
+  assert(
+    pinned.settingRows.some((row) => row.label === translate('booklet.label.trochoidalAdvance') && row.value === '0.25 × D'),
+    'an explicitly edited advance must be reported as edited, not replaced by the default',
+  )
+
+  // No tool to derive from. There is nothing honest to print, but the booklet
+  // still has to build: the report already carries the no-tool warning that
+  // explains the zero, and it cannot be the thing that throws.
+  const toolless = buildOperationBookletReport({
+    project,
+    operation: trochoidalEdge,
+    tool: null,
+    toolpath,
+    generatedAt: new Date('2026-06-04T12:00:00Z'),
+  })
+
+  assert(
+    toolless.settingRows.some((row) => row.label === translate('booklet.label.trochoidalCutWidth') && row.value === '0 mm'),
+    'with no tool there is no width to derive, so the row falls back to zero',
+  )
+  assert(
+    toolless.warnings.includes(translate('warnings.bookletNoTool')),
+    'the zero width is only honest because the no-tool warning explains it',
+  )
+}
+
 function testReportIncludesTrochoidalCarveSettings(): void {
   console.log('Testing operation booklet reports trochoidal Engrave settings...')
   const { project, operation, toolpath } = fixture()
@@ -480,6 +561,7 @@ testFeedTimeFallsBackToToolDefaultFeed()
 testFeedTimeUsesScaledSlotFeed()
 testReportIncludesEnabledRoundOutsideCorners()
 testReportIncludesTrochoidalSettings()
+testReportIncludesTrochoidalEdgeSettingsResolvedFromTool()
 testReportIncludesTrochoidalCarveSettings()
 testLocalizedReportContent()
 await testGermanLabelLayout()

--- a/src/engine/operationBooklet/report.ts
+++ b/src/engine/operationBooklet/report.ts
@@ -265,11 +265,14 @@ function settingRows(operation: Operation, project: Project, tool: NormalizedToo
     rows.push({ label: translate('booklet.label.machiningOrder'), value: machiningOrderLabel(operation.machiningOrder ?? 'level_first') })
   }
 
+  // Neither field is seeded at creation: unset means "follow the tool", and the
+  // engine re-derives it on every run. The booklet is read at the machine, so it
+  // must print the width that will actually be cut, never a placeholder zero.
   if (isTrochoidalEdgeRoughing(operation)) {
     rows.push(
       { label: translate('booklet.label.edgeStrategy'), value: edgeStrategyLabel('trochoidal') },
-      { label: translate('booklet.label.trochoidalCutWidth'), value: lengthWithUnits(operation.trochoidalCutWidth ?? 0, units) },
-      { label: translate('booklet.label.trochoidalAdvance'), value: `${formatNumber(operation.trochoidalAdvance ?? 0, 3)} × D` },
+      { label: translate('booklet.label.trochoidalCutWidth'), value: lengthWithUnits(operation.trochoidalCutWidth ?? (tool ? tool.diameter * 1.5 : 0), units) },
+      { label: translate('booklet.label.trochoidalAdvance'), value: `${formatNumber(operation.trochoidalAdvance ?? 0.1, 3)} × D` },
     )
   }
 


### PR DESCRIPTION
Closes #463

A trochoidal Edge Route whose trochoidal fields were never edited — the common case, since the derived defaults are good — printed a channel that does not exist:

```
  Strategy             = Trochoidal
  Trochoidal Cut Width = 0 mm      <- engine cuts 9 mm (1.5 x 6 mm cutter)
  Advance per Loop     = 0 × D     <- engine advances 0.1 x D
```

Both fields are deliberately unseeded at operation creation: undefined means *"follow the tool"*, so swapping cutters re-derives the channel instead of leaving a width that belonged to the previous cutter. `appendTrochoidalContoursAtLevels`, the trochoidal validation pass, and `CAMPanel` all honour that with `?? tool.diameter * 1.5` / `?? 0.1`. The Edge Route rows of the booklet used `?? 0`, which reads "follow the tool" as "zero".

The booklet is the shop-floor document, so a zero there contradicts the toolpath rather than omitting it.

Pre-existing — shipped with #448 / PR #454, not introduced by #455. The fix makes the block match the Engrave block ten lines below it, which #455 already got right.

## Change

Two lines in the `isTrochoidalEdgeRoughing` block of `settingRows`, plus a comment recording why the fallback is not zero. No signature change: `settingRows` already takes `tool: NormalizedTool | null`.

## Tests

`testReportIncludesTrochoidalEdgeSettingsResolvedFromTool` covers all three directions:

- unset → tool-derived (`9 mm`, `0.1 × D`), asserted against `tool.diameter * 1.5` rather than a hardcoded number
- explicitly edited → reported as edited (`11 mm`, `0.25 × D`)
- null tool → `0 mm` plus the existing no-tool warning, no throw

The explicit-edit case is new coverage rather than a restatement. The pre-existing `testReportIncludesTrochoidalSettings` uses `trochoidalCutWidth: 9` and `trochoidalAdvance: 0.1` against the 6 mm fixture tool — both exactly equal to what the tool derives, so it passes identically whether the value is honoured or ignored. That is why it never caught this. The new values are chosen to differ from the derived ones so the assertion has something to prove.

Verified by mutation, each independently:

| Mutation | Caught by |
| --- | --- |
| cut width back to `?? 0` | `unset cut width must resolve against the tool (expected 9 mm)` |
| advance back to `?? 0` | `unset advance must resolve to the 0.1 x D default rather than reporting zero` |
| always derive, ignore the explicit value | `an explicitly edited cut width must be reported as edited, not re-derived from the tool` |
| `tool!.diameter` instead of the null guard | `TypeError: Cannot read properties of null (reading 'diameter')` |

## Checks

`npm run build` green — docs check, lint, tsc, 166 test files, vite.

No e2e: no rendered DOM, menu wiring, or dialog behaviour changes. The booklet row content is data returned by `buildOperationBookletReport`, fully covered by the structural test above.

## Lane

Full lane — plan approved on #463 before the first commit. Not labelled `fast-lane`, though `npm run check:fast-lane` does report it eligible (1 counted file, 7 lines, test exempt).
