### PR TITLE
Booklet: show roundLinkCorners beside roundOutsideCorners

### DIFF
--- a/src/engine/operationBooklet/operationBooklet.test.ts
+++ b/src/engine/operationBooklet/operationBooklet.test.ts
@@ -169,6 +169,61 @@ function testReportIncludesEnabledRoundOutsideCorners(): void {
   )
 }
 
+function testReportIncludesEnabledRoundLinkCorners(): void {
+  console.log('Testing operation booklet reports enabled round link corners...')
+  const { project, operation, toolpath } = fixture()
+  const report = buildOperationBookletReport({
+    project,
+    operation: {
+      ...operation,
+      kind: 'pocket',
+      pocketPattern: 'offset',
+      roundLinkCorners: true,
+    },
+    tool: normalizeToolForProject(project.tools[0], project),
+    toolpath,
+    generatedAt: new Date('2026-06-04T12:00:00Z'),
+  })
+
+  assert(
+    report.settingRows.some((row) => row.label === translate('booklet.label.roundLinkCorners') && row.value === translate('booklet.value.enabled')),
+    'enabled round link corners should be reported for offset pockets',
+  )
+}
+
+function testReportOmitsRoundLinkCornersWhenInapplicable(): void {
+  console.log('Testing operation booklet omits round link corners when inapplicable...')
+  const { project, operation, toolpath } = fixture()
+  const parallelReport = buildOperationBookletReport({
+    project,
+    operation: {
+      ...operation,
+      kind: 'pocket',
+      pocketPattern: 'parallel',
+      roundLinkCorners: true,
+    },
+    tool: normalizeToolForProject(project.tools[0], project),
+    toolpath,
+    generatedAt: new Date('2026-06-04T12:00:00Z'),
+  })
+  assert(
+    !parallelReport.settingRows.some((row) => row.label === translate('booklet.label.roundLinkCorners')),
+    'parallel pockets must not report round link corners (a documented no-op)',
+  )
+
+  const disabledReport = buildOperationBookletReport({
+    project,
+    operation: { ...operation, kind: 'pocket', pocketPattern: 'offset', roundLinkCorners: false },
+    tool: normalizeToolForProject(project.tools[0], project),
+    toolpath,
+    generatedAt: new Date('2026-06-04T12:00:00Z'),
+  })
+  assert(
+    !disabledReport.settingRows.some((row) => row.label === translate('booklet.label.roundLinkCorners')),
+    'disabled round link corners must not be reported for offset pockets',
+  )
+}
+
 function testReportIncludesTrochoidalSettings(): void {
   console.log('Testing operation booklet reports trochoidal settings...')
   const { project, operation, toolpath } = fixture()
@@ -603,6 +658,8 @@ testFeedTimeFallsBackToToolDefaultFeed()
 testFeedTimeUsesScaledSlotFeed()
 testReportIncludesEngagementModeRow()
 testReportIncludesEnabledRoundOutsideCorners()
+testReportIncludesEnabledRoundLinkCorners()
+testReportOmitsRoundLinkCornersWhenInapplicable()
 testReportIncludesTrochoidalSettings()
 testReportIncludesTrochoidalEdgeSettingsResolvedFromTool()
 testReportIncludesTrochoidalCarveSettings()

--- a/src/engine/operationBooklet/report.ts
+++ b/src/engine/operationBooklet/report.ts
@@ -111,6 +111,13 @@ function operationUsesRoundOutsideCorners(operation: Operation): boolean {
   )
 }
 
+/** Tangential S-links apply to offset pocket clearing only (issue #545): the
+ *  parallel pattern has no ring-to-ring links, so the setting is a no-op
+ *  there and the booklet must not show it. */
+function operationUsesTangentLinks(operation: Operation): boolean {
+  return operation.kind === 'pocket' && operation.pocketPattern !== 'parallel'
+}
+
 function targetSummary(project: Project, target: OperationTarget): string {
   if (target.source === 'stock') {
     return translate('booklet.target.stock')
@@ -312,6 +319,10 @@ function settingRows(operation: Operation, project: Project, tool: NormalizedToo
 
   if ((operation.roundOutsideCorners ?? false) && operationUsesRoundOutsideCorners(operation)) {
     rows.push({ label: translate('booklet.label.roundOutsideCorners'), value: translate('booklet.value.enabled') })
+  }
+
+  if ((operation.roundLinkCorners ?? false) && operationUsesTangentLinks(operation)) {
+    rows.push({ label: translate('booklet.label.roundLinkCorners'), value: translate('booklet.value.enabled') })
   }
 
   const cornerRelief = operation.cornerRelief ?? 'none'

--- a/src/i18n/locales/de/booklet.ts
+++ b/src/i18n/locales/de/booklet.ts
@@ -83,6 +83,7 @@ export const bookletDe: Record<keyof typeof bookletEn, string> = {
   'booklet.label.cutDirection': 'Schnittrichtung',
   'booklet.label.machiningOrder': 'Bearbeitungsreihenfolge',
   'booklet.label.roundOutsideCorners': 'Außenecken abrunden',
+  'booklet.label.roundLinkCorners': 'Übergänge abrunden',
   'booklet.label.cornerRelief': 'Eckenfreistellung',
   'booklet.label.pattern': 'Muster',
   'booklet.label.pocketAngle': 'Taschenwinkel',

--- a/src/i18n/locales/en/booklet.ts
+++ b/src/i18n/locales/en/booklet.ts
@@ -78,6 +78,7 @@ export const bookletEn = {
   'booklet.label.cutDirection': 'Cut direction',
   'booklet.label.machiningOrder': 'Machining order',
   'booklet.label.roundOutsideCorners': 'Round outside corners',
+  'booklet.label.roundLinkCorners': 'Round link junctions',
   'booklet.label.cornerRelief': 'Corner relief',
   'booklet.label.pattern': 'Pattern',
   'booklet.label.pocketAngle': 'Pocket angle',

--- a/src/i18n/locales/es/booklet.ts
+++ b/src/i18n/locales/es/booklet.ts
@@ -80,6 +80,7 @@ export const bookletEs: Record<keyof typeof bookletEn, string> = {
   'booklet.label.cutDirection': 'Dirección de corte',
   'booklet.label.machiningOrder': 'Orden de mecanizado',
   'booklet.label.roundOutsideCorners': 'Esquinas exteriores redondeadas',
+  'booklet.label.roundLinkCorners': 'Redondear uniones de enlace',
   'booklet.label.cornerRelief': 'Relieve de esquinas',
   'booklet.label.pattern': 'Patrón',
   'booklet.label.pocketAngle': 'Ángulo de la cajera',

--- a/src/i18n/locales/fr/booklet.ts
+++ b/src/i18n/locales/fr/booklet.ts
@@ -80,6 +80,7 @@ export const bookletFr: Record<keyof typeof bookletEn, string> = {
   'booklet.label.cutDirection': 'Sens de coupe',
   'booklet.label.machiningOrder': 'Ordre d’usinage',
   'booklet.label.roundOutsideCorners': 'Arrondir les coins extérieurs',
+  'booklet.label.roundLinkCorners': 'Arrondir les jonctions de liaison',
   'booklet.label.cornerRelief': 'Dégagement de coin',
   'booklet.label.pattern': 'Motif',
   'booklet.label.pocketAngle': 'Angle de poche',

--- a/src/i18n/locales/zh-CN/booklet.ts
+++ b/src/i18n/locales/zh-CN/booklet.ts
@@ -80,6 +80,7 @@ export const bookletZhCN: Record<keyof typeof bookletEn, string> = {
   'booklet.label.cutDirection': '切削方向',
   'booklet.label.machiningOrder': '加工顺序',
   'booklet.label.roundOutsideCorners': '圆角外侧拐角',
+  'booklet.label.roundLinkCorners': '圆角连接节点',
   'booklet.label.cornerRelief': '拐角让位',
   'booklet.label.pattern': '路径图案',
   'booklet.label.pocketAngle': '挖槽角度',


### PR DESCRIPTION
Closes #551

Follow-up to #549/#545: the operation booklet now shows `roundLinkCorners` next to `roundOutsideCorners` when it applies.

What changed:
- `report.ts`: `operationUsesTangentLinks()` gate (offset pockets only) + `booklet.label.roundLinkCorners` row when `roundLinkCorners` is enabled. Parallel pockets never show it (the setting is a documented no-op there).
- Five locale `booklet.ts` files: label for the new row (en/de/fr/es/zh-CN).
- `operationBooklet.test.ts`: three cases — enabled offset pocket reports the row, parallel pocket omits it, disabled offset pocket omits it.

No e2e: booklet rows are covered by the structural report tests, which is where all existing booklet behavior is asserted.