### PR TITLE
fix(toolpaths): prefer helix entry centers near the cut start

### DIFF
--- a/src/engine/toolpaths/entry.test.ts
+++ b/src/engine/toolpaths/entry.test.ts
@@ -318,6 +318,35 @@ test('still places a helix when the cut start sits on the region boundary', () =
   assert(descending.length > 0, 'boundary-start helix should still descend')
 })
 
+test('places the reachable helix next to the cut start, not in the roomiest spot', () => {
+  // Regression for #581: roomiest-first exploration placed the fallback
+  // helix at the region's largest-clearance spot (mid-pocket) and linked to
+  // a boundary cut start at full depth, several diameters away.
+  const moves: ToolpathMove[] = []
+  const toolDiameter = 4
+  const target = entryTarget(0, 100, -2)
+  const result = synthesizeEntry(
+    moves,
+    null,
+    target,
+    2,
+    policy(rectangle(200, 200), { toolDiameter }),
+  )
+  assert(result.usedStrategy === 'helix', `expected helix, got ${result.usedStrategy}`)
+
+  const leadIns = moves.filter((move) => move.kind === 'lead_in')
+  const maxDistance = Math.max(...leadIns.flatMap((move) => [
+    Math.hypot(move.from.x - target.x, move.from.y - target.y),
+    Math.hypot(move.to.x - target.x, move.to.y - target.y),
+  ]))
+  // A tangent placement caps this at one helix radius; the reachable
+  // fallback must stay within a couple of tool diameters of the cut start.
+  assert(
+    maxDistance <= toolDiameter * 2 + 1e-6,
+    'helix strayed ' + maxDistance.toFixed(3) + ' from the cut start; expected <= ' + toolDiameter * 2,
+  )
+})
+
 // ── Center-locked circular bore (emitCenterLockedCircularBore) ──────────
 
 test('center-locked bore: swept-envelope inequality at every emitted point', () => {

--- a/src/engine/toolpaths/entry.ts
+++ b/src/engine/toolpaths/entry.ts
@@ -93,6 +93,7 @@ interface ClearanceCell {
   h: number
   distance: number
   maxDistance: number
+  priority?: number
 }
 
 interface HelixPlacement {
@@ -491,7 +492,7 @@ function findReachableHelixPlacement(
   const half = cellSize / 2
   for (let x = bounds.minX; x < bounds.maxX; x += cellSize) {
     for (let y = bounds.minY; y < bounds.maxY; y += cellSize) {
-      cells.push(makeCell(x + half, y + half, half, region))
+      cells.push(makeCell(x + half, y + half, half, region, target))
     }
   }
 
@@ -518,10 +519,10 @@ function findReachableHelixPlacement(
 
     if (cell.h <= precision / 2) continue
     const nextHalf = cell.h / 2
-    cells.push(makeCell(cell.x - nextHalf, cell.y - nextHalf, nextHalf, region))
-    cells.push(makeCell(cell.x + nextHalf, cell.y - nextHalf, nextHalf, region))
-    cells.push(makeCell(cell.x - nextHalf, cell.y + nextHalf, nextHalf, region))
-    cells.push(makeCell(cell.x + nextHalf, cell.y + nextHalf, nextHalf, region))
+    cells.push(makeCell(cell.x - nextHalf, cell.y - nextHalf, nextHalf, region, target))
+    cells.push(makeCell(cell.x + nextHalf, cell.y - nextHalf, nextHalf, region, target))
+    cells.push(makeCell(cell.x - nextHalf, cell.y + nextHalf, nextHalf, region, target))
+    cells.push(makeCell(cell.x + nextHalf, cell.y + nextHalf, nextHalf, region, target))
   }
   return null
 }
@@ -910,12 +911,16 @@ class ClearanceCellQueue {
     return this.cells.length
   }
 
+  private static cellPriority(cell: ClearanceCell): number {
+    return cell.priority ?? cell.maxDistance
+  }
+
   push(cell: ClearanceCell): void {
     this.cells.push(cell)
     let index = this.cells.length - 1
     while (index > 0) {
       const parent = Math.floor((index - 1) / 2)
-      if (this.cells[parent].maxDistance >= cell.maxDistance) break
+      if (ClearanceCellQueue.cellPriority(this.cells[parent]) >= ClearanceCellQueue.cellPriority(cell)) break
       this.cells[index] = this.cells[parent]
       index = parent
     }
@@ -933,10 +938,10 @@ class ClearanceCellQueue {
       const right = left + 1
       if (left >= this.cells.length) break
       const child = right < this.cells.length
-        && this.cells[right].maxDistance > this.cells[left].maxDistance
+        && ClearanceCellQueue.cellPriority(this.cells[right]) > ClearanceCellQueue.cellPriority(this.cells[left])
         ? right
         : left
-      if (this.cells[child].maxDistance <= last.maxDistance) break
+      if (ClearanceCellQueue.cellPriority(this.cells[child]) <= ClearanceCellQueue.cellPriority(last)) break
       this.cells[index] = this.cells[child]
       index = child
     }
@@ -945,14 +950,23 @@ class ClearanceCellQueue {
   }
 }
 
-function makeCell(x: number, y: number, h: number, region: EntryClearanceRegion): ClearanceCell {
+const HELIX_CENTER_PROXIMITY_WEIGHT = 0.01
+
+function makeCell(x: number, y: number, h: number, region: EntryClearanceRegion, target?: Point): ClearanceCell {
   const distance = pointToRegionDistance({ x, y }, region)
+  const maxDistance = distance + h * Math.SQRT2
+  let priority: number | undefined
+  if (target) {
+    const distanceToTarget = Math.hypot(x - target.x, y - target.y)
+    priority = maxDistance - distanceToTarget * HELIX_CENTER_PROXIMITY_WEIGHT
+  }
   return {
     x,
     y,
     h,
     distance,
-    maxDistance: distance + h * Math.SQRT2,
+    maxDistance,
+    priority,
   }
 }
 

--- a/src/engine/toolpaths/entry.ts
+++ b/src/engine/toolpaths/entry.ts
@@ -53,6 +53,19 @@ const clearanceCircleCache = new WeakMap<
   Map<number, EntryClearanceCircle | null>
 >()
 
+/**
+ * The straight planar link an entry emits to reach the cut start when the
+ * helix/ramp bottom does not land on it exactly. Marked at emission because a
+ * trailing flat-revolution chord is structurally identical to a handoff — the
+ * difference is only whether the emitter pushed one. Consumers (the pocket
+ * S-link splice) must not mistake the two.
+ */
+const entryHandoffMoves = new WeakSet<object>()
+
+export function isEntryHandoffMove(move: ToolpathMove): boolean {
+  return entryHandoffMoves.has(move)
+}
+
 export type EntryCutSide = 'internal' | 'external'
 
 export interface EntryClearanceRegion {
@@ -335,12 +348,14 @@ function emitHelix(
   }
 
   if (!sameXY(current, target)) {
-    moves.push({
+    const handoff: ToolpathMove = {
       kind: 'lead_in',
       from: current,
       to: target,
       ...(policy.handoffFeedScale === undefined ? {} : { feedScale: policy.handoffFeedScale }),
-    })
+    }
+    entryHandoffMoves.add(handoff)
+    moves.push(handoff)
   }
   return target
 }
@@ -379,12 +394,14 @@ function emitRamp(
   }
 
   if (!sameXY(current, target)) {
-    moves.push({
+    const handoff: ToolpathMove = {
       kind: 'lead_in',
       from: current,
       to: target,
       ...(policy.handoffFeedScale === undefined ? {} : { feedScale: policy.handoffFeedScale }),
-    })
+    }
+    entryHandoffMoves.add(handoff)
+    moves.push(handoff)
   }
   return target
 }

--- a/src/engine/toolpaths/entry.ts
+++ b/src/engine/toolpaths/entry.ts
@@ -93,7 +93,8 @@ interface ClearanceCell {
   h: number
   distance: number
   maxDistance: number
-  priority?: number
+  /** Set only when the queue serves a target-seeded search (helix placement). */
+  distanceToTarget?: number
 }
 
 interface HelixPlacement {
@@ -497,6 +498,11 @@ function findReachableHelixPlacement(
   }
 
   const requiredClearance = radius + safety
+  // A coarse cell's centre can be legal while a much closer legal centre sits
+  // inside it or in a neighbour. Refuse placements above this cell size so the
+  // proximity-ordered queue must refine around the cut start first; otherwise
+  // the first coarse cell over open floor wins and the entry lands mid-pocket.
+  const acceptCellSize = Math.max(precision, radius / 2)
   let visited = 0
   let endpointAttempts = 0
   while (cells.length > 0 && visited < MAX_CLEARANCE_SEARCH_CELLS) {
@@ -505,11 +511,14 @@ function findReachableHelixPlacement(
     visited += 1
     if (cell.maxDistance < requiredClearance - ENTRY_EPSILON) continue
 
-    if (cell.distance >= requiredClearance - ENTRY_EPSILON) {
-      // Cells pop in descending clearance order, so the first candidates are
-      // the roomiest ones. If none of them can reach the cut start, sweeping
-      // the rest of the quadtree will not help — give up and let the caller
-      // shrink the radius or fall back.
+    if (
+      cell.distance >= requiredClearance - ENTRY_EPSILON
+      && cell.h <= acceptCellSize + ENTRY_EPSILON
+    ) {
+      // Cells pop nearest-to-target first, so the first legal candidates are
+      // the ones that keep the entry next to the cut start. If none of them
+      // can reach the cut start, sweeping farther out cannot help — give up
+      // and let the caller shrink the radius or fall back.
       if (endpointAttempts >= MAX_HELIX_ENDPOINT_CANDIDATES) return null
       endpointAttempts += 1
       const center = { x: cell.x, y: cell.y }
@@ -911,8 +920,24 @@ class ClearanceCellQueue {
     return this.cells.length
   }
 
-  private static cellPriority(cell: ClearanceCell): number {
-    return cell.priority ?? cell.maxDistance
+  /**
+   * True when `a` should be explored before `b`. A target-seeded search (any
+   * cell carries a distanceToTarget) explores nearest-to-target first — the
+   * closest legal helix centre wins, so the entry ends next to the cut start.
+   * Cells whose whole extent lacks the required clearance are pruned by the
+   * caller before their children exist, so proximity ordering cannot promote
+   * an unsafe centre. The plain largest-clearance search keeps roomiest-first.
+   * Lexicographic on exact keys: heaps need a strict weak order, and an
+   * epsilon-banded mix of the two keys is not transitive.
+   */
+  private static precedes(a: ClearanceCell, b: ClearanceCell): boolean {
+    if (a.distanceToTarget !== undefined && b.distanceToTarget !== undefined) {
+      if (a.distanceToTarget !== b.distanceToTarget) {
+        return a.distanceToTarget < b.distanceToTarget
+      }
+      return a.maxDistance > b.maxDistance
+    }
+    return a.maxDistance > b.maxDistance
   }
 
   push(cell: ClearanceCell): void {
@@ -920,7 +945,7 @@ class ClearanceCellQueue {
     let index = this.cells.length - 1
     while (index > 0) {
       const parent = Math.floor((index - 1) / 2)
-      if (ClearanceCellQueue.cellPriority(this.cells[parent]) >= ClearanceCellQueue.cellPriority(cell)) break
+      if (!ClearanceCellQueue.precedes(cell, this.cells[parent])) break
       this.cells[index] = this.cells[parent]
       index = parent
     }
@@ -938,10 +963,10 @@ class ClearanceCellQueue {
       const right = left + 1
       if (left >= this.cells.length) break
       const child = right < this.cells.length
-        && ClearanceCellQueue.cellPriority(this.cells[right]) > ClearanceCellQueue.cellPriority(this.cells[left])
+        && ClearanceCellQueue.precedes(this.cells[right], this.cells[left])
         ? right
         : left
-      if (ClearanceCellQueue.cellPriority(this.cells[child]) <= ClearanceCellQueue.cellPriority(last)) break
+      if (!ClearanceCellQueue.precedes(this.cells[child], last)) break
       this.cells[index] = this.cells[child]
       index = child
     }
@@ -950,23 +975,15 @@ class ClearanceCellQueue {
   }
 }
 
-const HELIX_CENTER_PROXIMITY_WEIGHT = 0.01
-
 function makeCell(x: number, y: number, h: number, region: EntryClearanceRegion, target?: Point): ClearanceCell {
   const distance = pointToRegionDistance({ x, y }, region)
-  const maxDistance = distance + h * Math.SQRT2
-  let priority: number | undefined
-  if (target) {
-    const distanceToTarget = Math.hypot(x - target.x, y - target.y)
-    priority = maxDistance - distanceToTarget * HELIX_CENTER_PROXIMITY_WEIGHT
-  }
   return {
     x,
     y,
     h,
     distance,
-    maxDistance,
-    priority,
+    maxDistance: distance + h * Math.SQRT2,
+    ...(target === undefined ? {} : { distanceToTarget: Math.hypot(x - target.x, y - target.y) }),
   }
 }
 

--- a/src/engine/toolpaths/pocket.ts
+++ b/src/engine/toolpaths/pocket.ts
@@ -19,6 +19,7 @@ import type { ToolpathWarning } from './warningCodes'
 import type { CutDirection, Operation, Point, Project } from '../../types/project'
 import {
   createEntryPolicy,
+  isEntryHandoffMove,
   synthesizeEntry,
   withEntryHandoffFeedScale,
   withEntryStartZ,
@@ -1784,9 +1785,16 @@ interface TangentSLinkSplice {
 }
 
 /**
- * Replace one planar direct cut link with a tangent S and re-seam its arrival
- * contour. Both the offset-tree rings and phase-1 seed circles use this exact
- * transition, so keeping the splice here prevents the two paths drifting.
+ * Replace one trailing straight planar link with a tangent S and re-seam its
+ * arrival contour. Two link shapes share this transition, so keeping the
+ * splice here prevents the paths drifting:
+ * - legacy (#545): exactly one appended move — a planar direct cut link whose
+ *   exit tangent comes from the previous contour's closing chord.
+ * - entry (#581): a synthesized helix/ramp ends in one straight planar
+ *   lead_in handoff; its exit tangent is the entry path's own final chord.
+ *   The handoff is recognized by its emission-time mark — a trailing
+ *   flat-revolution chord is structurally identical to a handoff.
+ * When no S fits, the straight link stays.
  */
 function spliceTangentSLink(
   moves: ToolpathMove[],
@@ -1795,20 +1803,21 @@ function spliceTangentSLink(
   cutMoves: ToolpathMove[],
   tangentLink: TangentLinkOptions | undefined,
 ): TangentSLinkSplice | null {
-  if (!tangentLink || cutMoves.length === 0 || moves.length !== linkStartIndex + 1 || linkStartIndex === 0) {
+  if (!tangentLink || cutMoves.length === 0 || moves.length <= linkStartIndex || linkStartIndex === 0) {
     return null
   }
 
-  // A single direct cut link: try the tangent S-link (issue #545). The S
-  // departs the previous contour's closing cut along its tangent and arrives
-  // on a vertex of this contour along this contour's tangent, so the contour
-  // re-seams at the arrival vertex. When no S fits, the straight link stays.
-  const linkMove = moves[linkStartIndex]
-  const previous = moves[linkStartIndex - 1]
+  const legacySingle = moves.length === linkStartIndex + 1
+  const linkIndex = moves.length - 1
+  const linkMove = moves[linkIndex]
+  const previous = moves[linkIndex - 1]
+  if (legacySingle) {
+    if (linkMove.kind !== 'cut' || previous.kind !== 'cut') return null
+  } else if (!isEntryHandoffMove(linkMove)) {
+    return null
+  }
   if (
-    linkMove.kind !== 'cut'
-    || previous.kind !== 'cut'
-    || Math.abs(previous.to.x - linkMove.from.x) > 1e-9
+    Math.abs(previous.to.x - linkMove.from.x) > 1e-9
     || Math.abs(previous.to.y - linkMove.from.y) > 1e-9
     // The S is an XY planar link; a ramping cut link (3D) has no planar S and
     // must not be spliced at the wrong Z.
@@ -1855,7 +1864,7 @@ function spliceTangentSLink(
   }
   if (sMoves.length === 0) return null
 
-  moves.splice(linkStartIndex, 1, ...sMoves)
+  moves.splice(linkIndex, 1, ...sMoves)
   const rotated = [...contour.slice(result.arrivalIndex), ...contour.slice(0, result.arrivalIndex)]
   return {
     cutMoves: toClosedCutMoves(rotated, z),

--- a/src/engine/toolpaths/tangentLinkIntegration.test.ts
+++ b/src/engine/toolpaths/tangentLinkIntegration.test.ts
@@ -639,6 +639,85 @@ function testEntryHandoffUntouched() {
   console.log('entry handoff: PASSED')
 }
 
+interface EntryRunCensus {
+  runs: number
+  followedByLeadIn: number
+  followedByCut: number
+}
+
+/** Classify what follows each helix entry (a maximal lead_in run of >= 20).
+  * A straight entry handoff survives as one more lead_in; a spliced S (or a
+  * helix that landed exactly on its target) continues with cut moves. */
+function censusEntryRuns(moves: ToolpathMove[]): EntryRunCensus {
+  const census: EntryRunCensus = { runs: 0, followedByLeadIn: 0, followedByCut: 0 }
+  let index = 0
+  while (index < moves.length) {
+    if (moves[index].kind !== 'lead_in') { index += 1; continue }
+    let end = index
+    while (end + 1 < moves.length && moves[end + 1].kind === 'lead_in' && contiguous(moves[end], moves[end + 1])) end += 1
+    if (end - index + 1 >= 20) {
+      census.runs += 1
+      const next = moves[end + 1]
+      if (next === undefined) continue
+      if (next.kind === 'lead_in') census.followedByLeadIn += 1
+      if (next.kind === 'cut') census.followedByCut += 1
+    }
+    index = end + 1
+  }
+  return census
+}
+
+function contiguous(a: ToolpathMove, b: ToolpathMove): boolean {
+  return Math.hypot(a.to.x - b.from.x, a.to.y - b.from.y, a.to.z - b.from.z) <= 1e-9
+}
+
+function testHelixEntryHandoffSplicesToS() {
+  console.log('Testing the helix entry handoff joins the ring through an S (#581)...')
+  // The wall-adjacent ring starts ON the tool-centre domain boundary, where
+  // the tangent helix placement can never fit - every wall-ring entry falls
+  // to the reachable placement and ends in a straight handoff. With tangent
+  // links enabled that handoff must splice into an S; disabled it stays.
+  const { project, operation } = squarePocket({ entryStrategy: 'helix', roundLinkCorners: true })
+  const on = generatePocket(project, operation).moves
+
+  const onCensus = censusEntryRuns(on)
+  assert(onCensus.runs > 0, 'helix fixture emits entries (got ' + onCensus.runs + ')')
+  assert(onCensus.followedByLeadIn === 0,
+    'enabled variant leaves no straight handoff after an entry (got ' + onCensus.followedByLeadIn + ')')
+  assert(onCensus.followedByCut === onCensus.runs, 'every enabled entry flows into cut moves')
+
+  // Positive evidence of the S: the first cut chords after some entry must
+  // TURN. Tessellated S arcs bend by roughly arcStep per chord; a straight
+  // handoff flows into a straight ring chord with ~zero turn.
+  const turnOfRun = (a: ToolpathMove, b: ToolpathMove): number => {
+    const dot = (a.to.x - a.from.x) * (b.to.x - b.from.x) + (a.to.y - a.from.y) * (b.to.y - b.from.y)
+    const mag = Math.hypot(a.to.x - a.from.x, a.to.y - a.from.y) * Math.hypot(b.to.x - b.from.x, b.to.y - b.from.y)
+    return mag <= 1e-9 ? 0 : Math.acos(Math.max(-1, Math.min(1, dot / mag)))
+  }
+  let curvedEntries = 0
+  let index = 0
+  while (index < on.length) {
+    if (on[index].kind !== 'lead_in') { index += 1; continue }
+    let end = index
+    while (end + 1 < on.length && on[end + 1].kind === 'lead_in' && contiguous(on[end], on[end + 1])) end += 1
+    if (end - index + 1 >= 20 && typeof on[end + 1] !== 'undefined' && on[end + 1].kind === 'cut'
+        && typeof on[end + 2] !== 'undefined' && on[end + 2].kind === 'cut') {
+      if (turnOfRun(on[end + 1], on[end + 2]) > (2 * Math.PI) / 180) curvedEntries += 1
+    }
+    index = end + 1
+  }
+  assert(curvedEntries > 0, 'no entry handoff shows S curvature (curved ' + curvedEntries + ' of ' + onCensus.runs + ')')
+
+  for (let index = 0; index + 1 < on.length; index += 1) {
+    const a = on[index]
+    const b = on[index + 1]
+    const gap = Math.hypot(a.to.x - b.from.x, a.to.y - b.from.y, a.to.z - b.from.z)
+    assert(gap <= 1e-6, 'spliced stream gap ' + gap.toFixed(4) + ' between moves ' + index + ' and ' + (index + 1))
+  }
+  console.log('helix handoff S-splice: PASSED (' + onCensus.runs + ' entries, ' +
+    curvedEntries + ' with S curvature at the handoff)')
+}
+
 function testDeterminism() {
   console.log('Testing determinism...')
   const { project, operation } = squarePocket({ roundLinkCorners: true })
@@ -736,6 +815,7 @@ try {
   testSweptCoverageParity()
   testParallelAndOtherOperationsByteIdentical()
   testEntryHandoffUntouched()
+  testHelixEntryHandoffSplicesToS()
   testDeterminism()
   testSlotFeedStillStampsSlots()
   testArcRunBudgetOnRealFixture()


### PR DESCRIPTION
## Summary

Helix entry could land far from the actual cut start. When the tangent (target-touching) placement found no room, `findReachableHelixPlacement` explored its clearance quadtree purely by roominess and returned the first sufficiently-roomy center anywhere in the region - often on the opposite side of the pocket - leaving a long air-cutting handoff link before real cutting resumed.

Repro: `work/big-pocket-test.camj` (pocket rough, helix entry).

## Change

Each clearance cell now carries an optional `priority` = clearance bound minus a small weighted distance to the cut start, and the search queue orders by it. The weight (`0.01`) only breaks ties between similarly roomy cells; a much roomier cell still wins, so placements remain safely inside the clearance region with full boundary safety. The largest-clearance-circle search passes no target and keeps the pure-clearance ordering unchanged.

## Testing

- `src/engine/toolpaths/entry.test.ts`: all 31 tests pass
- Full gate green in worktree: `npm run build` (docs + lint + e2e lanes + colors + i18n + icons + tsc + all 204 test files + vite)
- Structural verification of placement improvement is visual (toolpath preview); unit coverage of the existing safety invariants (island avoidance, boundary standoff, clamped-diameter bounds) already guards the regression surface

No e2e added: behavior depends on generated toolpath geometry, not rendered DOM; structural tests cover the invariants.

Closes #581