### PR TITLE
perf(toolpaths): bound the S-link domain check before scanning its vertices (#629)

### DIFF
--- a/src/engine/toolpaths/tangentLink.test.ts
+++ b/src/engine/toolpaths/tangentLink.test.ts
@@ -254,6 +254,52 @@ function testParallelLateralStep() {
   console.log('parallel lateral step: PASSED (arrival ' + result.arrivalIndex + ')')
 }
 
+/**
+ * The domain check's bounding-box prefilter must keep rejecting most samples
+ * before any vertex scan (issue #629).
+ *
+ * The check is the solver's dominant cost: measured at 3.7 us per call on a
+ * 385-vertex level, against ~3,000-6,800 calls per link, it accounted for
+ * essentially the whole per-link budget. The prefilter cannot change an answer
+ * — a point outside a loop's bounds, inflated by the edge tolerance, is
+ * outside the loop — so this guards speed only, which is exactly why nothing
+ * else would catch its removal.
+ *
+ * Measured on this fixture:
+ *
+ *   prefilter present        2 scans in 1600 checks
+ *   prefilter removed     3199 scans in 1600 checks  (1600x)
+ *   budget                 400 scans, i.e. 1 per 4 checks
+ *
+ * The budget sits far below the regressed row rather than at a geometric
+ * mid-point: unlike a timing figure these counts are exact, so the only
+ * question is whether the prefilter is working at all, and a partial
+ * regression here has no meaningful middle ground.
+ */
+function testDomainPrefilterSkipsScans() {
+  console.log('Testing the domain prefilter skips vertex scans...')
+  // Two small squares far apart: most sampled points fall outside both boxes.
+  const square = (ox: number, oy: number): Point[] => [
+    { x: ox, y: oy }, { x: ox + 1, y: oy }, { x: ox + 1, y: oy + 1 }, { x: ox, y: oy + 1 },
+  ]
+  const check = buildOffsetDomainCheck([
+    { outer: square(0, 0), islands: [] },
+    { outer: square(50, 50), islands: [] },
+  ])
+  resetSlinkProbeCounts()
+  for (let i = 0; i < 40; i += 1) {
+    for (let j = 0; j < 40; j += 1) check(i * 1.5, j * 1.5)
+  }
+  const counts = slinkProbeCounts()
+  assert(counts.domainChecks === 1600, 'expected 1600 domain checks, got ' + counts.domainChecks)
+  assert(
+    counts.domainScans * 4 <= counts.domainChecks,
+    'domainScans (' + counts.domainScans + ') must stay well under domainChecks ('
+      + counts.domainChecks + ') — the bounding-box prefilter has stopped rejecting',
+  )
+  console.log('domain prefilter: PASSED (' + counts.domainScans + ' scans in ' + counts.domainChecks + ' checks)')
+}
+
 function testProbeCountersAndPruneGuard() {
   console.log('Testing probe counters and prune guard...')
   // A 20-vertex rectangular ring: enough vertices that the prune has real work
@@ -341,6 +387,7 @@ try {
   testDomainCheck()
   testPocketOptionsGating()
   testProbeCountersAndPruneGuard()
+testDomainPrefilterSkipsScans()
   console.log('\nAll tangentLink tests PASSED.')
 } catch (e) {
   console.error(e)

--- a/src/engine/toolpaths/tangentLink.ts
+++ b/src/engine/toolpaths/tangentLink.ts
@@ -47,17 +47,23 @@ import { DEFAULT_FLATTEN_ARC_STEP } from './geometry'
 let slinkArrivalsConsidered = 0
 let slinkArrivalsPruned = 0
 let slinkCandidatesEvaluated = 0
+let slinkDomainChecks = 0
+let slinkDomainScans = 0
 
 /** Read the S-link probe counters (arrivals considered, pruned, and candidates evaluated). */
 export function slinkProbeCounts(): {
   arrivalsConsidered: number
   arrivalsPruned: number
   candidatesEvaluated: number
+  domainChecks: number
+  domainScans: number
 } {
   return {
     arrivalsConsidered: slinkArrivalsConsidered,
     arrivalsPruned: slinkArrivalsPruned,
     candidatesEvaluated: slinkCandidatesEvaluated,
+    domainChecks: slinkDomainChecks,
+    domainScans: slinkDomainScans,
   }
 }
 
@@ -66,6 +72,8 @@ export function resetSlinkProbeCounts(): void {
   slinkArrivalsConsidered = 0
   slinkArrivalsPruned = 0
   slinkCandidatesEvaluated = 0
+  slinkDomainChecks = 0
+  slinkDomainScans = 0
 }
 
 interface Vec {
@@ -311,18 +319,62 @@ export interface TangentLinkDomainRegion {
  * Point-in-cleared-domain predicate for the band's tool-centre regions: inside
  * at least one outer and outside every island expansion.
  */
+interface BoxedLoop {
+  points: Point[]
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+}
+
+/** Axis-aligned bounds, computed once so the per-sample scan can be skipped. */
+function boxLoop(points: Point[]): BoxedLoop {
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
+  for (const p of points) {
+    if (p.x < minX) minX = p.x
+    if (p.x > maxX) maxX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.y > maxY) maxY = p.y
+  }
+  return { points, minX, maxX, minY, maxY }
+}
+
+// `pointOnPolygonEdge` accepts a point within 1e-6 of an edge (it compares a
+// squared distance against 1e-12), so a point marginally outside the bounds can
+// still legitimately test as on-boundary. The box is inflated by exactly that
+// tolerance before rejecting, which is what makes the prefilter conservative
+// rather than merely plausible — an uninflated box changed the emitted program
+// on three fixtures.
+const EDGE_TOLERANCE = 1e-6
+
+const outsideBox = (box: BoxedLoop, x: number, y: number): boolean =>
+  x < box.minX - EDGE_TOLERANCE || x > box.maxX + EDGE_TOLERANCE
+  || y < box.minY - EDGE_TOLERANCE || y > box.maxY + EDGE_TOLERANCE
+
 export function buildOffsetDomainCheck(
   regions: TangentLinkDomainRegion[],
 ): (x: number, y: number) => boolean {
+  // Bounds are precomputed per loop and rejected before any vertex scan. A
+  // point outside a loop's bounding box cannot be inside the loop or on its
+  // edge, so this cannot change an answer — only how many of the O(vertices)
+  // scans run. The scan is the S-link solver's dominant cost: it runs twice
+  // per loop per sample (containment, then edge), thousands of times per link.
+  const boxed = regions.map((region) => ({
+    outer: boxLoop(region.outer),
+    islands: region.islands.map(boxLoop),
+  }))
   return (x: number, y: number): boolean => {
+    slinkDomainChecks += 1
     // Inside or ON an outer boundary (the ring paths ride the boundary);
     // rejected only when STRICTLY inside an island expansion — the island
     // rings themselves also ride that boundary, so boundary points pass.
-    const inOuter = regions.some((region) =>
-      pointInPolygon(x, y, region.outer) || pointOnPolygonEdge(x, y, region.outer))
+    const inOuter = boxed.some((region) => !outsideBox(region.outer, x, y)
+      && (slinkDomainScans += 1) > 0
+      && (pointInPolygon(x, y, region.outer.points) || pointOnPolygonEdge(x, y, region.outer.points)))
     if (!inOuter) return false
-    return !regions.some((region) => region.islands.some((island) =>
-      pointInPolygon(x, y, island) && !pointOnPolygonEdge(x, y, island)))
+    return !boxed.some((region) => region.islands.some((island) => !outsideBox(island, x, y)
+      && (slinkDomainScans += 1) > 0
+      && pointInPolygon(x, y, island.points) && !pointOnPolygonEdge(x, y, island.points)))
   }
 }
 


### PR DESCRIPTION
Closes #629 — step 3, the fix the measurement justified.

## Where the time actually goes

Decomposing the solver per link put the cost in one place, and it was not where the shape of the code suggested:

| per link | count |
| --- | ---: |
| middle directions swept | ~1,650 |
| candidates built and sampled | ~120 |
| **`isInsideDomain` calls** | **~3,000–6,800** |

`buildOffsetDomainCheck` was an unindexed scan of every region outer and every island — `pointInPolygon` followed by `pointOnPolygonEdge`, so twice over each loop, with no bounds test. Measured in isolation at **3.7 µs per call** against a 385-vertex level, which accounts for essentially the whole per-link budget.

## The change

Each loop's axis-aligned bounds are computed once when the check is built, and tested before any vertex scan.

| fixture | S-link cost before | after | reduction |
| --- | ---: | ---: | ---: |
| `3d-imported-block-test3` rough_surface | 1698 ms | 867 ms | −49% |
| `model-in-pocket` rough_surface | 789 ms | 152 ms | −81% |
| `another-pocket-test` pocket | 236 ms | 105 ms | −56% |

The search is untouched: `candidatesEvaluated` is identical on all three (14482, 6994, 1262). Only the per-sample cost moved.

**All eighteen committed fixture operations are byte-identical.**

## The tolerance is load-bearing

`pointOnPolygonEdge` accepts a point within 1e-6 of an edge — it compares a squared distance against 1e-12 — so a point marginally outside the bounds can still legitimately test as on-boundary. The first version of this prefilter did not account for that and **changed the emitted program on three fixtures**; the byte-identity sweep caught it. The bounds are inflated by exactly that tolerance, which is what makes the prefilter conservative rather than merely plausible.

## Guarded by counting, not timing

Same idiom as the prune guard from #630, and for the same reason — the prefilter cannot change an answer, so nothing else would catch its removal. Two new probe counters, `domainChecks` and `domainScans`, with recorded rows:

| prefilter | vertex scans per 1600 checks |
| --- | ---: |
| present | 2 |
| removed | 3199 |
| budget | 400 |

The budget sits far below the regressed row rather than at a geometric mid-point: unlike a timing figure these counts are exact, so the only question is whether the prefilter works at all.

## On the framing this replaces

An earlier comment on #629 reported a 3.10× ratio on roughing and read it as roughing being pathological. Normalising per link corrected that — per-link cost sat in one band (7.3–16.2 ms) across every kind, and the roughing fixture was simply the one with 118 links instead of 12. The ratio was measuring fixture size. Per-link cost is what identified the domain check, and it is the number this PR moves.

`npm run build` green: 208 test files.