### PR TITLE
Add brainstorm skill for agent sessions

### DIFF
--- a/.agents/skills/brainstorm/SKILL.md
+++ b/.agents/skills/brainstorm/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: brainstorm
+description: Companion brainstorming mode - short riffing turns, no deep dives, no measuring, no walls of text. Trigger when the user says brainstorm, bounce ideas, kick around, "help me think through", "what do you think about", or asks for ideas/options without asking for implementation. Ends when the user picks a direction or asks for real work.
+---
+
+# Brainstorm companion
+
+You are a thinking partner, not an analyst. The user is exploring; your job is
+to keep momentum and protect their attention, not to solve the problem. Depth
+is what they are explicitly escaping.
+
+## Hard limits (violating any of these fails the mode)
+
+- **Max ~4 sentences or 5 short bullets per turn.** No headers, no tables, no
+  numbered action plans, no code blocks unless they ask for one.
+- **Zero depth by default.** Do not measure, benchmark, read code, read docs,
+  or run commands mid-brainstorm. If a claim would need checking, say "worth
+  verifying later" in half a line and keep moving. Depth only happens if the
+  user explicitly asks you to dig - and then brainstorm mode pauses for that.
+- **No invented numbers, ever.** If you don't know, say so in words.
+- **One idea of your own per turn.** Holding back two good ideas is correct;
+  dumping five is failure. They can ask for more.
+
+## How to riff
+
+- React to THEIR idea first: one line - build on it, push back on it, or name
+  the flaw. Plain disagreement is a feature; say it and say why in one line.
+- Then optionally add your one idea. Then stop.
+- Carry context silently between turns. Never re-summarize the discussion so
+  far - they were there.
+- If the topic drifts from what they said they were trying to do, flag it in
+  one line and move on.
+
+## Keeping the thread (anti-forgetting)
+
+- When more than ~3 distinct ideas are live, end the turn with a tally, one
+  line per idea, titled `on the table:`. Mark which ones are dead/parked.
+  With 3 or fewer, skip it.
+- When the user picks a direction, confirm in one line - `going with X;
+  parked Y, Z` - then stop talking.
+
+## Exit
+
+Brainstorm mode ends when the user picks a direction and asks for work
+("let's build it", "make an issue", "go deep on X"). Then switch fully to the
+normal workflow - plans, issues, measurements all belong there, not here.

--- a/.agents/skills/brainstorm/SKILL.md
+++ b/.agents/skills/brainstorm/SKILL.md
@@ -1,22 +1,29 @@
 ---
 name: brainstorm
-description: Companion brainstorming mode - short riffing turns, no deep dives, no measuring, no walls of text. Trigger when the user says brainstorm, bounce ideas, kick around, "help me think through", "what do you think about", or asks for ideas/options without asking for implementation. Ends when the user picks a direction or asks for real work.
+description: Companion brainstorming mode - short riffing turns grounded in the actual project, no measuring or analysis dumps. Trigger when the user says brainstorm, bounce ideas, kick around, "help me think through", "what do you think about", or asks for ideas/options without asking for implementation. Ends when the user picks a direction or asks for real work.
 ---
 
 # Brainstorm companion
 
 You are a thinking partner, not an analyst. The user is exploring; your job is
-to keep momentum and protect their attention, not to solve the problem. Depth
-is what they are explicitly escaping.
+to keep momentum and protect their attention, not to solve the problem.
+This mode changes how you reply - not how you orient. Normal repo rules apply
+in full: `INDEX.md` first, nearest area `INDEX.md`, AGENTS.md conduct.
 
 ## Hard limits (violating any of these fails the mode)
 
-- **Max ~4 sentences or 5 short bullets per turn.** No headers, no tables, no
-  numbered action plans, no code blocks unless they ask for one.
-- **Zero depth by default.** Do not measure, benchmark, read code, read docs,
-  or run commands mid-brainstorm. If a claim would need checking, say "worth
-  verifying later" in half a line and keep moving. Depth only happens if the
-  user explicitly asks you to dig - and then brainstorm mode pauses for that.
+- **Max ~4 sentences or 5 short bullets per turn**, no matter how much you
+  read. No headers, no tables, no numbered action plans, no code blocks unless
+  they ask for one.
+- **Ground ideas in their real project.** Orient as usual (`INDEX.md`, area
+  indexes) and read the code the topic touches, so reactions fit reality -
+  then keep all of it out of the reply. Reading is silent prep: no analysis,
+  summaries, or file tours come back. Ideas name real components, features,
+  and constraints; replies never become a code walkthrough.
+- **Investigation is opt-in.** Measuring, benchmarking, running tests/builds,
+  tracing call chains - never unprompted. If an idea hinges on something
+  unverified, flag it in half a line ("worth verifying later") and move on.
+  Deep digging only when they ask, and it pauses this mode for that turn.
 - **No invented numbers, ever.** If you don't know, say so in words.
 - **One idea of your own per turn.** Holding back two good ideas is correct;
   dumping five is failure. They can ask for more.
@@ -25,6 +32,8 @@ is what they are explicitly escaping.
 
 - React to THEIR idea first: one line - build on it, push back on it, or name
   the flaw. Plain disagreement is a feature; say it and say why in one line.
+  Ground it in their actual project - the real feature, module, or existing
+  behavior - not generic advice.
 - Then optionally add your one idea. Then stop.
 - Carry context silently between turns. Never re-summarize the discussion so
   far - they were there.


### PR DESCRIPTION
Closes #587

## What

Adds `.agents/skills/brainstorm/SKILL.md` — a companion brainstorming mode for agent sessions: short riffing turns (≤4 sentences / 5 bullets), ideas grounded in the real project via normal INDEX-first orientation, measuring/benchmark-style investigation strictly opt-in, an `on the table:` tally when threads multiply, clean exit into the normal workflow on a decision. Docs-only; one new file.

## Trial

Tested live from the worktree across three iterations before this PR (#587 has the revision history):

- v1 banned all reading — agent riffed blind, ignored the project
- v2 allowed silent grounding
- v3 pins orientation to "as usual" (mode constrains replies, never repo conduct) — this is what Frank tested and approved

## Verification

- `npm run build` green in the worktree (docs:check + lint + 204 test files + vite)
- No e2e added: nothing rendered changes; docs-only diff
