### PR TITLE
Make DSH live tail incremental and bounded

### DIFF
--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -19,7 +19,7 @@ available; do not treat one-off diagnostics as normal quality gates.
 
 - [`dispatch-task.sh`](dispatch-task.sh), [`finish-task.sh`](finish-task.sh), and [`worker-status.sh`](worker-status.sh) — provider-neutral integration-manager worktree lifecycle. `claude-deepseek` remains the default provider; select `--provider dsh` for DeepSeek Harness. `dispatch-task.sh --handoff REPO_PATH` gives either provider a compact bootstrap to read a tracked in-worktree handoff; direct stdin is reserved for a small instruction.
 - [`run-claude-deepseek-agent.sh`](run-claude-deepseek-agent.sh) — credential-backed Claude/DeepSeek leaf launcher.
-- [`run-dsh-agent.sh`](run-dsh-agent.sh) and [`dsh-progress-filter.jq`](dsh-progress-filter.jq) — DeepSeek Harness leaf launcher and live session-event filter. They use DSH's own credential store and sandbox modes, tail observed assistant/tool/tool-result records into the manager log, and leave the full raw session under `~/.dsh`.
+- [`run-dsh-agent.sh`](run-dsh-agent.sh) and [`dsh-progress-filter.jq`](dsh-progress-filter.jq) — DeepSeek Harness leaf launcher and incremental live session-event filter. They use DSH's own credential store and sandbox modes, tail newly appended observed assistant/tool/tool-result records into the manager log, and leave the full raw session under `~/.dsh`.
 - [`claude-deepseek-agent-prompt.md`](claude-deepseek-agent-prompt.md) — bounded provider-neutral worker prompt template (historic filename retained for compatibility).
 - [`test-claude-deepseek-agent.sh`](test-claude-deepseek-agent.sh), [`test-dsh-agent.sh`](test-dsh-agent.sh), [`test-dispatch-task.sh`](test-dispatch-task.sh), and [`worker-progress-filter.jq`](worker-progress-filter.jq) — harness tests and Claude progress filtering.
 

--- a/scripts/dsh-progress-filter.jq
+++ b/scripts/dsh-progress-filter.jq
@@ -1,21 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # dsh-progress-filter.jq — distill DSH session JSONL records into observed,
-# one-line manager-progress events. run-dsh-agent.sh repeatedly decodes DSH's
-# growing session artifact and de-duplicates records by sequence number.
+# one-line manager-progress events. run-dsh-agent.sh decodes newly appended
+# zstd frames and de-duplicates records by sequence number as a safety net.
 #
 # Output is: sequence<TAB>event-kind<TAB>normalized-payload
-
-def one_line:
-  tostring | gsub("[\r\n\t]+"; " ") | gsub(" +"; " ");
 
 def excerpt($limit):
   if length > $limit then .[0:($limit - 1)] + "…" else . end;
 
+def one_line($limit):
+  tostring
+  | excerpt($limit)
+  | gsub("[\r\n\t]+"; " ")
+  | gsub(" +"; " ");
+
 def assistant_text:
   [.data.message.content[]? | select(.type == "text") | .text // empty]
   | join(" ")
-  | one_line;
+  | one_line($event_max_chars);
 
 def tool_result_text:
   [.data.message.content[]?
@@ -24,11 +27,12 @@ def tool_result_text:
    | select(.type == "text")
    | .text // empty]
   | join(" ")
-  | one_line;
+  | one_line($tool_result_max_chars);
 
 inputs
 | fromjson? // empty
 | select(type == "object" and (.seq | type == "number"))
+| select(.seq > $last_event_seq)
 | if .type == "assistant/message" then
     assistant_text as $text
     | select($text != "")
@@ -36,12 +40,12 @@ inputs
   elif .type == "tool/call" then
     [ .seq,
       "tool",
-      (((.data.name // "unknown") + " " + (.data.arguments // "")) | one_line)
+      (((.data.name // "unknown") + " " + (.data.arguments // "")) | one_line($event_max_chars))
     ] | @tsv
   elif .type == "tool/result" then
     tool_result_text as $text
     | select($text != "")
-    | [.seq, "tool-result", ($text | excerpt($tool_result_max_chars))] | @tsv
+    | [.seq, "tool-result", $text] | @tsv
   else
     empty
   end

--- a/scripts/run-dsh-agent.sh
+++ b/scripts/run-dsh-agent.sh
@@ -122,12 +122,13 @@ result_file="$(mktemp -t run-dsh-agent-result)"
 stderr_file="$(mktemp -t run-dsh-agent-stderr)"
 session_snapshot_file="$(mktemp -t run-dsh-agent-sessions)"
 decoded_events_file="$(mktemp -t run-dsh-agent-events)"
+tail_segment_file="$(mktemp -t run-dsh-agent-segment)"
 worker_pid=""
 cleanup() {
   if [[ -n "$worker_pid" ]] && kill -0 "$worker_pid" 2>/dev/null; then
     kill "$worker_pid" 2>/dev/null || true
   fi
-  rm -f "$result_file" "$stderr_file" "$session_snapshot_file" "$decoded_events_file"
+  rm -f "$result_file" "$stderr_file" "$session_snapshot_file" "$decoded_events_file" "$tail_segment_file"
 }
 trap cleanup EXIT INT TERM
 : > "$progress_log"
@@ -155,7 +156,8 @@ fi
 tail_enabled=true
 tail_state="waiting"
 tail_artifact=""
-last_artifact_size=""
+tail_cursor=0
+tail_cursor_needs_recovery=false
 last_event_seq=0
 
 if ! command -v zstd >/dev/null 2>&1; then
@@ -171,15 +173,6 @@ elif [[ ! -f "$DSH_PROGRESS_FILTER" ]]; then
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$progress_log"
   tail_enabled=false
 fi
-
-clip_event_payload() {
-  local payload="$1"
-  if (( ${#payload} > event_max_chars )); then
-    printf '%s…' "${payload:0:event_max_chars}"
-  else
-    printf '%s' "$payload"
-  fi
-}
 
 find_session_artifact() {
   local -a new_sessions=()
@@ -211,8 +204,62 @@ find_session_artifact() {
   return 1
 }
 
+append_decoded_events() {
+  local seq event_kind payload
+
+  while IFS=$'\t' read -r seq event_kind payload; do
+    [[ "$seq" =~ ^[0-9]+$ ]] || continue
+    (( seq > last_event_seq )) || continue
+    printf '%s [%s] provider=dsh %s\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$event_kind" "$payload" >> "$progress_log"
+    last_event_seq="$seq"
+  done < "$decoded_events_file"
+}
+
+decode_observed_events() {
+  local source="$1"
+
+  if ! zstd -dc "$source" 2>/dev/null \
+      | jq -nRr --unbuffered \
+        --argjson event_max_chars "$event_max_chars" \
+        --argjson tool_result_max_chars "$tool_result_max_chars" \
+        --argjson last_event_seq "$last_event_seq" \
+        -f "$DSH_PROGRESS_FILTER" > "$decoded_events_file"; then
+    return 1
+  fi
+  append_decoded_events
+}
+
+copy_artifact_segment() {
+  local start_byte="$1"
+  local byte_count="$2"
+  local copied_size
+
+  # Bound the read to the size observed before copying. If DSH appends during
+  # this pipeline, head may close tail early; verify the captured size instead
+  # of treating tail's SIGPIPE as an artifact failure.
+  tail -c "+$((start_byte + 1))" "$tail_artifact" 2>/dev/null \
+    | head -c "$byte_count" > "$tail_segment_file" || true
+  copied_size="$(stat -f '%z' "$tail_segment_file" 2>/dev/null \
+    || stat -c '%s' "$tail_segment_file" 2>/dev/null)" || return 1
+  [[ "$copied_size" == "$byte_count" ]]
+}
+
+tail_full_artifact() {
+  local artifact_size
+
+  [[ -f "$tail_artifact" ]] || return 0
+  artifact_size="$(stat -f '%z' "$tail_artifact" 2>/dev/null \
+    || stat -c '%s' "$tail_artifact" 2>/dev/null)" || return 0
+  if ! decode_observed_events "$tail_artifact"; then
+    return 0
+  fi
+  tail_cursor="$artifact_size"
+  tail_cursor_needs_recovery=false
+}
+
 tail_observed_events() {
-  local artifact_size seq event_kind payload
+  local artifact_size append_size
 
   [[ "$tail_enabled" == true ]] || return 0
   if [[ -z "$tail_artifact" ]] && ! find_session_artifact; then
@@ -222,23 +269,27 @@ tail_observed_events() {
 
   artifact_size="$(stat -f '%z' "$tail_artifact" 2>/dev/null \
     || stat -c '%s' "$tail_artifact" 2>/dev/null)" || return 0
-  [[ "$artifact_size" != "$last_artifact_size" ]] || return 0
+  if (( artifact_size < tail_cursor )); then
+    printf '%s [tail] provider=dsh artifact-truncated; restarting cursor\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$progress_log"
+    tail_cursor=0
+  fi
+  append_size=$((artifact_size - tail_cursor))
+  (( append_size > 0 )) || return 0
 
-  if ! zstd -dc "$tail_artifact" 2>/dev/null \
-      | jq -nRr --unbuffered --argjson tool_result_max_chars "$tool_result_max_chars" \
-        -f "$DSH_PROGRESS_FILTER" > "$decoded_events_file"; then
+  if ! copy_artifact_segment "$tail_cursor" "$append_size"; then
+    tail_cursor_needs_recovery=true
     return 0
   fi
-  last_artifact_size="$artifact_size"
-
-  while IFS=$'\t' read -r seq event_kind payload; do
-    [[ "$seq" =~ ^[0-9]+$ ]] || continue
-    (( seq > last_event_seq )) || continue
-    payload="$(clip_event_payload "$payload")"
-    printf '%s [%s] provider=dsh %s\n' \
-      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$event_kind" "$payload" >> "$progress_log"
-    last_event_seq="$seq"
-  done < "$decoded_events_file"
+  if ! decode_observed_events "$tail_segment_file"; then
+    # DSH may be midway through appending a zstd frame. Keep the cursor in
+    # place so the next poll replays this segment; sequence filtering prevents
+    # duplicates if the decoder emitted complete preceding frames first.
+    tail_cursor_needs_recovery=true
+    return 0
+  fi
+  tail_cursor="$artifact_size"
+  tail_cursor_needs_recovery=false
 }
 
 run_dsh >"$result_file" 2>"$stderr_file" &
@@ -266,6 +317,11 @@ worker_status=$?
 set -e
 worker_pid=""
 tail_observed_events
+if [[ "$tail_cursor_needs_recovery" == true ]]; then
+  printf '%s [tail] provider=dsh final-recovery=full-decode\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$progress_log"
+  tail_full_artifact
+fi
 cat "$result_file"
 cat "$stderr_file" >&2
 printf '%s [exit] provider=dsh worker exited code=%s\n' \

--- a/scripts/test-dsh-agent.sh
+++ b/scripts/test-dsh-agent.sh
@@ -48,15 +48,20 @@ if [[ "${FAKE_DSH_STREAM_EVENTS:-}" == true ]]; then
   cat > "$session_root/session-stream-$stream_id/session.jsonl.zstd" <<'JSON'
 {"type":"assistant/message","seq":10,"data":{"message":{"content":[{"type":"reasoning","text":"internal reasoning must stay hidden"},{"type":"text","text":"Reading project context\nnow"}]}}}
 JSON
-  sleep 2
+  sleep 1
   cat >> "$session_root/session-stream-$stream_id/session.jsonl.zstd" <<'JSON'
 {"type":"tool/call","seq":11,"data":{"name":"read_file","arguments":"{\"path\":\"INDEX.md\"}"}}
 JSON
-  sleep 2
+  sleep 1
   cat >> "$session_root/session-stream-$stream_id/session.jsonl.zstd" <<'JSON'
 {"type":"tool/result","seq":12,"data":{"message":{"content":[{"type":"tool-result","content":[{"type":"text","text":"# INDEX\nScripts overview"}]}]}}}
 JSON
-  sleep 2
+  sleep 1
+  if [[ "${FAKE_DSH_FINAL_EVENT:-}" == true ]]; then
+    cat >> "$session_root/session-stream-$stream_id/session.jsonl.zstd" <<'JSON'
+{"type":"assistant/message","seq":13,"data":{"message":{"content":[{"type":"text","text":"Final worker response"}]}}}
+JSON
+  fi
 fi
 if [[ "${FAKE_DSH_AMBIGUOUS:-}" == true ]]; then
   session_path="${PWD#/}"
@@ -78,6 +83,14 @@ cat > "$TEMP_DIR/bin/zstd" <<'EOF'
 set -euo pipefail
 [[ "$1" == "-dc" ]] || exit 2
 [[ "${FAKE_ZSTD_FAIL:-}" != true ]] || exit 1
+if [[ "${FAKE_ZSTD_FAIL_ONCE:-}" == true && ! -f "${FAKE_ZSTD_FAIL_ONCE_STATE:?}" ]]; then
+  touch "$FAKE_ZSTD_FAIL_ONCE_STATE"
+  exit 1
+fi
+if [[ -n "${FAKE_ZSTD_INPUT_LOG:-}" ]]; then
+  cat "$2" >> "$FAKE_ZSTD_INPUT_LOG"
+  printf '%s\n' '-- zstd input boundary --' >> "$FAKE_ZSTD_INPUT_LOG"
+fi
 cat "$2"
 EOF
 chmod +x "$TEMP_DIR/bin/dsh"
@@ -133,7 +146,9 @@ assert_contains "$progress_content" '[exit] provider=dsh worker exited code=0'
 
 # ---- session artifacts stream observed text, tool calls, and tool results ----
 stream_progress_log="$TEMP_DIR/stream.progress.log"
+stream_input_log="$TEMP_DIR/stream.zstd-input.log"
 printf 'task\n' | DSH_HEARTBEAT_SECONDS=1 FAKE_DSH_STREAM_EVENTS=true \
+  FAKE_ZSTD_INPUT_LOG="$stream_input_log" \
   run_launcher --mode review --worktree "$TEMP_DIR/wt" \
   --progress-log "$stream_progress_log" >/dev/null
 stream_progress_content="$(cat "$stream_progress_log")"
@@ -143,6 +158,27 @@ assert_contains "$stream_progress_content" '[tool-result] provider=dsh # INDEX S
 assert_not_contains "$stream_progress_content" 'internal reasoning must stay hidden'
 [[ "$(grep -F -c '[tool] provider=dsh read_file' "$stream_progress_log")" -eq 1 ]] \
   || fail 'repeated session decodes duplicated the tool event'
+[[ "$(grep -F -c '"seq":10' "$stream_input_log")" -eq 1 ]] \
+  || fail 'incremental tail re-decoded the first session record'
+
+# ---- a failed segment decode retries from the same cursor ----
+retry_progress_log="$TEMP_DIR/retry.progress.log"
+retry_state_file="$TEMP_DIR/zstd-failed-once"
+printf 'task\n' | DSH_HEARTBEAT_SECONDS=1 FAKE_DSH_STREAM_EVENTS=true \
+  FAKE_ZSTD_FAIL_ONCE=true FAKE_ZSTD_FAIL_ONCE_STATE="$retry_state_file" \
+  run_launcher --mode review --worktree "$TEMP_DIR/wt" \
+  --progress-log "$retry_progress_log" >/dev/null
+retry_progress_content="$(cat "$retry_progress_log")"
+[[ -f "$retry_state_file" ]] || fail 'the injected decode failure did not run'
+assert_contains "$retry_progress_content" '[assistant] provider=dsh Reading project context now'
+
+# ---- the post-exit drain captures an event written immediately before exit ----
+final_progress_log="$TEMP_DIR/final.progress.log"
+printf 'task\n' | DSH_HEARTBEAT_SECONDS=1 FAKE_DSH_STREAM_EVENTS=true FAKE_DSH_FINAL_EVENT=true \
+  run_launcher --mode review --worktree "$TEMP_DIR/wt" \
+  --progress-log "$final_progress_log" >/dev/null
+final_progress_content="$(cat "$final_progress_log")"
+assert_contains "$final_progress_content" '[assistant] provider=dsh Final worker response'
 
 # ---- ambiguous artifacts retain heartbeat-only fallback ----
 ambiguous_progress_log="$TEMP_DIR/ambiguous.progress.log"
@@ -170,6 +206,19 @@ printf 'task\n' | DSH_TOOL_RESULT_MAX_CHARS=1 FAKE_DSH_STREAM_EVENTS=true \
 bounded_progress_content="$(cat "$bounded_progress_log")"
 assert_contains "$bounded_progress_content" '[tool-result] provider=dsh …'
 assert_contains "$bounded_progress_content" '[assistant] provider=dsh Reading project context now'
+
+# ---- filter discards emitted sequences and bounds before whitespace cleanup ----
+filter_input="$(jq -cn \
+  --arg oversized_text "start$(printf '%*s' 10000 '')end" \
+  '[
+    {type: "assistant/message", seq: 14, data: {message: {content: [{type: "text", text: "already emitted"}]}}},
+    {type: "assistant/message", seq: 15, data: {message: {content: [{type: "text", text: $oversized_text}]}}}
+  ][]')"
+filter_output="$(printf '%s\n' "$filter_input" \
+  | jq -nRr --argjson event_max_chars 32 --argjson tool_result_max_chars 16 --argjson last_event_seq 14 \
+    -f "$SCRIPT_DIR/dsh-progress-filter.jq")"
+assert_not_contains "$filter_output" 'already emitted'
+assert_contains "$filter_output" $'15\tassistant\tstart …'
 
 # ---- worker failure propagates ----
 if FAKE_DSH_EXIT=7 run_launcher --mode review --worktree "$TEMP_DIR/wt" \


### PR DESCRIPTION
## Summary

- Decode only DSH session bytes appended after the last successful cursor, with a final full-drain fallback when a cursor segment cannot be decoded.
- Discard already-emitted event sequences in jq and truncate assistant, tool-call, and tool-result payloads before whitespace normalization.
- Add coverage for incremental input, retry after a failed segment decode, terminal output, and bounded whitespace-heavy payloads.

Closes #513

## Verification

- `bash scripts/test-dsh-agent.sh`
- `bash scripts/build-summary.sh` (passed: docs, lint, typecheck, 179 test files, Vite build)
