### PR TITLE
Add DSH delegated-worker provider

### DIFF
--- a/.agents/skills/manager-delegate/SKILL.md
+++ b/.agents/skills/manager-delegate/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: manager-delegate
-description: Run the integration-manager delegation loop — analyze a task, plan it in a GitHub issue, get approval, delegate implementation to the DeepSeek-backed Claude CLI worker in an isolated worktree, review the real diff, then merge into the integration branch. Use when acting as the manager session that dispatches bounded implementation slices rather than writing the code directly.
+description: Run the integration-manager delegation loop — analyze a task, plan it in a GitHub issue, get approval, delegate one bounded implementation slice to a configured external-worker provider in an isolated worktree, review the real diff, then merge into the integration branch. Use when acting as the manager session that dispatches bounded implementation slices rather than writing the code directly.
 ---
 
 # manager-delegate
 
 This skill encodes PureCutCNC's integration-manager loop: **you plan and review; a
-DeepSeek-backed worker implements** one bounded slice at a time in its own git
+configured external worker implements** one bounded slice at a time in its own git
 worktree. You never let the worker's self-report stand in for acceptance — you
 verify the real artifacts and own the merge.
 
-Read `AGENTS.md` (§"DeepSeek implementation workers", §"Git & Branching",
-§"Workflow: Issue → Plan → Approve → Implement → PR") first — it is authoritative.
+Read `AGENTS.md` (§"Execution Modes", §"Git & Branching", §"Workflow: Issue →
+Plan → Approve → Implement → PR") first — it is authoritative.
 This skill automates that documented flow; it does not replace those rules.
 
 ## The loop
@@ -24,8 +24,8 @@ This skill automates that documented flow; it does not replace those rules.
    forbidden files, invariants, required checks, plan + handoff paths). Those
    referenced paths must be **tracked files visible in the worktree** — never
    `work/` (gitignored, absent from worktrees). Save to a temp file.
-3. **Request permission (see below), then dispatch.** Pipe the prompt into
-   `scripts/dispatch-task.sh`. It creates the worktree+branch, runs the worker,
+3. **Select a provider and request permission (see below), then dispatch.** Pipe
+   the prompt into `scripts/dispatch-task.sh`. It creates the worktree+branch, runs the worker,
    runs an independent build gate, and reports — it does **not** merge.
    Run it in the background (redirect output to a file) and watch the slice's
    progress log instead of blocking a foreground call on the whole run (see
@@ -41,32 +41,39 @@ This skill automates that documented flow; it does not replace those rules.
 
 ## Required permissions — request BEFORE dispatching
 
-`dispatch-task.sh` needs three elevated capabilities at once:
+Every provider sends the prompt and any repository content the worker reads to
+its configured external service. **Ask the user for explicit approval before
+invoking dispatch — and do not silently skip the dispatch step.** If the
+sandbox/approval blocks it, surface the blocker and ask; never quietly fall back
+to implementing the slice yourself or abandoning the delegation.
 
-1. **Read the credential file** `.env.agent` (the DeepSeek key).
-2. **Outbound network** to the DeepSeek endpoint (`api.deepseek.com`).
-3. **Spawn a `bypassPermissions` worker** `claude` process in the task worktree.
-
-Sandboxed agents block network and the credential read by default. **Ask the user
-for explicit approval for these three capabilities before invoking dispatch — and
-do not silently skip the dispatch step.** If the sandbox/approval blocks it,
-surface the blocker and ask; never quietly fall back to implementing the slice
-yourself or abandoning the delegation.
+- `claude-deepseek` (the default) reads `.env.agent`, connects to the DeepSeek
+  endpoint, and spawns a `bypassPermissions` Claude worker. It is the legacy
+  credential-backed path.
+- `dsh` runs `dsh --profile headless` using DSH's configured credential store.
+  It does not read or forward `.env.agent`; DSH persists normal profile/session
+  state under `~/.dsh`. Review workers use DSH `read-only`; implementation
+  workers use DSH `workspace-write` rooted at the task worktree. Any DSH
+  escalation without an interactive approver fails closed.
 
 - **Codex:** run from the worktree/repo root with `sandbox=workspace-write`,
   `sandbox_workspace_write.network_access=true`, and `approval-policy=on-request`.
 - **Claude Code:** approve the `dispatch-task.sh` Bash invocation when prompted.
 
-The user's explicit approval is required before any credential-backed dispatch
-(AGENTS.md §"Credential & token handling").
+The user's explicit approval is required before any external-worker dispatch.
 
 ## Watching a dispatched worker — judge idle time, never wall-clock
 
-The worker streams its activity into a per-slice progress log at
+Claude/DeepSeek streams observed activity into a per-slice progress log at
 `$PURECUT_WORKTREE_BASE/SLUG.progress.log` (path echoed at dispatch time; the
 raw event stream is kept beside it at `….progress.log.ndjson`). Long slices
 are normal: a healthy worker can run 10+ minutes while emitting a steady drip
 of `[note]`/`[tool]`/`[gen]` lines.
+
+DSH headless only returns its final response. Its leaf writes `[start]`,
+`[heartbeat]`, and `[exit]` markers; a heartbeat means the DSH process remains
+alive, **not** that the worker made tool-level progress. Inspect the worktree and
+final response before treating a long DSH run as healthy.
 
 - Dispatch in the background with output redirected to a file; do not block a
   foreground shell call (with its own timeout) on the whole slice.
@@ -80,9 +87,8 @@ of `[note]`/`[tool]`/`[gen]` lines.
     be quiet for a while. Kill only if clearly wedged.
   - `verifying` — worker done, independent build gate running.
   - `done` — read the dispatch report and start the review.
-- `[tool]` lines are tool calls observed by the harness — the model cannot
-  fake or forget them, so they are the reliable liveness signal. `[note]`
-  lines are the worker narrating its phases.
+- For Claude/DeepSeek, `[tool]` lines are observed tool calls and `[note]` lines
+  are worker narration. DSH does not expose either stream through headless mode.
 
 ## Verify before you accept
 
@@ -192,13 +198,13 @@ single — so match the file, not the sibling.
 
 ```
 # Dispatch one implement slice (after approval). Prompt on stdin.
-scripts/dispatch-task.sh --issue NN --task-slug SLUG [--base BRANCH] < prompt.md
+scripts/dispatch-task.sh --issue NN --task-slug SLUG [--base BRANCH] [--provider claude-deepseek|dsh] < prompt.md
 #   default --base: feat/core-arch-simplification
 #   creates worktree at $PURECUT_WORKTREE_BASE/SLUG on feat/issue-NN-SLUG
 #   runs the worker, then `npm run build` as an independent gate; never merges.
 
 # Read-only review of an existing worktree (optional helper).
-scripts/dispatch-task.sh --mode review --worktree DIR < prompt.md
+scripts/dispatch-task.sh --mode review --worktree DIR [--provider claude-deepseek|dsh] < prompt.md
 
 # Poll a running dispatch (instant; see "Watching a dispatched worker").
 scripts/worker-status.sh --slug SLUG
@@ -209,9 +215,10 @@ scripts/finish-task.sh --slug SLUG [--base BRANCH]
 #   also removes the slice's progress log artifacts.
 ```
 
-The leaf launcher `scripts/run-claude-deepseek-agent.sh` (credential scrub,
-worktree confinement, mode→permission mapping) is the trusted primitive both
-scripts call. Do not modify it.
+The provider leaf launchers own provider-specific credential handling,
+worktree confinement, and permission mapping. `run-claude-deepseek-agent.sh`
+remains the trusted Claude/DeepSeek primitive; `run-dsh-agent.sh` keeps DSH
+within its own read-only/workspace-write modes.
 
 ## Guardrails (enforced by the scripts — do not re-derive)
 

--- a/.agents/skills/manager-delegate/SKILL.md
+++ b/.agents/skills/manager-delegate/SKILL.md
@@ -19,13 +19,17 @@ This skill automates that documented flow; it does not replace those rules.
 1. **Analyze & plan in a GitHub issue.** Open an issue, write the plan in it,
    get the user's approval before implementing. No `planning/*_Plan.md` files —
    the issue is the plan of record. (See the issue-driven gate in AGENTS.md.)
-2. **Write the handoff prompt.** Copy `scripts/claude-deepseek-agent-prompt.md`
-   and fill every bracketed field for the slice (slice id, summary, allowed/
-   forbidden files, invariants, required checks, plan + handoff paths). Those
-   referenced paths must be **tracked files visible in the worktree** — never
-   `work/` (gitignored, absent from worktrees). Save to a temp file.
-3. **Select a provider and request permission (see below), then dispatch.** Pipe
-   the prompt into `scripts/dispatch-task.sh`. It creates the worktree+branch, runs the worker,
+2. **Write the handoff.** Copy `scripts/claude-deepseek-agent-prompt.md` and
+   fill every bracketed field for the slice (slice id, summary, allowed/
+   forbidden files, invariants, required checks, plan + handoff paths). Save the
+   completed handoff at a **tracked path visible in the task worktree** — never
+   `work/` (gitignored, absent from worktrees). The selected base must already
+   contain that file. Keep stdin to a brief instruction; direct prompts are
+   capped at 4 KiB.
+3. **Select a provider and request permission (see below), then dispatch.** Pass
+   `--handoff REPO_PATH` and pipe the brief instruction into
+   `scripts/dispatch-task.sh`. It validates the path in the actual worktree,
+   creates one compact provider-neutral bootstrap, runs the worker,
    runs an independent build gate, and reports — it does **not** merge.
    Run it in the background (redirect output to a file) and watch the slice's
    progress log instead of blocking a foreground call on the whole run (see
@@ -197,14 +201,19 @@ single — so match the file, not the sibling.
 ## Commands
 
 ```
-# Dispatch one implement slice (after approval). Prompt on stdin.
-scripts/dispatch-task.sh --issue NN --task-slug SLUG [--base BRANCH] [--provider claude-deepseek|dsh] < prompt.md
+# Dispatch one implement slice (after approval). The detailed handoff is tracked;
+# stdin holds only a short manager instruction.
+printf '%s\n' 'Implement the assigned slice and report results.' | \
+  scripts/dispatch-task.sh --issue NN --task-slug SLUG \
+  [--base BRANCH] [--provider claude-deepseek|dsh] --handoff REPO_PATH
 #   default --base: feat/core-arch-simplification
 #   creates worktree at $PURECUT_WORKTREE_BASE/SLUG on feat/issue-NN-SLUG
 #   runs the worker, then `npm run build` as an independent gate; never merges.
 
 # Read-only review of an existing worktree (optional helper).
-scripts/dispatch-task.sh --mode review --worktree DIR [--provider claude-deepseek|dsh] < prompt.md
+printf '%s\n' 'Review the assigned diff and report findings.' | \
+  scripts/dispatch-task.sh --mode review --worktree DIR \
+  [--provider claude-deepseek|dsh] --handoff REPO_PATH
 
 # Poll a running dispatch (instant; see "Watching a dispatched worker").
 scripts/worker-status.sh --slug SLUG

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -16,10 +16,11 @@ available; do not treat one-off diagnostics as normal quality gates.
 
 ## Optional delegated-agent harness
 
-- [`dispatch-task.sh`](dispatch-task.sh), [`finish-task.sh`](finish-task.sh), and [`worker-status.sh`](worker-status.sh) — integration-manager worktree lifecycle.
-- [`run-claude-deepseek-agent.sh`](run-claude-deepseek-agent.sh) — credential-backed leaf launcher.
-- [`claude-deepseek-agent-prompt.md`](claude-deepseek-agent-prompt.md) — bounded worker prompt template.
-- [`test-claude-deepseek-agent.sh`](test-claude-deepseek-agent.sh) and [`worker-progress-filter.jq`](worker-progress-filter.jq) — harness tests and progress filtering.
+- [`dispatch-task.sh`](dispatch-task.sh), [`finish-task.sh`](finish-task.sh), and [`worker-status.sh`](worker-status.sh) — provider-neutral integration-manager worktree lifecycle. `claude-deepseek` remains the default provider; select `--provider dsh` for DeepSeek Harness.
+- [`run-claude-deepseek-agent.sh`](run-claude-deepseek-agent.sh) — credential-backed Claude/DeepSeek leaf launcher.
+- [`run-dsh-agent.sh`](run-dsh-agent.sh) — DeepSeek Harness leaf launcher using DSH's own credential store and sandbox modes.
+- [`claude-deepseek-agent-prompt.md`](claude-deepseek-agent-prompt.md) — bounded provider-neutral worker prompt template (historic filename retained for compatibility).
+- [`test-claude-deepseek-agent.sh`](test-claude-deepseek-agent.sh), [`test-dsh-agent.sh`](test-dsh-agent.sh), [`test-dispatch-task.sh`](test-dispatch-task.sh), and [`worker-progress-filter.jq`](worker-progress-filter.jq) — harness tests and Claude progress filtering.
 
 Use this path only after explicit delegation approval and follow
 [`manager-delegate`](../.agents/skills/manager-delegate/SKILL.md). Direct

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -16,7 +16,7 @@ available; do not treat one-off diagnostics as normal quality gates.
 
 ## Optional delegated-agent harness
 
-- [`dispatch-task.sh`](dispatch-task.sh), [`finish-task.sh`](finish-task.sh), and [`worker-status.sh`](worker-status.sh) — provider-neutral integration-manager worktree lifecycle. `claude-deepseek` remains the default provider; select `--provider dsh` for DeepSeek Harness.
+- [`dispatch-task.sh`](dispatch-task.sh), [`finish-task.sh`](finish-task.sh), and [`worker-status.sh`](worker-status.sh) — provider-neutral integration-manager worktree lifecycle. `claude-deepseek` remains the default provider; select `--provider dsh` for DeepSeek Harness. `dispatch-task.sh --handoff REPO_PATH` gives either provider a compact bootstrap to read a tracked in-worktree handoff; direct stdin is reserved for a small instruction.
 - [`run-claude-deepseek-agent.sh`](run-claude-deepseek-agent.sh) — credential-backed Claude/DeepSeek leaf launcher.
 - [`run-dsh-agent.sh`](run-dsh-agent.sh) — DeepSeek Harness leaf launcher using DSH's own credential store and sandbox modes.
 - [`claude-deepseek-agent-prompt.md`](claude-deepseek-agent-prompt.md) — bounded provider-neutral worker prompt template (historic filename retained for compatibility).

--- a/scripts/claude-deepseek-agent-prompt.md
+++ b/scripts/claude-deepseek-agent-prompt.md
@@ -1,8 +1,12 @@
-# Delegated implementation-worker prompt template
+# Delegated implementation-worker handoff template
 
-Use this as the complete prompt supplied to either supported leaf launcher through
-`scripts/dispatch-task.sh`. Replace only the bracketed fields before dispatching
-a slice.
+For a detailed slice, save a completed copy at a **tracked path in the selected
+base/worktree**, then dispatch every provider with `--handoff REPO_PATH` and a
+short stdin instruction. The dispatcher gives the provider a compact bootstrap;
+the full handoff never becomes a command-line argument. Direct stdin prompts are
+reserved for small tasks.
+
+Replace only the bracketed fields before dispatching a slice.
 
 ```text
 You are the implementation worker for slice [SLICE_ID] of [TOPIC].

--- a/scripts/claude-deepseek-agent-prompt.md
+++ b/scripts/claude-deepseek-agent-prompt.md
@@ -1,6 +1,8 @@
-# DeepSeek implementation-worker prompt template
+# Delegated implementation-worker prompt template
 
-Use this as the complete prompt supplied to `scripts/run-claude-deepseek-agent.sh`. Replace only the bracketed fields before dispatching a slice.
+Use this as the complete prompt supplied to either supported leaf launcher through
+`scripts/dispatch-task.sh`. Replace only the bracketed fields before dispatching
+a slice.
 
 ```text
 You are the implementation worker for slice [SLICE_ID] of [TOPIC].
@@ -37,7 +39,7 @@ Required invariants: [INVARIANTS]
 Required checks: [REQUIRED_CHECKS]
 
 Rules:
-- Narrate your progress: before each phase (reading context, editing a group of files, running a check, committing), print one short line saying what you are about to do. These lines stream to the manager while you work; do not batch them up for the end.
+- Narrate your progress in the final report. Claude/DeepSeek streams observed tool activity; DSH headless returns only its final response, so its manager log can prove process liveness but not individual tool calls.
 - Make the smallest change that satisfies the slice.
 - Do not perform unrelated cleanup or change public/frozen contracts unless this slice explicitly permits it.
 - Do not edit the detailed integration handoff unless this slice explicitly assigns documentation.

--- a/scripts/dispatch-task.sh
+++ b/scripts/dispatch-task.sh
@@ -129,8 +129,8 @@ prompt_bytes="$(wc -c < "$prompt_file" | tr -d '[:space:]')"
 validate_handoff() {
   local worktree="$1"
   [[ -n "$handoff" ]] || return 0
-  [[ "$handoff" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]] \
-    || fail "--handoff must be a relative repository path without spaces or shell characters: $handoff"
+  [[ "$handoff" != /* && "$handoff" != *$'\n'* && "$handoff" != *$'\r'* ]] \
+    || fail "--handoff must be a relative repository path without line breaks: $handoff"
   [[ "$handoff" != ./* && "$handoff" != */./* && "$handoff" != */ && "$handoff" != *//* ]] \
     || fail "--handoff must be a normalized relative file path: $handoff"
   [[ "/$handoff/" != *"/../"* ]] \

--- a/scripts/dispatch-task.sh
+++ b/scripts/dispatch-task.sh
@@ -1,65 +1,63 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 
-# dispatch-task.sh — integration-manager orchestrator around the DeepSeek leaf
-# launcher (run-claude-deepseek-agent.sh). It automates the manual steps from
-# AGENTS.md "DeepSeek implementation workers": create the task worktree+branch,
-# run one bounded worker on the piped prompt, then run an independent build gate
-# and report. It deliberately does NOT merge — review is the manager's job; use
-# finish-task.sh after approval.
-#
-# This step needs elevated access: it reads the .env.agent credential file,
-# makes outbound network calls to the DeepSeek endpoint, and (in implement mode)
-# spawns a bypassPermissions worker. Request the user's approval before running.
+# dispatch-task.sh — integration-manager orchestrator around supported external
+# worker providers. It creates a task worktree+branch, runs one bounded worker
+# on the piped prompt, then runs an independent build gate. It deliberately does
+# NOT merge — review is the manager's job; use finish-task.sh after approval.
 
 set -euo pipefail
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-readonly LEAF="$SCRIPT_DIR/run-claude-deepseek-agent.sh"
+readonly CLAUDE_DEEPSEEK_LEAF="$SCRIPT_DIR/run-claude-deepseek-agent.sh"
+readonly DSH_LEAF="$SCRIPT_DIR/run-dsh-agent.sh"
 readonly DEFAULT_BASE="feat/core-arch-simplification"
 WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-$(dirname "$REPO_ROOT")/worktrees/$(basename "$REPO_ROOT")}"
 
 usage() {
   cat <<'EOF'
 Usage:
-  Implement: scripts/dispatch-task.sh --issue NN --task-slug SLUG [--base BRANCH] < prompt.md
-  Review:    scripts/dispatch-task.sh --mode review --worktree DIR < prompt.md
+  Implement: scripts/dispatch-task.sh --issue NN --task-slug SLUG [--base BRANCH] [--provider PROVIDER] < prompt.md
+  Review:    scripts/dispatch-task.sh --mode review --worktree DIR [--provider PROVIDER] < prompt.md
 
-Orchestrate one DeepSeek worker session and verify the result. The prompt is
-piped on stdin (fill scripts/claude-deepseek-agent-prompt.md first).
+Orchestrate one bounded external-worker session and verify the result. The
+prompt is piped on stdin (fill scripts/claude-deepseek-agent-prompt.md first).
 
 Implement mode (default):
   Creates a worktree at $PURECUT_WORKTREE_BASE/SLUG on a new branch
-  feat/issue-NN-SLUG based off --base, runs a bypass worker there, then runs an
-  independent build gate. Reports branch, worktree, diffstat, build result, and
-  the worker completion block. Does NOT merge.
+  feat/issue-NN-SLUG based off --base, runs the selected worker there, then runs
+  an independent build gate. Reports branch, worktree, diffstat, build result,
+  and the worker completion block. Does NOT merge.
 
 Options:
   --issue NN          Issue number (implement mode; used in the branch name).
   --task-slug SLUG    Short kebab-case slug (implement mode; worktree dir + branch).
   --base BRANCH       Integration branch to branch from (default: feat/core-arch-simplification).
+  --provider NAME     claude-deepseek (default) or dsh.
   --mode MODE         implement (default) or review.
   --worktree DIR      Existing worktree to review (review mode only).
   --skip-build        Skip the post-worker build gate (implement mode).
   --progress-log FILE Progress log path (default in implement mode:
                       $PURECUT_WORKTREE_BASE/SLUG.progress.log; review mode
-                      only streams progress when this is set explicitly).
+                      only writes one when this is set explicitly).
   --help              Show this help.
 
-Progress: the worker streams one-line progress entries into the progress log
-as it works. Dispatch in the background and poll scripts/worker-status.sh
---slug SLUG (instant, bounded) instead of blocking on — or killing — a long
-foreground run. Judge the worker by idle time in the log, not total runtime.
+Progress: Claude/DeepSeek logs observed worker events. DSH logs only lifecycle
+and process-alive heartbeats, not tool activity. Dispatch in the background and
+poll scripts/worker-status.sh --slug SLUG instead of killing a long run.
 
-Permissions: this command reads .env.agent, connects to the DeepSeek endpoint,
-and (implement) runs a bypassPermissions worker. Get explicit approval first.
+Permissions: every provider sends the prompt to its configured external service,
+so get explicit approval first. claude-deepseek reads .env.agent and runs a
+bypassPermissions Claude worker; dsh uses its own configured credentials and
+confines worker tool calls to DSH's read-only/workspace-write modes.
 EOF
 }
 
 fail() { printf 'dispatch-task: %s\n' "$*" >&2; exit 1; }
 
 mode="implement"
+provider="claude-deepseek"
 issue=""
 slug=""
 base="$DEFAULT_BASE"
@@ -72,6 +70,7 @@ while [[ $# -gt 0 ]]; do
     --issue)        [[ $# -ge 2 ]] || fail "--issue requires a number"; issue="$2"; shift 2 ;;
     --task-slug)    [[ $# -ge 2 ]] || fail "--task-slug requires a value"; slug="$2"; shift 2 ;;
     --base)         [[ $# -ge 2 ]] || fail "--base requires a branch"; base="$2"; shift 2 ;;
+    --provider)     [[ $# -ge 2 ]] || fail "--provider requires claude-deepseek or dsh"; provider="$2"; shift 2 ;;
     --mode)         [[ $# -ge 2 ]] || fail "--mode requires implement or review"; mode="$2"; shift 2 ;;
     --worktree)     [[ $# -ge 2 ]] || fail "--worktree requires a directory"; review_worktree="$2"; shift 2 ;;
     --skip-build)   skip_build=true; shift ;;
@@ -81,42 +80,69 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Append a lifecycle marker to the progress log so worker-status.sh can tell
-# "worker finished, gate running" from "dispatch fully done". Best-effort only.
+# Append a lifecycle marker so worker-status.sh can tell "worker finished, gate
+# running" from "dispatch fully done". Best-effort only.
 progress_mark() {
   [[ -n "$progress_log" ]] || return 0
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$progress_log" 2>/dev/null || true
 }
-
-[[ -x "$LEAF" ]] || fail "leaf launcher not found or not executable: $LEAF"
-# Without redirection the worker's `claude --print` would block on the terminal.
-[[ ! -t 0 ]] || fail "no prompt on stdin; pipe one, e.g.: $0 ... < prompt.md"
 
 case "$mode" in
   implement|review) ;;
   *) fail "--mode must be implement or review" ;;
 esac
 
-# Buffer the prompt so it can be fed to the leaf (and re-read if ever needed).
+case "$provider" in
+  claude-deepseek)
+    leaf="$CLAUDE_DEEPSEEK_LEAF"
+    ;;
+  dsh)
+    leaf="$DSH_LEAF"
+    ;;
+  *)
+    fail "--provider must be claude-deepseek or dsh: $provider"
+    ;;
+esac
+[[ -x "$leaf" ]] || fail "leaf launcher not found or not executable: $leaf"
+
+# Without redirection a worker can block waiting for the terminal.
+[[ ! -t 0 ]] || fail "no prompt on stdin; pipe one, e.g.: $0 ... < prompt.md"
+
+# Buffer the prompt so it can be fed to either leaf without changing its
+# contract. The provider receives it only when the leaf is invoked below.
 prompt_file="$(mktemp -t dispatch-task-prompt)"
 trap 'rm -f "$prompt_file"' EXIT
 cat > "$prompt_file"
 [[ -s "$prompt_file" ]] || fail "the piped prompt is empty"
 
-# The leaf finds credentials via DEEPSEEK_AGENT_ENV_FILE; default to the one
-# canonical file in the primary checkout (never copied into a task worktree).
-export DEEPSEEK_AGENT_ENV_FILE="${DEEPSEEK_AGENT_ENV_FILE:-$REPO_ROOT/.env.agent}"
+if [[ "$provider" == "claude-deepseek" ]]; then
+  # The Claude/DeepSeek leaf reads the canonical credential file in the primary
+  # checkout; it is never copied into a task worktree.
+  export DEEPSEEK_AGENT_ENV_FILE="${DEEPSEEK_AGENT_ENV_FILE:-$REPO_ROOT/.env.agent}"
+else
+  # DSH resolves its configured credentials itself. Do not expose the legacy
+  # credential-file path to this provider.
+  unset DEEPSEEK_AGENT_ENV_FILE
+fi
+
+run_review() {
+  local status=0
+  local -a leaf_args=(--mode review --worktree "$review_worktree")
+  if [[ "$provider" == "claude-deepseek" ]]; then
+    leaf_args+=(--output-format text)
+  fi
+  [[ -n "$progress_log" ]] && leaf_args+=(--progress-log "$progress_log")
+  "$leaf" "${leaf_args[@]}" < "$prompt_file" || status=$?
+  progress_mark "[dispatch] done provider=$provider worker_exit=$status build=n/a"
+  return "$status"
+}
 
 if [[ "$mode" == "review" ]]; then
   [[ -n "$review_worktree" ]] || fail "review mode requires --worktree DIR (an existing worktree)"
   [[ -d "$review_worktree" ]] || fail "--worktree is not a directory: $review_worktree"
-  printf '== review worker (read-only) in %s ==\n' "$review_worktree" >&2
-  leaf_args=(--mode review --worktree "$review_worktree" --output-format text)
-  [[ -n "$progress_log" ]] && leaf_args+=(--progress-log "$progress_log")
-  review_status=0
-  "$LEAF" "${leaf_args[@]}" < "$prompt_file" || review_status=$?
-  progress_mark "[dispatch] done worker_exit=$review_status build=n/a"
-  exit "$review_status"
+  printf '== review worker (%s, read-only) in %s ==\n' "$provider" "$review_worktree" >&2
+  run_review
+  exit $?
 fi
 
 # ---- implement mode ----
@@ -141,17 +167,17 @@ printf '== creating worktree %s on %s (from %s) ==\n' "$worktree_dir" "$branch" 
 git -C "$REPO_ROOT" worktree add "$worktree_dir" -b "$branch" "$base" \
   || fail "failed to create worktree"
 
-# Per-slice progress log: the worker streams one-line entries here as it works,
-# so a backgrounded dispatch can be polled (worker-status.sh) instead of killed
-# for looking silent.
 [[ -n "$progress_log" ]] || progress_log="$WORKTREE_BASE/$slug.progress.log"
 printf '== progress log: %s ==\n' "$progress_log" >&2
 printf '== poll with: scripts/worker-status.sh --slug %s ==\n' "$slug" >&2
 
-printf '== dispatching implement worker (bypass) ==\n' >&2
+printf '== dispatching implement worker (%s) ==\n' "$provider" >&2
 worker_status=0
-"$LEAF" --mode implement --allow-bypass --worktree "$worktree_dir" \
-  --output-format text --progress-log "$progress_log" < "$prompt_file" || worker_status=$?
+leaf_args=(--mode implement --worktree "$worktree_dir" --progress-log "$progress_log")
+if [[ "$provider" == "claude-deepseek" ]]; then
+  leaf_args+=(--allow-bypass --output-format text)
+fi
+"$leaf" "${leaf_args[@]}" < "$prompt_file" || worker_status=$?
 if [[ "$worker_status" -ne 0 ]]; then
   printf '\n!! worker exited non-zero (%s); worktree left in place for inspection !!\n' \
     "$worker_status" >&2
@@ -170,7 +196,7 @@ if [[ "$skip_build" == false ]]; then
     if ( cd "$worktree_dir" && npm run build ); then build_result="passed"; else build_result="FAILED"; fi
   fi
 fi
-progress_mark "[dispatch] done worker_exit=$worker_status build=$build_result"
+progress_mark "[dispatch] done provider=$provider worker_exit=$worker_status build=$build_result"
 
 # ---- report ----
 last_commit="$(git -C "$worktree_dir" log -1 --oneline 2>/dev/null || echo '(none)')"
@@ -182,6 +208,7 @@ cat <<EOF
 ================ dispatch-task report ================
 issue:        #$issue
 slug:         $slug
+provider:     $provider
 branch:       $branch
 worktree:     $worktree_dir
 base:         $base
@@ -200,6 +227,5 @@ Review the real diff, then merge with:
   scripts/finish-task.sh --slug $slug --base $base
 EOF
 
-# Surface a non-zero status to the caller if the gate failed, so automation halts.
 [[ "$build_result" == "FAILED" || "$build_result" == "install-failed" ]] && exit 1
 exit 0

--- a/scripts/dispatch-task.sh
+++ b/scripts/dispatch-task.sh
@@ -13,16 +13,19 @@ readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 readonly CLAUDE_DEEPSEEK_LEAF="$SCRIPT_DIR/run-claude-deepseek-agent.sh"
 readonly DSH_LEAF="$SCRIPT_DIR/run-dsh-agent.sh"
 readonly DEFAULT_BASE="feat/core-arch-simplification"
+readonly MAX_DIRECT_PROMPT_BYTES=4096
 WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-$(dirname "$REPO_ROOT")/worktrees/$(basename "$REPO_ROOT")}"
 
 usage() {
   cat <<'EOF'
 Usage:
-  Implement: scripts/dispatch-task.sh --issue NN --task-slug SLUG [--base BRANCH] [--provider PROVIDER] < prompt.md
-  Review:    scripts/dispatch-task.sh --mode review --worktree DIR [--provider PROVIDER] < prompt.md
+  Implement: scripts/dispatch-task.sh --issue NN --task-slug SLUG [--base BRANCH] [--provider PROVIDER] [--handoff REPO_PATH] < brief.txt
+  Review:    scripts/dispatch-task.sh --mode review --worktree DIR [--provider PROVIDER] [--handoff REPO_PATH] < brief.txt
 
 Orchestrate one bounded external-worker session and verify the result. The
-prompt is piped on stdin (fill scripts/claude-deepseek-agent-prompt.md first).
+brief instruction is piped on stdin. For a detailed task, use --handoff with a
+tracked path relative to the task worktree; the provider receives a compact
+bootstrap that tells it to read that file.
 
 Implement mode (default):
   Creates a worktree at $PURECUT_WORKTREE_BASE/SLUG on a new branch
@@ -35,6 +38,8 @@ Options:
   --task-slug SLUG    Short kebab-case slug (implement mode; worktree dir + branch).
   --base BRANCH       Integration branch to branch from (default: feat/core-arch-simplification).
   --provider NAME     claude-deepseek (default) or dsh.
+  --handoff REPO_PATH Optional tracked, relative handoff path in the task
+                      worktree. The full file stays out of command arguments.
   --mode MODE         implement (default) or review.
   --worktree DIR      Existing worktree to review (review mode only).
   --skip-build        Skip the post-worker build gate (implement mode).
@@ -58,6 +63,7 @@ fail() { printf 'dispatch-task: %s\n' "$*" >&2; exit 1; }
 
 mode="implement"
 provider="claude-deepseek"
+handoff=""
 issue=""
 slug=""
 base="$DEFAULT_BASE"
@@ -71,6 +77,7 @@ while [[ $# -gt 0 ]]; do
     --task-slug)    [[ $# -ge 2 ]] || fail "--task-slug requires a value"; slug="$2"; shift 2 ;;
     --base)         [[ $# -ge 2 ]] || fail "--base requires a branch"; base="$2"; shift 2 ;;
     --provider)     [[ $# -ge 2 ]] || fail "--provider requires claude-deepseek or dsh"; provider="$2"; shift 2 ;;
+    --handoff)      [[ $# -ge 2 ]] || fail "--handoff requires a tracked repository path"; handoff="$2"; shift 2 ;;
     --mode)         [[ $# -ge 2 ]] || fail "--mode requires implement or review"; mode="$2"; shift 2 ;;
     --worktree)     [[ $# -ge 2 ]] || fail "--worktree requires a directory"; review_worktree="$2"; shift 2 ;;
     --skip-build)   skip_build=true; shift ;;
@@ -111,9 +118,41 @@ esac
 # Buffer the prompt so it can be fed to either leaf without changing its
 # contract. The provider receives it only when the leaf is invoked below.
 prompt_file="$(mktemp -t dispatch-task-prompt)"
-trap 'rm -f "$prompt_file"' EXIT
+worker_prompt_file="$prompt_file"
+trap 'rm -f "$prompt_file" "$worker_prompt_file"' EXIT
 cat > "$prompt_file"
 [[ -s "$prompt_file" ]] || fail "the piped prompt is empty"
+prompt_bytes="$(wc -c < "$prompt_file" | tr -d '[:space:]')"
+[[ "$prompt_bytes" -le "$MAX_DIRECT_PROMPT_BYTES" ]] \
+  || fail "the brief instruction exceeds ${MAX_DIRECT_PROMPT_BYTES} bytes; store the full task in a tracked handoff and use --handoff REPO_PATH"
+
+validate_handoff() {
+  local worktree="$1"
+  [[ -n "$handoff" ]] || return 0
+  [[ "$handoff" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]] \
+    || fail "--handoff must be a relative repository path without spaces or shell characters: $handoff"
+  [[ "$handoff" != ./* && "$handoff" != */./* && "$handoff" != */ && "$handoff" != *//* ]] \
+    || fail "--handoff must be a normalized relative file path: $handoff"
+  [[ "/$handoff/" != *"/../"* ]] \
+    || fail "--handoff must not contain parent-directory traversal: $handoff"
+  git -C "$worktree" ls-files --error-unmatch -- "$handoff" >/dev/null 2>&1 \
+    || fail "--handoff must name a tracked file in the task worktree: $handoff"
+  [[ -f "$worktree/$handoff" && ! -L "$worktree/$handoff" ]] \
+    || fail "--handoff must name a regular tracked file in the task worktree: $handoff"
+}
+
+prepare_worker_prompt() {
+  local worktree="$1"
+  [[ -n "$handoff" ]] || return 0
+  validate_handoff "$worktree"
+  worker_prompt_file="$(mktemp -t dispatch-task-worker-prompt)"
+  {
+    printf 'Read the complete task handoff at %s in the current worktree.\n' "$handoff"
+    printf 'That tracked file is the primary specification; follow it exactly.\n\n'
+    printf 'Short manager instruction:\n'
+    cat "$prompt_file"
+  } > "$worker_prompt_file"
+}
 
 if [[ "$provider" == "claude-deepseek" ]]; then
   # The Claude/DeepSeek leaf reads the canonical credential file in the primary
@@ -132,7 +171,7 @@ run_review() {
     leaf_args+=(--output-format text)
   fi
   [[ -n "$progress_log" ]] && leaf_args+=(--progress-log "$progress_log")
-  "$leaf" "${leaf_args[@]}" < "$prompt_file" || status=$?
+  "$leaf" "${leaf_args[@]}" < "$worker_prompt_file" || status=$?
   progress_mark "[dispatch] done provider=$provider worker_exit=$status build=n/a"
   return "$status"
 }
@@ -140,6 +179,7 @@ run_review() {
 if [[ "$mode" == "review" ]]; then
   [[ -n "$review_worktree" ]] || fail "review mode requires --worktree DIR (an existing worktree)"
   [[ -d "$review_worktree" ]] || fail "--worktree is not a directory: $review_worktree"
+  prepare_worker_prompt "$review_worktree"
   printf '== review worker (%s, read-only) in %s ==\n' "$provider" "$review_worktree" >&2
   run_review
   exit $?
@@ -172,12 +212,13 @@ printf '== progress log: %s ==\n' "$progress_log" >&2
 printf '== poll with: scripts/worker-status.sh --slug %s ==\n' "$slug" >&2
 
 printf '== dispatching implement worker (%s) ==\n' "$provider" >&2
+prepare_worker_prompt "$worktree_dir"
 worker_status=0
 leaf_args=(--mode implement --worktree "$worktree_dir" --progress-log "$progress_log")
 if [[ "$provider" == "claude-deepseek" ]]; then
   leaf_args+=(--allow-bypass --output-format text)
 fi
-"$leaf" "${leaf_args[@]}" < "$prompt_file" || worker_status=$?
+"$leaf" "${leaf_args[@]}" < "$worker_prompt_file" || worker_status=$?
 if [[ "$worker_status" -ne 0 ]]; then
   printf '\n!! worker exited non-zero (%s); worktree left in place for inspection !!\n' \
     "$worker_status" >&2

--- a/scripts/run-dsh-agent.sh
+++ b/scripts/run-dsh-agent.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+# run-dsh-agent.sh — run one DeepSeek Harness headless worker inside a bounded
+# git worktree. DSH owns its configured credentials; this script never reads
+# .env.agent or forwards its path to the worker.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run-dsh-agent.sh --mode review|implement [options] < prompt.md
+
+Run one DeepSeek Harness headless session with the prompt supplied on stdin.
+
+Options:
+  --mode MODE            Required: review or implement.
+  --worktree DIR         Git worktree to run the session in. Required with
+                         --mode implement; optional for review (defaults to cwd).
+  --progress-log FILE    Append lifecycle and process-alive markers to FILE.
+  --help                 Show this help.
+
+Review sessions run with DSH_PERMISSION_MODE=read-only. Implementation sessions
+run with DSH_PERMISSION_MODE=workspace-write and must remain in the supplied
+worktree. DSH stores its own configured credential and session state under
+~/.dsh; this launcher does not read .env.agent.
+EOF
+}
+
+fail() { printf 'run-dsh-agent: %s\n' "$*" >&2; exit 1; }
+
+mode=""
+worktree=""
+progress_log=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      [[ $# -ge 2 ]] || fail "--mode requires review or implement"
+      mode="$2"
+      shift 2
+      ;;
+    --worktree)
+      [[ $# -ge 2 ]] || fail "--worktree requires a directory"
+      worktree="$2"
+      shift 2
+      ;;
+    --progress-log)
+      [[ $# -ge 2 ]] || fail "--progress-log requires a file path"
+      progress_log="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+case "$mode" in
+  review|implement) ;;
+  *) fail "--mode review or --mode implement is required" ;;
+esac
+
+[[ ! -t 0 ]] || fail "no prompt on stdin; pipe one, e.g.: $0 --mode $mode < prompt.md"
+
+if [[ "$mode" == "implement" && -z "$worktree" ]]; then
+  fail "--mode implement requires --worktree DIR to confine the session"
+fi
+worktree="${worktree:-$PWD}"
+[[ -d "$worktree" ]] || fail "--worktree path is not a directory: $worktree"
+git -C "$worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || fail "--worktree path is not a git worktree: $worktree"
+
+command -v dsh >/dev/null 2>&1 || fail "dsh executable was not found on PATH"
+
+task="$(cat)"
+[[ -n "${task//[[:space:]]/}" ]] || fail "the piped prompt is empty"
+[[ ${#task} -le 131072 ]] || fail "the piped prompt exceeds the 128 KiB DSH command-line limit"
+
+if [[ "$mode" == "review" ]]; then
+  sandbox_mode="read-only"
+else
+  sandbox_mode="workspace-write"
+fi
+
+run_dsh() {
+  (
+    cd "$worktree" || exit 1
+    env -u DEEPSEEK_AGENT_ENV_FILE -u DEEPSEEK_API_KEY \
+      DSH_PERMISSION_MODE="$sandbox_mode" \
+      dsh --profile headless "$task"
+  )
+}
+
+if [[ -z "$progress_log" ]]; then
+  run_dsh
+  exit $?
+fi
+
+mkdir -p "$(dirname "$progress_log")" 2>/dev/null \
+  || fail "cannot create progress log directory for: $progress_log"
+result_file="$(mktemp -t run-dsh-agent-result)"
+stderr_file="$(mktemp -t run-dsh-agent-stderr)"
+worker_pid=""
+cleanup() {
+  if [[ -n "$worker_pid" ]] && kill -0 "$worker_pid" 2>/dev/null; then
+    kill "$worker_pid" 2>/dev/null || true
+  fi
+  rm -f "$result_file" "$stderr_file"
+}
+trap cleanup EXIT INT TERM
+: > "$progress_log"
+printf '%s [start] provider=dsh mode=%s sandbox=%s\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$mode" "$sandbox_mode" >> "$progress_log"
+
+run_dsh >"$result_file" 2>"$stderr_file" &
+worker_pid=$!
+heartbeat_seconds="${DSH_HEARTBEAT_SECONDS:-15}"
+[[ "$heartbeat_seconds" =~ ^[1-9][0-9]*$ ]] \
+  || fail "DSH_HEARTBEAT_SECONDS must be a positive integer"
+
+seconds_since_heartbeat=0
+while kill -0 "$worker_pid" 2>/dev/null; do
+  sleep 1
+  kill -0 "$worker_pid" 2>/dev/null || break
+  seconds_since_heartbeat=$((seconds_since_heartbeat + 1))
+  if (( seconds_since_heartbeat >= heartbeat_seconds )); then
+    printf '%s [heartbeat] provider=dsh process-alive (not tool activity)\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$progress_log"
+    seconds_since_heartbeat=0
+  fi
+done
+
+set +e
+wait "$worker_pid"
+worker_status=$?
+set -e
+worker_pid=""
+cat "$result_file"
+cat "$stderr_file" >&2
+printf '%s [exit] provider=dsh worker exited code=%s\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$worker_status" >> "$progress_log"
+exit "$worker_status"

--- a/scripts/test-dispatch-task.sh
+++ b/scripts/test-dispatch-task.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly DISPATCH="$SCRIPT_DIR/dispatch-task.sh"
+readonly TEMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'test-dispatch-task: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  [[ "$haystack" == *"$needle"* ]] || fail "expected output to contain: $needle"
+}
+
+mkdir -p "$TEMP_DIR/bin"
+cat > "$TEMP_DIR/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'provider=claude\n'
+printf 'args:\n'
+printf '<%s>\n' "$@"
+cat
+EOF
+cat > "$TEMP_DIR/bin/dsh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'provider=dsh sandbox=<%s>\n' "${DSH_PERMISSION_MODE:-}"
+printf 'args:\n'
+printf '<%s>\n' "$@"
+EOF
+chmod +x "$TEMP_DIR/bin/claude" "$TEMP_DIR/bin/dsh"
+
+cat > "$TEMP_DIR/agent.env" <<'EOF'
+DEEPSEEK_API_KEY=test-secret
+EOF
+chmod 600 "$TEMP_DIR/agent.env"
+git init -q "$TEMP_DIR/wt"
+
+# ---- omitted provider preserves the Claude/DeepSeek dispatch path ----
+claude_output="$(printf 'default task\n' | PATH="$TEMP_DIR/bin:$PATH" \
+  DEEPSEEK_AGENT_ENV_FILE="$TEMP_DIR/agent.env" "$DISPATCH" --mode review --worktree "$TEMP_DIR/wt")"
+assert_contains "$claude_output" 'provider=claude'
+assert_contains "$claude_output" '<--permission-mode>'
+assert_contains "$claude_output" '<plan>'
+assert_contains "$claude_output" 'default task'
+
+# ---- explicit DSH provider selects the DSH leaf and read-only mode ----
+dsh_output="$(printf 'dsh task\n' | PATH="$TEMP_DIR/bin:$PATH" \
+  DEEPSEEK_AGENT_ENV_FILE="$TEMP_DIR/agent.env" "$DISPATCH" \
+    --provider dsh --mode review --worktree "$TEMP_DIR/wt")"
+assert_contains "$dsh_output" 'provider=dsh sandbox=<read-only>'
+assert_contains "$dsh_output" '<--profile>'
+assert_contains "$dsh_output" '<headless>'
+assert_contains "$dsh_output" 'dsh task'
+
+if invalid_provider_error="$(printf 'task\n' | "$DISPATCH" --provider invalid --mode review --worktree "$TEMP_DIR/wt" 2>&1)"; then
+  fail 'dispatch unexpectedly accepted an invalid provider'
+fi
+assert_contains "$invalid_provider_error" '--provider must be claude-deepseek or dsh'
+
+printf 'test-dispatch-task: passed\n'

--- a/scripts/test-dispatch-task.sh
+++ b/scripts/test-dispatch-task.sh
@@ -46,6 +46,13 @@ DEEPSEEK_API_KEY=test-secret
 EOF
 chmod 600 "$TEMP_DIR/agent.env"
 git init -q "$TEMP_DIR/wt"
+mkdir -p "$TEMP_DIR/wt/handoffs"
+cat > "$TEMP_DIR/wt/handoffs/slice.md" <<'EOF'
+This is the complete tracked handoff. It must not be included in the provider command.
+EOF
+git -C "$TEMP_DIR/wt" add handoffs/slice.md
+git -C "$TEMP_DIR/wt" -c user.name=test -c user.email=test@example.com \
+  commit -qm 'add handoff fixture'
 
 # ---- omitted provider preserves the Claude/DeepSeek dispatch path ----
 claude_output="$(printf 'default task\n' | PATH="$TEMP_DIR/bin:$PATH" \
@@ -63,6 +70,45 @@ assert_contains "$dsh_output" 'provider=dsh sandbox=<read-only>'
 assert_contains "$dsh_output" '<--profile>'
 assert_contains "$dsh_output" '<headless>'
 assert_contains "$dsh_output" 'dsh task'
+
+# ---- optional handoff is provider-neutral and keeps its contents out of argv ----
+dsh_handoff_output="$(printf 'review the assigned slice\n' | PATH="$TEMP_DIR/bin:$PATH" \
+  DEEPSEEK_AGENT_ENV_FILE="$TEMP_DIR/agent.env" "$DISPATCH" \
+    --provider dsh --mode review --worktree "$TEMP_DIR/wt" --handoff handoffs/slice.md)"
+assert_contains "$dsh_handoff_output" 'Read the complete task handoff at handoffs/slice.md in the current worktree.'
+assert_contains "$dsh_handoff_output" 'Short manager instruction:'
+assert_contains "$dsh_handoff_output" 'review the assigned slice'
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  [[ "$haystack" != *"$needle"* ]] || fail "expected output not to contain: $needle"
+}
+assert_not_contains "$dsh_handoff_output" 'This is the complete tracked handoff.'
+
+claude_handoff_output="$(printf 'review the assigned slice\n' | PATH="$TEMP_DIR/bin:$PATH" \
+  DEEPSEEK_AGENT_ENV_FILE="$TEMP_DIR/agent.env" "$DISPATCH" \
+    --mode review --worktree "$TEMP_DIR/wt" --handoff handoffs/slice.md)"
+assert_contains "$claude_handoff_output" 'Read the complete task handoff at handoffs/slice.md in the current worktree.'
+assert_not_contains "$claude_handoff_output" 'This is the complete tracked handoff.'
+
+if untracked_handoff_error="$(printf 'brief\n' | "$DISPATCH" --provider dsh --mode review \
+  --worktree "$TEMP_DIR/wt" --handoff handoffs/missing.md 2>&1)"; then
+  fail 'dispatch unexpectedly accepted an untracked handoff'
+fi
+assert_contains "$untracked_handoff_error" '--handoff must name a tracked file'
+
+if absolute_handoff_error="$(printf 'brief\n' | "$DISPATCH" --provider dsh --mode review \
+  --worktree "$TEMP_DIR/wt" --handoff /private/secret.md 2>&1)"; then
+  fail 'dispatch unexpectedly accepted an absolute handoff'
+fi
+assert_contains "$absolute_handoff_error" '--handoff must be a relative repository path'
+
+oversized_brief="$(printf '%*s' 4097 '' | tr ' ' x)"
+if oversized_prompt_error="$(printf '%s' "$oversized_brief" | "$DISPATCH" --provider dsh --mode review \
+  --worktree "$TEMP_DIR/wt" 2>&1)"; then
+  fail 'dispatch unexpectedly accepted an oversized direct instruction'
+fi
+assert_contains "$oversized_prompt_error" 'use --handoff REPO_PATH'
 
 if invalid_provider_error="$(printf 'task\n' | "$DISPATCH" --provider invalid --mode review --worktree "$TEMP_DIR/wt" 2>&1)"; then
   fail 'dispatch unexpectedly accepted an invalid provider'

--- a/scripts/test-dispatch-task.sh
+++ b/scripts/test-dispatch-task.sh
@@ -50,7 +50,10 @@ mkdir -p "$TEMP_DIR/wt/handoffs"
 cat > "$TEMP_DIR/wt/handoffs/slice.md" <<'EOF'
 This is the complete tracked handoff. It must not be included in the provider command.
 EOF
-git -C "$TEMP_DIR/wt" add handoffs/slice.md
+cat > "$TEMP_DIR/wt/handoffs/slice handoff.md" <<'EOF'
+This tracked handoff verifies that spaces in safe repository paths work.
+EOF
+git -C "$TEMP_DIR/wt" add handoffs
 git -C "$TEMP_DIR/wt" -c user.name=test -c user.email=test@example.com \
   commit -qm 'add handoff fixture'
 
@@ -84,6 +87,12 @@ assert_not_contains() {
   [[ "$haystack" != *"$needle"* ]] || fail "expected output not to contain: $needle"
 }
 assert_not_contains "$dsh_handoff_output" 'This is the complete tracked handoff.'
+
+spaced_handoff_output="$(printf 'review the assigned slice\n' | PATH="$TEMP_DIR/bin:$PATH" \
+  DEEPSEEK_AGENT_ENV_FILE="$TEMP_DIR/agent.env" "$DISPATCH" \
+    --provider dsh --mode review --worktree "$TEMP_DIR/wt" --handoff 'handoffs/slice handoff.md')"
+assert_contains "$spaced_handoff_output" 'Read the complete task handoff at handoffs/slice handoff.md in the current worktree.'
+assert_not_contains "$spaced_handoff_output" 'This tracked handoff verifies'
 
 claude_handoff_output="$(printf 'review the assigned slice\n' | PATH="$TEMP_DIR/bin:$PATH" \
   DEEPSEEK_AGENT_ENV_FILE="$TEMP_DIR/agent.env" "$DISPATCH" \

--- a/scripts/test-dsh-agent.sh
+++ b/scripts/test-dsh-agent.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly LAUNCHER="$SCRIPT_DIR/run-dsh-agent.sh"
+readonly TEMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'test-dsh-agent: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  [[ "$haystack" == *"$needle"* ]] || fail "expected output to contain: $needle"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  [[ "$haystack" != *"$needle"* ]] || fail "expected output not to contain: $needle"
+}
+
+mkdir -p "$TEMP_DIR/bin"
+cat > "$TEMP_DIR/bin/dsh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'cwd=<%s>\n' "$PWD"
+printf 'sandbox=<%s>\n' "${DSH_PERMISSION_MODE:-}"
+printf 'legacy-env=<%s>\n' "${DEEPSEEK_AGENT_ENV_FILE:-}"
+printf 'legacy-key=<%s>\n' "${DEEPSEEK_API_KEY:-}"
+printf 'args:\n'
+printf '<%s>\n' "$@"
+sleep "${FAKE_DSH_SLEEP_SECONDS:-0}"
+exit "${FAKE_DSH_EXIT:-0}"
+EOF
+chmod +x "$TEMP_DIR/bin/dsh"
+
+git init -q "$TEMP_DIR/wt"
+
+run_launcher() {
+  PATH="$TEMP_DIR/bin:$PATH" \
+    DEEPSEEK_AGENT_ENV_FILE=/private/secret/.env.agent \
+    DEEPSEEK_API_KEY=test-secret \
+    "$LAUNCHER" "$@"
+}
+
+# ---- review mode: readonly sandbox, cwd, prompt argv, no legacy credential env ----
+review_output="$(printf 'first line\nsecond line\n' | run_launcher --mode review --worktree "$TEMP_DIR/wt")"
+assert_contains "$review_output" "cwd=<$TEMP_DIR/wt>"
+assert_contains "$review_output" 'sandbox=<read-only>'
+assert_contains "$review_output" '<--profile>'
+assert_contains "$review_output" '<headless>'
+assert_contains "$review_output" 'first line'
+assert_contains "$review_output" 'second line'
+assert_contains "$review_output" 'legacy-env=<>'
+assert_contains "$review_output" 'legacy-key=<>'
+assert_not_contains "$review_output" 'test-secret'
+
+# ---- implementation guard and workspace-write sandbox ----
+if implement_error="$(printf 'implement task\n' | run_launcher --mode implement 2>&1)"; then
+  fail 'implementation mode unexpectedly ran without --worktree'
+fi
+assert_contains "$implement_error" '--mode implement requires --worktree'
+
+implement_output="$(printf 'implement task\n' | run_launcher --mode implement --worktree "$TEMP_DIR/wt")"
+assert_contains "$implement_output" 'sandbox=<workspace-write>'
+
+# ---- missing dsh fails clearly ----
+if missing_dsh_error="$(printf 'review\n' | PATH=/usr/bin:/bin "$LAUNCHER" --mode review --worktree "$TEMP_DIR/wt" 2>&1)"; then
+  fail 'launcher unexpectedly ran without dsh on PATH'
+fi
+assert_contains "$missing_dsh_error" 'dsh executable was not found on PATH'
+
+# ---- lifecycle log identifies a process heartbeat as non-tool activity ----
+progress_log="$TEMP_DIR/slice.progress.log"
+printf 'task\n' | DSH_HEARTBEAT_SECONDS=1 FAKE_DSH_SLEEP_SECONDS=2 \
+  run_launcher --mode review --worktree "$TEMP_DIR/wt" \
+  --progress-log "$progress_log" >/dev/null
+progress_content="$(cat "$progress_log")"
+assert_contains "$progress_content" '[start] provider=dsh mode=review sandbox=read-only'
+assert_contains "$progress_content" '[heartbeat] provider=dsh process-alive (not tool activity)'
+assert_contains "$progress_content" '[exit] provider=dsh worker exited code=0'
+
+# ---- worker failure propagates ----
+if FAKE_DSH_EXIT=7 run_launcher --mode review --worktree "$TEMP_DIR/wt" \
+     < <(printf 'task\n') >/dev/null 2>&1; then
+  fail 'launcher unexpectedly exited zero when dsh failed'
+fi
+
+printf 'test-dsh-agent: passed\n'

--- a/scripts/worker-status.sh
+++ b/scripts/worker-status.sh
@@ -2,11 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # worker-status.sh — cheap, bounded status probe for a dispatched slice.
-# Reads the progress log written by dispatch-task.sh / run-claude-deepseek-agent.sh
-# and reports the worker's state plus its recent activity. Designed for a manager
-# to poll every 30-60s instead of blocking on (or killing) a long dispatch:
-# judge the worker by idle time since its last progress entry, never by total
-# wall-clock runtime — a healthy slice can run 10+ minutes.
+# Reads the progress log written by dispatch-task.sh and its provider leaves and
+# reports the worker's state plus its recent marker. Designed for a manager to
+# poll every 30-60s instead of blocking on (or killing) a long dispatch: judge
+# the worker by idle time since its last marker, never by total wall-clock runtime.
 
 set -euo pipefail
 
@@ -21,12 +20,15 @@ Usage: scripts/worker-status.sh --slug SLUG [options]
 
 Report the state of a dispatched worker from its progress log:
   state=waiting     log not created yet (dispatch still setting up)
-  state=running     worker active; idle= shows seconds since the last entry
-  state=stale       no progress for --stale-after seconds — inspect the log
+  state=running     worker active; idle= shows seconds since the last marker
+  state=stale       no marker for --stale-after seconds — inspect the log
                     tail and worktree before deciding anything; do not kill
                     on this signal alone
   state=verifying   worker exited; independent build gate in progress
   state=done        dispatch finished; read the dispatch report
+
+DSH emits process-alive heartbeats, not tool-level activity, so inspect its
+final response and worktree before treating a long-running DSH worker as healthy.
 
 Options:
   --slug SLUG         Locate the log at $PURECUT_WORKTREE_BASE/SLUG.progress.log.
@@ -82,7 +84,7 @@ fi
 
 printf 'state=%s idle=%ss log=%s\n' "$state" "$idle" "$log"
 if [[ "$state" == "stale" ]]; then
-  printf 'no progress for %ss — inspect the log tail and worktree before acting; do not kill on this alone\n' "$idle"
+  printf 'no marker for %ss — inspect the log tail and worktree before acting; do not kill on this alone\n' "$idle"
 fi
 printf -- '--- last %s entries ---\n' "$lines"
 tail -n "$lines" "$log"


### PR DESCRIPTION
## Summary

- Add an explicit `dsh` provider to the delegated-worker dispatcher while preserving `claude-deepseek` as the default.
- Run DSH headless workers in `read-only` review or `workspace-write` implementation mode without forwarding legacy `.env.agent` credentials.
- Add provider-specific lifecycle/heartbeat reporting, deterministic fake-provider tests, and provider-neutral dispatch documentation.

Closes #502

## Verification

- `scripts/test-claude-deepseek-agent.sh`
- `scripts/test-dsh-agent.sh`
- `scripts/test-dispatch-task.sh`
- `npm run build`
- Live DSH read-only smoke through `scripts/dispatch-task.sh --provider dsh`

## Notes

- DSH headless returns a final response only; its heartbeats prove process liveness, not tool-level progress.
