### PR TITLE
drilling: warn when a pre-3.1 load re-expresses retract heights

### DIFF
--- a/src/store/helpers/projectFormat.ts
+++ b/src/store/helpers/projectFormat.ts
@@ -78,7 +78,16 @@ export interface DecodedProjectFormat {
   project: Project
   sourceVersion: string | null
   convertedLegacy: boolean
+  /** Drilling retract-height values re-expressed absolute → relative by the
+   *  format-3.1 migration on this decode (#481/#599); 0 when nothing moved. */
+  retractHeightsReexpressed: number
   machineMigration: DecodedMachineMigration
+}
+
+/** Out-param for callers that need to know what {@link normalizeProject}'s
+ *  migrations rewrote, without widening its Project-returning signature. */
+export interface ProjectMigrationInfo {
+  retractHeightsReexpressed: number
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -342,15 +351,15 @@ function migrateRetractHeightToRelative(
   project: Project,
   sourceVersion: string | null,
   fileRetractPositions: ReadonlySet<number>,
-): Project {
+): { project: Project; rewritten: number } {
   if (sourceVersion !== null) {
     const [major, minor] = parseProjectVersion(sourceVersion)
-    if (major > 3 || (major === 3 && minor >= 1)) return project
+    if (major > 3 || (major === 3 && minor >= 1)) return { project, rewritten: 0 }
   }
   // A stock without a finite thickness has no meaningful surface. Leave
   // everything untouched rather than compute NaN offsets — NaN survives
   // Math.max(0, …) and would post as a literal Z NaN (issue #481 review).
-  if (!Number.isFinite(project.stock.thickness)) return project
+  if (!Number.isFinite(project.stock.thickness)) return { project, rewritten: 0 }
   const stockTop = project.stock.thickness
 
   // z_top is a DimensionRef — constraint-linked instances carry a key string,
@@ -375,7 +384,7 @@ function migrateRetractHeightToRelative(
     return Math.max(stockTop, top ?? stockTop)
   }
 
-  let changed = false
+  let rewritten = 0
   const operations = project.operations.map((operation, index) => {
     if (!fileRetractPositions.has(index)) return operation
     if (typeof operation.retractHeight !== 'number' || !Number.isFinite(operation.retractHeight)) return operation
@@ -383,10 +392,10 @@ function migrateRetractHeightToRelative(
     if (surface === null) return operation
     const next = Math.max(0, operation.retractHeight - surface)
     if (next === operation.retractHeight) return operation
-    changed = true
+    rewritten += 1
     return { ...operation, retractHeight: next }
   })
-  return changed ? { ...project, operations } : project
+  return rewritten > 0 ? { project: { ...project, operations }, rewritten } : { project, rewritten: 0 }
 }
 
 /** Decode 1.0/2.0/2.1 baked rows or validate a lightweight 3.x project. */
@@ -404,10 +413,12 @@ export function decodeProjectFormat(input: unknown): DecodedProjectFormat {
     throw new Error(`Project format ${sourceVersion ?? '(missing)'} contains legacy baked feature geometry.`)
   }
   const machines = normalizeMachineDefinitions(input as unknown as Project)
+  const migrationInfo: ProjectMigrationInfo = { retractHeightsReexpressed: 0 }
   return {
-    project: normalizeProject(input),
+    project: normalizeProject(input, migrationInfo),
     sourceVersion,
     convertedLegacy,
+    retractHeightsReexpressed: migrationInfo.retractHeightsReexpressed,
     machineMigration: {
       customDefinitions: machines.customDefinitions,
       compacted: machines.compacted,
@@ -417,7 +428,7 @@ export function decodeProjectFormat(input: unknown): DecodedProjectFormat {
 }
 
 /** Normalize a decoded project without ever placing resolved geometry in features. */
-export function normalizeProject(input: ProjectFormatInput): Project {
+export function normalizeProject(input: ProjectFormatInput, migrationInfo?: ProjectMigrationInfo): Project {
   // Read before the envelope below is stamped with LATEST_PROJECT_VERSION:
   // the retract-height migration keys on what the file claims to be.
   const sourceVersion = typeof input.version === 'string' ? input.version : null
@@ -575,7 +586,7 @@ export function normalizeProject(input: ProjectFormatInput): Project {
   const resolvedStockSource = prunedProject.stock.sourceFeature
     ? resolveFeatureRow(prunedProject, prunedProject.stock.sourceFeature)
     : null
-  const project = migrateRetractHeightToRelative(resolvedStockSource
+  const migrated = migrateRetractHeightToRelative(resolvedStockSource
     ? {
         ...prunedProject,
         stock: {
@@ -587,6 +598,7 @@ export function normalizeProject(input: ProjectFormatInput): Project {
         },
       }
     : prunedProject, sourceVersion, fileRetractPositions)
-  syncIdCounter(project)
-  return project
+  if (migrationInfo) migrationInfo.retractHeightsReexpressed = migrated.rewritten
+  syncIdCounter(migrated.project)
+  return migrated.project
 }

--- a/src/store/operationMigration.test.ts
+++ b/src/store/operationMigration.test.ts
@@ -32,7 +32,7 @@ import {
   type SketchFeature,
   type Tool,
 } from '../types/project'
-import { normalizeProject, type ProjectFormatInput } from './helpers/projectFormat'
+import { decodeProjectFormat, normalizeProject, type ProjectFormatInput } from './helpers/projectFormat'
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
@@ -324,6 +324,56 @@ test('3.1 files already carry distances and are never re-migrated', () => {
   assert(Math.abs((op.retractHeight ?? NaN) - 2) < 1e-9, `a 3.1 distance must survive untouched, got ${op.retractHeight}`)
   const reloaded = findDrillOp(normalizeProject(JSON.parse(JSON.stringify(once))))
   assert(Math.abs((reloaded.retractHeight ?? NaN) - 2) < 1e-9, 'save/reload must be stable for the field')
+})
+
+/** A modern-envelope .camj body with one drilling operation, as a real 3.0/3.1
+ *  file would carry it. Built by normalizing once (decodeProjectFormat rejects
+ *  legacy baked rows outright), then re-stamping the claimed version and — when
+ *  given — the raw absolute retractHeight the file "read". */
+function drillingFile(options: { retractHeight?: number; version?: '3.0' | '3.1' }): ProjectFormatInput {
+  const base = normalizeProject(drillingProject({
+    omitRetractHeight: true,
+    extraFeatures: [drillableFeature('hole', 20)],
+    featureIds: ['hole'],
+  }))
+  const stored = findDrillOp(base)
+  const fileOp: typeof stored = { ...stored }
+  if (options.retractHeight === undefined) {
+    // The first normalize injected the relative default; a real file with no
+    // stored value simply lacks the key, so remove it rather than let decode
+    // mistake the injected number for an absolute Z.
+    delete fileOp.retractHeight
+  } else {
+    fileOp.retractHeight = options.retractHeight
+  }
+  return {
+    ...base,
+    version: options.version ?? '3.0',
+    operations: [fileOp],
+  }
+}
+
+test('decode reports how many retract heights were re-expressed (#599)', () => {
+  // The load warning keys on this count: a 3.0 file whose stored absolute Z
+  // actually moves must surface the conversion instead of silently changing
+  // what the number in the panel means.
+  const decoded = decodeProjectFormat(drillingFile({ retractHeight: 22 }))
+  assert(decoded.retractHeightsReexpressed === 1, `expected 1 rewrite, got ${decoded.retractHeightsReexpressed}`)
+  const op = findDrillOp(decoded.project)
+  assert(Math.abs((op.retractHeight ?? NaN) - 2) < 1e-9, `expected offset 2 alongside the report, got ${op.retractHeight}`)
+})
+
+test('no re-expression is reported when no stored value moved', () => {
+  // Without a file-read value the migration deliberately skips the position —
+  // normalizeOperation's injected relative default is not a rewrite.
+  const decoded = decodeProjectFormat(drillingFile({}))
+  assert(decoded.retractHeightsReexpressed === 0, `expected 0 rewrites, got ${decoded.retractHeightsReexpressed}`)
+})
+
+test('3.1 files report zero re-expressions', () => {
+  const decoded = decodeProjectFormat(drillingFile({ retractHeight: 2, version: '3.1' }))
+  assert(decoded.retractHeightsReexpressed === 0, `expected 0 rewrites, got ${decoded.retractHeightsReexpressed}`)
+  assert(findDrillOp(decoded.project).retractHeight === 2, 'a 3.1 distance must survive untouched')
 })
 
 console.log(`\noperationMigration.test.ts: ${passed} passed, ${failed} failed`)

--- a/src/store/slices/projectLifecycleSlice.ts
+++ b/src/store/slices/projectLifecycleSlice.ts
@@ -313,6 +313,9 @@ export function createProjectLifecycleSlice(
           migratedMachineLibrary
             ? 'Machine definitions moved to the application library. This project now stores only its selected machine; any custom machines it carried were added to My Machines. The original file is unchanged until you save.'
             : null,
+          decoded.retractHeightsReexpressed > 0
+            ? `${decoded.retractHeightsReexpressed === 1 ? 'One drilling retract height was' : `${decoded.retractHeightsReexpressed} drilling retract heights were`} re-expressed relative to the material surface to match the current file format (issue #481). The original file is unchanged until you save.`
+            : null,
           machineWarning,
         ),
         pendingAdd: null,


### PR DESCRIPTION
Closes #599.

## What

Opening a pre-3.1 project whose drilling retract heights the format-3.1 migration rewrote now surfaces the existing load-warning banner instead of silently changing what the number means (#481 follow-up).

- `decodeProjectFormat` reports `retractHeightsReexpressed` (count of rewritten stored values), threaded out via an optional `ProjectMigrationInfo` out-param so `normalizeProject`'s Project-returning signature stays frozen for its many callers.
- `projectLifecycleSlice` folds it into `joinWarnings`: "One drilling retract height was re-expressed relative to the material surface to match the current file format (issue #481). The original file is unchanged until you save."
- Deliberately **not** marking the project dirty — nagging about unsaved changes when the user touched nothing is worse than the silence (per the issue's explicit out-of-scope).

## Why now

v0.3.0 predates #589: 0.4.0 is the first release shipping the migration, so first contact with pre-3.1 files peaks at 0.4.0 adoption. A banner landed later misses most affected users. Timing approved during #599/#606 planning.

## Verification

- 3 new boundary tests in `src/store/operationMigration.test.ts` (report set / unset / version-gated); suite green 14/14.
- Full `npm run build` green in the worktree (lint + tsc + structural tests + vite).
- No e2e added deliberately: the change is store-state text rendered by the existing load-warning UI — no new DOM, menu wiring, or dialog behavior.
