### PR TITLE
fix(cam): keep the entry-positioning rapid every operation opens with

### DIFF
--- a/src/engine/gcode/postprocessor.test.ts
+++ b/src/engine/gcode/postprocessor.test.ts
@@ -21,7 +21,7 @@
  */
 
 import type { ToolpathWarning } from '../toolpaths/warningCodes'
-import { circleProfile, defaultTool, newProject } from '../../types/project'
+import { circleProfile, defaultTool, newProject, rectProfile } from '../../types/project'
 import type { Operation, SketchFeature } from '../../types/project'
 import { replaceProjectFeatures } from '../../test/projectFixtures'
 import { normalizeToolForProject } from '../toolpaths/geometry'
@@ -1432,6 +1432,157 @@ function testCaptureMotionTrace(): void {
   assert(withoutTrace.motionTraces === undefined, 'motionTraces absent when captureMotionTrace=false')
 }
 
+// ── Entry positioning: no fed move travels while descending (#467) ──
+
+interface EmittedMotion {
+  command: string
+  lineIndex: number
+  x: number | null
+  y: number | null
+  z: number | null
+}
+
+/**
+ * Replays the emitted program the way a controller would — modal motion
+ * command, modal axis words — and returns the motion blocks. Must be run over
+ * the whole program: a modal `X.. Y..` line carries the command from an earlier
+ * block, so replaying a slice misreads the first motion in it.
+ */
+function emittedMotions(gcode: string): EmittedMotion[] {
+  const motions: EmittedMotion[] = []
+  let command: string | null = null
+  let x: number | null = null
+  let y: number | null = null
+  let z: number | null = null
+
+  gcode.split('\n').forEach((raw, lineIndex) => {
+    const line = raw.split(';')[0].trim()
+    if (line.length === 0) return
+
+    const commandMatch = line.match(/^(G0?[0123])\b/)
+    if (commandMatch) {
+      command = commandMatch[1]
+    }
+
+    const xMatch = line.match(/X(-?[\d.]+)/)
+    const yMatch = line.match(/Y(-?[\d.]+)/)
+    const zMatch = line.match(/Z(-?[\d.]+)/)
+    if (!xMatch && !yMatch && !zMatch) return
+    if (command === null) return
+
+    if (xMatch) x = parseFloat(xMatch[1])
+    if (yMatch) y = parseFloat(yMatch[1])
+    if (zMatch) z = parseFloat(zMatch[1])
+    motions.push({ command, lineIndex, x, y, z })
+  })
+
+  return motions
+}
+
+function pocketOperation(id: string, name: string): Operation {
+  return {
+    id, name, kind: 'pocket', pass: 'rough',
+    enabled: true, showToolpath: true, debugToolpath: false,
+    target: { source: 'features', featureIds: ['pocket-feature'] }, toolRef: 't1',
+    stepdown: 1, stepover: 0.4, feed: 600, plungeFeed: 180, rpm: 12000,
+    pocketPattern: 'offset', pocketAngle: 0, stockToLeaveRadial: 0,
+    stockToLeaveAxial: 0, finishWalls: true, finishFloor: true,
+    carveDepth: 1, maxCarveDepth: 1, cutDirection: 'climb',
+    machiningOrder: 'level_first', debugShowRejectedCorners: false,
+  }
+}
+
+/**
+ * The full app pipeline — generate, optimize, postprocess — for two operations.
+ * `optimizeLinearMoves` used to delete the zero-length rapid that marks each
+ * operation's entry point, so the first fed move of the program travelled
+ * diagonally across the workpiece at plunge feed while descending to full
+ * depth, cutting the stock wherever it crossed the surface (issue #467).
+ *
+ * Asserts the shape the machine needs: rapid first, then a vertical plunge.
+ */
+function testOperationEntryRapidsSurviveOptimization(): void {
+  console.log('Testing every operation starts with a rapid, then a vertical plunge...')
+
+  const project = newProject('Entry Test', 'mm')
+  const toolRecord = { ...defaultTool('mm', 1), id: 't1', name: '6 mm Endmill' }
+  project.tools = [toolRecord]
+  const tool = normalizeToolForProject(toolRecord, project)
+
+  const pocketFeature: SketchFeature = {
+    id: 'pocket-feature',
+    name: 'Pocket',
+    kind: 'rect',
+    folderId: null,
+    sketch: {
+      profile: rectProfile(20, 20, 40, 30),
+      origin: { x: 0, y: 0 },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+    operation: 'subtract',
+    z_top: 0,
+    z_bottom: -3,
+    visible: true,
+    locked: false,
+  }
+  replaceProjectFeatures(project, [pocketFeature])
+
+  const operations = [
+    pocketOperation('op1', 'First Pocket'),
+    pocketOperation('op2', 'Second Pocket'),
+  ].map((operation) => {
+    const toolpath = optimizeLinearMoves(generatePocketToolpath(project, operation))
+    assert(toolpath.moves.length > 0, `${operation.name} should produce moves`)
+    return { operation, tool, toolpath }
+  })
+
+  const gcode = runPostProcessor({
+    project,
+    definition: testDefinition(['; Operation {operationIndex}: {operationName}']),
+    operations,
+    options: { emitToolChanges: true, emitCoolant: false, programName: project.meta.name },
+  }).gcode
+
+  const motions = emittedMotions(gcode)
+  assert(motions.length > 0, 'program should emit motion')
+  assert(motions[0].command === 'G0', `program must open with a rapid, got ${motions[0].command}`)
+
+  // Every fed move must be either a constant-Z cut or a pure-Z plunge. A G1
+  // that changes XY *and* descends is the gouge this test exists to catch.
+  // This covers operations 2..n; operation 1 has no preceding motion to
+  // compare against, which is what the opening-rapid assertion above is for.
+  let previous: EmittedMotion | null = null
+  let sawPlunge = false
+  for (const motion of motions) {
+    if (motion.command === 'G1' && previous !== null) {
+      const movedXY = motion.x !== previous.x || motion.y !== previous.y
+      const descended = motion.z !== null && previous.z !== null && motion.z < previous.z
+      assert(
+        !(movedXY && descended),
+        `G1 to (${motion.x}, ${motion.y}, ${motion.z}) travels in XY while descending from `
+        + `(${previous.x}, ${previous.y}, ${previous.z})`,
+      )
+      if (descended) sawPlunge = true
+    }
+    previous = motion
+  }
+  assert(sawPlunge, 'expected at least one fed descent (the plunge) in the program')
+
+  // The second operation must reposition too, not carry the first one's end
+  // point into its own plunge. Modal G0 means its first block is often a bare
+  // "X.. Y.." line, so this reads the replayed command, not the raw text.
+  const headerLine = gcode.split('\n').findIndex((line) => line.includes('; Operation 2:'))
+  assert(headerLine > 0, 'second operation header should be emitted')
+  const secondEntry = motions.find((motion) => motion.lineIndex > headerLine)
+  assert(secondEntry !== undefined, 'second operation should emit motion')
+  assert(
+    secondEntry!.command === 'G0',
+    `second operation must open with a rapid, got ${secondEntry!.command}`,
+  )
+}
+
 testArcOutputIJ()
 testArcOutputR()
 testArcDisabledLinearFallback()
@@ -1443,5 +1594,6 @@ testArcNoRegressionLinear()
 testArcMixedRapidAndCut()
 testArcMoveCountReflectsFittedOutput()
 testCaptureMotionTrace()
+testOperationEntryRapidsSurviveOptimization()
 
 console.log('gcode postprocessor tests passed')

--- a/src/engine/toolpaths/INDEX.md
+++ b/src/engine/toolpaths/INDEX.md
@@ -30,7 +30,7 @@ Toolpath generators. Each file owns one strategy. `index.ts` re-exports everythi
 - `guideFragments.ts` — cyclic closed-guide fragmentation against pre-unioned keep-outs; preserves every safe span before entry-bearing motion is generated
 - `tabs.ts` also owns the shared tab footprint geometry (`expandedTabFootprints`) and `applyEdgeRouteTabs`, the edge-route tab pass that deliberately returns trochoidal results untouched — see `planning/TROCHOIDAL_EDGE_DESIGN.md`
 - `offsetSmoothing.ts` — emit-time corner fillet for the outer/wall clearing rings (`roundContourCorners`, `smoothClosedContours`, `cornerSmoothingRadius`); shared by pocket + surface clearing when `roundOutsideCorners` is enabled. Bounds the setback so acute corners leave no crescent; the offset-tree emitter keeps each region's wall-adjacent (root) outer ring sharp so no corner stock stacks into a chip (interior rings self-clean). Islands are rounded the opposite way — via `jtRound` Clipper offsets (see `buildInsetRegions` island join), so the tool wraps convex island corners smoothly without gouging.
-- `linearMoveOptimization.ts` — pure generation-stage finalizer that removes zero-length duplicate moves and merges contiguous, direction-preserving, collinear XY moves; applied after tabs but before clamp warnings
+- `linearMoveOptimization.ts` — pure generation-stage finalizer that removes zero-length duplicate moves and merges contiguous, direction-preserving, collinear XY moves; applied after tabs but before clamp warnings. Zero-length **rapids** are kept: they are each operation's entry-positioning marker for the postprocessor, not noise
 - `arcReconstruction.ts` — recovers arcs/circles/beziers from flattened Clipper output: known-circle reconstruction, segment-preserving boolean reconstruction (annotation map), and the Clipper-offset simplification pipeline (Kasa fit + RDP)
 - `regions.ts` — region computation (which area belongs to which op)
 - `resolver.ts` — resolves features+operations into clipper input regions; V-carve accepts closed Subtract and Line features (S2), Pocket remains Subtract-only; Line paths use even-odd fill semantics for nested contour holes
@@ -41,7 +41,7 @@ Toolpath generators. Each file owns one strategy. `index.ts` re-exports everythi
 - `clamps.ts` — clamp clearance / avoidance regions
 
 ## Tests
-- `linearMoveOptimization.test.ts` — zero-length removal, collinear merge, and boundary preservation
+- `linearMoveOptimization.test.ts` — zero-length removal, entry-marker (zero-length rapid) preservation, collinear merge, and boundary preservation
 - `trochoidalEdge.test.ts` — deterministic closed/open orbit sampling, seam closure, direction, normalized duplicate vertices, and fail-closed budgets. Integrated cut-direction parity (trochoidal vs contour, inside and outside), circular/multi-target guides, and overlapping tabs live in `toolpaths.test.ts`
 - `feed.test.ts` — shared effectiveFeed helper: cut/plunge/lead-in/lead-out move kinds, feedScale present/absent, and plunge ignores-feedScale invariance
 - `entry.test.ts` — helix pitch/direction, region/island clearance, no-core diameter bounds, bottom flattening, ramp fallback, and plunge-feed limiting

--- a/src/engine/toolpaths/linearMoveOptimization.test.ts
+++ b/src/engine/toolpaths/linearMoveOptimization.test.ts
@@ -99,6 +99,84 @@ function testAllMovesZeroLength() {
   console.log('All moves zero-length: PASSED')
 }
 
+/**
+ * The entry marker every generator opens an operation with: a zero-length rapid
+ * at safe Z that tells the postprocessor to establish XY and Z before the
+ * plunge. Removing it as a duplicate made the first fed move travel diagonally
+ * across the workpiece at plunge feed (issue #467).
+ */
+function testZeroLengthRapidPreserved() {
+  console.log('Testing zero-length rapid entry marker is preserved...')
+
+  const r = optimizeLinearMoves(
+    result({
+      moves: [
+        move('rapid', 10, 20, 10, 20, 5), // entry marker — zero-length
+        { kind: 'plunge' as const, from: pt(10, 20, 5), to: pt(10, 20, -1) },
+        move('cut', 10, 20, 30, 20, -1),
+      ],
+    }),
+  )
+
+  assert(r.moves.length === 3, 'zero-length rapid kept alongside plunge and cut')
+  assert(r.moves[0].kind === 'rapid', 'marker still first')
+  assert(
+    r.moves[0].from.x === 10 && r.moves[0].from.y === 20 && r.moves[0].from.z === 5,
+    'marker start untouched',
+  )
+  assert(
+    r.moves[0].to.x === 10 && r.moves[0].to.y === 20 && r.moves[0].to.z === 5,
+    'marker stays zero-length',
+  )
+  assert(r.moves[1].kind === 'plunge', 'plunge follows the marker')
+
+  console.log('Zero-length rapid preserved: PASSED')
+}
+
+function testZeroLengthNonRapidStillRemoved() {
+  console.log('Testing zero-length plunge and lead_in are still removed...')
+
+  const r = optimizeLinearMoves(
+    result({
+      moves: [
+        move('rapid', 0, 0, 10, 20, 5),
+        { kind: 'plunge' as const, from: pt(10, 20, 5), to: pt(10, 20, 5) }, // zero-length
+        move('lead_in', 10, 20, 10, 20, 5), // zero-length
+        move('cut', 10, 20, 30, 20, -1),
+      ],
+    }),
+  )
+
+  assert(r.moves.length === 2, 'zero-length plunge and lead_in removed')
+  assert(r.moves[0].kind === 'rapid', 'non-zero rapid kept')
+  assert(r.moves[1].kind === 'cut', 'cut kept')
+
+  console.log('Zero-length non-rapid still removed: PASSED')
+}
+
+function testPreservedMarkerDoesNotMerge() {
+  console.log('Testing a preserved marker never merges with the rapid after it...')
+
+  const r = optimizeLinearMoves(
+    result({
+      moves: [
+        move('rapid', 10, 20, 10, 20, 5), // entry marker — zero-length
+        move('rapid', 10, 20, 40, 20, 5), // real travel from the same point
+        move('rapid', 40, 20, 60, 20, 5), // collinear continuation
+      ],
+    }),
+  )
+
+  assert(r.moves.length === 2, 'marker kept separate, the two real rapids merged')
+  assert(
+    r.moves[0].from.x === 10 && r.moves[0].to.x === 10,
+    'marker did not absorb the travel that follows it',
+  )
+  assert(r.moves[1].from.x === 10 && r.moves[1].to.x === 60, 'real rapids merged')
+
+  console.log('Preserved marker does not merge: PASSED')
+}
+
 // ── Collinear merge ──────────────────────────────────────────────────
 
 function testCollinearMergeSameFeedScale() {
@@ -581,6 +659,9 @@ function testLeadInOutPreserved() {
 try {
   testZeroLengthMovesRemoved()
   testAllMovesZeroLength()
+  testZeroLengthRapidPreserved()
+  testZeroLengthNonRapidStillRemoved()
+  testPreservedMarkerDoesNotMerge()
   testCollinearMergeSameFeedScale()
   testCollinearMergeUndefinedFeedScale()
   testCollinearMergeDiagonal()

--- a/src/engine/toolpaths/linearMoveOptimization.ts
+++ b/src/engine/toolpaths/linearMoveOptimization.ts
@@ -36,7 +36,7 @@ export function optimizeLinearMoves(result: ToolpathResult): ToolpathResult {
   const optimized: ToolpathMove[] = []
 
   for (const move of result.moves) {
-    if (isZeroLength(move)) {
+    if (isZeroLength(move) && !isPositioningDirective(move)) {
       continue
     }
 
@@ -65,6 +65,30 @@ export function optimizeLinearMoves(result: ToolpathResult): ToolpathResult {
     moves: optimized,
     bounds: computeBounds(optimized),
   }
+}
+
+/**
+ * A zero-length rapid is a positioning directive, never noise.
+ *
+ * Generators open an operation with `from === null` — nothing is known about
+ * where the machine is — and mark the entry point with a rapid whose `from`
+ * equals its `to` at safe Z (`pushRapidAndPlunge` in `pocket.ts`,
+ * `rapidToEntryStart` and `emitCenterLockedCircularBore` in `entry.ts`). The
+ * postprocessor reads that marker and emits G0 to safe Z, then G0 to the entry
+ * XY, before the plunge descends.
+ *
+ * Dropping it as a duplicate left the first fed move of every operation to do
+ * the travelling: one `G1 X Y Z` at plunge feed, diagonally across the
+ * workpiece while descending, cutting the stock wherever it crossed the
+ * surface (issue #467). Keeping it costs one move per operation and nothing
+ * downstream — `emitRapid` compares against its own tracked machine position
+ * and emits only the axes that actually change, or no line at all.
+ *
+ * Zero-length `cut` / `plunge` / `lead_in` moves carry no such meaning and are
+ * still removed.
+ */
+function isPositioningDirective(move: ToolpathMove): boolean {
+  return move.kind === 'rapid'
 }
 
 function isZeroLength(move: ToolpathMove): boolean {


### PR DESCRIPTION
Closes #467

## The bug

The first fed move of **every** operation travelled diagonally across the
workpiece at plunge feed while descending to depth. On a full-depth pass it
crossed the stock surface mid-travel and cut there — off the intended contour,
at plunge feed. Reproduced on a plain pocket, no drill op or tool change
needed.

## Root cause

Three layers:

1. Generators open an operation with `from === null` — nothing is known about
   where the machine is — and mark the entry point with a **zero-length rapid**
   at safe Z (`pushRapidAndPlunge` in `pocket.ts`, `rapidToEntryStart` and
   `emitCenterLockedCircularBore` in `entry.ts`). The postprocessor reads that
   marker and emits G0 to safe Z, then G0 to the entry XY, before the plunge.
2. `optimizeLinearMoves` deleted **every** zero-length move, marker included.
3. The postprocessor emits each fed move from `move.to` only, so with no
   preceding rapid the plunge inherited the travel.

## The fix

Keep zero-length **rapids** in `optimizeLinearMoves`; keep removing zero-length
`cut` / `plunge` / `lead_in`, which carry no such meaning.

No postprocessor change is needed — `emitRapid` already splits Z-then-XY off a
null machine position, which is exactly the required sequence. It just never
got called.

Same pocket, generate → optimize → postprocess:

```diff
- G1 X47.4 Y42.6 Z-22 F180          ; diagonal + full depth at plunge feed
+ G0 Z5                              ; retract first
+ X47.4 Y42.6                        ; modal G0 — travel at safe Z
+ G1 X47.4 Y42.6 Z-22 F180           ; vertical plunge only
```

## Blast radius

Probed every generator (pocket offset / helix / ramp entry, edge route
inside+outside ± tabs, v_carve, v_carve_medial, follow_line, drilling):

- Each emits exactly **one** marker, so the fix is uniform across operation
  kinds. `drilling simple` opens with a real non-zero rapid and is unaffected.
  The tab pipeline preserves the marker; only `optimizeLinearMoves` dropped it.
- **No** real toolpath contains a zero-length non-rapid move, so this adds one
  move per operation and nothing else.
- Checked the consumers that could divide by a zero length:
  `Viewport3D.getHorizontalDirection` and
  `previewPrimitives.normalizedMoveDirection` both return `null` below a length
  threshold, and `PlaybackRunner.step` has an explicit `length <= 1e-9` branch.

## Tests

- `linearMoveOptimization.test.ts` — marker preserved; zero-length `plunge` /
  `lead_in` still removed; a preserved marker never becomes a merge partner for
  the real travel that follows it.
- `postprocessor.test.ts` — pipeline regression over two operations: the
  program opens with a rapid, no `G1` travels in XY while descending, and
  operation 2 repositions rather than carrying operation 1's end point into its
  plunge. Reads the *replayed modal* command, since a modal `X.. Y..` line
  carries G0 from an earlier block.

Both mutation-checked — reverting the fix fails them with
`program must open with a rapid, got G1` and
`G1 (47.4,42.6,-21) travels in XY while descending from (57,33,5)`.

## Verification

`npm run build` green (166 test files, lint, tsc, docs:check).

## Follow-up (not in this PR)

The deeper invariant — *never emit a fed move from a position the machine is
not known to be at* — still rests on a convention (an empty move carrying
meaning) rather than a check. This restores the convention; it does not make it
robust.
