### PR TITLE
docs: archive the issue #518 execution ledger

### DIFF
--- a/planning/INDEX.md
+++ b/planning/INDEX.md
@@ -31,7 +31,6 @@ architecture contracts.
 - [REGION_FEATURE_SEMANTICS.md](REGION_FEATURE_SEMANTICS.md) — regions as machining filters rather than material or standalone targets.
 - [TROCHOIDAL_EDGE_DESIGN.md](TROCHOIDAL_EDGE_DESIGN.md) — trochoidal Edge Route roughing: guide-domain fragmentation, the clearance budget, and the pipeline stages it must bypass.
 - [INTEGRATION_HANDOFF_TEMPLATE.md](INTEGRATION_HANDOFF_TEMPLATE.md) — optional execution-ledger template for explicitly delegated, multi-slice work.
-- [ISSUE_518_INTEGRATION_HANDOFF.md](ISSUE_518_INTEGRATION_HANDOFF.md) — active execution ledger for issue #518 (per-operation toolpath cache invalidation) on `perf/issue-518-toolpath-cache`.
 - [ISSUE_498_INTEGRATION_HANDOFF.md](ISSUE_498_INTEGRATION_HANDOFF.md) — engagement-estimator domain contract and active execution ledger for issue #498 (cutter engagement model) on `feat/issue-498-engagement`.
 - [ISSUE_468_INTEGRATION_HANDOFF.md](ISSUE_468_INTEGRATION_HANDOFF.md) — active execution ledger for issue #468 (bulk tab and clamp editing) on `feat/issue-468-bulk-tabs-clamps`.
 - [ISSUE_414_INTEGRATION_HANDOFF.md](ISSUE_414_INTEGRATION_HANDOFF.md) — active execution ledger for issue #414 (smooth tabs) on `feat/issue-414-smooth-tabs`.

--- a/planning/archive/ISSUE_518_INTEGRATION_HANDOFF.md
+++ b/planning/archive/ISSUE_518_INTEGRATION_HANDOFF.md
@@ -1,6 +1,6 @@
 ---
-status: current
-authoritative-for: delegated execution ledger for issue #518 (per-operation toolpath cache invalidation)
+status: Done
+authoritative-for: nothing — completed execution ledger, retained as the review record for issue #518 (delivered by PR #525)
 last-verified: 2026-08-15
 ---
 


### PR DESCRIPTION
Closes #530

`planning/ISSUE_518_INTEGRATION_HANDOFF.md` landed on `main` still describing itself
as an **active** execution ledger on `perf/issue-518-toolpath-cache` — a branch
deleted when #525 merged — and `planning/INDEX.md` linked it as active.
`planning/INDEX.md`'s own rule puts completed execution ledgers in `archive/`.

## Changes

- `git mv planning/ISSUE_518_INTEGRATION_HANDOFF.md planning/archive/`
- removed its entry from `planning/INDEX.md`
- frontmatter now `status: Done`, and `authoritative-for` disclaims authority and
  names the delivering PR, so the document is self-describing once out of the index

**No content was rewritten.** The slice-by-slice review record is the reason to keep
it — including the non-target-subtract measurements that became #526 and the probe
caution that goes with them.

## Full lane, and why

`npm run check:fast-lane` says **2657 changed lines / 25**:

```
planning/INDEX.md                                  +0     -1     = 1
planning/ISSUE_518_INTEGRATION_HANDOFF.md          +0     -1328  = 1328
planning/archive/ISSUE_518_INTEGRATION_HANDOFF.md  +1328  -0     = 1328
```

The check counts with `git diff --numstat --no-renames`, so a pure move is a full
delete plus a full add even though not one line of content differs. Plan written
into #530 and approved before implementation, per the full-lane rule. No
`fast-lane` label.

Worth noting for later, not changed here: this makes *any* file move full-lane
regardless of content. That is defensible — the budget exists to keep unreviewed
change small, and rename detection can be fooled by a move-plus-rewrite — but if
archiving ledgers becomes routine it will hit this every time.

## Verification

`npm run build` green (187 test files); `docs:check` is part of it and validates the
index, reporting 59 active docs / 15 planning references after the move.
