### PR TITLE
test: assert perf ratios against invariant work, not CPU budgets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,18 +181,31 @@ Always run `npm run build` from the project root to verify changes compile befor
 
 `npm run test:e2e` is a separate PR CI gate, not part of `npm run build`. User-facing UI or workflow changes should add or extend an `e2e/*.smoke.spec.ts` test when the behavior depends on rendered DOM, menu wiring, dialogs, or browser-only boot paths. If lower-level structural tests are sufficient, say so in the PR description so the lack of e2e coverage is deliberate.
 
-### Performance assertions measure CPU time, never wall clock
+### Performance assertions compare against invariant work, never against a millisecond constant
 
-`scripts/run-tests.ts` runs test files in a parallel pool of up to 10 processes, so wall-clock timings vary with unrelated load and cannot distinguish *"the algorithm regressed"* from *"the machine is busy"* — and `build` is a required status check, so a wall-clock assertion intermittently blocks merges. This cost three issues in a week (#383, #386); on the same fixture, wall clock drifted 102ms → 202ms under 8-core saturation while CPU time held 126ms → 112ms.
+`build` is a required status check, so any timing assertion that drifts blocks merges for everyone. Three issues have now been spent here (#383, #386, #508). Each of the first two fixed the *units* and left the *shape* of the assertion alone, and each decayed within weeks. The rule below is the third answer; read the whole of it before writing a timing assertion.
 
-So: measure with `process.cpuUsage()`, take the **minimum** across a few repetitions (contention and GC can only ever add cost), and build the fixture outside the measured region.
+**No absolute millisecond budget survives.** Not in wall clock, and not in CPU time either:
 
-Then pick the comparison to match what the test actually guards — check this before writing the assertion, because the wrong instrument passes against the very regression it exists to catch:
+- Wall clock counts time the process spends descheduled while `scripts/run-tests.ts` runs its pool (`min(10, cores - 2)`), so it moves with unrelated load. This is what #383/#386 diagnosed, correctly.
+- `process.cpuUsage()` fixes only that. It measures **time on CPU, not work done**, so it still moves with the effective clock rate — turbo limits, thermal throttling, SMT sibling contention. Measured for #508 on `classifier.test.ts`, against this project's own test pool: wall clock 569ms → 942ms, CPU time 156ms → 325ms (**2.1x**), while a ratio against invariant work moved 1.16x. An allocation-free reference loop inflated 1.6x in lockstep over the same runs, which rules out GC as the cause.
 
-- **A complexity property → assert the shape of the cost curve.** A ratio between two input sizes is machine-independent, so it neither flakes on a slow runner nor needs revisiting when hardware changes. Reference: `bestNonFittingCpuMs` in `src/engine/toolpaths/arcReconstruction.test.ts`.
-- **A constant factor → assert an absolute CPU budget.** When the guarded work is already in the same complexity class as its regression — a cheap reject that gates expensive per-pair work, say — the ratio barely moves and a ratio assertion is blind. Reference: `bestClassifyCpuMs` in `src/import/classifier.test.ts`, where dropping a bbox gate cost 12x in absolute CPU but moved the ratio only 3.19x → 4.07x, inside the baseline's own run-to-run spread.
+The earlier claim in this section that CPU time "is NOT contention dependent" was wrong, and both budgets written under it had already drifted past their recorded baselines before anyone noticed.
 
-An absolute budget is machine-speed dependent, which is a real cost but a *different* one from the contention flake above. Where you use one, record in the test the measured baseline, the measured regression, and the headroom either side, so the next reader can re-derive the number instead of guessing at it. And verify the assertion actually fails against the regression it guards, by temporarily reintroducing the slow path.
+**So: measure the guarded work against the same code path on a fixture that provably cannot benefit from the optimization being guarded, and assert the ratio.** Both halves then share machine, clock rate, allocator and microarchitecture, so only the optimization itself moves the number. Use `cpuRatio` from [`src/test/cpuRatio.ts`](src/test/cpuRatio.ts); it takes the **minimum** across repetitions, since contention and GC can only ever add cost.
+
+Finding the invariant half is the design work, and it is usually a fixture, not a code change — never add a test-only toggle to production code for this, because if the toggle breaks the ratio silently collapses to 1 and the test passes while measuring nothing. Two worked examples:
+
+| test | guards | subject | invariant reference |
+|---|---|---|---|
+| `classifier.test.ts` | bbox reject gating pairwise nesting | 2,980 **disjoint** rects — gate rejects nearly every pair | 200 **concentric** rects — every bbox pair overlaps, so the gate never rejects |
+| `importBulk.test.ts` | suffix cursor in `createNameAllocator` | 2,980 **repeated** names — every one hits the suffix loop | 2,980 **unique** names — never `taken`, so they return before the loop |
+
+**A ratio between two input sizes is a different instrument, and not this one.** It sees a complexity change but is blind to a constant factor: on the classifier, dropping the bbox gate cost ~10x in absolute CPU but moved the size ratio only 3.19x → 4.07x, inside the baseline's own spread. Use a size ratio only when the property under test genuinely *is* the shape of the cost curve — `bestNonFittingCpuMs` in `src/engine/toolpaths/arcReconstruction.test.ts` is the correct use of it, and needs no change.
+
+Whichever you write, record in the test the measured baseline row, the measured regressed row, and the headroom either side, so the next reader can re-derive the constant instead of guessing at it. Set the threshold at the geometric mid-point of the *worst* pair — highest observed baseline against lowest observed regression — not of the averages.
+
+**Verify by mutation, not by a green run.** Temporarily delete the optimization, confirm the assertion fails, and restore. A perf test that has never been shown to fail against its own regression is not evidence of anything. Check the reference column stayed put across that mutation too: if both columns moved, the reference is contaminated and the ratio understates the regression.
 
 ## Git & Branching
 

--- a/src/import/classifier.test.ts
+++ b/src/import/classifier.test.ts
@@ -23,6 +23,7 @@
 import { classifyImportShapes, inferNestedSolidOperation } from './classifier'
 import type { ImportGeometryMode, ImportedShape } from './types'
 import { polygonProfile, rectProfile } from '../types/project'
+import { cpuRatio } from '../test/cpuRatio'
 
 function assert(cond: boolean, msg: string): void {
   if (!cond) throw new Error('FAIL: ' + msg)
@@ -495,31 +496,21 @@ function test_manual_ambiguous_contact_stays_add(): void {
 }
 
 /**
- * Lowest CPU time, in ms, across `reps` classifications of the same batch.
+ * Concentric rects: every bbox pair overlaps, so `bboxesOverlapOrTouch` can
+ * never reject a pair and the expensive edge-intersection work runs on all of
+ * them regardless of whether that gate exists.
  *
- * Measures CPU time (`process.cpuUsage`) rather than wall clock, because
- * `scripts/run-tests.ts` executes test files in a parallel pool of up to 10
- * processes. Wall clock counts time this process spends descheduled while
- * sibling test files run; CPU time does not. Measured on this fixture:
- *
- *   wall clock   102ms idle  ->  202ms under 8-core saturation
- *   CPU time     126ms idle  ->  112ms under 8-core saturation
- *
- * The previous `elapsedMs < 3_000` wall-clock assertion failed at 3,411ms on
- * unchanged code for exactly that reason.
- *
- * Minimum rather than mean, since contention and GC can only ever add cost.
- * Shapes are built once so fixture allocation stays outside the measured region.
+ * That makes this the invariant half of the ratio below. Kept far smaller than
+ * the subject fixture because the ungated pair scan is ~n^2.1 here: 200 shapes
+ * costs ~120ms, 800 costs ~1.9s.
  */
-function bestClassifyCpuMs(shapes: ImportedShape[], reps = 5): number {
-  let best = Infinity
-  for (let rep = 0; rep < reps; rep += 1) {
-    const before = process.cpuUsage()
-    classifyImportShapes(shapes, 'auto', 'dxf')
-    const delta = process.cpuUsage(before)
-    best = Math.min(best, (delta.user + delta.system) / 1000)
-  }
-  return best
+function concentricRects(count: number): ImportedShape[] {
+  return Array.from({ length: count }, (_, index) => ({
+    name: `concentric-${index}`,
+    sourceType: 'dxf' as const,
+    layerName: null,
+    profile: rectProfile(index * 0.01, index * 0.01, 200 - index * 0.02, 200 - index * 0.02),
+  }))
 }
 
 function test_large_disjoint_dxf_auto_batch_is_bounded(): void {
@@ -529,43 +520,67 @@ function test_large_disjoint_dxf_auto_batch_is_bounded(): void {
     return closedRect(`shape-${index}`, null, column * 20, row * 20, 10, 10)
   })
 
-  // Correctness first; this call also warms the JIT for the measurement below.
+  const reference = concentricRects(200)
+
+  // Correctness first; these calls also warm the JIT for the measurement below.
   const { classified, result } = classifyImportShapes(shapes, 'auto', 'dxf')
   assert(classified.length === shapes.length, 'all disjoint contours classified')
   assert(result.addCount === shapes.length, 'all disjoint contours stay top-level Add')
 
-  // An ABSOLUTE CPU budget, not a scaling ratio — deliberately, and unlike
-  // `bestNonFittingCpuMs` in arcReconstruction.test.ts. What this guards is
-  // that the expensive pairwise work in `buildNestingTree` (edge-intersection
-  // tests, Clipper differences) stays behind its cheap bbox rejects. The pair
-  // scan is quadratic by design, so dropping a bbox gate multiplies the
-  // constant factor without changing the complexity class — which is exactly
-  // what a ratio cannot see. Removing the `bboxesOverlapOrTouch` gate from the
-  // edge-contact loop:
+  const referenceRun = classifyImportShapes(reference, 'auto', 'dxf')
+  assert(referenceRun.classified.length === reference.length, 'reference contours classified')
+
+  // What this guards: the expensive pairwise work in `buildNestingTree`
+  // (edge-intersection tests, Clipper differences) stays behind its cheap bbox
+  // rejects. The pair scan is quadratic by design, so dropping a bbox gate
+  // multiplies the constant factor without changing the complexity class.
   //
-  //                              CPU at 2,980   ratio 1,490 -> 2,980
-  //     current                    142..183ms         3.19x
-  //     bbox gate removed             1374ms          4.07x
+  // Measured as a RATIO against concentric shapes, not an absolute budget.
+  // Every concentric bbox pair overlaps, so `bboxesOverlapOrTouch` never
+  // rejects there and that fixture costs the same with or without the gate —
+  // it is the invariant yardstick. The disjoint fixture is the opposite: the
+  // gate rejects essentially every pair, so it is what the gate makes cheap.
+  // Remove the gate and the subject rises to meet the reference:
   //
-  // The current ratio measured 3.03..3.48x across trials, overlapping the
-  // regressed 4.07x, so a ratio assertion here would be blind. The ~8x gap in
-  // absolute CPU is not. (Removing the `bboxesEqual` gate from the duplicate
-  // loop is far louder still: 52x at n=745, and quadratic from there.)
+  //                        subject (2,980)   reference (200)   subject/reference
+  //     current              150.. 383ms        72..140ms         1.99.. 2.89
+  //     bbox gate removed   1476..3766ms       106..153ms        13.94..24.4
   //
-  // The `current` range is the spread over 12 full `npm test` runs, 8 idle and
-  // 4 under 8-core saturation — the two are indistinguishable, which is the
-  // whole point of measuring CPU. The budget is roughly the geometric
-  // mid-point of the two rows, leaving ~2.5x either way: it holds on a machine
-  // 2.5x slower than this one, and still catches the regression on one 3x
-  // faster. Tradeoff, stated honestly: an absolute
-  // budget is machine-speed dependent in a way a ratio is not. It is NOT
-  // contention dependent, which is the part that made the old wall-clock
-  // assertion flake. If typical hardware outgrows this, re-measure both
-  // columns and retighten — widening on its own only blinds the test.
-  const cpuMs = bestClassifyCpuMs(shapes)
-  console.log(`  2,980 disjoint DXF contours classified in ${cpuMs.toFixed(0)}ms CPU`)
-  assert(cpuMs < 450,
-    `2,980 disjoint DXF contours classified in ${cpuMs.toFixed(0)}ms CPU (budget 450ms) — `
+  // The reference column barely moves between those two rows, which is the
+  // property that makes this work — verify it stayed put if you ever retune the
+  // fixtures. The limit is the geometric mid-point of the *worst* pair (2.89
+  // baseline against 13.94 regressed), so ~2.2x clear either way. Note the
+  // regressed ratio is lowest on a cold machine: thermal load inflates the
+  // subject more than the reference, so contention makes the regression easier
+  // to catch, not harder.
+  //
+  // The baseline range spans a cold machine and a thermally-loaded one. Ratio
+  // spread within one session is ~1.12x; across sessions 1.45x, against 2.55x
+  // for the subject's absolute CPU over the same span. Cancellation is good but
+  // not total — the two halves differ in work mix, the subject being dominated
+  // by bbox rejects and the reference by edge-intersection and Clipper.
+  //
+  // Both halves run the same function on the same machine microseconds apart,
+  // so clock rate cancels: that is the whole point, and it is what the two
+  // previous absolute budgets (#383 wall clock, #386 CPU time) each lacked.
+  // CPU time is NOT contention independent — measured 2.1x inflation under this
+  // project's own test pool, which is what made the 450ms budget flake. See
+  // `src/test/cpuRatio.ts` and AGENTS.md § Build & Verify.
+  //
+  // Not an input-size ratio: at 1,490 -> 2,980 the regression moved the number
+  // only 3.19x -> 4.07x, inside the baseline's own 3.03..3.48x spread. Scaling
+  // ratios see complexity changes, not constant factors.
+  const { ratio, subjectMs, referenceMs } = cpuRatio(
+    { run: () => { classifyImportShapes(shapes, 'auto', 'dxf') } },
+    { run: () => { classifyImportShapes(reference, 'auto', 'dxf') } },
+  )
+  console.log(
+    `  2,980 disjoint DXF contours: ${subjectMs.toFixed(0)}ms CPU vs `
+    + `${referenceMs.toFixed(0)}ms concentric reference (ratio ${ratio.toFixed(2)})`,
+  )
+  assert(ratio < 7,
+    `2,980 disjoint DXF contours cost ${ratio.toFixed(2)}x the concentric reference `
+    + `(limit 7x; ${subjectMs.toFixed(0)}ms vs ${referenceMs.toFixed(0)}ms CPU) — `
     + 'check that pairwise nesting work is still gated by a cheap bbox reject')
 }
 

--- a/src/store/importBulk.test.ts
+++ b/src/store/importBulk.test.ts
@@ -19,6 +19,7 @@ import { rectProfile } from '../types/project'
 import { useProjectStore } from './projectStore'
 import { resolvedProjectFeatures } from './helpers/resolveFeatures'
 import { LARGE_IMPORT_THRESHOLD } from './slices/importMergeSlice'
+import { cpuRatio, type CpuWork } from '../test/cpuRatio'
 
 function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
@@ -61,31 +62,16 @@ function importFixture(count: number, options?: Parameters<typeof makeImport>[1]
 }
 
 /**
- * Lowest CPU time, in ms, across `reps` bulk imports of the same fixture.
- *
- * Measures CPU time (`process.cpuUsage`) rather than wall clock, because
- * `scripts/run-tests.ts` executes test files in a parallel pool of up to 10
- * processes. Wall clock counts time this process spends descheduled while
- * sibling test files run; CPU time does not. Measured on this fixture:
- *
- *   wall clock   15ms idle  ->  33ms under 8-core saturation
- *   CPU time     16ms idle  ->  17ms under 8-core saturation
- *
- * Minimum rather than mean, since contention and GC can only ever add cost.
- * The fixture is built once, and the store reset outside the measured region,
- * so only `importShapes` is timed.
+ * One bulk import of a prebuilt fixture, with the store reset outside the
+ * measured region so only `importShapes` is timed.
  */
-function bestImportCpuMs(count: number, reps = 5): number {
-  const fixture = makeImport(count, { repeatedNames: true })
-  let best = Infinity
-  for (let rep = 0; rep < reps; rep += 1) {
-    resetStore()
-    const before = process.cpuUsage()
-    useProjectStore.getState().importShapes({ fileName: 'synthetic.dxf', sourceType: 'dxf', ...fixture })
-    const delta = process.cpuUsage(before)
-    best = Math.min(best, (delta.user + delta.system) / 1000)
+function importWork(fixture: ReturnType<typeof makeImport>): CpuWork {
+  return {
+    setup: resetStore,
+    run: () => {
+      useProjectStore.getState().importShapes({ fileName: 'synthetic.dxf', sourceType: 'dxf', ...fixture })
+    },
   }
-  return best
 }
 
 function test2980RepeatedNamesBulkImport(): void {
@@ -118,35 +104,44 @@ function test2980RepeatedNamesBulkImport(): void {
   assert(state.selection.selectedNode?.type === 'folder', 'large import selects a folder representative')
   assert(state.history.past.length === historyBefore + 1, 'bulk import records one undo snapshot')
 
-  // An ABSOLUTE CPU budget, not a scaling ratio. What this guards is the
-  // suffix cursor in `createNameAllocator`: without it, every repeated name
-  // rescans from suffix 2, making name allocation quadratic in batch size.
-  // That IS a complexity change, so a ratio can see it in principle — but at
-  // this fixture size the whole import is only tens of ms, and the ratio
-  // measured 1.75..2.67x across trials against a regressed 3.57x, too narrow
-  // a gap to assert on. Measured with the cursor removed:
+  // What this guards is the suffix cursor in `createNameAllocator`: without it,
+  // every repeated name rescans from suffix 2, making name allocation quadratic
+  // in batch size.
   //
-  //                              CPU at 2,980   ratio 1,490 -> 2,980
-  //     current                     17..37ms          2.30x
-  //     suffix cursor removed          306ms          3.57x
+  // Measured as a RATIO against the same import with unique names. A unique
+  // name is never `taken`, so it returns before reaching the suffix loop at all
+  // — that fixture costs the same with or without the cursor, which makes it
+  // the invariant yardstick. Everything else about the two imports is identical:
+  // same count, same profiles, same store writes.
   //
-  // The ~8x gap in absolute CPU is the sharper instrument here. Sizing the
-  // fixture up until a ratio became stable would cost far more suite time than
-  // this test is worth.
+  //                        repeated (2,980)   unique (2,980)   repeated/unique
+  //     current                 22..27ms         18..22ms          1.18.. 1.26
+  //     suffix cursor removed  857..998ms        30..38ms         26.44..28.61
   //
-  // The `current` range is the spread over 12 full `npm test` runs, 8 idle and
-  // 4 under 8-core saturation — the two are indistinguishable, which is the
-  // whole point of measuring CPU. The budget is roughly the geometric
-  // mid-point of the two rows, leaving ~3x either way. Tradeoff, stated
-  // honestly: an absolute budget is machine-speed
-  // dependent in a way a ratio is not. It is NOT contention dependent, which
-  // is the part that made the old `elapsed < 5000` wall-clock assertion a
-  // latent flake.
-  const cpuMs = bestImportCpuMs(2980)
-  assert(cpuMs < 100,
-    `2,980 repeated-name contours imported in ${cpuMs.toFixed(0)}ms CPU (budget 100ms) — `
+  // The reference column stays put across those rows — that is the property to
+  // re-verify if the fixtures are ever retuned. The limit is the geometric
+  // mid-point of the worst pair (1.26 baseline against 26.44 regressed), so
+  // ~4.6x clear either way. The baseline is tight because the two halves differ
+  // only in whether names collide; everything else is identical work.
+  //
+  // Both halves run the same function on the same machine microseconds apart,
+  // so clock rate cancels. That is what the previous absolute budget lacked:
+  // CPU time is not contention independent (measured 2.1x inflation under this
+  // project's own test pool), and at 33..48ms against a 100ms budget this
+  // assertion was already within a whisker of flaking. See `src/test/cpuRatio.ts`
+  // and AGENTS.md § Build & Verify.
+  const { ratio, subjectMs, referenceMs } = cpuRatio(
+    importWork(makeImport(2980, { repeatedNames: true })),
+    importWork(makeImport(2980, { repeatedNames: false })),
+  )
+  console.log(
+    `  2,980 repeated-name contours: ${subjectMs.toFixed(0)}ms CPU vs `
+    + `${referenceMs.toFixed(0)}ms unique-name reference (ratio ${ratio.toFixed(2)})`,
+  )
+  assert(ratio < 6,
+    `2,980 repeated-name contours cost ${ratio.toFixed(2)}x the unique-name reference `
+    + `(limit 6x; ${subjectMs.toFixed(0)}ms vs ${referenceMs.toFixed(0)}ms CPU) — `
     + 'check that repeated-name allocation is still linear in batch size')
-  console.log(`  2,980 repeated-name contours imported in ${cpuMs.toFixed(0)}ms CPU`)
 }
 
 function testThresholdBoundaryAndManyLayers(): void {

--- a/src/test/cpuRatio.ts
+++ b/src/test/cpuRatio.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Performance assertions, measured as a ratio against invariant work.
+ *
+ * Absolute millisecond budgets do not survive in a required status check. Two
+ * earlier attempts (#383, #386) both decayed, and #508 explains why: wall clock
+ * counts time spent descheduled, and `process.cpuUsage()` — which fixes that —
+ * still measures *time on CPU*, not work done. Time on CPU moves with the
+ * effective clock rate, so turbo limits, thermal throttling and SMT contention
+ * all inflate it. Measured on the fixture in `classifier.test.ts`, against this
+ * project's own `npm test` pool:
+ *
+ *     wall clock          569ms -> 942ms   (the #383/#386 failure)
+ *     CPU time            156ms -> 325ms   (2.1x — the #508 failure)
+ *     ratio vs invariant work        1.16x
+ *
+ * So measure the guarded work against **the same code path on a fixture that
+ * cannot benefit from the optimization being guarded**. Both halves then share
+ * machine, clock rate, allocator and microarchitecture, and only the
+ * optimization itself moves the number. A ratio between two *input sizes* is a
+ * different instrument: it sees a complexity change but is blind to a constant
+ * factor, so it does not fit here — see `AGENTS.md` for which to reach for.
+ *
+ * Minimum rather than mean, since contention and GC can only ever add cost.
+ * Build fixtures outside the callbacks so allocation stays out of the measured
+ * region, and call each once beforehand to warm the JIT.
+ */
+
+export interface CpuWork {
+  /** The measured region. Keep fixture allocation out of it. */
+  run: () => void
+  /** Runs before each rep, outside the measured region — store resets and such. */
+  setup?: () => void
+  reps?: number
+}
+
+/** Lowest CPU time, in ms, that `work.run` takes across its reps. */
+export function bestCpuMs(work: CpuWork, defaultReps = 5): number {
+  const reps = work.reps ?? defaultReps
+  let best = Infinity
+  for (let rep = 0; rep < reps; rep += 1) {
+    work.setup?.()
+    const before = process.cpuUsage()
+    work.run()
+    const delta = process.cpuUsage(before)
+    best = Math.min(best, (delta.user + delta.system) / 1000)
+  }
+  return best
+}
+
+/**
+ * Cost of `subject` expressed in units of `reference`.
+ *
+ * `reference` must exercise the same code path as `subject` on a fixture that
+ * provably bypasses the optimization under test, so that removing the
+ * optimization moves `subject` and leaves `reference` alone. Verify that by
+ * deleting the optimization and re-measuring: if both columns move, the
+ * reference is contaminated and the ratio understates the regression.
+ */
+export function cpuRatio(
+  subject: CpuWork,
+  reference: CpuWork,
+): { ratio: number; subjectMs: number; referenceMs: number } {
+  const subjectMs = bestCpuMs(subject, 5)
+  const referenceMs = bestCpuMs(reference, 3)
+  return { ratio: subjectMs / referenceMs, subjectMs, referenceMs }
+}


### PR DESCRIPTION
Closes #508.

Third pass at a perf assertion that keeps blocking merges (#383, #386). Both
earlier passes fixed the *units* and left the *shape* of the assertion alone,
which is why each decayed within weeks.

## Why CPU time was not enough

`process.cpuUsage()` measures **time on CPU, not work done**. It survives being
descheduled — the #383/#386 diagnosis, which was correct — but still moves with
the effective clock rate: turbo limits, thermal throttling, SMT contention.
Measured on the classifier fixture against this project's own `npm test` pool:

| instrument | idle | under the pool | inflation |
|---|---|---|---|
| wall clock | — | 569 → 942ms | blows up (#383/#386) |
| CPU time | 156–211ms | 181–325ms | **2.1x** (#508) |
| ratio vs invariant work | 0.385–0.410 | 0.387–0.448 | **1.16x** |

An allocation-free reference loop inflated 1.6x in lockstep over the same runs,
which rules out GC as the cause.

Both budgets had already drifted past their recorded baselines before this PR:
`classifier` documented 142–183ms but measured 163–244ms pooled and up to 772ms
standalone, against a 450ms limit; `importBulk` documented 17–37ms but measured
33–48ms against a 100ms limit — 48 × 2.1 ≈ 101ms, i.e. already over the line
whenever two worktree test pools overlap.

## What replaces them

Measure the guarded work against **the same code path on a fixture that cannot
benefit from the optimization**, and assert the ratio. Both halves then share
machine, clock rate, allocator and microarchitecture.

| test | subject | invariant reference |
|---|---|---|
| `classifier` | 2,980 disjoint rects — gate rejects nearly every pair | 200 concentric rects — every bbox pair overlaps, so the gate never rejects |
| `importBulk` | 2,980 repeated names — every one hits the suffix loop | 2,980 unique names — never `taken`, so they return before the loop |

Finding the invariant half is a *fixture* choice, deliberately not a test-only
toggle in production code: a toggle that silently broke would collapse the ratio
to 1 and the test would pass while measuring nothing.

## Verified by mutation, not by a green run

Each optimization was deleted for real, measured, and restored:

| | baseline | regressed | limit | margin |
|---|---|---|---|---|
| `classifier` | 1.99–2.89 | 13.94–24.4 | 7 | 2.4x / 2.0x |
| `importBulk` | 1.18–1.26 | 26.44–30.66 | 6 | 4.8x / 4.4x |

The reference column stayed put across both mutations (114–153ms and 18–38ms),
confirming it is genuinely invariant — if it had moved, the ratio would
understate the regression.

Under the real test pool, five consecutive full-suite runs measured 2.21–2.63
and 1.35–1.93. All green.

## AGENTS.md

The section claimed CPU time "is NOT contention dependent", which is what
licensed both budgets. Corrected with the measured 2.1x, and it now distinguishes
two instruments that the old text conflated:

- an **input-size ratio** sees a complexity change but is blind to a constant
  factor (dropping the bbox gate cost ~10x in CPU but moved the size ratio only
  3.19x → 4.07x, inside the baseline spread) — this is why absolute budgets were
  reached for, and that reasoning was sound;
- a **calibration ratio** against invariant work keeps the full signal.

`arcReconstruction.test.ts` uses an input-size ratio to guard a genuine
complexity property. That is the correct instrument there and it is unchanged.

## Notes

- New helper `src/test/cpuRatio.ts`, so the next perf assertion has one path to
  follow rather than a hand-rolled budget.
- Thresholds are set from this machine (i7-8850H). They should be
  machine-independent by construction, and the margins are wide, but the ratios
  are logged on every run — worth a glance at the first few `ubuntu-latest` runs
  to confirm the baseline lands where expected.
- No lint rule or CI tooling to catch future absolute budgets, and no sweep of
  other tests, per the issue's out-of-scope note.
