### PR TITLE
fix(docs-check): report a missing entrypoint instead of crashing

### DIFF
--- a/scripts/check-docs.test.ts
+++ b/scripts/check-docs.test.ts
@@ -15,11 +15,15 @@
  */
 
 import assert from 'node:assert/strict'
-import { resolve } from 'node:path'
+import { existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
+  AGENT_ENTRYPOINTS,
   extractMarkdownLinkTargets,
   normalizeLocalLinkTarget,
   parseFrontmatter,
+  readTextFileOrProblem,
   validateAgentEntrypoint,
   validateDocumentLinks,
   validatePlanningMetadata,
@@ -118,6 +122,44 @@ function testAgentEntrypointValidation(): void {
   )
 }
 
+function testUnreadableReadBecomesProblem(): void {
+  const enoent = Object.assign(
+    new Error("ENOENT: no such file or directory, open '/repo/.roorulez'"),
+    { code: 'ENOENT' },
+  )
+  assert.deepEqual(
+    readTextFileOrProblem('agent entrypoint', '.roorulez', '/repo/.roorulez', () => {
+      throw enoent
+    }),
+    { file: '.roorulez', message: 'agent entrypoint is missing from the repository' },
+  )
+
+  const eacces = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+  assert.deepEqual(
+    readTextFileOrProblem('planning document', 'planning/design.md', '/repo/planning/design.md', () => {
+      throw eacces
+    }),
+    { file: 'planning/design.md', message: 'planning document could not be read (EACCES)' },
+  )
+
+  assert.equal(
+    readTextFileOrProblem('agent entrypoint', 'CLAUDE.md', '/repo/CLAUDE.md', () => 'content'),
+    'content',
+  )
+}
+
+function testEveryAgentEntrypointExists(): void {
+  const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  for (const file of AGENT_ENTRYPOINTS) {
+    assert.ok(
+      existsSync(join(repositoryRoot, file)),
+      `${file} is listed in AGENT_ENTRYPOINTS but missing from the repository`,
+    )
+  }
+}
+
+testUnreadableReadBecomesProblem()
+testEveryAgentEntrypointExists()
 testFrontmatterParsing()
 testPlanningMetadataValidation()
 testMarkdownLinkExtractionAndNormalization()

--- a/scripts/check-docs.ts
+++ b/scripts/check-docs.ts
@@ -20,6 +20,7 @@ import { fileURLToPath } from 'node:url'
 import {
   AGENT_ENTRYPOINTS,
   type DocumentationProblem,
+  readTextFileOrProblem,
   validateAgentEntrypoint,
   validateDocumentLinks,
   validatePlanningMetadata,
@@ -74,12 +75,13 @@ function main(): void {
   })
   for (const document of planningDocuments) {
     const file = relative(REPOSITORY_ROOT, document)
-    problems.push(...validatePlanningMetadata(file, readFileSync(document, 'utf8')))
+    const content = readTextFileOrProblem('planning document', file, document)
+    problems.push(...(typeof content === 'string' ? validatePlanningMetadata(file, content) : [content]))
   }
 
   for (const file of AGENT_ENTRYPOINTS) {
-    const path = join(REPOSITORY_ROOT, file)
-    problems.push(...validateAgentEntrypoint(file, readFileSync(path, 'utf8')))
+    const content = readTextFileOrProblem('agent entrypoint', file, join(REPOSITORY_ROOT, file))
+    problems.push(...(typeof content === 'string' ? validateAgentEntrypoint(file, content) : [content]))
   }
 
   problems.sort((left, right) => {

--- a/scripts/docs-check-core.ts
+++ b/scripts/docs-check-core.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { dirname, isAbsolute, relative, resolve } from 'node:path'
 
 export interface DocumentationProblem {
@@ -204,4 +204,29 @@ export function validateAgentEntrypoint(
   return REQUIRED_AGENT_MARKERS
     .filter((marker) => !content.includes(marker))
     .map((marker) => ({ file, message: `agent entrypoint is missing ${marker}` }))
+}
+
+export type TextFileReader = (path: string) => string
+
+/**
+ * Read a repository text file, turning an unreadable path into a normal
+ * DocumentationProblem so one bad entry cannot abort the whole check run.
+ */
+export function readTextFileOrProblem(
+  subject: string,
+  file: string,
+  path: string,
+  readFile: TextFileReader = (candidate) => readFileSync(candidate, 'utf8'),
+): string | DocumentationProblem {
+  try {
+    return readFile(path)
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null)?.code
+    return {
+      file,
+      message: code === 'ENOENT'
+        ? `${subject} is missing from the repository`
+        : `${subject} could not be read${code ? ` (${code})` : ''}`,
+    }
+  }
 }


### PR DESCRIPTION
Closes #438

## What

`npm run docs:check` no longer aborts with an unhandled `ENOENT` when a path in `AGENT_ENTRYPOINTS` (or a planning document read) is missing or unreadable:

- `readTextFileOrProblem` in `docs-check-core.ts` turns a failed read into a normal `DocumentationProblem` — ENOENT becomes `agent entrypoint is missing from the repository`; other codes are reported as `${subject} could not be read (CODE)`.
- Both the planning-metadata loop and the agent-entrypoint loop in `check-docs.ts` use it, so one bad entry can no longer hide problems in the entries after it.
- New tests in `check-docs.test.ts`: every `AGENT_ENTRYPOINTS` path must exist on disk (previously the array's contents were never tested directly), and an injected-throwing reader proves both failure wordings plus the pass-through case.

## Verification

- Full negative check per the issue: appended two bogus entries to `AGENT_ENTRYPOINTS` → checker printed `docs-check: FAIL — 2 problem(s)` naming both files (no stack trace, run continued past the first), and the new unit test failed naming the bogus file. Reverted → green.
- `bash scripts/build-summary.sh`: PASS (docs:check, lint, typecheck, 205 unit test files, vite build).
