### PR TITLE
fix(e2e): feedColours slots-only test — pin fixture slot feed to 100%

### DIFF
--- a/e2e/feedColours.smoke.spec.ts
+++ b/e2e/feedColours.smoke.spec.ts
@@ -56,6 +56,14 @@ function resolvedRectProfile(cx: number, cy: number, w: number, h: number) {
  * emits no scaled moves at all, so its cuts must stay a single colour.
  * `slotPercent` varies the engagement ladder's slot feed (issue #498 S5): the
  * emitted rungs and the legend both derive from it.
+ *
+ * The slots-only variant pins its slot feed to 100% explicitly: an unset
+ * `pocketSlotFeedPercent` is normalized to the app default of 60% on load
+ * (issue #524), which makes the engine stamp its full-width slot stretches
+ * with a scaled feed — real product behaviour, but not the "no scaled moves"
+ * contract this variant exists to pin. 100% is the engine's no-feed anchor
+ * (`resolveSlotFeedScale` returns null there), so the move stream carries no
+ * feed scales and toggling feed colours must not change the canvas.
  */
 function buildFeedColoursProjectJson(mode: 'slots_only' | 'engagement', slotPercent = 40): string {
   const now = '2026-01-01T00:00:00.000Z'
@@ -163,7 +171,7 @@ function buildFeedColoursProjectJson(mode: 'slots_only' | 'engagement', slotPerc
         pocketAngle: 0,
         ...(mode === 'engagement'
           ? { pocketSlotFeedPercent: slotPercent, pocketFeedReduction: 'engagement' }
-          : { pocketFeedReduction: 'slots_only' }),
+          : { pocketSlotFeedPercent: 100, pocketFeedReduction: 'slots_only' }),
         roundOutsideCorners: false,
         stockToLeaveRadial: 0,
         stockToLeaveAxial: 0,
@@ -286,12 +294,7 @@ test.describe('Feed-coloured toolpath smoke', () => {
     }, { timeout: 10000 }).toBeGreaterThanOrEqual(2)
   })
 
-  // Known failure, tracked in #524: the vacuous-pass guard at the end of this
-  // test times out, which means the colour equality it protects is currently
-  // passing without constraining anything. `fixme` rather than `fail` on
-  // purpose — the assertion is a canvas-pixel poll, so it is timing-sensitive
-  // and `test.fail` would be flaky in the opposite direction.
-  test.fixme('slots-only pocket renders cut segments in exactly one colour with the toggle on', async ({ app, ui }) => {
+  test('slots-only pocket renders cut segments in exactly one colour with the toggle on', async ({ app, ui }) => {
     await seedProject(app.page, SLOTS_ONLY_FIXTURE_JSON)
 
     const panel = ui.toolpathVis.sketchPanel(app.page)


### PR DESCRIPTION
Closes #524.

## Problem

`e2e/feedColours.smoke.spec.ts` — *"slots-only pocket renders cut segments in exactly one colour with the toggle on"* — was annotated `fixme` because it failed on `main`. Un-fixing it on `main` (`3648d3c`) showed the failure has moved: the vacuous-pass guard now works (cut pixels are sampled), and the colour equality at line 316 fails instead — toggling feed colours changes the canvas.

## Root cause

The fixture's premise ("slots-only cuts carry no feed scale") is stale. The slots-only variant left `pocketSlotFeedPercent` unset, and `normalizeOperation` fills the app default of **60%** on load (since #498's `e5c1c68`). With a slot feed in force, the engine legitimately stamps full-width slot stretches with `feedScale 0.6`, and the feed-colour toggle paints them at the slowest rung — the canvas changes, the equality fails. (The original `6aae5fc` symptom — guard timing out on an empty sample — was the toolpath-cache timing gap, since fixed by #518.)

## Fix

The fixture's "no scaled moves" contract is pinned explicitly: the slots-only variant now sets `pocketSlotFeedPercent: 100` — the engine's documented no-feed anchor (`resolveSlotFeedScale` returns null), so the move stream carries no feed scales, toggling feed colours changes nothing, and the cuts-visibility guard keeps the equality non-vacuous. `test.fixme` and its #524 comment are removed.

## Verification

- `PURECUT_E2E_PORT=1443 PURECUT_E2E_ISOLATED=1 npx playwright test e2e/feedColours.smoke.spec.ts --workers=1` — 3/3 pass (pre-fix: equality failed, +3 ramp-colour groups).
- `npm run build` green (187 test files).
- `npm run check:fast-lane` eligible: 1 test file changed, exempt from counts.