### PR TITLE
fix(skill): correct setIssueFieldValue option id type in github-issues

### DIFF
--- a/.agents/skills/github-issues/SKILL.md
+++ b/.agents/skills/github-issues/SKILL.md
@@ -79,7 +79,7 @@ Area guidance: engine/toolpath → `toolpath`, canvas/panels → `ui`, palette �
        gql('mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){ updateProjectV2ItemFieldValue(input:{'
            'projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$v}}){ clientMutationId } }',
            p=PROJECT, i=item_id, f=field, v=value)
-   gql('mutation($i:ID!,$f:ID!,$v:String!){ setIssueFieldValue(input:{issueId:$i,'
+   gql('mutation($i:ID!,$f:ID!,$v:ID!){ setIssueFieldValue(input:{issueId:$i,'
        'issueFields:[{fieldId:$f,singleSelectOptionId:$v}]}){ clientMutationId } }',
        i=issue_id, f=PRIO[0], v=PRIO[1])
    print('wired', item_id)
@@ -107,6 +107,20 @@ the mutation top level fails validation. There is **no** REST endpoint for
 setting org issue fields; only read them via REST (`.issue_field_values`, used
 by `scripts/backlog-hygiene.ts`). Priority is the **native org issue field**,
 not a board field — do not set it through `updateProjectV2ItemFieldValue`.
+
+**The two mutations disagree on the type of `singleSelectOptionId`**, and the
+same option id therefore needs a different variable declaration in each:
+
+| Mutation | Declare as |
+| --- | --- |
+| `updateProjectV2ItemFieldValue` (board fields) | `$v:String!` |
+| `setIssueFieldValue` (org issue fields) | `$v:ID!` |
+
+Getting it wrong fails at validation, before any network effect, with
+`Type mismatch on variable $v and argument singleSelectOptionId (String! / ID)`.
+Harmless but it costs a turn — and in the batched recipe above it aborts the
+script *after* Status/Size/Area are already set, so re-running the whole block
+is safe but only Priority is actually missing.
 
 ## Board item lookup
 


### PR DESCRIPTION
Closes #540

The `github-issues` skill's Priority recipe declared the option id as `$v:String!`, but `setIssueFieldValue` types `singleSelectOptionId` as `ID`, so the pasted block died at GraphQL validation:

```
Type mismatch on variable $v and argument singleSelectOptionId (String! / ID)
```

The two mutations genuinely disagree on the type. Board fields (`updateProjectV2ItemFieldValue`) keep `String!` and were already correct; only the org-issue-field call was wrong.

## Changes

- Corrected the declaration in the recipe.
- Documented the asymmetry as a table in "Priority — the exact shape that costs discovery", with the failure text so it is greppable.
- Recorded the half-wired abort: in the batched recipe the failure lands *after* Status/Size/Area are set and before Priority, so the card looks broken when only one field is actually missing. Re-running the block is safe.

## Verification

Confirmed by execution, not just by reading — the corrected form is what wired #499 earlier today (`String!` for board fields, `ID!` for Priority), with the card verified afterwards as Backlog / toolpath / M, Priority Medium. The same corrected recipe then wired #540's own card.

`npm run build` green (188 test files, 0 skipped), re-run after rebasing onto `bc8498d`. `npm run check:fast-lane` green: 1 file, 16 lines.

## Note for a follow-up, not fixed here

`check-fast-lane.sh`'s protected list covers `.claude/**` but not `.agents/**`, where the skills actually live. This diff is genuinely fast-lane-eligible either way — a skill doc cannot affect machine output, saved projects, or gate behaviour — but the omission looks like the list not having followed the skills when they landed under `.agents/`. Worth a decision on whether skill docs belong in the protected set.
