### PR TITLE
Drop --with-deps from Playwright install in pr-check lanes (#564)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -53,7 +53,12 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        # No --with-deps (issue #564): the apt half re-downloads system/font
+        # packages on every run and has repeatedly blown the lane's 10-minute
+        # timeout on degraded mirrors. The runner image already carries the
+        # shared libraries Chromium needs; the browser binary comes from
+        # Playwright's CDN, which is fast and unaffected.
+        run: npx playwright install chromium
 
       - name: Run Playwright e2e lane
         run: npm run ${{ matrix.command }}


### PR DESCRIPTION
Closes #564

Drops `--with-deps` from the Playwright install step in the `pr-check.yml` e2e lanes: `npx playwright install chromium` instead of `npx playwright install --with-deps chromium`.

## Why

The apt half of `--with-deps` re-downloads system/font packages on every lane run and has repeatedly blown the lane's 10-minute timeout on degraded `azure.archive.ubuntu.com` mirrors (packages at ~200 KB/s), cancelling the e2e lanes before a single test ran — seen on #563, where four attempts died in the install step while `build`/`gcode-conformance` stayed green and the same lanes passed earlier the same day.

## What changes

- Browser install is now CDN-only (fast, unaffected by apt mirrors).
- Shared libraries come from the `ubuntu-latest` runner image (it ships Chrome, which pulls the same lib set). The slow CJK font packages are only needed for glyph rendering, which no e2e test asserts.

## Verification

- This PR's own checks exercise the modified workflow: a green `build` + `e2e` here is the live proof the lanes run without the apt step.
- YAML parses; `npm run build` green locally.

## Tradeoff

If a runner image ever drops the libs Chromium needs, the lanes will fail at browser launch with a clear "missing shared libraries" message rather than silently passing — the failure mode is loud, and the fix would be to reintroduce `--with-deps` (or a cached deps install).
