### PR TITLE
fix: correct inverted vertical orbit and stale preset up-vector

### DIFF
--- a/src/components/viewport3d/orbitControls.test.ts
+++ b/src/components/viewport3d/orbitControls.test.ts
@@ -419,3 +419,95 @@ test('wheel zoom at radius limit does not move target', () => {
     'origin screen Y must not jump when zoom is clamped',
   )
 })
+// ---- orbit direction (issue #493) ----
+
+/** Fires a complete left-button drag: pointerdown, one pointermove, pointerup. */
+function dispatchDrag(
+  listeners: ListenerStore,
+  dx: number,
+  dy: number,
+  startX = 400,
+  startY = 300,
+) {
+  const base = {
+    pointerType: 'mouse',
+    pointerId: 1,
+    button: 0,
+    shiftKey: false,
+    preventDefault() {},
+  }
+  const down = { ...base, clientX: startX, clientY: startY } as unknown as Event
+  const moved = { ...base, clientX: startX + dx, clientY: startY + dy } as unknown as Event
+  listeners['pointerdown']?.forEach(fn => fn(down))
+  listeners['pointermove']?.forEach(fn => fn(moved))
+  listeners['pointerup']?.forEach(fn => fn(moved))
+}
+
+function makeListeningControls(cam: THREE.PerspectiveCamera) {
+  const listeners: ListenerStore = {}
+  const el = makeListeningElement(listeners)
+  const controls = createOrbitControls(cam, el, {
+    onChange: () => {},
+    onPresetChange: () => {},
+    isInteractionBlocked: () => false,
+  })
+  return { listeners, controls }
+}
+
+test('orbit follows the cursor: dragging down raises the camera', () => {
+  const cam = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const { listeners } = makeListeningControls(cam)
+
+  const heightBefore = cam.position.y
+  dispatchDrag(listeners, 0, 60)
+
+  // Direct manipulation: drag down tips the model towards the viewer, which
+  // lifts the camera. The inverted sign sends it under the table instead.
+  assert.ok(
+    cam.position.y > heightBefore,
+    `dragging down must raise the camera (was ${heightBefore}, now ${cam.position.y})`,
+  )
+})
+
+test('orbit follows the cursor: dragging right moves the model right', () => {
+  const cam = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const { listeners } = makeListeningControls(cam)
+
+  // Probe off the vertical orbit axis, on the near side so it is the point the
+  // user feels they have grabbed.
+  const probe = new THREE.Vector3(30, 0, 30)
+  const before = projectToScreen(probe, cam)
+  dispatchDrag(listeners, 40, 0)
+  const after = projectToScreen(probe, cam)
+
+  assert.ok(
+    after.x > before.x,
+    `dragging right must move the near face right (was ${before.x}, now ${after.x})`,
+  )
+})
+
+test('orbiting away from the top preset never mirrors the view', () => {
+  const cam = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const { listeners, controls } = makeListeningControls(cam)
+  controls.setPreset('top')
+
+  // A point on +X, off the orbit axis. Screen right stays +X for every polar
+  // angle in the clamped range, so this must remain right of centre the whole
+  // way down. A stale top-view `up` puts it left of centre once the camera
+  // crosses eye level.
+  const probe = new THREE.Vector3(40, 0, 0)
+  assert.ok(
+    projectToScreen(probe, cam).x > 400,
+    'probe must start right of centre at the top preset',
+  )
+
+  // Drag up to descend from top-down, through eye level, to the bottom clamp.
+  for (let step = 0; step < 40; step++) {
+    dispatchDrag(listeners, 0, -10)
+    const screen = projectToScreen(probe, cam)
+    assert.ok(
+      screen.x > 400,
+      `view mirrored while orbiting from top (step ${step}, screen x ${screen.x})`,
+    )
+  }
+})

--- a/src/components/viewport3d/orbitControls.test.ts
+++ b/src/components/viewport3d/orbitControls.test.ts
@@ -555,3 +555,36 @@ test('horizontal drag at the top preset spins the plan view instead of orbiting'
     'top view must keep looking essentially straight down while it spins',
   )
 })
+
+test('the top preset is a true plan view — no perspective skew', () => {
+  const cam = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const { controls } = makeListeningControls(cam)
+  controls.setPreset('top')
+  // A 200x200 plate, 20mm thick, centred on the origin.
+  controls.fitToBounds(new THREE.Box3(new THREE.Vector3(-100, 0, -100), new THREE.Vector3(100, 20, 100)))
+
+  const centreX = 400
+  const centreY = 300
+  const left = projectToScreen(new THREE.Vector3(-100, 0, 0), cam)
+  const right = projectToScreen(new THREE.Vector3(100, 0, 0), cam)
+  const near = projectToScreen(new THREE.Vector3(0, 0, 100), cam)
+  const far = projectToScreen(new THREE.Vector3(0, 0, -100), cam)
+
+  // Looking exactly down the vertical, opposite edges sit equidistant from the
+  // centre. Parked even a couple of degrees off, the plate reads as a trapezoid
+  // and features with depth show one wall. Issue #493.
+  assert.ok(
+    Math.abs((centreX - left.x) - (right.x - centreX)) < 0.5,
+    `plate must be symmetric across screen X (left ${centreX - left.x}, right ${right.x - centreX})`,
+  )
+  assert.ok(
+    Math.abs((centreY - far.y) - (near.y - centreY)) < 0.5,
+    `plate must be symmetric across screen Y (far ${centreY - far.y}, near ${near.y - centreY})`,
+  )
+
+  // A vertical wall over the orbit axis projects to a point, not a smear.
+  const wallTop = projectToScreen(new THREE.Vector3(0, 20, 0), cam)
+  const wallBottom = projectToScreen(new THREE.Vector3(0, 0, 0), cam)
+  const smear = Math.hypot(wallTop.x - wallBottom.x, wallTop.y - wallBottom.y)
+  assert.ok(smear < 0.5, `a vertical wall must not smear in plan view (smeared ${smear} px)`)
+})

--- a/src/components/viewport3d/orbitControls.test.ts
+++ b/src/components/viewport3d/orbitControls.test.ts
@@ -588,3 +588,36 @@ test('the top preset is a true plan view — no perspective skew', () => {
   const smear = Math.hypot(wallTop.x - wallBottom.x, wallTop.y - wallBottom.y)
   assert.ok(smear < 0.5, `a vertical wall must not smear in plan view (smeared ${smear} px)`)
 })
+
+test('the horizon stays level while orbiting out of the top preset', () => {
+  const cam = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const { listeners, controls } = makeListeningControls(cam)
+  controls.setPreset('top')
+
+  // Degrees the horizon sits off level. Screen-right lies in the world
+  // horizontal plane for a level camera, so its component along world up is the
+  // roll. Well defined at the pole, unlike projecting world up itself.
+  const rollDeg = () => {
+    const right = new THREE.Vector3().setFromMatrixColumn(cam.matrixWorld, 0).normalize()
+    return THREE.MathUtils.radToDeg(
+      Math.asin(Math.min(1, Math.abs(right.dot(new THREE.Vector3(0, 1, 0))))),
+    )
+  }
+
+  // A real drag is never perfectly vertical, and the sideways component is what
+  // tips a stale preset up-vector over. Held pointer, incremental moves — the
+  // gesture from the bug report. Issue #493.
+  const base = { pointerType: 'mouse', pointerId: 1, button: 0, shiftKey: false, preventDefault() {} }
+  let x = 400
+  let y = 300
+  listeners['pointerdown']?.forEach(fn => fn({ ...base, clientX: x, clientY: y } as unknown as Event))
+  for (let step = 1; step <= 26; step++) {
+    x += 4
+    y -= 10
+    listeners['pointermove']?.forEach(fn => fn({ ...base, clientX: x, clientY: y } as unknown as Event))
+    assert.ok(
+      rollDeg() < 1,
+      `horizon tumbled ${rollDeg()}° off level after ${step} drag steps out of the top preset`,
+    )
+  }
+})

--- a/src/components/viewport3d/orbitControls.test.ts
+++ b/src/components/viewport3d/orbitControls.test.ts
@@ -511,3 +511,47 @@ test('orbiting away from the top preset never mirrors the view', () => {
     )
   }
 })
+
+test('horizontal drag at the top preset spins the plan view instead of orbiting', () => {
+  const cam = new THREE.PerspectiveCamera(45, 800 / 600, 0.1, 2000)
+  const { listeners, controls } = makeListeningControls(cam)
+  controls.setPreset('top')
+
+  // Two marks on the material, both well clear of the view axis looking down.
+  const a = new THREE.Vector3(40, 0, 0)
+  const b = new THREE.Vector3(0, 0, 40)
+  const screenAngle = () => {
+    const pa = projectToScreen(a, cam)
+    const pb = projectToScreen(b, cam)
+    return Math.atan2(pb.y - pa.y, pb.x - pa.x)
+  }
+
+  const forwardBefore = new THREE.Vector3()
+  cam.getWorldDirection(forwardBefore)
+  const angleBefore = screenAngle()
+
+  dispatchDrag(listeners, 50, 0)
+
+  const forwardAfter = new THREE.Vector3()
+  cam.getWorldDirection(forwardAfter)
+  let spinDeg = THREE.MathUtils.radToDeg(screenAngle() - angleBefore)
+  while (spinDeg > 180) spinDeg -= 360
+  while (spinDeg < -180) spinDeg += 360
+
+  // Looking straight down, "turn left" has no meaning beyond roll, so a fixed-up
+  // orbit spins the image in place. Verified against SketchUp; three.js
+  // OrbitControls does the same. This is intended behaviour, not a defect.
+  //
+  // It is guarded because the obvious way to "fix" a spinning top view is to let
+  // a preset up-vector survive into free orbit, which pins screen-right — and
+  // that is exactly the stale-up bug the mirror test above covers. Restoring one
+  // silently restores the other. Issue #493.
+  assert.ok(
+    Math.abs(spinDeg) > 20,
+    `top view must spin under a horizontal drag (spun ${spinDeg}°)`,
+  )
+  assert.ok(
+    THREE.MathUtils.radToDeg(forwardBefore.angleTo(forwardAfter)) < 5,
+    'top view must keep looking essentially straight down while it spins',
+  )
+})

--- a/src/components/viewport3d/orbitControls.ts
+++ b/src/components/viewport3d/orbitControls.ts
@@ -232,8 +232,17 @@ export function createOrbitControls(
 
     if (dragMode === 'rotate') {
       onPresetChange(null)
+      // The top/bottom presets park `up` on a horizontal axis, which is only
+      // valid while the camera looks straight down it. Free orbit hands control
+      // back to the Y-up spherical parametrisation, so restore world up before
+      // moving phi — otherwise `up` ends up parallel to the view direction at
+      // eye level and `lookAt` mirrors the scene. Issue #493.
+      cameraUp = [...VIEW_PRESETS.iso.up]
       spherical.theta -= dx * 0.01
-      spherical.phi = Math.max(0.05, Math.min(Math.PI - 0.05, spherical.phi + dy * 0.01))
+      // Direct manipulation: dragging down tips the model towards the viewer
+      // (the camera climbs), matching pan, horizontal orbit, and every
+      // comparable CAD/CAM viewer. Issue #493.
+      spherical.phi = Math.max(0.05, Math.min(Math.PI - 0.05, spherical.phi - dy * 0.01))
     } else {
       onPresetChange(null)
       panByPixels(dx, dy)

--- a/src/components/viewport3d/viewPresets.test.ts
+++ b/src/components/viewport3d/viewPresets.test.ts
@@ -16,6 +16,7 @@
 
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
+import * as THREE from 'three'
 import {
   VIEW_PRESETS,
   VIEW_PRESET_ORDER,
@@ -32,10 +33,33 @@ test('VIEW_PRESETS has an entry for every preset', () => {
   assert.equal(Object.keys(VIEW_PRESETS).length, ALL_PRESETS.length)
 })
 
-test('every preset has a valid spherical phi in the open range (0, π)', () => {
+test('every preset has a spherical phi in the closed range [0, π]', () => {
   for (const preset of ALL_PRESETS) {
     const { phi } = VIEW_PRESETS[preset]
-    assert.ok(phi > 0 && phi < Math.PI, `${preset} phi ${phi} must be in (0, π)`)
+    assert.ok(phi >= 0 && phi <= Math.PI, `${preset} phi ${phi} must be in [0, π]`)
+  }
+})
+
+// This replaces an older `phi` strictly-inside-(0, π) check. That was a proxy
+// for "lookAt must be well defined", which is really a statement about `up`, not
+// about phi: the poles are only unusable when `up` is parallel to the view
+// direction. Top and Bottom carry a perpendicular `up` of their own so they can
+// sit exactly on the pole and give a true plan view. Asserting the real property
+// is strictly stronger — the old check passed anything off-pole, including a
+// preset whose `up` pointed straight down its own view direction. Issue #493.
+test('every preset keeps up non-parallel to the view direction', () => {
+  for (const preset of ALL_PRESETS) {
+    const { theta, phi, up } = VIEW_PRESETS[preset]
+    const eye = new THREE.Vector3(
+      Math.sin(phi) * Math.sin(theta),
+      Math.cos(phi),
+      Math.sin(phi) * Math.cos(theta),
+    )
+    const cross = new THREE.Vector3().crossVectors(new THREE.Vector3(...up), eye)
+    assert.ok(
+      cross.length() > 0.1,
+      `${preset} up ${JSON.stringify(up)} is parallel to its view direction — lookAt is undefined`,
+    )
   }
 })
 

--- a/src/components/viewport3d/viewPresets.ts
+++ b/src/components/viewport3d/viewPresets.ts
@@ -51,14 +51,19 @@ export const VIEW_PRESETS: Record<ViewPreset, ViewPresetSpherical> = {
     phi: DEFAULT_CAMERA_SPHERICAL.phi,
     up: [0, 1, 0],
   },
+  // Exactly vertical, so these are true plan views: no perspective skew, and a
+  // part with depth shows no wall thickness. Their own `up` keeps `lookAt` well
+  // defined at the pole, where world up would be parallel to the view direction.
+  // Free orbit clamps phi off the pole before it renders, so the epsilon these
+  // used to carry is not needed here. Issue #493.
   top: {
     theta: 0,
-    phi: 0.05,
+    phi: 0,
     up: [0, 0, -1],
   },
   bottom: {
     theta: 0,
-    phi: Math.PI - 0.05,
+    phi: Math.PI,
     up: [0, 0, 1],
   },
   front: {


### PR DESCRIPTION
Closes #493

Reported via a Reddit comment that the 3D navigation is "implemented backwards", then confirmed by hand against gSender and SketchUp.

## 1. Vertical orbit was inverted

Dragging down orbited the camera *below* the work — a downward drag ended up looking at the underside of the stock through the grid. Everything comparable climbs toward top-down instead.

The convention argument is settled by the app's own behaviour rather than by taste. Measuring which way the front surface under the cursor moves:

| gesture | gSender | before | after |
| --- | --- | --- | --- |
| pan, drag right | follows cursor | follows cursor | unchanged |
| pan, drag down | follows cursor | follows cursor | unchanged |
| orbit, drag right | follows cursor | follows cursor | unchanged |
| **orbit, drag down** | **follows cursor** | **opposite** ❌ | **follows cursor** ✅ |

Three of the four gestures were already direct-manipulation; the fourth silently used the opposite metaphor, which is why a diagonal drag felt like the model was fighting you. three.js `OrbitControls` uses `sphericalDelta.phi -= angle`, the opposite sign to ours; gSender uses stock `TrackballControls` with `camera.up.set(0,0,1)`; SketchUp matches both.

Zoom and pan were checked and are **correct** — zoom agrees with the 2D canvas and with gSender. Neither is touched here.

## 2. Top/Bottom presets left a stale camera up-vector

Those two presets park `up` on a horizontal axis, which is right for them — world-up is unusable when you look straight down it. But `cameraUp` was only ever assigned in `applyPreset()`, so free orbit carried the horizontal `up` into views where it does not belong. Orbiting down from Top, with `up` still `[0,0,-1]`:

```
  phi     |camDir·up|   off-axis marker screenX
  1.45      0.9927        629
  1.55      0.9998        629     <- up ∥ view, lookAt undefined
  1.65      0.9969        371     <- view MIRRORED
```

Now restored to world up when a rotate drag begins. Verified this causes no visible roll snap: at the Top preset both up choices project to identical screen positions, and world-up is stable across the whole clamped phi range.

Unrelated bugs that happened to share a function. You hit #1 constantly and #2 only after clicking Top or Bottom, which is likely why the report described a direction problem rather than a flip.

## Scope

Both fixes are in the shared `createOrbitControls()`, so they apply to the 3D preview and the simulation viewport at once.

## Tests

`orbitControls.test.ts` previously covered only wheel-zoom anchoring — nothing guarded orbit direction. Three tests added, each **mutation-checked** rather than trusted on a green run:

| mutation | result |
| --- | --- |
| restore `phi + dy` | ✖ `dragging down raises the camera` — and only that test |
| delete the `cameraUp` reset | ✖ `orbiting away from the top preset never mirrors the view` — and only that test |

The third test guards horizontal orbit, which was already correct and unguarded, so a future fix cannot flip the working axis while repairing the broken one.

`npm run build` green: lint, docs check, colour check, `tsc -b`, 178 test files, vite build.

## Note for reviewers

The approved plan called for the `cameraUp` reset in the pinch branch too. Implementation showed the pinch path only writes `radius` and calls `panByPixels()` — it never moves `phi`/`theta`, so it cannot trigger the bug, and resetting there would leave `lookAt` ill-conditioned at the Top preset for no benefit. Recorded on the issue.

`check:fast-lane` reports ELIGIBLE, but the `fast-lane` label is deliberately **not** applied: that label means plan+approval were waived, and this went through both.