### PR TITLE
feat: join a qualifying selection without the confirmation panel

### DIFF
--- a/e2e/canvasWorkflowPanel.smoke.spec.ts
+++ b/e2e/canvasWorkflowPanel.smoke.spec.ts
@@ -21,6 +21,7 @@ import {
   startJoinFeatures,
   startRotateFeature,
   getKeepOriginals,
+  getFeatureCount,
 } from './helpers'
 import { seedOverlapFeatureProject } from './overlapFeatureSelection.helpers'
 
@@ -132,7 +133,10 @@ test('rotate panel collapses its all-false fragment body', async ({ app }) => {
 
 test('K toggles keep originals on the join panel', async ({ app }) => {
   await seedOverlapFeatureProject(app.page, 2)
-  await startJoinFeatures(app.page, ['f-overlap-1', 'f-overlap-2'])
+  // One feature only. Since issue #522 a selection of both would qualify and
+  // join outright, leaving no panel to toggle — the fixture's two features are
+  // coincident full-stock rects, i.e. exactly the qualifying case.
+  await startJoinFeatures(app.page, ['f-overlap-1'])
 
   const panel = app.page.locator('.canvas-workflow-panel--join')
   await expect(panel).toBeVisible()
@@ -154,4 +158,16 @@ test('K toggles keep originals on the join panel', async ({ app }) => {
   // Modifier combinations stay free for the app's own bindings.
   await app.page.keyboard.press('Meta+k')
   await expect(checkbox).not.toBeChecked()
+})
+
+test('a qualifying selection joins with no panel at all (issue #522)', async ({ app }) => {
+  await seedOverlapFeatureProject(app.page, 2)
+  expect(await getFeatureCount(app.page)).toBe(2)
+
+  await startJoinFeatures(app.page, ['f-overlap-1', 'f-overlap-2'])
+
+  // The selection had already answered the panel's only question, so the join
+  // runs outright and the originals are consumed into one feature.
+  await expect.poll(() => getFeatureCount(app.page)).toBe(1)
+  await expect(app.page.locator('.canvas-workflow-panel--join')).toHaveCount(0)
 })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -159,7 +159,12 @@ if (import.meta.env.DEV) {
       const { useProjectStore } = await _pcTestStore()
       return useProjectStore.getState().project.features.length
     },
-    /** Selects the given features and opens the Join workflow panel. */
+    /**
+     * Selects the given features and invokes Join. Since issue #522 that either
+     * joins them outright (selection already qualifies) or opens the Join
+     * workflow panel — pass a selection that cannot qualify, e.g. a single
+     * feature, when the panel itself is what's under test.
+     */
     startJoinFeatures: async (ids: string[]) => {
       const { useProjectStore } = await _pcTestStore()
       useProjectStore.getState().selectFeatures(ids)

--- a/src/store/INDEX.md
+++ b/src/store/INDEX.md
@@ -37,6 +37,7 @@ Zustand store. The single source of truth for the current `.camj` project. **All
   - `featureRoles.ts` — single source of truth for feature roles (issue #199): isMachinable/isRegion/isConstruction/isSolid predicates, modelFeatures() CSG gate, and sectionForOperation tree sectioning. Use these instead of `operation !== 'region'` checks. `isSolid` (issue #270) returns true only for add/subtract/model — the base-solid invariant gate.
   - `geometry.ts` — geometric utilities (bounds, transforms)
   - `transform.ts` — point/profile/clamp/tab translation, rotation, mirroring, and affine transforms; arc→bezier conversion
+  - `shapeActionEligibility.ts` — shared join/cut selection eligibility (issue #522): `selectionQualifiesForImmediateJoin` decides whether a selection has already said enough to skip the join confirmation panel, `selectionQualifiesAsCutCutter` whether one selected feature is an unambiguous cutter. Every clause exists so the shortcut drops no member of the selection; anything failing falls back to the panel unchanged
   - `vcarveTargets.ts` — shared V-carve target eligibility predicate (issue #270 S2): `isVCarveCompatibleFeature` is the single source of truth for "can this feature be a V-carve machining target?"; used by UI hints, compatible selection, CAM panel validation, persisted target validation, and fallback target selection
   - `referenceTransforms.ts` — feature/backdrop resize, rotate, mirror from reference geometry; corner fillet radius and application
   - `modelAssets.ts` — imported model (STL) asset normalization, storage deduplication, and feature classification
@@ -73,6 +74,7 @@ Zustand store. The single source of truth for the current `.camj` project. **All
 - `geometryFidelity.test.ts` — per-FeatureKind × transform-class resolveProfile fidelity, edit round-trip, duplicate-as-reference, per-kind store transforms
 - `helpers/clipping.test.ts` — join-connectivity predicates (issue #271): shared-edge, corner-contact, disjoint, overlap, and hole-forming union cases for featuresOverlap and the grouping helpers
 - `instanceTransforms.test.ts` — instance transform matrix composition
+- `joinImmediate.test.ts` — skipping the confirmation panel for a qualifying selection (issue #522): the immediate join and its single undo step, the cut cutter-phase skip, and the fallback matrix proving every non-qualifying selection (partial group, open, locked, text, model, mixed operation, one or none selected) still opens the panel with nothing dropped
 - `joinSharedEdge.test.ts` — store-level join of edge-adjacent closed features (issue #271): grouping, session click-to-add, merge result, keepOriginals
 - `linkedConstraintResolve.test.ts` — linked constraint re-solve through resolved instances after definition edits; direct-edit regression; no-drift idempotency
 - `lineTopZFromEnclosingFeature.test.ts` — Line `z_top` inheritance from the smallest enclosing solid (issue #351): subtract floor / add top, nested innermost wins, on-wall inheritance, construction keeps default, store wiring for closed primitives, open polylines, and open composites

--- a/src/store/helpers/shapeActionEligibility.ts
+++ b/src/store/helpers/shapeActionEligibility.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shape-action (join / cut) selection eligibility — the single source of truth
+ * for "has the selection already said enough to skip the workflow panel?"
+ * (issue #522).
+ *
+ * The join panel does two different jobs. With no group selected it is a
+ * *picking mode*: clicking shapes on canvas builds the group. With the group
+ * already selected it is only a *confirmation*, and that is the half an
+ * external report asked us to drop — "if I've already decided that I want to
+ * unite two shapes, why do I still get asked whether I want to unite two
+ * shapes?"
+ *
+ * Every clause below exists so the shortcut does exactly what confirming the
+ * panel at its defaults would have done, and **drops nothing**. Anything that
+ * fails falls back to the panel unchanged, so no capability is removed — the
+ * panel is short-circuited, never replaced.
+ *
+ * Both predicates must stay in this file. Join is reachable from the toolbar,
+ * the feature-tree context menu, keyboard commands, and the e2e test hooks; a
+ * rule re-spelled per call site would drift.
+ */
+
+import type { Project } from '../../types/project'
+import { featuresFormConnectedOverlapGroup } from './clipping'
+import { resolveFeatureInstances } from './resolveFeatures'
+
+/**
+ * True when `featureIds` can be joined immediately, with no confirmation panel.
+ *
+ * Requires, in order:
+ * 1. at least two features — one shape is a picking session, not a join;
+ * 2. every id resolves — a stale id would silently shrink the operation;
+ * 3. every profile closed — `mergeSelectedFeatures` filters open profiles out,
+ *    so an open member would vanish with no prompt;
+ * 4. nothing locked — matches the feature-tree context menu, which already
+ *    disables Join on a locked selection;
+ * 5. no text feature and no imported model — the union discards the text/mesh
+ *    identity and leaves a plain profile, which is too surprising to do silently;
+ * 6. one shared operation — the union inherits the first feature's operation, so
+ *    a mixed add/subtract selection silently reassigns roles. This also subsumes
+ *    the tree-section rule: same operation implies same section;
+ * 7. one connected overlap group — `startJoinSelectedFeatures` otherwise narrows
+ *    to the *largest* connected group, so a selection with a stray member is a
+ *    partial qualification and must keep its confirmation.
+ */
+export function selectionQualifiesForImmediateJoin(project: Project, featureIds: string[]): boolean {
+  if (featureIds.length < 2) {
+    return false
+  }
+
+  const features = resolveFeatureInstances(project, featureIds)
+  if (features.length !== featureIds.length) {
+    return false
+  }
+
+  if (features.some((feature) => !feature.sketch.profile.closed || feature.locked)) {
+    return false
+  }
+
+  if (features.some((feature) => feature.kind === 'text' || feature.operation === 'model')) {
+    return false
+  }
+
+  const operation = features[0].operation
+  if (features.some((feature) => feature.operation !== operation)) {
+    return false
+  }
+
+  return featuresFormConnectedOverlapGroup(features)
+}
+
+/**
+ * True when `featureIds` unambiguously names the cutter for a cut, letting the
+ * flow open straight on target selection instead of re-asking for cutters.
+ *
+ * Deliberately limited to a single feature. With two or more selected, which
+ * ones are cutters and which are targets is genuinely ambiguous — the two cut
+ * paths in the store already disagree (`startCutSelectedFeatures` treats the
+ * whole selection as cutters, `cutSelectedFeatures` treats the last as the
+ * cutter and the rest as targets) — so that case keeps the cutter phase.
+ *
+ * The cut itself is never skipped: targets cannot be inferred from a selection
+ * that was consumed as the cutter.
+ */
+export function selectionQualifiesAsCutCutter(project: Project, featureIds: string[]): boolean {
+  if (featureIds.length !== 1) {
+    return false
+  }
+
+  const features = resolveFeatureInstances(project, featureIds)
+  return features.length === 1 && !features[0].locked
+}

--- a/src/store/joinImmediate.test.ts
+++ b/src/store/joinImmediate.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Skipping the confirmation panel when the selection already qualifies
+ * (issue #522).
+ *
+ * Two halves, and the second matters more than the first:
+ *
+ * - a qualifying selection joins outright, in one undoable step;
+ * - **every** non-qualifying selection still opens the panel, and no member of
+ *   the selection is silently dropped on either path. The dangerous shape here
+ *   is a *partial* qualification: `startJoinSelectedFeatures` narrows to the
+ *   largest connected group, so auto-joining a selection with a stray member
+ *   would consume the rest and quietly leave the stray behind.
+ *
+ * Run with: npx tsx src/store/joinImmediate.test.ts
+ */
+
+import {
+  IDENTITY_MATRIX,
+  newProject,
+  rectProfile,
+  type FeatureDefinition,
+  type FeatureInstance,
+  type FeatureKind,
+  type FeatureOperation,
+  type Project,
+} from '../types/project'
+import { useProjectStore } from './projectStore'
+import type { ProjectStore } from './types'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+let passed = 0
+let failed = 0
+
+function test(name: string, fn: () => void): void {
+  try {
+    fn()
+    passed += 1
+    console.log(`   ✓ ${name}`)
+  } catch (err: unknown) {
+    failed += 1
+    const msg = err instanceof Error ? err.message : String(err)
+    console.log(`   ✗ ${name}: ${msg}`)
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+interface RectOptions {
+  operation?: FeatureOperation
+  kind?: FeatureKind
+  locked?: boolean
+  closed?: boolean
+}
+
+function resetStore(): void {
+  useProjectStore.setState({
+    project: newProject(),
+    selection: { selectedFeatureIds: [], selectedTabIds: [], selectedClampIds: [] },
+    pendingShapeAction: null,
+    history: { past: [], future: [], transactionStart: null },
+  } as unknown as Partial<ProjectStore>)
+}
+
+/** Add a strict instance + canonical definition via direct state mutation. */
+function addRect(id: string, x: number, y: number, w: number, h: number, options: RectOptions = {}): void {
+  const profile = rectProfile(x, y, w, h)
+  const definition: FeatureDefinition = {
+    id: `def-${id}`,
+    kind: options.kind ?? 'rect',
+    profile: options.closed === false ? { ...profile, closed: false } : profile,
+    dimensions: [],
+    text: options.kind === 'text' ? { text: 'Hi', style: 'outline', font: 'simple_stroke', size: 10 } : null,
+    stl: null,
+    operation: options.operation ?? 'add',
+  } as FeatureDefinition
+  const feature: FeatureInstance = {
+    id,
+    name: id,
+    definitionId: `def-${id}`,
+    transform: { ...IDENTITY_MATRIX },
+    constraints: [],
+    folderId: null,
+    z_top: 5,
+    z_bottom: 0,
+    visible: true,
+    locked: options.locked ?? false,
+  }
+
+  const state = useProjectStore.getState()
+  useProjectStore.setState({
+    project: {
+      ...state.project,
+      features: [...state.project.features, feature],
+      featureDefinitions: { ...state.project.featureDefinitions, [`def-${id}`]: definition },
+    },
+  } as unknown as Partial<ProjectStore>)
+}
+
+function selectFeatures(ids: string[]): void {
+  useProjectStore.setState({
+    selection: {
+      ...useProjectStore.getState().selection,
+      selectedFeatureIds: ids,
+      selectedFeatureId: ids.at(-1) ?? null,
+      selectedNode: ids.length > 0 ? { type: 'feature', featureId: ids[ids.length - 1] } : null,
+      mode: 'feature',
+      activeControl: null,
+    },
+  } as unknown as Partial<ProjectStore>)
+}
+
+function getProject(): Project {
+  return useProjectStore.getState().project
+}
+
+function featureIds(): string[] {
+  return getProject().features.map((feature) => feature.id)
+}
+
+function joinPanelIds(): string[] | null {
+  const pending = useProjectStore.getState().pendingShapeAction
+  return pending?.kind === 'join' ? pending.entityIds : null
+}
+
+/** Two overlapping rects that qualify on every clause. */
+function seedQualifyingPair(options: RectOptions = {}): void {
+  resetStore()
+  addRect('a', 0, 0, 10, 10, options)
+  addRect('b', 5, 0, 10, 10, options)
+  selectFeatures(['a', 'b'])
+}
+
+/** Asserts the panel opened and nothing was merged. */
+function assertPanelOpened(reason: string): void {
+  assert(joinPanelIds() !== null, `${reason}: the join panel must still open`)
+  assert(featureIds().includes('a'), `${reason}: originals must survive`)
+  assert(featureIds().includes('b'), `${reason}: originals must survive`)
+}
+
+// ────────────────────────────────────────────────────────────────────
+
+console.log('\nJoin — skip the confirmation panel for a qualifying selection (issue #522)')
+
+test('a qualifying selection joins outright, with no panel', () => {
+  seedQualifyingPair()
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  assert(joinPanelIds() === null, 'no join panel may be left pending')
+  const ids = featureIds()
+  assert(ids.length === 1, `originals must be replaced by one merged feature, got ${ids.length}`)
+  assert(!ids.includes('a') && !ids.includes('b'), `originals must be consumed, got ${ids.join(',')}`)
+  assert(
+    useProjectStore.getState().selection.selectedFeatureIds.join(',') === ids[0],
+    'the merged feature must be left selected',
+  )
+})
+
+test('the immediate join is a single undo step', () => {
+  seedQualifyingPair()
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+  useProjectStore.getState().undo()
+
+  const ids = featureIds().sort()
+  assert(ids.join(',') === 'a,b', `one undo must restore both originals, got ${ids.join(',')}`)
+})
+
+test('a partially qualifying selection keeps its panel and drops nothing', () => {
+  resetStore()
+  addRect('a', 0, 0, 10, 10)
+  addRect('b', 5, 0, 10, 10)
+  addRect('stray', 100, 100, 10, 10)
+  selectFeatures(['a', 'b', 'stray'])
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  const panelIds = joinPanelIds()
+  assert(panelIds !== null, 'a selection with a disconnected member must open the panel')
+  assert(panelIds.length === 2, `the panel must narrow to the connected group, got ${panelIds.join(',')}`)
+  const ids = featureIds().sort()
+  assert(ids.join(',') === 'a,b,stray', `nothing may be merged behind the prompt, got ${ids.join(',')}`)
+})
+
+test('one selected feature still opens the picking mode', () => {
+  resetStore()
+  addRect('a', 0, 0, 10, 10)
+  addRect('b', 5, 0, 10, 10)
+  selectFeatures(['a'])
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  assert(joinPanelIds()?.join(',') === 'a', 'a single selection must start a join session, not a join')
+  assert(featureIds().length === 2, 'nothing may be merged from a one-feature selection')
+})
+
+test('no selection opens the picking mode', () => {
+  resetStore()
+  addRect('a', 0, 0, 10, 10)
+  addRect('b', 5, 0, 10, 10)
+  selectFeatures([])
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  assert(joinPanelIds()?.length === 0, 'pressing Join with nothing selected must start an empty join session')
+  assert(featureIds().length === 2, 'nothing may be merged from an empty selection')
+})
+
+// Defence in depth: an open member also fails the connectivity clause, since
+// `featuresOverlap` rejects open profiles outright. The explicit closed check
+// stays because the reason it matters — `mergeSelectedFeatures` silently
+// filters open profiles out — is about the merge, not about connectivity, and
+// should not depend on a second helper keeping that property.
+test('an open profile in the selection keeps the panel', () => {
+  seedQualifyingPair()
+  addRect('open', 5, 0, 10, 10, { closed: false })
+  selectFeatures(['a', 'b', 'open'])
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  assert(joinPanelIds() !== null, 'an open member would be silently filtered by the merge — keep the prompt')
+  assert(featureIds().includes('open'), 'the open feature must survive')
+})
+
+test('a locked feature keeps the panel', () => {
+  seedQualifyingPair({ locked: true })
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  assertPanelOpened('locked selection')
+})
+
+test('a text feature keeps the panel', () => {
+  seedQualifyingPair({ kind: 'text' })
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  assertPanelOpened('text selection')
+})
+
+test('imported model features keep the panel', () => {
+  seedQualifyingPair({ operation: 'model' })
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  assertPanelOpened('model selection')
+})
+
+test('a mixed add/subtract selection keeps the panel', () => {
+  resetStore()
+  addRect('a', 0, 0, 10, 10, { operation: 'add' })
+  addRect('b', 5, 0, 10, 10, { operation: 'subtract' })
+  selectFeatures(['a', 'b'])
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  assertPanelOpened('mixed-operation selection')
+})
+
+test('a shared non-add operation still qualifies', () => {
+  seedQualifyingPair({ operation: 'subtract' })
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  assert(joinPanelIds() === null, 'two subtract features are unambiguous and must join outright')
+  const merged = getProject().features
+  assert(merged.length === 1, `expected one merged feature, got ${merged.length}`)
+  assert(
+    getProject().featureDefinitions[merged[0].definitionId].operation === 'subtract',
+    'the merged feature must keep the shared operation',
+  )
+})
+
+test('the panel path still merges when it is confirmed', () => {
+  resetStore()
+  addRect('a', 0, 0, 10, 10)
+  addRect('b', 5, 0, 10, 10)
+  addRect('stray', 100, 100, 10, 10)
+  selectFeatures(['a', 'b', 'stray'])
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+  const created = useProjectStore.getState().completePendingShapeAction()
+
+  assert(created.length === 1, `confirming the panel must still merge, got ${created.length}`)
+  const ids = featureIds().sort()
+  assert(ids.join(',') === `${created[0]},stray`, `only the group may be consumed, got ${ids.join(',')}`)
+})
+
+console.log('\nCut — skip the cutter phase for an unambiguous cutter (issue #522)')
+
+test('one selected feature opens cut on target selection', () => {
+  resetStore()
+  addRect('a', 0, 0, 10, 10)
+  addRect('b', 5, 0, 10, 10)
+  selectFeatures(['a'])
+
+  useProjectStore.getState().startCutSelectedFeatures()
+
+  const pending = useProjectStore.getState().pendingShapeAction
+  assert(pending?.kind === 'cut', 'cut must be pending')
+  assert(pending.phase === 'targets', `an unambiguous cutter must skip the cutter phase, got ${pending.phase}`)
+  assert(pending.cutterIds.join(',') === 'a', `the selection must become the cutter, got ${pending.cutterIds.join(',')}`)
+})
+
+test('two selected features keep the cutter phase', () => {
+  resetStore()
+  addRect('a', 0, 0, 10, 10)
+  addRect('b', 5, 0, 10, 10)
+  selectFeatures(['a', 'b'])
+
+  useProjectStore.getState().startCutSelectedFeatures()
+
+  const pending = useProjectStore.getState().pendingShapeAction
+  assert(pending?.kind === 'cut', 'cut must be pending')
+  assert(pending.phase === 'cutters', 'cutter-vs-target is ambiguous with two selected — keep the phase')
+})
+
+test('a locked feature keeps the cutter phase', () => {
+  resetStore()
+  addRect('a', 0, 0, 10, 10, { locked: true })
+  selectFeatures(['a'])
+
+  useProjectStore.getState().startCutSelectedFeatures()
+
+  const pending = useProjectStore.getState().pendingShapeAction
+  assert(pending?.kind === 'cut', 'cut must be pending')
+  assert(pending.phase === 'cutters', 'a locked cutter must not be locked in')
+})
+
+test('no selection opens cut on the cutter phase', () => {
+  resetStore()
+  addRect('a', 0, 0, 10, 10)
+  selectFeatures([])
+
+  useProjectStore.getState().startCutSelectedFeatures()
+
+  const pending = useProjectStore.getState().pendingShapeAction
+  assert(pending?.kind === 'cut', 'cut must be pending')
+  assert(pending.phase === 'cutters', 'with nothing selected the cutter phase is the whole point')
+})
+
+// ── Results ─────────────────────────────────────────────────────────
+
+console.log(`\n${passed} passed, ${failed} failed${failed > 0 ? ' ❌' : ' ✓'}\n`)
+
+if (failed > 0) throw new Error(`${failed} test(s) failed`)

--- a/src/store/joinSharedEdge.test.ts
+++ b/src/store/joinSharedEdge.test.ts
@@ -131,11 +131,16 @@ function joinEntityIds(): string[] {
 
 console.log('\nJoin — closed features sharing a line segment (issue #271)')
 
+// Since issue #522 a selection of only these two would join outright, so the
+// grouping and panel-confirmation tests below carry a disconnected `far` rect
+// to keep the panel in play. `far` never joins the group, so every assertion
+// about the a+b union is unchanged.
 test('startJoinSelectedFeatures groups edge-adjacent rects', () => {
   resetStore()
   addRectFeature('a', 'Left', 0, 0, 10, 10)
   addRectFeature('b', 'Right', 10, 0, 10, 10)
-  selectFeatures(['a', 'b'])
+  addRectFeature('far', 'Far', 100, 100, 10, 10)
+  selectFeatures(['a', 'b', 'far'])
 
   useProjectStore.getState().startJoinSelectedFeatures()
 
@@ -147,7 +152,8 @@ test('completePendingShapeAction merges edge-adjacent rects into one feature', (
   resetStore()
   addRectFeature('a', 'Left', 0, 0, 10, 10)
   addRectFeature('b', 'Right', 10, 0, 10, 10)
-  selectFeatures(['a', 'b'])
+  addRectFeature('far', 'Far', 100, 100, 10, 10)
+  selectFeatures(['a', 'b', 'far'])
 
   useProjectStore.getState().startJoinSelectedFeatures()
   const createdIds = useProjectStore.getState().completePendingShapeAction()
@@ -156,10 +162,34 @@ test('completePendingShapeAction merges edge-adjacent rects into one feature', (
   const project = getProject()
   assert(!project.features.find((feature) => feature.id === 'a'), 'original a must be consumed')
   assert(!project.features.find((feature) => feature.id === 'b'), 'original b must be consumed')
+  assert(project.features.find((feature) => feature.id === 'far'), 'a feature outside the group must be untouched')
 
   const merged = resolveFeatureInstance(project, createdIds[0])
   assert(merged, 'merged feature must exist in the project')
   assert(merged.sketch.profile.closed, 'merged profile must be closed')
+  const bounds = getProfileBounds(merged.sketch.profile)
+  assert(
+    bounds.minX === 0 && bounds.minY === 0 && bounds.maxX === 20 && bounds.maxY === 10,
+    `merged outline must span the combined rect, got ${JSON.stringify(bounds)}`,
+  )
+})
+
+// The same #271 geometry on the path that is now the default: shared-edge
+// adjacency counts as connected, so the pair qualifies and joins with no panel.
+test('edge-adjacent rects join outright when both are selected', () => {
+  resetStore()
+  addRectFeature('a', 'Left', 0, 0, 10, 10)
+  addRectFeature('b', 'Right', 10, 0, 10, 10)
+  selectFeatures(['a', 'b'])
+
+  useProjectStore.getState().startJoinSelectedFeatures()
+
+  assert(useProjectStore.getState().pendingShapeAction === null, 'no join panel may be left pending')
+  const project = getProject()
+  assert(project.features.length === 1, `originals must be replaced by one feature, got ${project.features.length}`)
+
+  const merged = resolveFeatureInstance(project, project.features[0].id)
+  assert(merged, 'merged feature must exist in the project')
   const bounds = getProfileBounds(merged.sketch.profile)
   assert(
     bounds.minX === 0 && bounds.minY === 0 && bounds.maxX === 20 && bounds.maxY === 10,

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -225,7 +225,7 @@ export const useProjectStore = create<ProjectStore>((rawSet, get) => {
   ...createSelectionSlice(set, get, {
     normalizeProject,
   }),
-  ...createPendingActionsSlice(set),
+  ...createPendingActionsSlice(set, get),
   ...createPendingCompletionSlice(set, get, {
     clearStaleConstraints,
     propagateConstraintsOnTranslate: (features, offsets) =>

--- a/src/store/slices/pendingActionsSlice.ts
+++ b/src/store/slices/pendingActionsSlice.ts
@@ -19,6 +19,7 @@ import type { Clamp, Project, Tab } from '../../types/project'
 import { largestConnectedOverlapGroup } from '../helpers/clipping'
 import { selectedClosedFeaturesFromIds } from '../helpers/derivedFeatures'
 import { nextPlacementSession } from '../helpers/ids'
+import { selectionQualifiesAsCutCutter, selectionQualifiesForImmediateJoin } from '../helpers/shapeActionEligibility'
 import type { ProjectStore } from '../types'
 import { resolveFeatureInstance, type ResolvedSketchFeature } from '../helpers/resolveFeatures'
 
@@ -70,6 +71,7 @@ function tabById(project: Project, id: string): Tab | null {
 
 export function createPendingActionsSlice(
   set: Parameters<StateCreator<ProjectStore>>[0],
+  get: Parameters<StateCreator<ProjectStore>>[1],
 ): PendingActionsSlice {
   return {
     pendingMove: null,
@@ -307,7 +309,22 @@ export function createPendingActionsSlice(
         }
       }),
 
-    startJoinSelectedFeatures: () =>
+    // Issue #522: a selection that already qualifies has answered the panel's
+    // only question, so join it outright. The panel still opens for everything
+    // else — including a selection that only *partially* qualifies, where the
+    // grouping below would quietly drop the members that don't fit.
+    startJoinSelectedFeatures: () => {
+      const state = get()
+      if (selectionQualifiesForImmediateJoin(state.project, state.selection.selectedFeatureIds)) {
+        set({ pendingAdd: null, sketchEditSession: null })
+        // mergeSelectedFeatures returns [] *before* it touches state when the
+        // union can't be rebuilt into a profile, so falling through to the
+        // panel leaves the user with a live workflow rather than a dead click.
+        if (get().mergeSelectedFeatures(false).length > 0) {
+          return
+        }
+      }
+
       set((s) => {
         const allClosed = selectedClosedFeaturesFromIds(s.project, s.selection.selectedFeatureIds)
         const connectedGroup = largestConnectedOverlapGroup(allClosed)
@@ -330,19 +347,24 @@ export function createPendingActionsSlice(
             activeControl: null,
           },
         }
-      }),
+      })
+    },
 
+    // Issue #522: one selected feature is an unambiguous cutter, so open on
+    // target selection rather than re-asking for the cutter. The cut itself is
+    // never skipped — targets can't be inferred from the cutter's selection.
     startCutSelectedFeatures: () =>
       set((s) => {
         const cutterIds = s.selection.selectedFeatureIds
           .filter((id) => s.project.features.some((f) => f.id === id))
+        const phase = selectionQualifiesAsCutCutter(s.project, cutterIds) ? 'targets' : 'cutters'
 
         return {
           pendingAdd: null,
           pendingMove: null,
           pendingTransform: null,
           pendingOffset: null,
-          pendingShapeAction: { kind: 'cut', cutterIds, targetIds: [], phase: 'cutters', keepOriginals: false, session: nextPlacementSession() },
+          pendingShapeAction: { kind: 'cut', cutterIds, targetIds: [], phase, keepOriginals: false, session: nextPlacementSession() },
           sketchEditSession: null,
           selection: {
             ...s.selection,


### PR DESCRIPTION
Closes #522

## What changed

Join no longer asks for confirmation when the selection has already answered the question. From @oscarcarserud: *"if I've already decided that I want to unite two shapes, why do I still get asked whether I want to unite two shapes?"*

The join panel was doing two different jobs. With no group selected it is a **picking mode** — clicking shapes on canvas builds the group. With the group already selected it is only a **confirmation**. This drops the second job and keeps the first intact.

- **Join** — a qualifying selection merges outright, no panel.
- **Cut** — opens on target selection when exactly one feature is selected. The cut itself still needs the panel, because targets can't be inferred from a selection that was consumed as the cutter. With ≥2 selected, which are cutters and which are targets is genuinely ambiguous — the two cut paths in the store already disagree on that — so that case keeps the cutter phase.
- **Offset** — untouched. Its panel asks for a distance; that's input, not confirmation, and nothing in a selection supplies it.

## "Qualify"

One shared predicate, `src/store/helpers/shapeActionEligibility.ts`, in the style of `helpers/vcarveTargets.ts`. The check lives in the store rather than the UI so the toolbar, the feature-tree context menu, keyboard commands and the e2e test hooks can't drift apart.

Every clause is there to guarantee the shortcut does what confirming the panel at its defaults would have done, and **drops nothing**: at least two features, all resolving, all closed, none locked, no text feature or imported model, one shared operation, and one connected overlap group.

That last clause is the one that matters most. `startJoinSelectedFeatures` narrows to the *largest* connected group, so a selection with a stray member is only a **partial** qualification — auto-joining there would consume the rest and quietly leave the stray behind. It keeps its prompt instead.

Anything that fails falls back to today's panel unchanged. The panel is short-circuited, never replaced, so no capability is removed.

## Undo

`mergeSelectedFeatures` already pushed exactly one history entry inside a single `set()`, so the immediate join is a single Ctrl+Z. There's a test for it rather than an assumption.

## Trade-off

With ≥2 qualifying shapes selected you can no longer *enter* join mode to click-add a third; you get the join. Escape hatches: undo, or press Join with ≤1 selected — the picking mode is unchanged and still admits shapes by clicking.

## Verification

`npm run build` green (docs, lint, `check:e2e-lanes`, typecheck, 188 unit files, vite). Full `test:e2e:project-input` lane green, 71 passed, on an isolated server (`PURECUT_E2E_PORT=1445 PURECUT_E2E_ISOLATED=1`).

**Verified by mutation, not by a green run.** Each clause was broken on purpose and the run confirmed a specific test catches it:

| clause broken | test that failed |
| --- | --- |
| connectivity forced true | `a partially qualifying selection keeps its panel and drops nothing` |
| ≥2 minimum removed | `no selection opens the picking mode` |
| locked check removed | `a locked feature keeps the panel` |
| text/model check removed | `a text feature keeps the panel`, `imported model features keep the panel` |
| shared-operation check removed | `a mixed add/subtract selection keeps the panel` |
| both cut length guards dropped | `two selected features keep the cutter phase` |
| predicate disabled entirely | the new e2e case (`getFeatureCount` stayed at 2) |

Two mutations were initially too weak to change behaviour and were redone until they did. One finding worth recording: the **closed-profile** clause is subsumed by the connectivity clause, since `featuresOverlap` rejects open profiles outright, so no mutation of it alone can fail a test. It is kept as defence in depth and the redundancy is documented at the test — the reason it matters (`mergeSelectedFeatures` silently filters open profiles) is about the merge, not about connectivity, and shouldn't depend on a second helper preserving that property.

## Tests that had to change

Three existing tests asserted on a panel for selections that now qualify and join outright. None were deleted or weakened:

- `src/store/joinSharedEdge.test.ts` (issue #271 grouping + panel merge) — both keep their assertions and gain a disconnected third rect so the panel is still in play, which also proves a feature outside the group is untouched. A third test adds the same shared-edge geometry on the path that is now the default.
- `e2e/canvasWorkflowPanel.smoke.spec.ts` (`K toggles keep originals`) — selects one feature instead of two. The fixture's two features are coincident full-stock rects, i.e. exactly the qualifying case, so the panel would never have opened.

No new i18n strings — nothing new is rendered.
