### PR TITLE
feat(canvas): anchor every movable sketch-view panel at page level

### DIFF
--- a/src/components/canvas/CanvasWorkflowPanel.tsx
+++ b/src/components/canvas/CanvasWorkflowPanel.tsx
@@ -43,6 +43,13 @@ interface CanvasWorkflowPanelProps {
   className?: string
   moveLabel?: string
   /**
+   * Render the panel root as a non-modal dialog with this accessible name.
+   * Use when the panel *is* the dialog (overlap picker): the role lives on
+   * the portaled element itself, so queries scoped through the dialog find
+   * the panel content instead of an empty shell left behind in the canvas.
+   */
+  dialogAria?: { label: string; modal?: boolean }
+  /**
    * Render through a portal to document.body with `position: fixed`, so the
    * panel can be dragged anywhere on the page. Must match the `pageLevel`
    * option on the `useCanvasWorkflowPanel` call that produced `position`.
@@ -62,6 +69,7 @@ export function CanvasWorkflowPanel({
   className = '',
   moveLabel,
   pageLevel = false,
+  dialogAria,
 }: CanvasWorkflowPanelProps) {
   const { t } = useI18n()
   const resolvedMoveLabel = moveLabel ?? t('canvas.common.moveControls')
@@ -115,6 +123,9 @@ export function CanvasWorkflowPanel({
       ref={panelRef}
       className={panelClassName}
       style={{ left: position.x, top: position.y }}
+      role={dialogAria ? 'dialog' : undefined}
+      aria-label={dialogAria?.label}
+      aria-modal={dialogAria ? dialogAria.modal ?? true : undefined}
       onKeyDownCapture={containTabWithinPanel}
     >
       <div className="canvas-workflow-panel__header">

--- a/src/components/canvas/ConstraintEditPanel.tsx
+++ b/src/components/canvas/ConstraintEditPanel.tsx
@@ -36,6 +36,7 @@ export function ConstraintEditPanel({ constraint }: ConstraintEditPanelProps) {
       position={constraint.constraintEditWorkflowPanel.position}
       panelRef={constraint.constraintEditWorkflowPanel.panelRef}
       handleProps={constraint.constraintEditWorkflowPanel.handleProps}
+      pageLevel
       actionRowProps={constraint.constraintEditWorkflowPanel.actionRowProps}
       className="canvas-workflow-panel--constraint-edit"
       moveLabel={t('canvas.constraint.moveLabel')}

--- a/src/components/canvas/DrivingDimensionPanel.tsx
+++ b/src/components/canvas/DrivingDimensionPanel.tsx
@@ -72,6 +72,7 @@ export function DrivingDimensionPanel({ driving }: DrivingDimensionPanelProps) {
       position={driving.drivingDimensionWorkflowPanel.position}
       panelRef={driving.drivingDimensionWorkflowPanel.panelRef}
       handleProps={driving.drivingDimensionWorkflowPanel.handleProps}
+      pageLevel
       actionRowProps={driving.drivingDimensionWorkflowPanel.actionRowProps}
       className="canvas-workflow-panel--driving-edit"
       moveLabel={t('canvas.driving.moveLabel')}

--- a/src/components/canvas/OverlapFeaturePicker.tsx
+++ b/src/components/canvas/OverlapFeaturePicker.tsx
@@ -51,6 +51,7 @@ export function OverlapFeaturePicker({ picker }: OverlapFeaturePickerProps) {
         position={picker.workflowPanel.position}
         panelRef={picker.workflowPanel.panelRef}
         handleProps={picker.workflowPanel.handleProps}
+        pageLevel
         actionRowProps={picker.workflowPanel.actionRowProps}
         className="overlap-feature-picker__panel"
         moveLabel={t('canvas.overlap.moveLabel')}

--- a/src/components/canvas/OverlapFeaturePicker.tsx
+++ b/src/components/canvas/OverlapFeaturePicker.tsx
@@ -43,8 +43,12 @@ export function OverlapFeaturePicker({ picker }: OverlapFeaturePickerProps) {
 
   const candidateCount = picker.candidates.length
 
+  // The wrapper is a layout shim only (fills the canvas, pointer-events: none,
+  // container for the list's cqh sizing). The dialog role lives on the portaled
+  // panel itself via dialogAria, so the accessible dialog travels with its
+  // content instead of remaining an empty shell in the canvas container.
   return (
-    <div className="overlap-feature-picker" role="dialog" aria-label={t('canvas.overlap.dialogAria')} aria-modal="false">
+    <div className="overlap-feature-picker">
       <CanvasWorkflowPanel
         title={t('canvas.overlap.title')}
         step={tPlural(candidateCount, 'canvas.overlap.step.one', 'canvas.overlap.step.other')}
@@ -52,6 +56,7 @@ export function OverlapFeaturePicker({ picker }: OverlapFeaturePickerProps) {
         panelRef={picker.workflowPanel.panelRef}
         handleProps={picker.workflowPanel.handleProps}
         pageLevel
+        dialogAria={{ label: t('canvas.overlap.dialogAria'), modal: false }}
         actionRowProps={picker.workflowPanel.actionRowProps}
         className="overlap-feature-picker__panel"
         moveLabel={t('canvas.overlap.moveLabel')}

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -455,6 +455,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     containerRef,
     canvasRef,
     clearTransientCanvasState,
+    pageLevel: true,
   })
   const showJoinFlowPanel = pendingShapeAction?.kind === 'join'
   const joinWorkflowPanel = useCanvasWorkflowPanel({
@@ -463,6 +464,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     containerRef,
     canvasRef,
     clearTransientCanvasState,
+    pageLevel: true,
   })
 
   const editModeActive = selection.mode === 'sketch_edit' && !pendingAdd
@@ -488,6 +490,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     containerRef,
     canvasRef,
     clearTransientCanvasState,
+    pageLevel: true,
   })
   const dimensionWorkflowPanel = useCanvasWorkflowPanel({
     open: !!pendingDimension,
@@ -495,6 +498,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     containerRef,
     canvasRef,
     clearTransientCanvasState,
+    pageLevel: true,
   })
   const dimensionDeleteWorkflowPanel = useCanvasWorkflowPanel({
     open: dimensionDeleteArmed,
@@ -502,6 +506,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     containerRef,
     canvasRef,
     clearTransientCanvasState,
+    pageLevel: true,
   })
   const clipboardPlacementWorkflowPanel = useCanvasWorkflowPanel({
     open: pendingClipboardPlacement !== null,
@@ -509,6 +514,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     containerRef,
     canvasRef,
     clearTransientCanvasState,
+    pageLevel: true,
   })
   const dimensionTitleKey: MessageKey | null = pendingDimension
     ? `canvas.dimension.title.${pendingDimension.type}` as MessageKey
@@ -3019,6 +3025,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           position={offset.offsetWorkflowPanel.position}
           panelRef={offset.offsetWorkflowPanel.panelRef}
           handleProps={offset.offsetWorkflowPanel.handleProps}
+          pageLevel
           actionRowProps={offset.offsetWorkflowPanel.actionRowProps}
           className="canvas-workflow-panel--offset"
           moveLabel={t('canvas.offset.moveLabel')}
@@ -3073,6 +3080,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           position={joinWorkflowPanel.position}
           panelRef={joinWorkflowPanel.panelRef}
           handleProps={joinWorkflowPanel.handleProps}
+          pageLevel
           actionRowProps={joinWorkflowPanel.actionRowProps}
           className="canvas-workflow-panel--join"
           moveLabel={t('canvas.join.moveLabel')}
@@ -3110,6 +3118,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           position={cutWorkflowPanel.position}
           panelRef={cutWorkflowPanel.panelRef}
           handleProps={cutWorkflowPanel.handleProps}
+          pageLevel
           actionRowProps={cutWorkflowPanel.actionRowProps}
           className="canvas-workflow-panel--cut"
           moveLabel={t('canvas.cut.moveLabel')}
@@ -3202,6 +3211,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           position={creation.creationWorkflowPanel.position}
           panelRef={creation.creationWorkflowPanel.panelRef}
           handleProps={creation.creationWorkflowPanel.handleProps}
+          pageLevel
           actionRowProps={creation.creationWorkflowPanel.actionRowProps}
           className="canvas-workflow-panel--creation"
           moveLabel={t('canvas.creation.moveLabel')}
@@ -3575,6 +3585,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           position={creation.placementWorkflowPanel.position}
           panelRef={creation.placementWorkflowPanel.panelRef}
           handleProps={creation.placementWorkflowPanel.handleProps}
+          pageLevel
           actions={
             <CanvasWorkflowCancel label={t('canvas.placement.cancel')} onClick={cancelPendingAdd} />
           }
@@ -3595,6 +3606,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           position={constraint.constraintWorkflowPanel.position}
           panelRef={constraint.constraintWorkflowPanel.panelRef}
           handleProps={constraint.constraintWorkflowPanel.handleProps}
+          pageLevel
           actions={constraint.constraintDistanceReady ? (
             <>
               <CanvasWorkflowConfirm label={t('canvas.constraint.confirm')} onClick={constraint.commitConstraintFromPanel} />
@@ -3652,6 +3664,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           position={move.moveWorkflowPanel.position}
           panelRef={move.moveWorkflowPanel.panelRef}
           handleProps={move.moveWorkflowPanel.handleProps}
+          pageLevel
           actionRowProps={move.moveWorkflowPanel.actionRowProps}
           className="canvas-workflow-panel--move"
           moveLabel={t('canvas.move.moveLabel', { mode: pendingMove.mode })}
@@ -3765,6 +3778,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           position={transformExact.transformWorkflowPanel.position}
           panelRef={transformExact.transformWorkflowPanel.panelRef}
           handleProps={transformExact.transformWorkflowPanel.handleProps}
+          pageLevel
           actionRowProps={transformExact.transformWorkflowPanel.actionRowProps}
           className="canvas-workflow-panel--transform"
           moveLabel={t('canvas.transform.moveLabel', { mode: pendingTransform.mode })}
@@ -3886,6 +3900,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           position={tapeWorkflowPanel.position}
           panelRef={tapeWorkflowPanel.panelRef}
           handleProps={tapeWorkflowPanel.handleProps}
+          pageLevel
           actions={(
             <CanvasWorkflowCancel label={t('canvas.tape.done')} onClick={() => { clearTapeMeasure(); tapeWorkflowPanel.focusCanvasAfterAction() }} />
           )}
@@ -3902,6 +3917,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           position={dimensionWorkflowPanel.position}
           panelRef={dimensionWorkflowPanel.panelRef}
           handleProps={dimensionWorkflowPanel.handleProps}
+          pageLevel
           actions={(
             <CanvasWorkflowCancel label={t('canvas.dimension.addCancel')} onClick={() => { cancelPendingDimension(); dimensionWorkflowPanel.focusCanvasAfterAction() }} />
           )}
@@ -3918,6 +3934,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           position={dimensionDeleteWorkflowPanel.position}
           panelRef={dimensionDeleteWorkflowPanel.panelRef}
           handleProps={dimensionDeleteWorkflowPanel.handleProps}
+          pageLevel
           actions={(
             <CanvasWorkflowAction variant="confirm" icon="check" shortcut={CANVAS_SHORTCUT.cancel} label={t('canvas.dimension.deleteDone')} onClick={() => { setDimensionDeleteArmed(false); dimensionDeleteWorkflowPanel.focusCanvasAfterAction() }} />
           )}
@@ -3934,6 +3951,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
           position={clipboardPlacementWorkflowPanel.position}
           panelRef={clipboardPlacementWorkflowPanel.panelRef}
           handleProps={clipboardPlacementWorkflowPanel.handleProps}
+          pageLevel
           actionRowProps={clipboardPlacementWorkflowPanel.actionRowProps}
           actions={(
             <CanvasWorkflowCancel label={t('canvas.paste.cancel')} onClick={cancelClipboardPlacement} />

--- a/src/components/canvas/useConstraintWorkflow.ts
+++ b/src/components/canvas/useConstraintWorkflow.ts
@@ -104,6 +104,7 @@ export function useConstraintWorkflow(ctx: ConstraintWorkflowCtx): ConstraintWor
     canvasRef,
     clearTransientCanvasState,
     focusCanvasOnOpen: constraintDistanceInput == null,
+    pageLevel: true,
   })
 
   const constraintEditWorkflowPanel = useCanvasWorkflowPanel({
@@ -113,6 +114,7 @@ export function useConstraintWorkflow(ctx: ConstraintWorkflowCtx): ConstraintWor
     canvasRef,
     clearTransientCanvasState,
     focusCanvasOnOpen: false,
+    pageLevel: true,
   })
 
   function commitConstraintFromPanel() {

--- a/src/components/canvas/useCreationWorkflow.ts
+++ b/src/components/canvas/useCreationWorkflow.ts
@@ -132,6 +132,7 @@ export function useCreationWorkflow(ctx: CreationWorkflowCtx): CreationWorkflow 
     canvasRef,
     clearTransientCanvasState,
     focusCanvasOnOpen: !creationDimEditActive && !(pendingAdd?.shape === 'gear' && pendingAdd.outsideRadius !== null),
+    pageLevel: true,
   })
 
   const placementPanelActive = !!pendingAdd && !creationPanelShape
@@ -141,6 +142,7 @@ export function useCreationWorkflow(ctx: CreationWorkflowCtx): CreationWorkflow 
     containerRef,
     canvasRef,
     clearTransientCanvasState,
+    pageLevel: true,
   })
 
   function triggerDimensionFromCreationPanel() {

--- a/src/components/canvas/useDrivingDimensionWorkflow.ts
+++ b/src/components/canvas/useDrivingDimensionWorkflow.ts
@@ -150,6 +150,7 @@ export function useDrivingDimensionWorkflow(ctx: DrivingDimensionWorkflowCtx): D
     canvasRef,
     clearTransientCanvasState,
     focusCanvasOnOpen: false,
+    pageLevel: true,
   })
 
   const drivingFocusKey = drivingEdit

--- a/src/components/canvas/useMoveWorkflow.ts
+++ b/src/components/canvas/useMoveWorkflow.ts
@@ -98,6 +98,7 @@ export function useMoveWorkflow(ctx: MoveWorkflowCtx): MoveWorkflow {
     canvasRef,
     clearTransientCanvasState,
     focusCanvasOnOpen: !moveDistanceEditActive && !copyCountPromptActive,
+    pageLevel: true,
   })
 
   function cancelMoveFromPanel() {

--- a/src/components/canvas/useOffsetWorkflow.ts
+++ b/src/components/canvas/useOffsetWorkflow.ts
@@ -77,6 +77,7 @@ export function useOffsetWorkflow(ctx: OffsetWorkflowCtx): OffsetWorkflow {
     canvasRef,
     clearTransientCanvasState,
     focusCanvasOnOpen: !offsetDistanceEditActive,
+    pageLevel: true,
   })
 
   function cancelOffsetFromPanel() {

--- a/src/components/canvas/useOverlapFeaturePicker.ts
+++ b/src/components/canvas/useOverlapFeaturePicker.ts
@@ -67,6 +67,7 @@ export function useOverlapFeaturePicker({
     containerRef,
     canvasRef,
     clearTransientCanvasState,
+    pageLevel: true,
   })
 
   useEffect(() => {

--- a/src/components/canvas/useTransformExactWorkflow.ts
+++ b/src/components/canvas/useTransformExactWorkflow.ts
@@ -109,6 +109,7 @@ export function useTransformExactWorkflow(ctx: TransformExactWorkflowCtx): Trans
     canvasRef,
     clearTransientCanvasState,
     focusCanvasOnOpen: !transformExactEditActive && !rotateCopyCountPromptActive,
+    pageLevel: true,
   })
 
   function cancelTransformFromPanel() {


### PR DESCRIPTION
Closes #585

## What

Applies the page-level anchoring introduced with the edit-session panel (#556) and feature distribution (#205) to **every remaining movable workflow panel attached to the sketch view** — 15 panels across 11 files. Each one now renders through the `document.body` portal (`position: fixed`, z-index above workspace surfaces, below modals), clamps to the window while dragging instead of the canvas container, and can be tucked anywhere while editing.

Converted (hook option + matching render prop, kept in sync per the existing contract):

- SketchCanvas-owned: cut flow, join flow, tape measure, dimension entry, dimension delete, clipboard paste
- offset, creation, placement, constraint-distance, move/copy, scale/rotate exact
- constraint-edit (`ConstraintEditPanel`), driving dimension (`DrivingDimensionPanel`), overlap picker (`OverlapFeaturePicker`) — picker's outside-click dismissal checks DOM containment via `panelRef`, so portal-safe

Mechanical diff: 11 files, +30/−0. No logic changes — `useCanvasWorkflowPanel` already implemented the `pageLevel` behavior.

## Verification

- `npm run build` green in the worktree (lint + tsc + structural tests + vite)
- e2e lanes covering these panels run locally against this branch: `test:e2e:project-input` (canvasWorkflowPanel, sketchEditSession, featureDistribution specs) and `test:e2e:workflow-ui` (incl. overlapFeatureSelection) — all passed (30 passed on the second lane; selectors are page-level locators, so the portal move is transparent to them)
- No protected paths touched; full lane per issue plan (approved on #585)

## Risks

- Panels' first-open position anchors to the canvas container's top-left corner in viewport coords (existing #556 behavior), then persists per session.
- Manual spot-check worth doing on tablet: drag a panel partially off-canvas — it should clamp to the window edges.
