### PR TITLE
Stream live DSH worker events

### DIFF
--- a/.agents/skills/manager-delegate/SKILL.md
+++ b/.agents/skills/manager-delegate/SKILL.md
@@ -74,10 +74,12 @@ raw event stream is kept beside it at `….progress.log.ndjson`). Long slices
 are normal: a healthy worker can run 10+ minutes while emitting a steady drip
 of `[note]`/`[tool]`/`[gen]` lines.
 
-DSH headless only returns its final response. Its leaf writes `[start]`,
-`[heartbeat]`, and `[exit]` markers; a heartbeat means the DSH process remains
-alive, **not** that the worker made tool-level progress. Inspect the worktree and
-final response before treating a long DSH run as healthy.
+DSH's leaf tails DSH's active local session artifact and writes observed
+`[assistant]`, `[tool]`, and `[tool-result]` entries as they arrive. Its
+`[heartbeat]` marker remains a fallback: it means the DSH process remains alive,
+**not** that the worker made tool-level progress. The full raw session remains
+under `~/.dsh`; rendered manager-log payloads are normalized and bounded.
+Inspect the worktree and final response before treating a long DSH run as healthy.
 
 - Dispatch in the background with output redirected to a file; do not block a
   foreground shell call (with its own timeout) on the whole slice.
@@ -92,7 +94,8 @@ final response before treating a long DSH run as healthy.
   - `verifying` — worker done, independent build gate running.
   - `done` — read the dispatch report and start the review.
 - For Claude/DeepSeek, `[tool]` lines are observed tool calls and `[note]` lines
-  are worker narration. DSH does not expose either stream through headless mode.
+  are worker narration. For DSH, `[assistant]`, `[tool]`, and `[tool-result]`
+  are observed from its session artifact, while `[heartbeat]` is liveness only.
 
 ## Verify before you accept
 

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -18,7 +18,7 @@ available; do not treat one-off diagnostics as normal quality gates.
 
 - [`dispatch-task.sh`](dispatch-task.sh), [`finish-task.sh`](finish-task.sh), and [`worker-status.sh`](worker-status.sh) — provider-neutral integration-manager worktree lifecycle. `claude-deepseek` remains the default provider; select `--provider dsh` for DeepSeek Harness. `dispatch-task.sh --handoff REPO_PATH` gives either provider a compact bootstrap to read a tracked in-worktree handoff; direct stdin is reserved for a small instruction.
 - [`run-claude-deepseek-agent.sh`](run-claude-deepseek-agent.sh) — credential-backed Claude/DeepSeek leaf launcher.
-- [`run-dsh-agent.sh`](run-dsh-agent.sh) — DeepSeek Harness leaf launcher using DSH's own credential store and sandbox modes.
+- [`run-dsh-agent.sh`](run-dsh-agent.sh) and [`dsh-progress-filter.jq`](dsh-progress-filter.jq) — DeepSeek Harness leaf launcher and live session-event filter. They use DSH's own credential store and sandbox modes, tail observed assistant/tool/tool-result records into the manager log, and leave the full raw session under `~/.dsh`.
 - [`claude-deepseek-agent-prompt.md`](claude-deepseek-agent-prompt.md) — bounded provider-neutral worker prompt template (historic filename retained for compatibility).
 - [`test-claude-deepseek-agent.sh`](test-claude-deepseek-agent.sh), [`test-dsh-agent.sh`](test-dsh-agent.sh), [`test-dispatch-task.sh`](test-dispatch-task.sh), and [`worker-progress-filter.jq`](worker-progress-filter.jq) — harness tests and Claude progress filtering.
 

--- a/scripts/claude-deepseek-agent-prompt.md
+++ b/scripts/claude-deepseek-agent-prompt.md
@@ -43,7 +43,7 @@ Required invariants: [INVARIANTS]
 Required checks: [REQUIRED_CHECKS]
 
 Rules:
-- Narrate your progress in the final report. Claude/DeepSeek streams observed tool activity; DSH headless returns only its final response, so its manager log can prove process liveness but not individual tool calls.
+- Narrate your progress in the final report. Claude/DeepSeek streams observed tool activity. DSH tails its local active session artifact for observed assistant, tool-call, and tool-result events; process-alive heartbeats remain a fallback, not proof of tool activity.
 - Make the smallest change that satisfies the slice.
 - Do not perform unrelated cleanup or change public/frozen contracts unless this slice explicitly permits it.
 - Do not edit the detailed integration handoff unless this slice explicitly assigns documentation.

--- a/scripts/dispatch-task.sh
+++ b/scripts/dispatch-task.sh
@@ -48,9 +48,10 @@ Options:
                       only writes one when this is set explicitly).
   --help              Show this help.
 
-Progress: Claude/DeepSeek logs observed worker events. DSH logs only lifecycle
-and process-alive heartbeats, not tool activity. Dispatch in the background and
-poll scripts/worker-status.sh --slug SLUG instead of killing a long run.
+Progress: Claude/DeepSeek logs observed worker events. DSH tails its own active
+session artifact for observed assistant, tool-call, and tool-result events;
+process-alive heartbeats remain a fallback. Dispatch in the background and poll
+scripts/worker-status.sh --slug SLUG instead of killing a long run.
 
 Permissions: every provider sends the prompt to its configured external service,
 so get explicit approval first. claude-deepseek reads .env.agent and runs a

--- a/scripts/dsh-progress-filter.jq
+++ b/scripts/dsh-progress-filter.jq
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# dsh-progress-filter.jq — distill DSH session JSONL records into observed,
+# one-line manager-progress events. run-dsh-agent.sh repeatedly decodes DSH's
+# growing session artifact and de-duplicates records by sequence number.
+#
+# Output is: sequence<TAB>event-kind<TAB>normalized-payload
+
+def one_line:
+  tostring | gsub("[\r\n\t]+"; " ") | gsub(" +"; " ");
+
+def assistant_text:
+  [.data.message.content[]? | select(.type == "text") | .text // empty]
+  | join(" ")
+  | one_line;
+
+def tool_result_text:
+  [.data.message.content[]?
+   | select(.type == "tool-result")
+   | .content[]?
+   | select(.type == "text")
+   | .text // empty]
+  | join(" ")
+  | one_line;
+
+inputs
+| fromjson? // empty
+| select(type == "object" and (.seq | type == "number"))
+| if .type == "assistant/message" then
+    assistant_text as $text
+    | select($text != "")
+    | [.seq, "assistant", $text] | @tsv
+  elif .type == "tool/call" then
+    [ .seq,
+      "tool",
+      (((.data.name // "unknown") + " " + (.data.arguments // "")) | one_line)
+    ] | @tsv
+  elif .type == "tool/result" then
+    tool_result_text as $text
+    | select($text != "")
+    | [.seq, "tool-result", $text] | @tsv
+  else
+    empty
+  end

--- a/scripts/run-dsh-agent.sh
+++ b/scripts/run-dsh-agent.sh
@@ -3,9 +3,15 @@
 
 # run-dsh-agent.sh — run one DeepSeek Harness headless worker inside a bounded
 # git worktree. DSH owns its configured credentials; this script never reads
-# .env.agent or forwards its path to the worker.
+# .env.agent or forwards its path to the worker. When a progress log is
+# requested, it tails DSH's own growing session artifact for observed assistant,
+# tool-call, and tool-result events.
 
 set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly DSH_PROGRESS_FILTER="$SCRIPT_DIR/dsh-progress-filter.jq"
+readonly DEFAULT_EVENT_MAX_CHARS=2048
 
 usage() {
   cat <<'EOF'
@@ -17,13 +23,16 @@ Options:
   --mode MODE            Required: review or implement.
   --worktree DIR         Git worktree to run the session in. Required with
                          --mode implement; optional for review (defaults to cwd).
-  --progress-log FILE    Append lifecycle and process-alive markers to FILE.
+  --progress-log FILE    Append lifecycle, observed DSH events, and fallback
+                         process-alive markers to FILE.
   --help                 Show this help.
 
 Review sessions run with DSH_PERMISSION_MODE=read-only. Implementation sessions
 run with DSH_PERMISSION_MODE=workspace-write and must remain in the supplied
 worktree. DSH stores its own configured credential and session state under
-~/.dsh; this launcher does not read .env.agent.
+~/.dsh; this launcher does not read .env.agent. The full raw session remains
+DSH-owned. Observed event payloads are normalized and capped at
+DSH_EVENT_MAX_CHARS (default: 2048) in the manager progress log.
 EOF
 }
 
@@ -74,6 +83,7 @@ worktree="${worktree:-$PWD}"
 [[ -d "$worktree" ]] || fail "--worktree path is not a directory: $worktree"
 git -C "$worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
   || fail "--worktree path is not a git worktree: $worktree"
+worktree="$(cd "$worktree" && pwd -P)"
 
 command -v dsh >/dev/null 2>&1 || fail "dsh executable was not found on PATH"
 
@@ -105,17 +115,122 @@ mkdir -p "$(dirname "$progress_log")" 2>/dev/null \
   || fail "cannot create progress log directory for: $progress_log"
 result_file="$(mktemp -t run-dsh-agent-result)"
 stderr_file="$(mktemp -t run-dsh-agent-stderr)"
+session_snapshot_file="$(mktemp -t run-dsh-agent-sessions)"
+decoded_events_file="$(mktemp -t run-dsh-agent-events)"
 worker_pid=""
 cleanup() {
   if [[ -n "$worker_pid" ]] && kill -0 "$worker_pid" 2>/dev/null; then
     kill "$worker_pid" 2>/dev/null || true
   fi
-  rm -f "$result_file" "$stderr_file"
+  rm -f "$result_file" "$stderr_file" "$session_snapshot_file" "$decoded_events_file"
 }
 trap cleanup EXIT INT TERM
 : > "$progress_log"
 printf '%s [start] provider=dsh mode=%s sandbox=%s\n' \
   "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$mode" "$sandbox_mode" >> "$progress_log"
+
+event_max_chars="${DSH_EVENT_MAX_CHARS:-$DEFAULT_EVENT_MAX_CHARS}"
+[[ "$event_max_chars" =~ ^[1-9][0-9]*$ ]] \
+  || fail "DSH_EVENT_MAX_CHARS must be a positive integer"
+
+# DSH keys sessions by an encoded physical cwd: /a/b becomes --a-b--.
+session_path="${worktree#/}"
+session_slug="--${session_path//\//-}--"
+session_root="${PURECUT_DSH_SESSIONS_ROOT:-$HOME/.dsh/sessions}"
+session_directory="$session_root/$session_slug"
+: > "$session_snapshot_file"
+if [[ -d "$session_directory" ]]; then
+  find "$session_directory" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null \
+    | sort > "$session_snapshot_file"
+fi
+
+tail_enabled=true
+tail_state="waiting"
+tail_artifact=""
+last_artifact_size=""
+last_event_seq=0
+
+if ! command -v zstd >/dev/null 2>&1; then
+  printf '%s [tail] provider=dsh unavailable: zstd not found; using heartbeats\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$progress_log"
+  tail_enabled=false
+elif ! command -v jq >/dev/null 2>&1; then
+  printf '%s [tail] provider=dsh unavailable: jq not found; using heartbeats\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$progress_log"
+  tail_enabled=false
+elif [[ ! -f "$DSH_PROGRESS_FILTER" ]]; then
+  printf '%s [tail] provider=dsh unavailable: filter missing; using heartbeats\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$progress_log"
+  tail_enabled=false
+fi
+
+clip_event_payload() {
+  local payload="$1"
+  if (( ${#payload} > event_max_chars )); then
+    printf '%s…' "${payload:0:event_max_chars}"
+  else
+    printf '%s' "$payload"
+  fi
+}
+
+find_session_artifact() {
+  local -a new_sessions=()
+  local candidate
+
+  [[ -d "$session_directory" ]] || return 1
+  while IFS= read -r candidate; do
+    grep -Fqx -- "$candidate" "$session_snapshot_file" \
+      || new_sessions+=("$candidate")
+  done < <(find "$session_directory" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null)
+
+  if (( ${#new_sessions[@]} > 1 )); then
+    if [[ "$tail_state" != "ambiguous" ]]; then
+      printf '%s [tail] provider=dsh session-attribution=ambiguous; using heartbeats\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$progress_log"
+    fi
+    tail_state="ambiguous"
+    tail_enabled=false
+    return 1
+  fi
+
+  if (( ${#new_sessions[@]} == 1 )); then
+    tail_artifact="${new_sessions[0]}/session.jsonl.zstd"
+    [[ -f "$tail_artifact" ]] || return 1
+    tail_state="active"
+    return 0
+  fi
+
+  return 1
+}
+
+tail_observed_events() {
+  local artifact_size seq event_kind payload
+
+  [[ "$tail_enabled" == true ]] || return 0
+  if [[ -z "$tail_artifact" ]] && ! find_session_artifact; then
+    return 0
+  fi
+  [[ -f "$tail_artifact" ]] || return 0
+
+  artifact_size="$(stat -f '%z' "$tail_artifact" 2>/dev/null \
+    || stat -c '%s' "$tail_artifact" 2>/dev/null)" || return 0
+  [[ "$artifact_size" != "$last_artifact_size" ]] || return 0
+
+  if ! zstd -dc "$tail_artifact" 2>/dev/null \
+      | jq -nRr --unbuffered -f "$DSH_PROGRESS_FILTER" > "$decoded_events_file"; then
+    return 0
+  fi
+  last_artifact_size="$artifact_size"
+
+  while IFS=$'\t' read -r seq event_kind payload; do
+    [[ "$seq" =~ ^[0-9]+$ ]] || continue
+    (( seq > last_event_seq )) || continue
+    payload="$(clip_event_payload "$payload")"
+    printf '%s [%s] provider=dsh %s\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$event_kind" "$payload" >> "$progress_log"
+    last_event_seq="$seq"
+  done < "$decoded_events_file"
+}
 
 run_dsh >"$result_file" 2>"$stderr_file" &
 worker_pid=$!
@@ -127,6 +242,7 @@ seconds_since_heartbeat=0
 while kill -0 "$worker_pid" 2>/dev/null; do
   sleep 1
   kill -0 "$worker_pid" 2>/dev/null || break
+  tail_observed_events
   seconds_since_heartbeat=$((seconds_since_heartbeat + 1))
   if (( seconds_since_heartbeat >= heartbeat_seconds )); then
     printf '%s [heartbeat] provider=dsh process-alive (not tool activity)\n' \
@@ -140,6 +256,7 @@ wait "$worker_pid"
 worker_status=$?
 set -e
 worker_pid=""
+tail_observed_events
 cat "$result_file"
 cat "$stderr_file" >&2
 printf '%s [exit] provider=dsh worker exited code=%s\n' \

--- a/scripts/test-dsh-agent.sh
+++ b/scripts/test-dsh-agent.sh
@@ -39,15 +39,56 @@ printf 'legacy-env=<%s>\n' "${DEEPSEEK_AGENT_ENV_FILE:-}"
 printf 'legacy-key=<%s>\n' "${DEEPSEEK_API_KEY:-}"
 printf 'args:\n'
 printf '<%s>\n' "$@"
+if [[ "${FAKE_DSH_STREAM_EVENTS:-}" == true ]]; then
+  session_path="${PWD#/}"
+  session_slug="--${session_path//\//-}--"
+  session_root="$HOME/.dsh/sessions/$session_slug"
+  stream_id="${RANDOM}${RANDOM}"
+  mkdir -p "$session_root/session-stream-$stream_id"
+  cat > "$session_root/session-stream-$stream_id/session.jsonl.zstd" <<'JSON'
+{"type":"assistant/message","seq":10,"data":{"message":{"content":[{"type":"reasoning","text":"internal reasoning must stay hidden"},{"type":"text","text":"Reading project context\nnow"}]}}}
+JSON
+  sleep 2
+  cat >> "$session_root/session-stream-$stream_id/session.jsonl.zstd" <<'JSON'
+{"type":"tool/call","seq":11,"data":{"name":"read_file","arguments":"{\"path\":\"INDEX.md\"}"}}
+JSON
+  sleep 2
+  cat >> "$session_root/session-stream-$stream_id/session.jsonl.zstd" <<'JSON'
+{"type":"tool/result","seq":12,"data":{"message":{"content":[{"type":"tool-result","content":[{"type":"text","text":"# INDEX\nScripts overview"}]}]}}}
+JSON
+  sleep 2
+fi
+if [[ "${FAKE_DSH_AMBIGUOUS:-}" == true ]]; then
+  session_path="${PWD#/}"
+  session_slug="--${session_path//\//-}--"
+  session_root="$HOME/.dsh/sessions/$session_slug"
+  ambiguous_id="${RANDOM}${RANDOM}"
+  mkdir -p "$session_root/session-ambiguous-a-$ambiguous_id" "$session_root/session-ambiguous-b-$ambiguous_id"
+  printf '%s\n' '{"type":"tool/call","seq":10,"data":{"name":"wrong","arguments":"{}"}}' \
+    > "$session_root/session-ambiguous-a-$ambiguous_id/session.jsonl.zstd"
+  printf '%s\n' '{"type":"tool/call","seq":11,"data":{"name":"wrong","arguments":"{}"}}' \
+    > "$session_root/session-ambiguous-b-$ambiguous_id/session.jsonl.zstd"
+  sleep 2
+fi
 sleep "${FAKE_DSH_SLEEP_SECONDS:-0}"
 exit "${FAKE_DSH_EXIT:-0}"
 EOF
+cat > "$TEMP_DIR/bin/zstd" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == "-dc" ]] || exit 2
+[[ "${FAKE_ZSTD_FAIL:-}" != true ]] || exit 1
+cat "$2"
+EOF
 chmod +x "$TEMP_DIR/bin/dsh"
+chmod +x "$TEMP_DIR/bin/zstd"
 
 git init -q "$TEMP_DIR/wt"
+canonical_wt="$(cd "$TEMP_DIR/wt" && pwd -P)"
 
 run_launcher() {
   PATH="$TEMP_DIR/bin:$PATH" \
+    HOME="$TEMP_DIR/home" \
     DEEPSEEK_AGENT_ENV_FILE=/private/secret/.env.agent \
     DEEPSEEK_API_KEY=test-secret \
     "$LAUNCHER" "$@"
@@ -55,7 +96,7 @@ run_launcher() {
 
 # ---- review mode: readonly sandbox, cwd, prompt argv, no legacy credential env ----
 review_output="$(printf 'first line\nsecond line\n' | run_launcher --mode review --worktree "$TEMP_DIR/wt")"
-assert_contains "$review_output" "cwd=<$TEMP_DIR/wt>"
+assert_contains "$review_output" "cwd=<$canonical_wt>"
 assert_contains "$review_output" 'sandbox=<read-only>'
 assert_contains "$review_output" '<--profile>'
 assert_contains "$review_output" '<headless>'
@@ -89,6 +130,44 @@ progress_content="$(cat "$progress_log")"
 assert_contains "$progress_content" '[start] provider=dsh mode=review sandbox=read-only'
 assert_contains "$progress_content" '[heartbeat] provider=dsh process-alive (not tool activity)'
 assert_contains "$progress_content" '[exit] provider=dsh worker exited code=0'
+
+# ---- session artifacts stream observed text, tool calls, and tool results ----
+stream_progress_log="$TEMP_DIR/stream.progress.log"
+printf 'task\n' | DSH_HEARTBEAT_SECONDS=1 FAKE_DSH_STREAM_EVENTS=true \
+  run_launcher --mode review --worktree "$TEMP_DIR/wt" \
+  --progress-log "$stream_progress_log" >/dev/null
+stream_progress_content="$(cat "$stream_progress_log")"
+assert_contains "$stream_progress_content" '[assistant] provider=dsh Reading project context now'
+assert_contains "$stream_progress_content" '[tool] provider=dsh read_file {"path":"INDEX.md"}'
+assert_contains "$stream_progress_content" '[tool-result] provider=dsh # INDEX Scripts overview'
+assert_not_contains "$stream_progress_content" 'internal reasoning must stay hidden'
+[[ "$(grep -F -c '[tool] provider=dsh read_file' "$stream_progress_log")" -eq 1 ]] \
+  || fail 'repeated session decodes duplicated the tool event'
+
+# ---- ambiguous artifacts retain heartbeat-only fallback ----
+ambiguous_progress_log="$TEMP_DIR/ambiguous.progress.log"
+printf 'task\n' | DSH_HEARTBEAT_SECONDS=1 FAKE_DSH_AMBIGUOUS=true \
+  run_launcher --mode review --worktree "$TEMP_DIR/wt" \
+  --progress-log "$ambiguous_progress_log" >/dev/null
+ambiguous_progress_content="$(cat "$ambiguous_progress_log")"
+assert_contains "$ambiguous_progress_content" '[tail] provider=dsh session-attribution=ambiguous; using heartbeats'
+assert_contains "$ambiguous_progress_content" '[heartbeat] provider=dsh process-alive (not tool activity)'
+assert_not_contains "$ambiguous_progress_content" '[tool] provider=dsh wrong'
+
+# ---- unreadable artifacts and bounded rendering retain safe behavior ----
+unreadable_progress_log="$TEMP_DIR/unreadable.progress.log"
+printf 'task\n' | DSH_HEARTBEAT_SECONDS=1 FAKE_DSH_STREAM_EVENTS=true FAKE_ZSTD_FAIL=true \
+  run_launcher --mode review --worktree "$TEMP_DIR/wt" \
+  --progress-log "$unreadable_progress_log" >/dev/null
+unreadable_progress_content="$(cat "$unreadable_progress_log")"
+assert_contains "$unreadable_progress_content" '[heartbeat] provider=dsh process-alive (not tool activity)'
+assert_not_contains "$unreadable_progress_content" '[assistant] provider=dsh'
+
+bounded_progress_log="$TEMP_DIR/bounded.progress.log"
+printf 'task\n' | DSH_EVENT_MAX_CHARS=1 FAKE_DSH_STREAM_EVENTS=true \
+  run_launcher --mode review --worktree "$TEMP_DIR/wt" \
+  --progress-log "$bounded_progress_log" >/dev/null
+assert_contains "$(cat "$bounded_progress_log")" '[tool-result] provider=dsh #…'
 
 # ---- worker failure propagates ----
 if FAKE_DSH_EXIT=7 run_launcher --mode review --worktree "$TEMP_DIR/wt" \

--- a/scripts/worker-status.sh
+++ b/scripts/worker-status.sh
@@ -27,8 +27,10 @@ Report the state of a dispatched worker from its progress log:
   state=verifying   worker exited; independent build gate in progress
   state=done        dispatch finished; read the dispatch report
 
-DSH emits process-alive heartbeats, not tool-level activity, so inspect its
-final response and worktree before treating a long-running DSH worker as healthy.
+DSH tails its own active session artifact for observed assistant, tool-call, and
+tool-result events. Its process-alive heartbeat is only a fallback, not
+tool-level activity; inspect the final response and worktree before treating a
+long-running DSH worker as healthy.
 
 Options:
   --slug SLUG         Locate the log at $PURECUT_WORKTREE_BASE/SLUG.progress.log.


### PR DESCRIPTION
## Summary

- Tail DSH's growing local session artifact into the manager progress log, emitting observed assistant text, tool calls, and tool results.
- Select only the new session for the actual worktree; fall back safely to heartbeats for missing, unreadable, or ambiguous artifacts.
- Bound rendered event payloads, retain the raw DSH-owned session under ~/.dsh, and document the live-observability contract.

## Verification

- scripts/test-dsh-agent.sh
- scripts/test-dispatch-task.sh
- scripts/test-claude-deepseek-agent.sh
- npm run docs:check
- npm run build
- Real DSH read-only disposable-worktree smoke: observed tool call and result before worker exit, followed by the final assistant event.

Closes #504
