### PR TITLE
Fix desktop browser project save extension

### DIFF
--- a/src/INDEX.md
+++ b/src/INDEX.md
@@ -24,7 +24,7 @@ Application source. React + TypeScript + Zustand. Tauri-wrapped for desktop.
 - [commands/](commands/INDEX.md) — shared desktop/tablet command descriptors and store-backed command predicates
 - [types/](types/) — core data model. `project.ts` is the canonical `.camj` schema
 - [utils/](utils/) — units, analytics, icons, version, misc helpers
-- [platform/](platform/) — platform abstraction (web vs Tauri), desktop integration, feature clipboard helpers, and hidden-iframe HTML printing (`printDocument.ts`)
+- [platform/](platform/) — platform abstraction (web vs Tauri), including touch-only `.camj.json` save compatibility, desktop integration, feature clipboard helpers, and hidden-iframe HTML printing (`printDocument.ts`)
 - [styles/](styles/) — shared CSS (incl. `tablet.css` for touch UX)
 - [assets/](assets/) — editable per-icon SVG sources in `icons/` (see `icons/README.md`), fonts, etc.
 - [test/](test/INDEX.md) — shared helpers for constructing strict current-format test projects

--- a/src/platform/browser.test.ts
+++ b/src/platform/browser.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for browser project-file persistence.
+ *
+ * Run with: npx tsx src/platform/browser.test.ts
+ */
+
+import { browserPlatform } from './browser'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`FAIL: ${message}`)
+}
+
+let touchDevice = false
+const downloadedNames: string[] = []
+
+const testGlobal = globalThis as typeof globalThis & {
+  document: Document
+  window: Window & typeof globalThis
+}
+
+testGlobal.window = {
+  matchMedia: () => ({ matches: touchDevice }),
+} as unknown as Window & typeof globalThis
+testGlobal.document = {
+  createElement: () => ({
+    href: '',
+    download: '',
+    click(this: HTMLAnchorElement): void {
+      downloadedNames.push(this.download)
+    },
+  }),
+} as unknown as Document
+
+async function saveProject(touch: boolean, suggestedName: string): Promise<string | null> {
+  touchDevice = touch
+  downloadedNames.length = 0
+  const savedName = await browserPlatform.saveProjectFile(suggestedName, '{}')
+  assert(downloadedNames.length === 1, 'fallback download runs once')
+  assert(downloadedNames[0] === savedName, 'returned filename matches downloaded filename')
+  return savedName
+}
+
+async function testProjectSaveExtensionFollowsInputMode(): Promise<void> {
+  assert(await saveProject(false, 'desktop-project') === 'desktop-project.camj',
+    'desktop fallback without File System Access API saves .camj')
+  assert(await saveProject(false, 'already.camj.json') === 'already.camj',
+    'desktop normalizes a previous mobile filename to .camj')
+  assert(await saveProject(true, 'tablet-project') === 'tablet-project.camj.json',
+    'touch browser saves .camj.json for iOS picker compatibility')
+  console.log('testProjectSaveExtensionFollowsInputMode PASS')
+}
+
+await testProjectSaveExtensionFollowsInputMode()

--- a/src/platform/browser.ts
+++ b/src/platform/browser.ts
@@ -131,14 +131,11 @@ export const browserPlatform: PlatformApi = {
   async saveProjectFile(suggestedName: string, content: string): Promise<string | null> {
     const baseName = suggestedName.replace(/\.camj(\.json)?$/i, '')
 
-    // Desktop browsers with the File System Access API can handle the custom
-    // .camj extension natively.  On mobile/tablet browsers we save as
-    // .camj.json so iOS recognises the file in the picker (it needs a known
-    // UTI — .json qualifies, .camj alone does not).
-    if (typeof window.showSaveFilePicker === 'function') {
-      return saveFile(content, `${baseName}.camj`, 'application/json', 'PureCutCNC Project', ['.camj'])
-    }
-    return saveFile(content, `${baseName}.camj.json`, 'application/json', 'PureCutCNC Project', ['.camj.json'])
+    // iOS needs the registered .json UTI for a saved project to appear in its
+    // file picker. Desktop browsers can download a custom .camj extension
+    // regardless of File System Access API support.
+    const extension = window.matchMedia('(pointer: coarse)').matches ? '.camj.json' : '.camj'
+    return saveFile(content, `${baseName}${extension}`, 'application/json', 'PureCutCNC Project', [extension])
   },
 
   async saveTextFile(


### PR DESCRIPTION
## Summary

- Save browser projects as `.camj` on non-touch devices, including browsers without File System Access API support.
- Keep `.camj.json` exclusively for touch devices, where iOS needs the registered JSON UTI to show a saved project in its picker.
- Add fallback-download regression coverage and document the platform behavior.

## Root cause

The prior tablet compatibility fix used File System Access API availability as a proxy for device type. Firefox, Safari, and Zen lack that API on desktop, so they incorrectly received the tablet-only filename extension.

Closes #495

## Verification

- `npx tsx src/platform/browser.test.ts`
- `npm run check:fast-lane`
- `npm run build` (179 structural test files)
