### PR TITLE
feat(canvas): select the topmost feature on interior clicks inside overlapping shapes (#521)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -65,7 +65,7 @@ Current smoke targets:
 - `importGeometry.smoke.spec.ts` — real-user import flow: dialog open/close, button state, file upload via hidden input, SVG/DXF mode selection with classification summary verification (Auto/Paths/Solid regions), real Import button, project-role verification through existing `getProject` seam, and landscape tablet layout. Synthetic inline fixtures only.
 - `modelOrientation.smoke.spec.ts` — post-import 3D orientation for imported models (issue #241): real STL import, 90° quick-rotate committing a rigid Z band and a re-projected silhouette, non-deforming lift, and reset to import orientation.
 - `machineLibrary.smoke.spec.ts` — application machine library (issue #403): My Machines persistence across projects and restarts, one-snapshot embedding on selection, the non-blocking update warning (keep vs. explicit update), and library deletion leaving a project's embedded machine usable.
-- `overlapFeatureSelection.smoke.spec.ts` — direct selection for clear outline clicks, ambiguous-overlap picker wiring, candidate hover/focus previews, non-topmost selection, boxed scroll behavior, next-action dismissal, and landscape-tablet availability.
+- `overlapFeatureSelection.smoke.spec.ts` — direct selection for clear outline clicks and interior clicks over stacked shapes (issue #521), picker wiring for coincident-outline clicks, candidate hover/focus previews, non-topmost selection, boxed scroll behavior, next-action dismissal, and landscape-tablet availability.
 
 ## Adding a test
 

--- a/e2e/overlapFeatureSelection.helpers.ts
+++ b/e2e/overlapFeatureSelection.helpers.ts
@@ -144,9 +144,143 @@ export async function seedObviousOverlapFeatureProject(page: Page): Promise<void
   await seedProject(page, buildOverlapFeatureProjectJson(2, true))
 }
 
+/**
+ * Outer rect drawn on top of a small inner rect (outer is last in the tree).
+ * A click near the inner rect's outline still selects the inner rect through
+ * the boundary rule, which is exactly the case where the old topmost-only
+ * context-menu hit test picked the outer rect instead (issue #521 follow-up).
+ */
+function buildStackedRectProjectJson(): string {
+  const now = '2026-07-13T00:00:00.000Z'
+  const stockWidth = 120
+  const stockHeight = 90
+  const featureRow = (id: string, name: string, definitionId: string) => ({
+    id,
+    name,
+    definitionId,
+    transform: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+    constraints: [] as unknown[],
+    folderId: null,
+    z_top: 5,
+    z_bottom: 0,
+    visible: true,
+    locked: false,
+  })
+  return JSON.stringify({
+    version: '3.0',
+    meta: {
+      name: 'Stacked rect E2E fixture',
+      created: now,
+      modified: now,
+      units: 'inch',
+      showFeatureInfo: true,
+      showDimensions: true,
+      copyMode: 'reference',
+      maxTravelZ: 2,
+      operationClearanceZ: 0.2,
+      clampClearanceXY: 0.5,
+      clampClearanceZ: 0.2,
+      machineDefinitions: [],
+      selectedMachineId: null,
+    },
+    grid: {
+      extent: 200,
+      majorSpacing: 1,
+      minorSpacing: 0.25,
+      snapEnabled: false,
+      snapIncrement: 0.25,
+      visible: true,
+    },
+    stock: {
+      profile: rectProfile(0, 0, stockWidth, stockHeight),
+      thickness: 2,
+      material: 'aluminum_6061',
+      color: '#b9a83c',
+      visible: true,
+      origin: { x: 0, y: 0 },
+    },
+    origin: { name: 'Origin', x: stockWidth / 2, y: stockHeight / 2, z: 2, visible: true },
+    backdrop: null,
+    dimensions: {},
+    annotations: [],
+    modelAssets: {},
+    featureDefinitions: {
+      'def-stacked-outer': definition('def-stacked-outer', 100, 80),
+      'def-stacked-inner': definition('def-stacked-inner', 20, 10),
+    },
+    // The outer rect is drawn on top (last in the tree) and fully covers the
+    // inner one. The inner rect is translated to world (30,25)-(50,35) so its
+    // outline stays clear of the outer rect's edges — a click just inside it
+    // indicates exactly one outline.
+    features: [
+      { ...featureRow('f-stacked-inner', 'Inner rect', 'def-stacked-inner'), transform: { a: 1, b: 0, c: 0, d: 1, e: 30, f: 25 } },
+      featureRow('f-stacked-outer', 'Outer rect', 'def-stacked-outer'),
+    ],
+    featureFolders: [],
+    featureTree: [],
+    global_constraints: [],
+    tools: [],
+    operations: [],
+    tabs: [],
+    clamps: [],
+    ai_history: [],
+  })
+}
+
+/** Seed an outer-on-top stacked rect project and return it for tests. */
+export async function seedStackedRectProject(page: Page): Promise<void> {
+  await seedProject(page, buildStackedRectProjectJson())
+}
+
 export async function clickCanvasCenter(canvas: Locator): Promise<void> {
   const box = await canvas.boundingBox()
   if (!box) throw new Error('sketch canvas did not have a bounding box')
 
   await canvas.click({ position: { x: box.width / 2, y: box.height / 2 } })
+}
+
+/**
+ * World→canvas-pixel mapping for these fixtures. Same rule as
+ * `computeBaseViewTransform` (VIEW_PADDING = 42): the base view fits the
+ * 120×90 stock into the canvas.
+ */
+export async function canvasWorldPoint(
+  canvas: Locator,
+  worldX: number,
+  worldY: number,
+): Promise<{ x: number; y: number }> {
+  const box = await canvas.boundingBox()
+  if (!box) throw new Error('sketch canvas did not have a bounding box')
+
+  const STOCK_W = 120
+  const STOCK_H = 90
+  const VIEW_PADDING = 42
+  const scale = Math.min(
+    (box.width - VIEW_PADDING * 2) / STOCK_W,
+    (box.height - VIEW_PADDING * 2) / STOCK_H,
+  )
+  return {
+    x: (box.width - STOCK_W * scale) / 2 + worldX * scale,
+    y: (box.height - STOCK_H * scale) / 2 + worldY * scale,
+  }
+}
+
+/** Click the canvas at a world point (button left or right). */
+export async function clickCanvasWorld(
+  canvas: Locator,
+  worldX: number,
+  worldY: number,
+  button: 'left' | 'right' = 'left',
+): Promise<void> {
+  await canvas.click({ position: await canvasWorldPoint(canvas, worldX, worldY), button })
+}
+
+/**
+ * Click just inside the shared left outline of the fixture's coincident
+ * full-stock rects (world ~(0.4, 45)). Every feature's outline passes through
+ * there, so the click stays ambiguous and opens the overlap picker even though
+ * interior clicks now resolve to the topmost feature (issue #521).
+ */
+export async function clickCanvasSharedEdge(canvas: Locator): Promise<void> {
+  await clickCanvasWorld(canvas, 0.4, 45)
 }

--- a/e2e/overlapFeatureSelection.smoke.spec.ts
+++ b/e2e/overlapFeatureSelection.smoke.spec.ts
@@ -17,9 +17,13 @@
 import { test, expect } from './fixtures'
 import { getHoveredFeatureId } from './helpers'
 import {
+  canvasWorldPoint,
   clickCanvasCenter,
+  clickCanvasSharedEdge,
+  clickCanvasWorld,
   seedObviousOverlapFeatureProject,
   seedOverlapFeatureProject,
+  seedStackedRectProject,
 } from './overlapFeatureSelection.helpers'
 
 test.describe('Overlap feature selection browser smoke', () => {
@@ -33,10 +37,50 @@ test.describe('Overlap feature selection browser smoke', () => {
     await expect(ui.tree.rowByName(app.page, 'Bottom overlap')).not.toHaveClass(/tree-row--selected/)
   })
 
-  test('shows overlapping candidates and lets the user select a non-topmost feature', async ({ app, ui }) => {
+  test('selects the topmost feature on an interior click without opening the picker', async ({ app, ui }) => {
     await seedOverlapFeatureProject(app.page)
 
     await clickCanvasCenter(ui.canvas.sketch(app.page))
+
+    await expect(ui.overlapFeaturePicker.root(app.page)).not.toBeVisible()
+    await expect(ui.tree.rowByName(app.page, 'Top overlap')).toHaveClass(/tree-row--selected/)
+    await expect(ui.tree.rowByName(app.page, 'Bottom overlap')).not.toHaveClass(/tree-row--selected/)
+  })
+
+  test('right-click keeps the click-resolved selection under a covering rect', async ({ app, ui }) => {
+    await seedStackedRectProject(app.page)
+
+    // Just inside the inner rect's left outline: the boundary rule selects the
+    // inner rect even though the outer rect is drawn on top.
+    await clickCanvasWorld(ui.canvas.sketch(app.page), 30.2, 30)
+    await expect(ui.tree.rowByName(app.page, 'Inner rect')).toHaveClass(/tree-row--selected/)
+    await expect(ui.tree.rowByName(app.page, 'Outer rect')).not.toHaveClass(/tree-row--selected/)
+
+    // The context menu must resolve the same feature an ordinary click does.
+    await clickCanvasWorld(ui.canvas.sketch(app.page), 30.2, 30, 'right')
+    await expect(ui.tree.rowByName(app.page, 'Inner rect')).toHaveClass(/tree-row--selected/)
+    await expect(ui.tree.rowByName(app.page, 'Outer rect')).not.toHaveClass(/tree-row--selected/)
+  })
+
+  test('selects a fully enclosed rect on an interior click even when covered', async ({ app, ui }) => {
+    await seedStackedRectProject(app.page)
+
+    // The outer rect is drawn on top, but the pointer is inside the enclosed
+    // inner rect: hover must preview the innermost shape, and the click must
+    // select it (issue #521 review feedback).
+    const canvas = ui.canvas.sketch(app.page)
+    await canvas.hover({ position: await canvasWorldPoint(canvas, 40, 30) })
+    await expect.poll(() => getHoveredFeatureId(app.page)).toBe('f-stacked-inner')
+
+    await clickCanvasWorld(canvas, 40, 30)
+    await expect(ui.tree.rowByName(app.page, 'Inner rect')).toHaveClass(/tree-row--selected/)
+    await expect(ui.tree.rowByName(app.page, 'Outer rect')).not.toHaveClass(/tree-row--selected/)
+  })
+
+  test('shows overlapping candidates and lets the user select a non-topmost feature', async ({ app, ui }) => {
+    await seedOverlapFeatureProject(app.page)
+
+    await clickCanvasSharedEdge(ui.canvas.sketch(app.page))
 
     const picker = ui.overlapFeaturePicker.root(app.page)
     await expect(picker).toBeVisible()
@@ -53,7 +97,7 @@ test.describe('Overlap feature selection browser smoke', () => {
 
   test('previews a hovered or focused candidate without selecting it', async ({ app, ui }) => {
     await seedOverlapFeatureProject(app.page)
-    await clickCanvasCenter(ui.canvas.sketch(app.page))
+    await clickCanvasSharedEdge(ui.canvas.sketch(app.page))
 
     const bottomCandidate = ui.overlapFeaturePicker.candidate(app.page, 'Bottom overlap')
     const topCandidate = ui.overlapFeaturePicker.candidate(app.page, 'Top overlap')
@@ -78,7 +122,7 @@ test.describe('Overlap feature selection browser smoke', () => {
     await app.page.setViewportSize({ width: 1024, height: 768 })
     await seedOverlapFeatureProject(app.page)
 
-    await clickCanvasCenter(ui.canvas.sketch(app.page))
+    await clickCanvasSharedEdge(ui.canvas.sketch(app.page))
 
     const picker = ui.overlapFeaturePicker.root(app.page)
     await expect(picker).toBeVisible()
@@ -93,7 +137,7 @@ test.describe('Overlap feature selection browser smoke', () => {
   test('boxes and scrolls a long candidate list', async ({ app, ui }) => {
     await seedOverlapFeatureProject(app.page, 17)
 
-    await clickCanvasCenter(ui.canvas.sketch(app.page))
+    await clickCanvasSharedEdge(ui.canvas.sketch(app.page))
 
     const list = ui.overlapFeaturePicker.list(app.page)
     await expect(list).toBeVisible()
@@ -115,7 +159,7 @@ test.describe('Overlap feature selection browser smoke', () => {
   test('dismisses when the user starts a different action', async ({ app, ui }) => {
     await seedOverlapFeatureProject(app.page)
 
-    await clickCanvasCenter(ui.canvas.sketch(app.page))
+    await clickCanvasSharedEdge(ui.canvas.sketch(app.page))
 
     const picker = ui.overlapFeaturePicker.root(app.page)
     await expect(picker).toBeVisible()

--- a/src/components/canvas/hitTest.test.ts
+++ b/src/components/canvas/hitTest.test.ts
@@ -263,24 +263,71 @@ function makeProject(
   console.log('   ✓ coincident outlines remain ambiguous')
 }
 
-// Shared interiors with no nearby outline remain ambiguous.
+// Shared interiors with no nearby outline select the topmost feature, which
+// is what the hover highlight previews (issue #521).
 {
-  console.log('9. Shared interior ambiguity...')
+  console.log('9. Shared interior selects topmost...')
 
   const bottom = makeFeature('bottom', rectProfile(0, 0, 20, 20))
   const top = makeFeature('top', rectProfile(0, 0, 20, 20))
   const features = resolvedProjectFeatures(makeProject([bottom, top]))
   const result = resolveFeatureSelectionHit({ x: 10, y: 10 }, features, preciseVt)
 
-  assert(result.kind === 'ambiguous', `expected ambiguous shared interior, got ${result.kind}`)
+  assert(result.kind === 'direct', `expected direct topmost shared interior, got ${result.kind}`)
+  assert(result.featureId === 'top', `expected topmost feature, got ${result.featureId}`)
   assert(result.candidateIds.join(',') === 'top,bottom', 'interior candidates should remain topmost-first')
 
-  console.log('   ✓ shared interiors remain ambiguous')
+  console.log('   ✓ shared interiors resolve to the topmost candidate')
+}
+
+// A hole nested inside a material: clicking inside the hole selects the hole
+// without the overlap picker, while clicking the material around it still
+// selects the material (issue #521 scenario).
+{
+  console.log('10. Nested hole-in-material interior click...')
+
+  const material = makeFeature('material', rectProfile(0, 0, 40, 40))
+  const hole = makeFeature('hole', rectProfile(15, 15, 10, 10))
+  const features = resolvedProjectFeatures(makeProject([material, hole]))
+
+  const holeInterior = resolveFeatureSelectionHit({ x: 20, y: 20 }, features, preciseVt)
+  assert(holeInterior.kind === 'direct', `expected direct hole interior, got ${holeInterior.kind}`)
+  assert(holeInterior.featureId === 'hole', `expected hole feature, got ${holeInterior.featureId}`)
+  assert(holeInterior.candidateIds.join(',') === 'hole,material', 'hole interior candidates should stay topmost-first')
+
+  const materialInterior = resolveFeatureSelectionHit({ x: 5, y: 5 }, features, preciseVt)
+  assert(materialInterior.kind === 'direct', `expected direct material interior, got ${materialInterior.kind}`)
+  assert(materialInterior.featureId === 'material', `expected material feature, got ${materialInterior.featureId}`)
+
+  const holeOutline = resolveFeatureSelectionHit({ x: 15, y: 20 }, features, preciseVt)
+  assert(holeOutline.kind === 'direct', `expected direct hole outline, got ${holeOutline.kind}`)
+  assert(holeOutline.featureId === 'hole', `expected hole on outline click, got ${holeOutline.featureId}`)
+
+  // Covered variant: the material is drawn on top. An interior click still
+  // resolves to the innermost hole instead of the covering material (the
+  // review-feedback case that extended issue #521).
+  const coveredFeatures = resolvedProjectFeatures(makeProject([hole, material]))
+  const coveredInterior = resolveFeatureSelectionHit({ x: 20, y: 20 }, coveredFeatures, preciseVt)
+  assert(coveredInterior.kind === 'direct', `expected direct covered hole interior, got ${coveredInterior.kind}`)
+  assert(coveredInterior.featureId === 'hole', `expected innermost hole, got ${coveredInterior.featureId}`)
+  assert(coveredInterior.candidateIds.join(',') === 'material,hole', 'covered candidates should stay topmost-first')
+
+  // Hover follows the same innermost resolution, in both draw orders.
+  assert(
+    findHitFeatureId({ x: 20, y: 20 }, features, preciseVt) === 'hole',
+    'hover should preview the innermost hole',
+  )
+  assert(
+    findHitFeatureId({ x: 20, y: 20 }, coveredFeatures, preciseVt) === 'hole',
+    'hover should preview the innermost hole even when covered',
+  )
+
+  console.log('   ✓ nested interior clicks resolve without the picker, even when covered')
 }
 
 // A lone hit keeps ordinary direct-selection behavior.
 {
-  console.log('10. Single candidate selection...')
+  console.log('11. Single candidate selection...')
 
   const feature = makeFeature('only', rectProfile(0, 0, 20, 20))
   const features = resolvedProjectFeatures(makeProject([feature]))

--- a/src/components/canvas/hitTest.ts
+++ b/src/components/canvas/hitTest.ts
@@ -61,6 +61,43 @@ export function pointInProfile(x: number, y: number, profile: SketchProfile): bo
   return inside
 }
 
+/**
+ * True when every sampled point of `inner` lies inside `outer` — i.e. `inner`
+ * is fully enclosed by `outer` regardless of draw order. Coincident profiles
+ * may return true in both directions; callers handle that as a tie.
+ */
+function profileContainedIn(inner: SketchProfile, outer: SketchProfile): boolean {
+  const innerPoints = sampleProfilePoints(inner)
+  if (innerPoints.length < 3) return false
+  return innerPoints.every((point) => pointInProfile(point.x, point.y, outer))
+}
+
+/**
+ * Picks the feature an interior hit resolves to: the unique innermost candidate
+ * (fully enclosed by every other candidate, regardless of draw order) when one
+ * exists, otherwise the topmost candidate — the first in `candidates`. Shared
+ * by click resolution, hover, and drag-pick so the highlight always predicts
+ * what a click selects.
+ */
+function resolveInnermostOrTopmostId(
+  candidates: { id: string; profile: SketchProfile }[],
+): string | null {
+  if (candidates.length === 0) return null
+  if (candidates.length === 1) return candidates[0].id
+
+  const containingSets = candidates.map((candidate) =>
+    candidates.filter(
+      (other) => other !== candidate && profileContainedIn(candidate.profile, other.profile),
+    ),
+  )
+  const maxContaining = Math.max(0, ...containingSets.map((set) => set.length))
+  const innermost = candidates.filter(
+    (_, index) => maxContaining > 0 && containingSets[index].length === maxContaining,
+  )
+  if (innermost.length === 1) return innermost[0].id
+  return candidates[0].id
+}
+
 function distancePointToSegment(point: Point, start: Point, end: Point): number {
   const dx = end.x - start.x
   const dy = end.y - start.y
@@ -276,7 +313,11 @@ export function findHitFeatureIds(worldPoint: Point, features: readonly FeatureL
 
 /**
  * Resolves ordinary feature selection without interrupting a clear outline
- * click. Interior-only and coincident-outline hits remain ambiguous so the
+ * click. An interior-only click over several shapes prefers the unique
+ * innermost candidate — a shape fully enclosed by the others, whatever the
+ * draw order — and falls back to the topmost candidate; the hover highlight
+ * uses the same resolution, so it always predicts the click (issue #521).
+ * Only a click on two or more coincident outlines stays ambiguous so the
  * overlap picker can expose every candidate.
  */
 export function resolveFeatureSelectionHit(
@@ -284,7 +325,7 @@ export function resolveFeatureSelectionHit(
   features: readonly FeatureLike[],
   vt: ViewTransform,
 ): FeatureSelectionHit {
-  const candidateIds: string[] = []
+  const candidates: { id: string; profile: SketchProfile }[] = []
   const nearbyOutlineIds: string[] = []
 
   for (let index = features.length - 1; index >= 0; index -= 1) {
@@ -296,31 +337,43 @@ export function resolveFeatureSelectionHit(
       continue
     }
 
-    candidateIds.push(feature.id)
+    candidates.push({ id: feature.id, profile: feature.sketch.profile })
     if (nearOutline) nearbyOutlineIds.push(feature.id)
   }
 
-  if (candidateIds.length === 0) {
+  const candidateIds = candidates.map((candidate) => candidate.id)
+
+  if (candidates.length === 0) {
     return { kind: 'none', candidateIds: [] }
   }
-  if (candidateIds.length === 1) {
-    return { kind: 'direct', featureId: candidateIds[0], candidateIds }
+  if (candidates.length === 1) {
+    return { kind: 'direct', featureId: candidates[0].id, candidateIds }
   }
   if (nearbyOutlineIds.length === 1) {
     return { kind: 'direct', featureId: nearbyOutlineIds[0], candidateIds }
+  }
+  if (nearbyOutlineIds.length === 0) {
+    // Interior-only click across several shapes: the same innermost-or-topmost
+    // resolution the hover highlight previews.
+    return {
+      kind: 'direct',
+      featureId: resolveInnermostOrTopmostId(candidates) ?? candidates[0].id,
+      candidateIds,
+    }
   }
   return { kind: 'ambiguous', candidateIds }
 }
 
 export function findHitFeatureId(worldPoint: Point, features: readonly FeatureLike[], vt: ViewTransform): string | null {
+  const candidates: { id: string; profile: SketchProfile }[] = []
   for (let index = features.length - 1; index >= 0; index -= 1) {
     const feature = features[index]
     if (!feature.visible) continue
     if (featureContainsPoint(feature, worldPoint, vt)) {
-      return feature.id
+      candidates.push({ id: feature.id, profile: feature.sketch.profile })
     }
   }
-  return null
+  return resolveInnermostOrTopmostId(candidates)
 }
 
 function pointInRect(point: Point, minX: number, minY: number, maxX: number, maxY: number): boolean {

--- a/src/components/canvas/useCanvasContextMenu.ts
+++ b/src/components/canvas/useCanvasContextMenu.ts
@@ -27,8 +27,8 @@ import type { Project } from '../../types/project'
 import { resolvedProjectFeatures } from '../../store/helpers/resolveFeatures'
 import {
   findHitClampId,
-  findHitFeatureId,
   findHitTabId,
+  resolveFeatureSelectionHit,
 } from './hitTest'
 import {
   canvasToWorld,
@@ -121,8 +121,13 @@ export function useCanvasContextMenu(ctx: CanvasContextMenuCtx): UseCanvasContex
       return
     }
 
-    const hitId = findHitFeatureId(world, resolvedProjectFeatures(project), vt)
-    if (!hitId) return
+    // Resolve the hit exactly like an ordinary click: a uniquely indicated
+    // outline wins, an interior click takes the topmost (hover-highlighted)
+    // feature. Coincident outlines cannot show the picker here, so fall back
+    // to the topmost candidate.
+    const featureHit = resolveFeatureSelectionHit(world, resolvedProjectFeatures(project), vt)
+    if (featureHit.kind === 'none') return
+    const hitId = featureHit.kind === 'direct' ? featureHit.featureId : featureHit.candidateIds[0]
 
     if (!selection.selectedFeatureIds.includes(hitId)) {
       selectFeature(hitId)


### PR DESCRIPTION
Closes #521

Interior-only clicks over stacked or overlapping shapes now resolve directly instead of opening the overlap picker. Resolution order: a uniquely indicated outline wins, otherwise the unique *innermost* candidate (a shape fully enclosed by the others, regardless of draw order) wins, otherwise the topmost candidate. Hover and drag-pick use the same innermost-or-topmost resolution, so the highlight always predicts the click. The picker still opens only for clicks on two or more coincident outlines.

- `hitTest.ts`: shared innermost-or-topmost resolution used by click selection, hover, and the context menu; overlapping non-nested and coincident shapes keep the topmost rule.
- `useCanvasContextMenu`: right-click resolves its target with the same resolution as an ordinary click, so the menu can no longer switch the selection to a covering feature.
- Structural tests: shared-interior topmost case, covered-nested innermost case (click and hover, both draw orders), nested hole-in-material scenario.
- e2e: interior-click smoke, covered-rect hover+click, covering-rect right-click regression; picker tests click the coincident shared outline so picker wiring stays exercised.

Extensions (innermost preference, hover alignment) were approved on the issue in review feedback — full lane, no fast-lane label. Checks: `npm run build` green; `overlapFeatureSelection` (9), `canvasWorkflowPanel`, and `creationTargets` smoke specs green locally.
