### PR TITLE
Harden DSH dispatch fallback

### DIFF
--- a/.agents/skills/manager-delegate/SKILL.md
+++ b/.agents/skills/manager-delegate/SKILL.md
@@ -58,7 +58,12 @@ to implementing the slice yourself or abandoning the delegation.
   It does not read or forward `.env.agent`; DSH persists normal profile/session
   state under `~/.dsh`. Review workers use DSH `read-only`; implementation
   workers use DSH `workspace-write` rooted at the task worktree. Any DSH
-  escalation without an interactive approver fails closed.
+  escalation without an interactive approver fails closed. A linked worktree's
+  Git metadata lives outside that writable root, so a DSH implementation worker
+  must leave edits uncommitted and report `COMMIT: none`. After a zero-exit DSH
+  run with changes, `dispatch-task.sh` creates exactly one manager-owned commit
+  and reports its hash. Failed and no-change DSH runs are never auto-committed;
+  inspect the worktree and dispatch report before deciding what to do next.
 
 - **Codex:** run from the worktree/repo root with `sandbox=workspace-write`,
   `sandbox_workspace_write.network_access=true`, and `approval-policy=on-request`.
@@ -79,6 +84,8 @@ DSH's leaf tails DSH's active local session artifact and writes observed
 `[heartbeat]` marker remains a fallback: it means the DSH process remains alive,
 **not** that the worker made tool-level progress. The full raw session remains
 under `~/.dsh`; rendered manager-log payloads are normalized and bounded.
+Tool-result snippets default to 320 characters; read the raw artifact when the
+full output matters.
 Inspect the worktree and final response before treating a long DSH run as healthy.
 
 - Dispatch in the background with output redirected to a file; do not block a

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -26,6 +26,14 @@ Use this path only after explicit delegation approval and follow
 [`manager-delegate`](../.agents/skills/manager-delegate/SKILL.md). Direct
 implementation remains the default execution mode.
 
+DSH implementation sessions intentionally leave worktree edits uncommitted:
+its workspace-write sandbox cannot write the linked worktree's shared Git
+metadata in the primary checkout. After a zero-exit DSH session with changes,
+`dispatch-task.sh` creates exactly one manager-owned commit; failed and
+no-change runs are never auto-committed. Live tool-result snippets are capped
+at 320 characters by default (`DSH_TOOL_RESULT_MAX_CHARS`); inspect DSH's raw
+session artifact when the full output matters.
+
 ## Diagnostics and fixtures
 
 The remaining TypeScript, Python, JSON, and `.camj` files are focused import,

--- a/scripts/claude-deepseek-agent-prompt.md
+++ b/scripts/claude-deepseek-agent-prompt.md
@@ -50,7 +50,7 @@ Rules:
 - Run the required checks. Do not claim an unrun check passed.
 - For the full build gate, run `scripts/build-summary.sh` ONCE instead of a bare `npm run build`: it saves the complete output to a log (path printed at the end) and summarizes the failing stage with extracted errors. Never re-run the build to hunt for an error you already hit — re-read that log, or run `scripts/build-summary.sh --from-log <path>`.
 - Editing files: prefer your built-in exact-match Edit tool. If it rejects an edit twice, do NOT fall back to `sed`/`awk`/`perl` — regex in-place edits mutate files invisibly and beyond the addressed lines. Use the deterministic line editor instead: `npx tsx scripts/edit-lines.ts show <file> <start> <end>` to re-read the exact current lines, then `replace <file> <start> <end> --expect "<substring of the old lines>" <<'EOF' … EOF` (also `insert-after`, `delete`; run with no arguments for usage). It refuses stale line numbers and prints a diff of exactly what changed. File-wide regex renames are forbidden in any tool.
-- Make exactly one commit for this slice. Do not add Co-Authored-By or generated-by footers.
+- Commit ownership depends on the provider. Claude/DeepSeek workers make exactly one commit for this slice, with no Co-Authored-By or generated-by footers. DSH implementation workers must not run git add or git commit: workspace-write intentionally cannot modify a linked worktree's shared Git metadata. Leave completed edits in the assigned worktree and report `COMMIT: none`; after a zero-exit DSH session, the dispatcher creates one manager-owned commit and reports its hash.
 
 Finish with exactly this completion block:
 STATUS: complete | blocked

--- a/scripts/dispatch-task.sh
+++ b/scripts/dispatch-task.sh
@@ -53,6 +53,12 @@ session artifact for observed assistant, tool-call, and tool-result events;
 process-alive heartbeats remain a fallback. Dispatch in the background and poll
 scripts/worker-status.sh --slug SLUG instead of killing a long run.
 
+DSH commit fallback: DSH workspace-write can edit the linked worktree but cannot
+write its shared Git metadata outside that boundary. After a zero-exit DSH
+implementation run, this manager-side dispatcher creates one commit if there
+are changes. It never auto-commits a failed or no-change DSH run. Claude/DeepSeek
+workers retain their existing worker-owned commit behavior.
+
 Permissions: every provider sends the prompt to its configured external service,
 so get explicit approval first. claude-deepseek reads .env.agent and runs a
 bypassPermissions Claude worker; dsh uses its own configured credentials and
@@ -225,9 +231,36 @@ if [[ "$worker_status" -ne 0 ]]; then
     "$worker_status" >&2
 fi
 
+# A linked worktree's .git file points to shared metadata in the primary
+# checkout. DSH's workspace-write sandbox correctly denies that path, so only
+# the manager process may turn a successful DSH worker's edits into a commit.
+# Keep this provider-specific: Claude/DeepSeek workers still own their commit.
+manager_commit_result="not-applicable (worker-owned commit)"
+manager_commit_failed=false
+if [[ "$provider" == "dsh" ]]; then
+  if [[ "$worker_status" -ne 0 ]]; then
+    manager_commit_result="not-attempted (worker failed)"
+  elif [[ -z "$(git -C "$worktree_dir" status --short)" ]]; then
+    manager_commit_result="not-needed (clean worktree)"
+  else
+    printf '== manager commit: applying successful DSH worker changes ==\n' >&2
+    progress_mark "[commit] provider=dsh manager commit starting"
+    if git -C "$worktree_dir" add -A \
+      && git -C "$worktree_dir" commit -m "chore: apply DSH worker changes for issue #$issue"; then
+      manager_commit_result="$(git -C "$worktree_dir" rev-parse HEAD)"
+      progress_mark "[commit] provider=dsh manager commit=$manager_commit_result"
+    else
+      manager_commit_result="FAILED"
+      manager_commit_failed=true
+      progress_mark "[commit] provider=dsh manager commit=FAILED"
+      printf '!! manager could not commit successful DSH worker changes; worktree left in place !!\n' >&2
+    fi
+  fi
+fi
+
 # ---- independent build gate (manager verification, not the worker's report) ----
 build_result="skipped"
-if [[ "$skip_build" == false ]]; then
+if [[ "$skip_build" == false && "$manager_commit_failed" == false ]]; then
   printf '== build gate: npm run build in worktree ==\n' >&2
   progress_mark "[gate] npm run build starting"
   if [[ ! -d "$worktree_dir/node_modules" ]]; then
@@ -255,11 +288,13 @@ branch:       $branch
 worktree:     $worktree_dir
 base:         $base
 worker exit:  $worker_status
+commit owner: ${provider/dsh/manager}
+commit result: $manager_commit_result
 build gate:   $build_result
 progress log: $progress_log
 last commit:  $last_commit
 
-uncommitted (should be empty if worker committed):
+uncommitted (should be empty after a successful worker/manager commit):
 ${status_short:-  (clean)}
 
 diffstat vs $base:
@@ -269,5 +304,5 @@ Review the real diff, then merge with:
   scripts/finish-task.sh --slug $slug --base $base
 EOF
 
-[[ "$build_result" == "FAILED" || "$build_result" == "install-failed" ]] && exit 1
+[[ "$manager_commit_failed" == true || "$build_result" == "FAILED" || "$build_result" == "install-failed" ]] && exit 1
 exit 0

--- a/scripts/dsh-progress-filter.jq
+++ b/scripts/dsh-progress-filter.jq
@@ -9,6 +9,9 @@
 def one_line:
   tostring | gsub("[\r\n\t]+"; " ") | gsub(" +"; " ");
 
+def excerpt($limit):
+  if length > $limit then .[0:($limit - 1)] + "…" else . end;
+
 def assistant_text:
   [.data.message.content[]? | select(.type == "text") | .text // empty]
   | join(" ")
@@ -38,7 +41,7 @@ inputs
   elif .type == "tool/result" then
     tool_result_text as $text
     | select($text != "")
-    | [.seq, "tool-result", $text] | @tsv
+    | [.seq, "tool-result", ($text | excerpt($tool_result_max_chars))] | @tsv
   else
     empty
   end

--- a/scripts/run-dsh-agent.sh
+++ b/scripts/run-dsh-agent.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly DSH_PROGRESS_FILTER="$SCRIPT_DIR/dsh-progress-filter.jq"
 readonly DEFAULT_EVENT_MAX_CHARS=2048
+readonly DEFAULT_TOOL_RESULT_MAX_CHARS=320
 
 usage() {
   cat <<'EOF'
@@ -29,10 +30,14 @@ Options:
 
 Review sessions run with DSH_PERMISSION_MODE=read-only. Implementation sessions
 run with DSH_PERMISSION_MODE=workspace-write and must remain in the supplied
-worktree. DSH stores its own configured credential and session state under
-~/.dsh; this launcher does not read .env.agent. The full raw session remains
-DSH-owned. Observed event payloads are normalized and capped at
-DSH_EVENT_MAX_CHARS (default: 2048) in the manager progress log.
+worktree. A linked worktree's Git metadata is outside that writable boundary,
+so DSH implementation workers leave their edits for dispatch-task.sh to commit
+after a successful exit. DSH stores its own configured credential and session
+state under ~/.dsh; this launcher does not read .env.agent. The full raw session
+remains DSH-owned. Assistant and tool-call payloads are capped at
+DSH_EVENT_MAX_CHARS (default: 2048); tool-result payloads are separately
+excerpted to DSH_TOOL_RESULT_MAX_CHARS (default: 320) before they reach the
+manager progress log.
 EOF
 }
 
@@ -132,6 +137,9 @@ printf '%s [start] provider=dsh mode=%s sandbox=%s\n' \
 event_max_chars="${DSH_EVENT_MAX_CHARS:-$DEFAULT_EVENT_MAX_CHARS}"
 [[ "$event_max_chars" =~ ^[1-9][0-9]*$ ]] \
   || fail "DSH_EVENT_MAX_CHARS must be a positive integer"
+tool_result_max_chars="${DSH_TOOL_RESULT_MAX_CHARS:-$DEFAULT_TOOL_RESULT_MAX_CHARS}"
+[[ "$tool_result_max_chars" =~ ^[1-9][0-9]*$ ]] \
+  || fail "DSH_TOOL_RESULT_MAX_CHARS must be a positive integer"
 
 # DSH keys sessions by an encoded physical cwd: /a/b becomes --a-b--.
 session_path="${worktree#/}"
@@ -217,7 +225,8 @@ tail_observed_events() {
   [[ "$artifact_size" != "$last_artifact_size" ]] || return 0
 
   if ! zstd -dc "$tail_artifact" 2>/dev/null \
-      | jq -nRr --unbuffered -f "$DSH_PROGRESS_FILTER" > "$decoded_events_file"; then
+      | jq -nRr --unbuffered --argjson tool_result_max_chars "$tool_result_max_chars" \
+        -f "$DSH_PROGRESS_FILTER" > "$decoded_events_file"; then
     return 0
   fi
   last_artifact_size="$artifact_size"

--- a/scripts/test-dispatch-task.sh
+++ b/scripts/test-dispatch-task.sh
@@ -38,6 +38,10 @@ set -euo pipefail
 printf 'provider=dsh sandbox=<%s>\n' "${DSH_PERMISSION_MODE:-}"
 printf 'args:\n'
 printf '<%s>\n' "$@"
+if [[ -n "${FAKE_DSH_WRITE_FILE:-}" ]]; then
+  printf 'worker change\n' > "$FAKE_DSH_WRITE_FILE"
+fi
+exit "${FAKE_DSH_EXIT:-0}"
 EOF
 chmod +x "$TEMP_DIR/bin/claude" "$TEMP_DIR/bin/dsh"
 
@@ -56,6 +60,20 @@ EOF
 git -C "$TEMP_DIR/wt" add handoffs
 git -C "$TEMP_DIR/wt" -c user.name=test -c user.email=test@example.com \
   commit -qm 'add handoff fixture'
+
+prepare_implement_fixture() {
+  local fixture_repo="$TEMP_DIR/implement-repo"
+  mkdir -p "$fixture_repo/scripts"
+  git init -q "$fixture_repo"
+  git -C "$fixture_repo" config user.name test
+  git -C "$fixture_repo" config user.email test@example.com
+  printf 'fixture\n' > "$fixture_repo/README.md"
+  git -C "$fixture_repo" add README.md
+  git -C "$fixture_repo" commit -qm 'fixture base'
+  cp "$DISPATCH" "$SCRIPT_DIR/run-dsh-agent.sh" "$SCRIPT_DIR/dsh-progress-filter.jq" "$fixture_repo/scripts/"
+  chmod +x "$fixture_repo/scripts/dispatch-task.sh" "$fixture_repo/scripts/run-dsh-agent.sh"
+  printf '%s' "$fixture_repo"
+}
 
 # ---- omitted provider preserves the Claude/DeepSeek dispatch path ----
 claude_output="$(printf 'default task\n' | PATH="$TEMP_DIR/bin:$PATH" \
@@ -123,5 +141,35 @@ if invalid_provider_error="$(printf 'task\n' | "$DISPATCH" --provider invalid --
   fail 'dispatch unexpectedly accepted an invalid provider'
 fi
 assert_contains "$invalid_provider_error" '--provider must be claude-deepseek or dsh'
+
+# ---- DSH implementation commits are owned by the manager, never the sandboxed worker ----
+implement_repo="$(prepare_implement_fixture)"
+implement_dispatch="$implement_repo/scripts/dispatch-task.sh"
+implement_base="$(git -C "$implement_repo" branch --show-current)"
+manager_commit_output="$(printf 'implement\n' | PATH="$TEMP_DIR/bin:$PATH" HOME="$TEMP_DIR/home" \
+  PURECUT_WORKTREE_BASE="$TEMP_DIR/implement-worktrees" FAKE_DSH_WRITE_FILE=worker-change.txt \
+  "$implement_dispatch" --provider dsh --issue 101 --task-slug manager-commit --base "$implement_base" --skip-build)"
+manager_worktree="$TEMP_DIR/implement-worktrees/manager-commit"
+assert_contains "$manager_commit_output" 'commit owner: manager'
+assert_not_contains "$manager_commit_output" 'commit result: not-needed'
+[[ "$(git -C "$manager_worktree" log --format=%s -1)" == 'chore: apply DSH worker changes for issue #101' ]] \
+  || fail 'manager did not create the expected DSH commit'
+[[ "$(git -C "$manager_worktree" status --short)" == "" ]] \
+  || fail 'manager-created DSH commit left changes behind'
+
+no_change_output="$(printf 'implement\n' | PATH="$TEMP_DIR/bin:$PATH" HOME="$TEMP_DIR/home" \
+  PURECUT_WORKTREE_BASE="$TEMP_DIR/implement-worktrees" \
+  "$implement_dispatch" --provider dsh --issue 102 --task-slug no-change --base "$implement_base" --skip-build)"
+assert_contains "$no_change_output" 'commit result: not-needed (clean worktree)'
+
+failed_output="$(printf 'implement\n' | PATH="$TEMP_DIR/bin:$PATH" HOME="$TEMP_DIR/home" \
+  PURECUT_WORKTREE_BASE="$TEMP_DIR/implement-worktrees" FAKE_DSH_WRITE_FILE=failed-change.txt FAKE_DSH_EXIT=9 \
+  "$implement_dispatch" --provider dsh --issue 103 --task-slug failed-worker --base "$implement_base" --skip-build)"
+failed_worktree="$TEMP_DIR/implement-worktrees/failed-worker"
+assert_contains "$failed_output" 'commit result: not-attempted (worker failed)'
+[[ "$(git -C "$failed_worktree" log --format=%s -1)" == 'fixture base' ]] \
+  || fail 'failed DSH worker was auto-committed'
+[[ "$(git -C "$failed_worktree" status --short)" == '?? failed-change.txt' ]] \
+  || fail 'failed DSH worker changes were not left for inspection'
 
 printf 'test-dispatch-task: passed\n'

--- a/scripts/test-dsh-agent.sh
+++ b/scripts/test-dsh-agent.sh
@@ -164,10 +164,12 @@ assert_contains "$unreadable_progress_content" '[heartbeat] provider=dsh process
 assert_not_contains "$unreadable_progress_content" '[assistant] provider=dsh'
 
 bounded_progress_log="$TEMP_DIR/bounded.progress.log"
-printf 'task\n' | DSH_EVENT_MAX_CHARS=1 FAKE_DSH_STREAM_EVENTS=true \
+printf 'task\n' | DSH_TOOL_RESULT_MAX_CHARS=1 FAKE_DSH_STREAM_EVENTS=true \
   run_launcher --mode review --worktree "$TEMP_DIR/wt" \
   --progress-log "$bounded_progress_log" >/dev/null
-assert_contains "$(cat "$bounded_progress_log")" '[tool-result] provider=dsh #…'
+bounded_progress_content="$(cat "$bounded_progress_log")"
+assert_contains "$bounded_progress_content" '[tool-result] provider=dsh …'
+assert_contains "$bounded_progress_content" '[assistant] provider=dsh Reading project context now'
 
 # ---- worker failure propagates ----
 if FAKE_DSH_EXIT=7 run_launcher --mode review --worktree "$TEMP_DIR/wt" \


### PR DESCRIPTION
## Summary

- Trim streamed DSH tool-result events to a separate 320-character default while preserving full raw session artifacts.
- Document the linked-worktree Git boundary in the DSH launcher, worker prompt, scripts index, and manager delegation skill.
- Have the dispatcher create one manager-owned commit only after a successful DSH implementation run with changes; preserve failed/no-change worktrees and the existing Claude commit path.
- Cover clipped output plus successful, no-change, and failed DSH manager-commit paths in the harness tests.

Closes #507

## Verification

- `scripts/test-dsh-agent.sh`
- `scripts/test-dispatch-task.sh`
- `scripts/test-claude-deepseek-agent.sh`
- `npm run docs:check`
- `npm run build`
