### PR TITLE
fix(ui): feed-colour legend shows only emitted scales and hides when off

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -5,7 +5,8 @@ Covers DOM render + menu→action wiring. Does **NOT** assert geometry or
 WebGL canvas contents — those are owned by `npm test`. One deliberate
 exception: `feedColours.smoke.spec.ts` samples 2D canvas pixels, because
 the feed-colour ramp (issue #498) is a rendering contract that only pixels
-can prove.
+can prove; it also asserts the data-driven feed-colour legend via DOM
+selectors (issue #535), the other half of that contract.
 
 ## Quick start
 

--- a/e2e/feedColours.smoke.spec.ts
+++ b/e2e/feedColours.smoke.spec.ts
@@ -64,13 +64,57 @@ function resolvedRectProfile(cx: number, cy: number, w: number, h: number) {
  * contract this variant exists to pin. 100% is the engine's no-feed anchor
  * (`resolveSlotFeedScale` returns null there), so the move stream carries no
  * feed scales and toggling feed colours must not change the canvas.
+ *
+ * Since #535 the legend is data-driven: it prints the union of the (scale,
+ * step) pairs actually emitted by the toolpaths in the preview — a slots-only
+ * pocket at 60% contributes its single slot rung, an engagement pocket its
+ * ladder, and a mixed preview both, independent of selection. The legend
+ * renders only while feed colours are on.
  */
-function buildFeedColoursProjectJson(mode: 'slots_only' | 'engagement', slotPercent = 40): string {
+interface PocketOperationFixture {
+  id: string
+  name: string
+  mode: 'slots_only' | 'engagement'
+  slotPercent: number
+}
+
+function pocketOperationJson({ id, name, mode, slotPercent }: PocketOperationFixture): Record<string, unknown> {
+  return {
+    id,
+    name,
+    kind: 'pocket',
+    pass: 'rough',
+    enabled: true,
+    showToolpath: true,
+    debugToolpath: false,
+    target: { source: 'features', featureIds: ['f-machinable-subtract'] },
+    toolRef: 'tool-1',
+    stepdown: 0.1,
+    stepover: 0.125,
+    feed: 60,
+    plungeFeed: 30,
+    rpm: 18000,
+    pocketPattern: 'offset',
+    pocketAngle: 0,
+    ...(mode === 'engagement'
+      ? { pocketSlotFeedPercent: slotPercent, pocketFeedReduction: 'engagement' }
+      : { pocketSlotFeedPercent: slotPercent, pocketFeedReduction: 'slots_only' }),
+    roundOutsideCorners: false,
+    stockToLeaveRadial: 0,
+    stockToLeaveAxial: 0,
+    finishWalls: false,
+    finishFloor: false,
+    carveDepth: 0,
+    maxCarveDepth: 0,
+  }
+}
+
+function feedColoursProjectJson(label: string, operations: Record<string, unknown>[]): string {
   const now = '2026-01-01T00:00:00.000Z'
   return JSON.stringify({
     version: '3.0',
     meta: {
-      name: `Feed Colours ${mode} Fixture`,
+      name: `Feed Colours ${label} Fixture`,
       created: now,
       modified: now,
       units: 'inch',
@@ -151,44 +195,47 @@ function buildFeedColoursProjectJson(mode: 'slots_only' | 'engagement', slotPerc
         maxCutDepth: 1,
       },
     ],
-    operations: [
-      {
-        id: 'op-pocket-a',
-        name: 'Pocket A',
-        kind: 'pocket',
-        pass: 'rough',
-        enabled: true,
-        showToolpath: true,
-        debugToolpath: false,
-        target: { source: 'features', featureIds: ['f-machinable-subtract'] },
-        toolRef: 'tool-1',
-        stepdown: 0.1,
-        stepover: 0.125,
-        feed: 60,
-        plungeFeed: 30,
-        rpm: 18000,
-        pocketPattern: 'offset',
-        pocketAngle: 0,
-        ...(mode === 'engagement'
-          ? { pocketSlotFeedPercent: slotPercent, pocketFeedReduction: 'engagement' }
-          : { pocketSlotFeedPercent: 100, pocketFeedReduction: 'slots_only' }),
-        roundOutsideCorners: false,
-        stockToLeaveRadial: 0,
-        stockToLeaveAxial: 0,
-        finishWalls: false,
-        finishFloor: false,
-        carveDepth: 0,
-        maxCarveDepth: 0,
-      },
-    ],
+    operations,
     tabs: [],
     clamps: [],
     ai_history: [],
   })
 }
 
+function buildFeedColoursProjectJson(mode: 'slots_only' | 'engagement', slotPercent = 40): string {
+  return feedColoursProjectJson(mode, [
+    pocketOperationJson({
+      id: 'op-pocket-a',
+      name: 'Pocket A',
+      mode,
+      slotPercent: mode === 'engagement' ? slotPercent : 100,
+    }),
+  ])
+}
+
+/** A slots-only pocket with an explicit slot feed below 100% — the classic
+ *  path stamps its full-width slot stretches with exactly this scale, so the
+ *  legend must show this single rung next to full feed. */
+function buildSlotsOnlyAtSlotFeedProjectJson(slotPercent: number): string {
+  return feedColoursProjectJson(`slots_only_${slotPercent}`, [
+    pocketOperationJson({ id: 'op-pocket-a', name: 'Pocket A', mode: 'slots_only', slotPercent }),
+  ])
+}
+
+/** Two pockets on the same feature: engagement at 75% (emits its ladder) plus
+ *  slots-only at 60% (emits its single slot scale). The legend must show the
+ *  union of both, whichever operation is selected. */
+function buildMixedFeedColoursProjectJson(): string {
+  return feedColoursProjectJson('mixed', [
+    pocketOperationJson({ id: 'op-pocket-a', name: 'Pocket A', mode: 'engagement', slotPercent: 75 }),
+    pocketOperationJson({ id: 'op-pocket-b', name: 'Pocket B', mode: 'slots_only', slotPercent: 60 }),
+  ])
+}
+
 const ENGAGEMENT_FIXTURE_JSON = buildFeedColoursProjectJson('engagement')
 const SLOTS_ONLY_FIXTURE_JSON = buildFeedColoursProjectJson('slots_only')
+const SLOTS_ONLY_SLOT_FEED_60_JSON = buildSlotsOnlyAtSlotFeedProjectJson(60)
+const MIXED_FIXTURE_JSON = buildMixedFeedColoursProjectJson()
 
 /** Distinct pixel colours covering at least MIN_GROUP_PIXELS each. */
 async function dominantPixelGroups(sketchCanvas: Locator): Promise<string[]> {
@@ -274,9 +321,13 @@ test.describe('Feed-coloured toolpath smoke', () => {
     await expect(feedToggle).toHaveAttribute('aria-pressed', 'true')
 
     // The legend prints the rungs derived from the 75% slot feed, not the
-    // hardcoded 40% ladder the engine no longer emits (issue #498 S5).
+    // hardcoded 40% ladder the engine no longer emits (issue #498 S5), and
+    // since #535 it is data-driven: it lists only the rungs the emitted moves
+    // actually carry. The 0.80 rung is absent because this fixture's geometry
+    // never quantizes there (minimum-fragment merges take the lower scale),
+    // so nothing on the canvas paints it and the legend must not claim it.
     await expect(panel.locator('.viewport-toolpath-vis__legend-step')).toHaveText([
-      '100%', '95%', '90%', '85%', '80%', '75%',
+      '100%', '95%', '90%', '85%', '75%',
     ])
 
     // Baseline: explicit off.
@@ -324,5 +375,70 @@ test.describe('Feed-coloured toolpath smoke', () => {
       const hiddenGroups = await dominantPixelGroups(sketchCanvas)
       return [...hiddenGroups].sort().join('|') !== offKeys
     }, { timeout: 10000 }).toBe(true)
+  })
+
+  test('slots-only pocket at 60% slot feed shows only its emitted rung and hides the legend when the toggle is off', async ({ app, ui }) => {
+    await seedProject(app.page, SLOTS_ONLY_SLOT_FEED_60_JSON)
+
+    const panel = ui.toolpathVis.sketchPanel(app.page)
+    await expect(panel).toBeVisible({ timeout: 30000 })
+
+    const feedToggle = ui.toolpathVis.sketchItems(app.page).filter({ hasText: 'Feed colours' })
+    await expect(feedToggle).toHaveCount(1)
+
+    // A slots-only operation defaults the feed-colour toggle off — and with
+    // feed colours off there is nothing for a legend to explain (issue #535).
+    await ui.operations.rowByName(app.page, 'Pocket A').click()
+    await expect(feedToggle).toHaveAttribute('aria-pressed', 'false')
+    await expect(panel.locator('.viewport-toolpath-vis__legend')).toHaveCount(0)
+
+    // On: the classic path emitted exactly one scale — the 60% slot feed — so
+    // the legend is full feed plus that single rung, not the 6-rung ladder.
+    await feedToggle.click()
+    await expect(feedToggle).toHaveAttribute('aria-pressed', 'true')
+    await expect(panel.locator('.viewport-toolpath-vis__legend-step')).toHaveText(['100%', '60%'])
+
+    await feedToggle.click()
+    await expect(panel.locator('.viewport-toolpath-vis__legend')).toHaveCount(0)
+  })
+
+  test('mixed pockets show the union of emitted scales in both panels, independent of selection', async ({ app, ui }) => {
+    await seedProject(app.page, MIXED_FIXTURE_JSON)
+
+    const panel = ui.toolpathVis.sketchPanel(app.page)
+    await expect(panel).toBeVisible({ timeout: 30000 })
+
+    const feedToggle = ui.toolpathVis.sketchItems(app.page).filter({ hasText: 'Feed colours' })
+    await expect(feedToggle).toHaveCount(1)
+
+    // The union of the engagement ladder (this fixture's geometry emits all
+    // rungs except 0.80 — see the 75% test) and the slots-only pocket's 60%
+    // rung, whichever operation is selected.
+    const unionSteps = ['100%', '95%', '90%', '85%', '75%', '60%']
+
+    // Selecting the engagement pocket defaults the toggle on; the legend is
+    // the union of the engagement ladder and the slots-only pocket's 60% rung.
+    await ui.operations.rowByName(app.page, 'Pocket A').click()
+    await expect(feedToggle).toHaveAttribute('aria-pressed', 'true')
+    await expect(panel.locator('.viewport-toolpath-vis__legend-step')).toHaveText(unionSteps)
+
+    // Make the toggle explicit so a selection change cannot move its default,
+    // then select the other operation: the union must not change.
+    await feedToggle.click()
+    await feedToggle.click()
+    await ui.operations.rowByName(app.page, 'Pocket B').click()
+    await expect(feedToggle).toHaveAttribute('aria-pressed', 'true')
+    await expect(panel.locator('.viewport-toolpath-vis__legend-step')).toHaveText(unionSteps)
+
+    // The 3D panel shares the visibility state and must show the same union.
+    const view3d = ui.toolpathVis.view3dPanel(app.page)
+    await expect(view3d).toBeAttached({ timeout: 15000 })
+    await expect(view3d.locator('.viewport-toolpath-vis__legend-step')).toHaveText(unionSteps)
+
+    // Toggle off hides the legend in both panels.
+    await feedToggle.click()
+    await expect(feedToggle).toHaveAttribute('aria-pressed', 'false')
+    await expect(panel.locator('.viewport-toolpath-vis__legend')).toHaveCount(0)
+    await expect(view3d.locator('.viewport-toolpath-vis__legend')).toHaveCount(0)
   })
 })

--- a/planning/ISSUE_498_INTEGRATION_HANDOFF.md
+++ b/planning/ISSUE_498_INTEGRATION_HANDOFF.md
@@ -517,6 +517,12 @@ G-code changes.
    it. Verify that by reverting to the constant and watching the test fail.
 5. Extend `e2e/feedColours.smoke.spec.ts` to cover a non-40% slot feed.
 
+> **Superseded by #535 (2026-08):** item 2's "rungs for the selected
+> operation" is gone. The legend is now data-driven — the union of the
+> (scale, step) pairs actually emitted by every toolpath in the preview,
+> cached per toolpath, and rendered only while feed colours are on. See
+> `src/components/toolpathVisibility.ts` (`unionFeedColourLegendSteps`).
+
 **Required checks:**
 
 ```bash

--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -9,7 +9,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 - `IconGallery.tsx` — dev/debug grid of all available icons
 - `Select.tsx` — shared styled `<select>` wrapper
 - `ToolpathVisibilityPanel.tsx` — toggles for showing/hiding toolpath layers
-- `toolpathVisibility.ts` — `ToolpathVisibility` type + default visibility constant (kept out of the panel component for fast refresh)
+- `toolpathVisibility.ts` — `ToolpathVisibility` type, default visibility constants, and the cached feed-colour legend steps (issue #535) (kept out of the panel component for fast refresh)
 - `UnsupportedMobileScreen.tsx` — phone-sized-device blocker screen shown instead of the app (extracted from `main.tsx`)
 - `errorFormat.ts` — shared error formatting
 - `useIconIds.ts` — hook listing available icon IDs

--- a/src/components/ToolpathVisibilityPanel.tsx
+++ b/src/components/ToolpathVisibilityPanel.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import type { ToolpathVisibility } from './toolpathVisibility'
+import type { FeedColourLegendStep, ToolpathVisibility } from './toolpathVisibility'
 import { useI18n } from '../i18n/i18nContext'
 import type { MessageKey } from '../i18n/locales/en'
 import { useTheme } from '../theme/themeContext'
-import { feedColourScales, canvasFeedColour } from '../theme/palette'
+import { canvasFeedColour } from '../theme/palette'
 import { Icon } from './Icon'
 
 interface ToolpathVisibilityPanelProps {
@@ -34,12 +34,13 @@ interface ToolpathVisibilityPanelProps {
    */
   feedColoursDefault?: boolean
   /**
-   * The selected operation's slot-feed percentage (1-99), or null when no
-   * ladder is in force. The legend prints the feed rungs derived from it, so
-   * it matches what the engine actually emits (issue #498 S5); null hides the
-   * legend because there is no ladder to print.
+   * The feed-colour legend rungs — the distinct (scale, step) pairs emitted by
+   * the toolpaths currently in the preview, precomputed and cached by the
+   * caller (issue #535). Empty/absent hides the legend; the old per-operation
+   * `slotFeedPercent` ladder is gone because it advertised rungs no visible
+   * toolpath emits (and missed rungs other operations did emit).
    */
-  slotFeedPercent?: number | null
+  legendSteps?: ReadonlyArray<FeedColourLegendStep>
 }
 
 const ITEMS: Array<{ key: keyof ToolpathVisibility; labelKey: MessageKey; swatch: string }> = [
@@ -53,9 +54,19 @@ const ITEMS: Array<{ key: keyof ToolpathVisibility; labelKey: MessageKey; swatch
   { key: 'feedColours', labelKey: 'appShell.toolpath.feedColours', swatch: 'viewport-toolpath-vis__swatch--cuts' },
 ]
 
-export function ToolpathVisibilityPanel({ visibility, onChange, className, expanded, onExpandedChange, feedColoursDefault, slotFeedPercent = null }: ToolpathVisibilityPanelProps) {
+export function ToolpathVisibilityPanel({ visibility, onChange, className, expanded, onExpandedChange, feedColoursDefault, legendSteps }: ToolpathVisibilityPanelProps) {
   const { t } = useI18n()
   const { palette } = useTheme()
+
+  // The feed-colour toggle is tri-state at the data level: undefined defers
+  // to the per-selection default, so display that default.
+  const feedColoursOn = visibility.feedColours ?? feedColoursDefault ?? false
+  // Only rungs the view actually paints, and only while feed colours are on —
+  // an off toggle means no feed colouring exists to explain (issue #535).
+  // A single full-feed rung means nothing is scaled, so there is no legend.
+  const showLegend = expanded
+    && feedColoursOn
+    && (legendSteps?.some((entry) => entry.step > 0) ?? false)
 
   return (
     <div className={`viewport-toolpath-vis${expanded ? ' viewport-toolpath-vis--expanded' : ''}${className ? ` ${className}` : ''}`}>
@@ -70,10 +81,8 @@ export function ToolpathVisibilityPanel({ visibility, onChange, className, expan
       </button>
       {expanded ? (
         ITEMS.map(({ key, labelKey, swatch }) => {
-          // The feed-colour toggle is tri-state at the data level: undefined
-          // defers to the per-selection default, so display that default.
           const selected = key === 'feedColours'
-            ? visibility.feedColours ?? feedColoursDefault ?? false
+            ? feedColoursOn
             : visibility[key]
           return (
             <button
@@ -94,15 +103,15 @@ export function ToolpathVisibilityPanel({ visibility, onChange, className, expan
           )
         })
       ) : null}
-      {expanded && slotFeedPercent !== null ? (
+      {showLegend && legendSteps ? (
         <div
           className="viewport-toolpath-vis__legend"
           aria-label={t('appShell.toolpath.feedLegend')}
           style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '2px 10px 6px' }}
         >
-          {feedColourScales(slotFeedPercent / 100).map((scale, step) => (
+          {legendSteps.map(({ scale, step }) => (
             <span
-              key={scale}
+              key={`${scale}:${step}`}
               className="viewport-toolpath-vis__legend-step"
               title={`${Math.round(scale * 100)}%`}
               style={{ display: 'flex', alignItems: 'center', gap: '3px' }}

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -17,7 +17,7 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import { ToolpathVisibilityPanel } from '../ToolpathVisibilityPanel'
 import { pocketSlotFeedPercent } from '../../theme/palette'
-import { toolpathHasEngagementTelemetry } from '../toolpathVisibility'
+import { toolpathHasEngagementTelemetry, unionFeedColourLegendSteps } from '../toolpathVisibility'
 import type { OpenProfileEndpoint, SketchControlRef } from '../../store/types'
 import { useProjectStore } from '../../store/projectStore'
 import { previewOffsetFeatures } from '../../store/helpers/derivedFeatures'
@@ -2844,6 +2844,16 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
   const pendingDraftExceedsStock =
     pendingDraftProfile ? profileExceedsStock(pendingDraftProfile, project.stock) : false
 
+  // Feed-colour legend steps for every toolpath the preview draws (issue #535).
+  // Selection-independent; the per-toolpath scans are cached by toolpath
+  // identity, so no move scan runs on this render path.
+  const feedColourLegendSteps = toolpaths && toolpaths.length > 0
+    ? unionFeedColourLegendSteps(toolpaths, (operationId) => {
+        const percent = pocketSlotFeedPercent(project.operations.find((op) => op.id === operationId))
+        return percent === null ? 1 : percent / 100
+      })
+    : []
+
   return (
     <div ref={containerRef} className="sketch-canvas-container">
       <canvas
@@ -2872,7 +2882,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           feedColoursDefault={
             toolpaths.some((toolpath) => toolpath.operationId === selectedOperationId && toolpathHasEngagementTelemetry(toolpath))
           }
-          slotFeedPercent={pocketSlotFeedPercent(project.operations.find((op) => op.id === selectedOperationId))}
+          legendSteps={feedColourLegendSteps}
         />
       )}
       <ConstraintEditPanel constraint={constraint} />

--- a/src/components/toolpathFeedLegend.test.ts
+++ b/src/components/toolpathFeedLegend.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Structural tests for the feed-colour legend steps (issue #535).
+ *
+ * The legend must describe exactly what the renderers paint: the distinct
+ * (scale, step) pairs on each visible toolpath's cut moves, cached by toolpath
+ * identity so the render path never rescans moves. These tests pin the
+ * correctness of the scan and the identity of the cache; the CPU-ratio test in
+ * `toolpathFeedLegendCpu.test.ts` pins that the cache actually makes the
+ * render path cheap.
+ *
+ * Run with: npx tsx src/components/toolpathFeedLegend.test.ts
+ */
+
+import assert from 'node:assert/strict'
+import type { ToolpathMove, ToolpathResult } from '../engine/toolpaths/types'
+import {
+  feedColourLegendSteps,
+  scanFeedColourLegendSteps,
+  unionFeedColourLegendSteps,
+  type FeedColourLegendStep,
+} from './toolpathVisibility'
+
+function cut(from: number, to: number, feedScale?: number): ToolpathMove {
+  return { kind: 'cut', from: { x: from, y: 0, z: 0 }, to: { x: to, y: 0, z: 0 }, ...(feedScale === undefined ? {} : { feedScale }) }
+}
+
+function toolpath(id: string, moves: ToolpathMove[]): ToolpathResult {
+  return { operationId: id, moves, warnings: [], bounds: null }
+}
+
+function keys(steps: readonly FeedColourLegendStep[]): string[] {
+  return steps.map((s) => `${s.scale}:${s.step}`)
+}
+
+// ── scan: distinct cut-move scales, absent feedScale is full feed ─────
+
+{
+  const steps = scanFeedColourLegendSteps([
+    cut(0, 1),                 // absent -> scale 1, step 0
+    cut(1, 2, 1),              // explicit 1 -> same entry
+    cut(2, 3, 0.6),            // reduced under slotScale 0.6 -> step 5 (slowest)
+    cut(3, 4, 0.6),            // duplicate scale/step
+    { kind: 'rapid', from: { x: 0, y: 0, z: 1 }, to: { x: 1, y: 0, z: 1 }, feedScale: 0.5 },
+    { kind: 'lead_in', from: { x: 0, y: 0, z: 1 }, to: { x: 0, y: 0, z: 0 }, feedScale: 0.5 },
+  ], 0.6)
+  assert.deepEqual(keys(steps), ['1:0', '0.6:5'], 'cut moves only; absent and 1 collapse to full feed')
+}
+
+{
+  // The same emitted scale can land on different ramp steps under different
+  // slot feeds — the step is what the swatch colour derives from.
+  const at60 = scanFeedColourLegendSteps([cut(0, 1, 0.6)], 0.6)
+  const at40 = scanFeedColourLegendSteps([cut(0, 1, 0.6)], 0.4)
+  assert.equal(at60[0].step, 5, '0.6 at slotScale 0.6 is the slowest rung')
+  assert.equal(at40[0].step, 4, '0.6 at slotScale 0.4 sits one rung up the ladder')
+}
+
+// ── cache: one scan per toolpath identity + slot scale ─────────────────
+
+{
+  const tp = toolpath('op-a', Array.from({ length: 1000 }, (_, i) => cut(i, i + 1, i % 2 === 0 ? undefined : 0.6)))
+  const first = feedColourLegendSteps(tp, 0.6)
+  const second = feedColourLegendSteps(tp, 0.6)
+  assert.equal(first, second, 'same toolpath and slot scale must return the cached array identity')
+
+  const otherScale = feedColourLegendSteps(tp, 0.4)
+  assert.notEqual(otherScale, first, 'a different slot scale must recompute')
+  assert.deepEqual(keys(otherScale), ['1:0', '0.6:4'])
+
+  const otherToolpath = toolpath('op-b', tp.moves)
+  assert.notEqual(feedColourLegendSteps(otherToolpath, 0.6), first, 'a different toolpath object must not share the cache')
+}
+
+// ── union: dedupe by (scale, step), sort by descending scale ──────────
+
+{
+  const engagement = toolpath('op-a', [cut(0, 1, 0.9), cut(1, 2, 0.75), cut(2, 3)])
+  const slots = toolpath('op-b', [cut(0, 1, 0.6), cut(1, 2)])
+  const empty = toolpath('op-c', [])
+  const slotScaleOf = (id: string): number => (id === 'op-a' ? 0.75 : 0.6)
+
+  const union = unionFeedColourLegendSteps([engagement, slots, empty], slotScaleOf)
+  assert.deepEqual(keys(union), ['1:0', '0.9:2', '0.75:5', '0.6:5'],
+    'union of engagement ladder and slot scale, full feed first, empty toolpath skipped')
+
+  // Two entries may share a step but never a (scale, step) pair.
+  const dup = unionFeedColourLegendSteps([engagement, engagement, slots], slotScaleOf)
+  assert.deepEqual(keys(dup), keys(union), 'duplicate toolpaths contribute one entry per pair')
+}
+
+console.log('toolpathFeedLegend.test.ts passed')

--- a/src/components/toolpathFeedLegendCpu.test.ts
+++ b/src/components/toolpathFeedLegendCpu.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * CPU-ratio guard for the feed-colour legend cache (issue #535).
+ *
+ * The legend render path must not scan moves: `feedColourLegendSteps` scans
+ * once per toolpath identity and returns a cached array afterwards. The
+ * reference here is the scan itself — the same code path on the same fixtures,
+ * provably unable to benefit from the cache — so the ratio measures only the
+ * cache. Deleting the cache collapses the ratio to ~1 (verified by mutation;
+ * see AGENTS.md §Performance).
+ *
+ * Run with: npx tsx src/components/toolpathFeedLegendCpu.test.ts
+ */
+
+import assert from 'node:assert/strict'
+import { cpuRatio } from '../test/cpuRatio'
+import type { ToolpathMove, ToolpathResult } from '../engine/toolpaths/types'
+import { feedColourLegendSteps, scanFeedColourLegendSteps } from './toolpathVisibility'
+
+const TOOLPATH_COUNT = 16
+const MOVES_PER_TOOLPATH = 25_000
+const SCALES = [undefined, 0.6, 0.75, 0.8, 0.9, 0.95, 1]
+
+function buildFixtures(): ToolpathResult[] {
+  const toolpaths: ToolpathResult[] = []
+  for (let t = 0; t < TOOLPATH_COUNT; t += 1) {
+    const moves: ToolpathMove[] = []
+    for (let i = 0; i < MOVES_PER_TOOLPATH; i += 1) {
+      const scale = SCALES[i % SCALES.length]
+      moves.push({
+        kind: 'cut',
+        from: { x: i, y: 0, z: 0 },
+        to: { x: i + 1, y: 0, z: 0 },
+        ...(scale === undefined ? {} : { feedScale: scale }),
+      })
+    }
+    toolpaths.push({ operationId: `op-${t}`, moves, warnings: [], bounds: null })
+  }
+  return toolpaths
+}
+
+// Built once, outside the measured region.
+const toolpaths = buildFixtures()
+const SLOT_SCALE = 0.75
+
+const subject = {
+  run: () => {
+    for (const toolpath of toolpaths) {
+      feedColourLegendSteps(toolpath, SLOT_SCALE)
+    }
+  },
+}
+const reference = {
+  run: () => {
+    for (const toolpath of toolpaths) {
+      scanFeedColourLegendSteps(toolpath.moves, SLOT_SCALE)
+    }
+  },
+}
+
+// Warm the JIT and prime the cache outside the measurement.
+subject.run()
+reference.run()
+
+const measured = cpuRatio(subject, reference)
+console.log(`toolpathFeedLegendCpu: ${JSON.stringify(measured)}`)
+assert.ok(measured.referenceMs > 0, 'reference must do measurable work or the ratio is meaningless')
+
+// Threshold = geometric midpoint of the worst pair, per AGENTS.md §Performance.
+//
+// Baseline (cache intact, 16 × 25k cut moves, 5 runs): ratio 0.000052–0.000091,
+// subjectMs 0.003–0.005, referenceMs 53.8–61.7.
+// Regression (cache hit deleted, mutation-verified): ratio 0.974,
+// subjectMs 60.8, referenceMs 62.4 — the reference stayed put, so it is not
+// contaminated. sqrt(0.000091 × 0.974) ≈ 0.0094. The bound leaves ~100x
+// headroom over the worst baseline and fails hard the moment the render path
+// rescans moves.
+assert.ok(
+  measured.ratio < 0.0095,
+  `cached legend derivation must stay far below a full move scan (ratio ${measured.ratio.toFixed(5)})`,
+)

--- a/src/components/toolpathVisibility.ts
+++ b/src/components/toolpathVisibility.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import type { ToolpathResult } from '../engine/toolpaths/types'
+import type { ToolpathMove, ToolpathResult } from '../engine/toolpaths/types'
+import { feedColourStep } from '../theme/palette'
 
 export interface ToolpathVisibility {
   cuts: boolean
@@ -57,4 +58,101 @@ export const ALL_TOOLPATH_HIDDEN: ToolpathVisibility = {
   plunges: false,
   retractions: false,
   directions: false,
+}
+
+// ── Feed-colour legend steps (issue #535) ────────────────────────────
+//
+// The legend must show only the feed scales the visible toolpaths actually
+// emit — the scales the canvas really paints — not a theoretical ladder
+// derived from the selected operation. The renderers already classify every
+// cut move through `feedColourStep`; these helpers collect that same
+// classification once per ToolpathResult and cache it, so the legend render
+// path never scans moves. A full scan here would run on every store update
+// (selection, hover, visibility) inside SketchCanvas, and large projects
+// carry tens of thousands of moves.
+
+/** One legend rung: a feed scale and the ramp step the renderers paint it at. */
+export interface FeedColourLegendStep {
+  /** Fraction of full feed this rung represents (1 = full feed). */
+  scale: number
+  /** Ramp step index (0 = `toolpathCut`, last = `toolpathCutSlow`) — the same
+   *  value `feedColourStep` returns for this scale under the toolpath's slot
+   *  feed, so the legend swatch always matches the painted colour. */
+  step: number
+}
+
+/**
+ * One O(moves) scan: the distinct (scale, step) pairs the cut layer paints
+ * for a toolpath when feed colours are on. A move without a `feedScale` runs
+ * at full feed, so it contributes scale 1 / step 0 exactly like an explicit
+ * 1. Non-cut moves never contribute. Exported for the performance test's
+ * invariant reference — callers should go through `feedColourLegendSteps`.
+ */
+export function scanFeedColourLegendSteps(
+  moves: readonly ToolpathMove[],
+  slotScale: number,
+): FeedColourLegendStep[] {
+  const seen = new Map<string, FeedColourLegendStep>()
+  for (const move of moves) {
+    if (move.kind !== 'cut') continue
+    const scale = move.feedScale ?? 1
+    const step = feedColourStep(scale, slotScale)
+    const key = `${scale}:${step}`
+    if (!seen.has(key)) {
+      seen.set(key, { scale, step })
+    }
+  }
+  return [...seen.values()]
+}
+
+interface CachedLegendSteps {
+  slotScale: number
+  steps: readonly FeedColourLegendStep[]
+}
+
+/**
+ * The legend steps for one toolpath, scanned once per toolpath object (and
+ * per slot scale — the same scale can land on a different ramp step under a
+ * different slot feed). `ToolpathResult` objects come out of
+ * `useToolpathGeneration`'s memoized cache, so they are referentially stable
+ * between regens: hits cost a WeakMap lookup, misses cost one scan per regen.
+ */
+const legendStepsCache = new WeakMap<ToolpathResult, CachedLegendSteps>()
+
+export function feedColourLegendSteps(
+  toolpath: ToolpathResult,
+  slotScale: number,
+): readonly FeedColourLegendStep[] {
+  const cached = legendStepsCache.get(toolpath)
+  if (cached !== undefined && cached.slotScale === slotScale) {
+    return cached.steps
+  }
+  const steps = scanFeedColourLegendSteps(toolpath.moves, slotScale)
+  legendStepsCache.set(toolpath, { slotScale, steps })
+  return steps
+}
+
+/**
+ * The union of legend steps across all toolpaths in the preview, sorted by
+ * descending scale (full feed first, like the old ladder). Toolpaths with no
+ * moves contribute nothing; entries are deduped by (scale, step) so the same
+ * scale painted at two different ramp steps by two different operations keeps
+ * both entries. Independent of selection — the preview draws every toolpath,
+ * so the legend describes every toolpath.
+ */
+export function unionFeedColourLegendSteps(
+  toolpaths: readonly ToolpathResult[],
+  slotScaleOf: (operationId: string) => number,
+): FeedColourLegendStep[] {
+  const byKey = new Map<string, FeedColourLegendStep>()
+  for (const toolpath of toolpaths) {
+    if (toolpath.moves.length === 0) continue
+    for (const step of feedColourLegendSteps(toolpath, slotScaleOf(toolpath.operationId))) {
+      const key = `${step.scale}:${step.step}`
+      if (!byKey.has(key)) {
+        byKey.set(key, step)
+      }
+    }
+  }
+  return [...byKey.values()].sort((a, b) => b.scale - a.scale || a.step - b.step)
 }

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -20,7 +20,7 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 import { ToolpathVisibilityPanel } from '../ToolpathVisibilityPanel'
-import { toolpathHasEngagementTelemetry, type ToolpathVisibility } from '../toolpathVisibility'
+import { toolpathHasEngagementTelemetry, unionFeedColourLegendSteps, type ToolpathVisibility } from '../toolpathVisibility'
 import type { ToolpathResult } from '../../engine/toolpaths/types'
 import { useProjectStore } from '../../store/projectStore'
 import { modelFeatures } from '../../store/helpers/featureRoles'
@@ -917,10 +917,17 @@ useImperativeHandle(ref, () => ({
 
   // The feed-colour toggle's auto default: on when the selected operation is
   // an engagement-mode pocket, off otherwise (issue #498 S4). The legend rungs
-  // derive from the selected operation's slot feed (issue #498 S5).
+  // are the scales every toolpath in the preview emits (issue #535) — the
+  // per-toolpath scans are cached by toolpath identity, so no move scan runs
+  // on this render path.
   const selectedToolpathForLegend = toolpaths.find((toolpath) => toolpath.operationId === selectedOperationId) ?? null
   const feedColoursDefault = selectedToolpathForLegend !== null && toolpathHasEngagementTelemetry(selectedToolpathForLegend)
-  const selectedSlotFeedPercent = pocketSlotFeedPercent(project.operations.find((op) => op.id === selectedOperationId))
+  const feedColourLegendSteps = toolpaths.length > 0
+    ? unionFeedColourLegendSteps(toolpaths, (operationId) => {
+        const percent = pocketSlotFeedPercent(project.operations.find((op) => op.id === operationId))
+        return percent === null ? 1 : percent / 100
+      })
+    : []
 
   return (
     <div style={{ width: '100%', height: '100%', position: 'relative' }}>
@@ -981,7 +988,7 @@ useImperativeHandle(ref, () => ({
           expanded={toolpathPanelExpanded}
           onExpandedChange={onToolpathPanelExpandedChange}
           feedColoursDefault={feedColoursDefault}
-          slotFeedPercent={selectedSlotFeedPercent}
+          legendSteps={feedColourLegendSteps}
         />
       )}
       <div className="viewport-presets">


### PR DESCRIPTION
Closes #535.

Implements the approved #535 plan: the feed-colour legend is now **data-driven** — the union of the (scale, step) pairs actually emitted by the toolpaths in the preview — instead of a theoretical ladder derived from the selected operation.

## Changes

- `src/components/toolpathVisibility.ts` — `scanFeedColourLegendSteps` / `feedColourLegendSteps` (one O(moves) scan per toolpath identity + slot scale, WeakMap-cached) and `unionFeedColourLegendSteps` (selection-independent union, sorted by descending scale).
- `ToolpathVisibilityPanel.tsx` — `slotFeedPercent` prop replaced by `legendSteps`; legend renders only while feed colours are effectively on and at least one reduced rung exists. Gradient swatch unchanged.
- `SketchCanvas.tsx` / `Viewport3D.tsx` — both pass the cached union of their own visible toolpaths; no move scan on the render path.

## What the tests revealed (the worth-check the issue asked for)

The 75% engagement fixture's moves never carry the **0.80 rung** — minimum-fragment merges take the lower scale — so the old legend advertised a rung nothing on the canvas painted. The S5 assertion now pins the actually-emitted set `[100, 95, 90, 85, 75]`; the mixed fixture pins the union `[100, 95, 90, 85, 75, 60]` across both panels, selection-independent, and legend-hiding when the toggle is off (sketch + 3D).

## Performance (part of the acceptance criteria)

- Structural: `toolpathFeedLegend.test.ts` — scan correctness, cache identity per toolpath/slot scale, union dedupe/sort.
- CPU ratio: `toolpathFeedLegendCpu.test.ts` — cached derivation vs a full move scan of the same 16×25k-cut-move fixtures. **Baseline ratio 0.000052–0.000091 (subject 3–5 µs vs reference 54–62 ms).** Mutation-verified: deleting the cache hit → ratio 0.974 with the reference unmoved. Threshold 0.0095 = geometric midpoint of the worst pair.

## Verification

- `npm run build` green (lint + tsc + 189 test files + docs + vite).
- `PURECUT_E2E_PORT=1443 PURECUT_E2E_ISOLATED=1 npx playwright test e2e/feedColours.smoke.spec.ts --workers=1` — 5/5 pass.
- Full lane: plan approved in #535; `check:fast-lane` correctly red (10 files).