### PR TITLE
fix(worktrees): contributor-agnostic base & never-inside-checkout guard (#637)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ coverage
 work/
 temp/
 
+# Worktrees must live outside every checkout (issue #637); ignored as
+# belt-and-braces so a stray nested one still cannot pollute git status.
+worktrees/
+
 # Env files (.env.agent contains the local DeepSeek worker token)
 .env
 .env.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,6 +292,16 @@ Two independent choices: **where** the work happens, and **who** does it.
 
 **Where — default to an isolated worktree.** New work starts in its own `git worktree` on its own branch unless the user says otherwise. This includes fast-lane changes: the reason is parallelism, not diff size. A worktree lets several branches be in flight at once without one agent's edits, build artifacts, or checkout state disturbing another's, and a one-line fix benefits from that as much as a large change does. Create it outside the repository directory, and do not commit the path.
 
+**Hard rule — a worktree is never created inside a checkout of this repository** (issue #637). Not inside the primary project folder, not inside another worktree, and not inside a dot-directory of either (`.claude/worktrees/`, `.tmp/`, …) — a leading dot does not put it outside. There is no exception for a scratch tree, a delegation slice, or one removed afterwards: a nested worktree pollutes the parent's `git status`, breaks scripts that derive paths from their location, recurses, and makes cleanup ambiguous.
+
+All task worktrees live under an external base, outside every checkout:
+
+```
+<parent-of-repo>/worktrees/<repo-name>/<branch-or-slug>
+```
+
+This is contributor-agnostic by construction: the base is always a sibling of whatever directory holds the checkout, on any machine, with nothing configured. `PURECUT_WORKTREE_BASE` is an escape hatch for a different layout; if set, it must be an absolute path, and `scripts/dispatch-task.sh` validates both the default and the override against every registered checkout (symlink-resolved), refusing to create a worktree inside one.
+
 A fresh worktree has no `node_modules`. Symlinking the primary checkout's copy avoids a full install:
 
 ```bash

--- a/scripts/dispatch-task.sh
+++ b/scripts/dispatch-task.sh
@@ -9,7 +9,16 @@
 set -euo pipefail
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# REPO_ROOT must be the repository, never the checkout the invoked copy lives
+# in (issue #637): every worktree has its own scripts/, so deriving it from
+# SCRIPT_DIR nests new worktrees inside the current one. The common dir points
+# at the primary checkout's .git from every worktree.
+if repo_common_dir="$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
+  readonly REPO_ROOT="$(dirname "$repo_common_dir")"
+else
+  printf 'dispatch-task: not inside a git repository: %s\n' "$SCRIPT_DIR" >&2
+  exit 1
+fi
 readonly CLAUDE_DEEPSEEK_LEAF="$SCRIPT_DIR/run-claude-deepseek-agent.sh"
 readonly DSH_LEAF="$SCRIPT_DIR/run-dsh-agent.sh"
 readonly DEFAULT_BASE="feat/core-arch-simplification"
@@ -67,6 +76,37 @@ EOF
 }
 
 fail() { printf 'dispatch-task: %s\n' "$*" >&2; exit 1; }
+
+# Absolute, symlink-resolved path (like realpath). The leaf may not exist yet,
+# so resolve the deepest existing ancestor and append the remainder textually.
+abs_path() {
+  local target="$1" resolved=""
+  if resolved="$(cd "$target" 2>/dev/null && pwd -P)"; then
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+  local parent base
+  parent="$(dirname "$target")"
+  base="$(basename "$target")"
+  if ! resolved="$(cd "$parent" 2>/dev/null && pwd -P)"; then
+    resolved="$parent"
+  fi
+  printf '%s/%s\n' "$resolved" "$base"
+}
+
+# Hard rule (issue #637): a worktree is never created inside a checkout of this
+# repository — not the primary, not another worktree, not a dot-directory of
+# either. Compares symlink-resolved paths against every checkout git knows.
+assert_outside_checkouts() {
+  local candidate="$(abs_path "$1")" registered="" other=""
+  while IFS= read -r registered; do
+    [[ -n "$registered" ]] || continue
+    other="$(abs_path "$registered")"
+    if [[ "$candidate" == "$other" || "$candidate" == "$other"/* ]]; then
+      fail "refusing to create a worktree inside a checkout: $candidate would land inside checkout $registered; worktrees must live under an external base like <parent-of-repo>/worktrees/<repo-name>/"
+    fi
+  done < <(git -C "$REPO_ROOT" worktree list --porcelain | sed -n 's/^worktree //p')
+}
 
 mode="implement"
 provider="claude-deepseek"
@@ -200,6 +240,10 @@ fi
 
 branch="feat/issue-${issue}-${slug}"
 worktree_dir="$WORKTREE_BASE/$slug"
+
+# An explicitly-set base pointing inside a checkout must not bypass the guard.
+assert_outside_checkouts "$WORKTREE_BASE"
+assert_outside_checkouts "$worktree_dir"
 
 git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
   || fail "primary checkout is not a git repo: $REPO_ROOT"

--- a/scripts/dispatch-task.sh
+++ b/scripts/dispatch-task.sh
@@ -24,6 +24,10 @@ readonly DSH_LEAF="$SCRIPT_DIR/run-dsh-agent.sh"
 readonly DEFAULT_BASE="feat/core-arch-simplification"
 readonly MAX_DIRECT_PROMPT_BYTES=4096
 WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-$(dirname "$REPO_ROOT")/worktrees/$(basename "$REPO_ROOT")}"
+if [[ -n "${PURECUT_WORKTREE_BASE:-}" && "$PURECUT_WORKTREE_BASE" != /* ]]; then
+  printf 'dispatch-task: PURECUT_WORKTREE_BASE must be an absolute path: %s\n' "$PURECUT_WORKTREE_BASE" >&2
+  exit 1
+fi
 
 usage() {
   cat <<'EOF'
@@ -78,20 +82,31 @@ EOF
 fail() { printf 'dispatch-task: %s\n' "$*" >&2; exit 1; }
 
 # Absolute, symlink-resolved path (like realpath). The leaf may not exist yet,
-# so resolve the deepest existing ancestor and append the remainder textually.
+# so walk up to the deepest existing ancestor and append the remainder textually.
 abs_path() {
   local target="$1" resolved=""
+  # Fast path: target itself exists.
   if resolved="$(cd "$target" 2>/dev/null && pwd -P)"; then
     printf '%s\n' "$resolved"
     return 0
   fi
-  local parent base
-  parent="$(dirname "$target")"
-  base="$(basename "$target")"
-  if ! resolved="$(cd "$parent" 2>/dev/null && pwd -P)"; then
-    resolved="$parent"
-  fi
-  printf '%s/%s\n' "$resolved" "$base"
+  # Walk up until we find an existing ancestor.
+  local cur="$target" suffix=""
+  while true; do
+    local dir
+    dir="$(dirname "$cur")"
+    if resolved="$(cd "$dir" 2>/dev/null && pwd -P)"; then
+      local leaf="${cur#"$dir"}"
+      # dir has no trailing / (except when root), leaf has a leading /.
+      printf '%s%s%s\n' "$resolved" "$leaf" "$suffix"
+      return 0
+    fi
+    [[ "$dir" != "$cur" ]] || break   # reached filesystem root
+    suffix="$(basename "$cur")${suffix:+/$suffix}"
+    cur="$dir"
+  done
+  # Last resort: nothing resolved — return the original unchanged.
+  printf '%s\n' "$target"
 }
 
 # Hard rule (issue #637): a worktree is never created inside a checkout of this
@@ -241,10 +256,6 @@ fi
 branch="feat/issue-${issue}-${slug}"
 worktree_dir="$WORKTREE_BASE/$slug"
 
-# An explicitly-set base pointing inside a checkout must not bypass the guard.
-assert_outside_checkouts "$WORKTREE_BASE"
-assert_outside_checkouts "$worktree_dir"
-
 git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
   || fail "primary checkout is not a git repo: $REPO_ROOT"
 git -C "$REPO_ROOT" rev-parse --verify --quiet "refs/heads/$base" >/dev/null \
@@ -252,6 +263,12 @@ git -C "$REPO_ROOT" rev-parse --verify --quiet "refs/heads/$base" >/dev/null \
 git -C "$REPO_ROOT" rev-parse --verify --quiet "refs/heads/$branch" >/dev/null \
   && fail "branch already exists: $branch"
 [[ -e "$worktree_dir" ]] && fail "worktree path already exists: $worktree_dir"
+
+# An explicitly-set base pointing inside a checkout must not bypass the guard.
+# Checked after the existence test so a re-dispatched slug gets a clear error
+# rather than the guard's "would land inside checkout" message (issue #637).
+assert_outside_checkouts "$WORKTREE_BASE"
+assert_outside_checkouts "$worktree_dir"
 
 mkdir -p "$WORKTREE_BASE"
 printf '== creating worktree %s on %s (from %s) ==\n' "$worktree_dir" "$branch" "$base" >&2

--- a/scripts/finish-task.sh
+++ b/scripts/finish-task.sh
@@ -77,22 +77,49 @@ task_branch="$(git -C "$worktree_dir" rev-parse --abbrev-ref HEAD)"
 
 git -C "$REPO_ROOT" rev-parse --verify --quiet "refs/heads/$base" >/dev/null \
   || fail "base branch does not exist: $base"
-[[ -z "$(git -C "$REPO_ROOT" status --porcelain)" ]] \
-  || fail "integration checkout has uncommitted changes; clean it before merging: $REPO_ROOT"
+# Find the checkout that has $base checked out. If another worktree holds it
+# (which is the normal integration-manager layout), merge there; falling back to
+# REPO_ROOT when nobody does. Blindly running "checkout $base" in REPO_ROOT
+# fails when git refuses to check out a branch that is already in use elsewhere.
+find_checkout_for_branch() {
+  local want="$1" entry="" branch_line=""
+  local worktree="" found=""
+  while IFS= read -r entry; do
+    case "$entry" in
+      worktree\ *) worktree="${entry#worktree }" ;;
+      branch\ *)   branch_line="${entry#branch }" ;;
+      "")          # blank line = end of record
+        if [[ "$branch_line" == "refs/heads/$want" ]]; then
+          found="$worktree"
+          break
+        fi
+        worktree=""; branch_line=""
+        ;;
+    esac
+  done < <(git -C "$REPO_ROOT" worktree list --porcelain; printf '\n')
+  [[ -n "$found" ]] && printf '%s\n' "$found" || printf '%s\n' "$REPO_ROOT"
+}
 
-original_branch="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+merge_target="$(find_checkout_for_branch "$base")"
 
-printf '== checking out %s and merging %s (--no-ff) ==\n' "$base" "$task_branch" >&2
-git -C "$REPO_ROOT" checkout "$base" || fail "could not checkout $base"
+[[ -z "$(git -C "$merge_target" status --porcelain)" ]] \
+  || fail "checkout holding $base has uncommitted changes; clean it before merging: $merge_target"
 
-if ! git -C "$REPO_ROOT" merge --no-ff "$task_branch" \
+original_branch="$(git -C "$merge_target" rev-parse --abbrev-ref HEAD)"
+
+printf '== checking out %s and merging %s (--no-ff) in %s ==\n' "$base" "$task_branch" "$merge_target" >&2
+git -C "$merge_target" checkout "$base" || fail "could not checkout $base in $merge_target"
+
+if ! git -C "$merge_target" merge --no-ff "$task_branch" \
        -m "Merge slice ${slug} (${task_branch}) into ${base}"; then
-  git -C "$REPO_ROOT" merge --abort 2>/dev/null || true
-  git -C "$REPO_ROOT" checkout "$original_branch" 2>/dev/null || true
+  git -C "$merge_target" merge --abort 2>/dev/null || true
+  git -C "$merge_target" checkout "$original_branch" 2>/dev/null || true
   fail "merge produced conflicts and was aborted; resolve manually"
 fi
 
-merge_commit="$(git -C "$REPO_ROOT" log -1 --oneline)"
+git -C "$merge_target" checkout "$original_branch" 2>/dev/null || true
+
+merge_commit="$(git -C "$merge_target" log -1 --oneline)"
 
 if [[ "$keep_worktree" == true ]]; then
   printf '\nMerged: %s\nKept worktree: %s (branch %s)\n' "$merge_commit" "$worktree_dir" "$task_branch"

--- a/scripts/finish-task.sh
+++ b/scripts/finish-task.sh
@@ -9,7 +9,14 @@
 set -euo pipefail
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# REPO_ROOT is the repository (primary checkout), not the invoked copy's
+# worktree — see issue #637.
+if repo_common_dir="$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
+  readonly REPO_ROOT="$(dirname "$repo_common_dir")"
+else
+  printf 'finish-task: not inside a git repository: %s\n' "$SCRIPT_DIR" >&2
+  exit 1
+fi
 readonly DEFAULT_BASE="feat/core-arch-simplification"
 WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-$(dirname "$REPO_ROOT")/worktrees/$(basename "$REPO_ROOT")}"
 

--- a/scripts/issue-545-junction-census.ts
+++ b/scripts/issue-545-junction-census.ts
@@ -32,10 +32,11 @@
  *     island boundaries) exactly as the implementation's domain check would.
  *     Reports the tangent-vs-fallback split and the segment-count delta.
  *
- * Usage: npx tsx scripts/issue-545-junction-census.ts [tracked] [nomesh]
- *   tracked — restrict the corpus to git-tracked .camj files
- *   nomesh  — exclude mesh/rest fixtures (stl-test-cat, rest-test,
- *             excluded-region-test, Tele53*)
+ * Usage: npx tsx scripts/issue-545-junction-census.ts [--root DIR] [tracked] [nomesh]
+ *   --root DIR  scan DIR instead of . (repo root)
+ *   tracked     restrict the corpus to git-tracked .camj files
+ *   nomesh      exclude mesh/rest fixtures (stl-test-cat, rest-test,
+ *               excluded-region-test, Tele53*)
  */
 
 import { readFileSync } from 'node:fs'
@@ -882,7 +883,8 @@ function censusFile(file: string): FileRow | null {
 
 const trackedOnly = process.argv.includes('tracked')
 const noMesh = process.argv.includes('nomesh')
-const ROOT = process.argv[2] ?? '.'
+const rootIdx = process.argv.indexOf('--root')
+const ROOT = rootIdx !== -1 && process.argv[rootIdx + 1] ? process.argv[rootIdx + 1] : '.'
 const allFiles = execSync("find . -path ./node_modules -prune -o -name '*.camj' -print", { cwd: ROOT })
   .toString().trim().split('\n')
   .filter((f) => f.includes('work/') || f.includes('public/examples') || f.includes('src/engine/test-fixtures'))

--- a/scripts/issue-545-junction-census.ts
+++ b/scripts/issue-545-junction-census.ts
@@ -882,7 +882,7 @@ function censusFile(file: string): FileRow | null {
 
 const trackedOnly = process.argv.includes('tracked')
 const noMesh = process.argv.includes('nomesh')
-const ROOT = '/Users/frankp/Projects/purecutcnc'
+const ROOT = process.argv[2] ?? '.'
 const allFiles = execSync("find . -path ./node_modules -prune -o -name '*.camj' -print", { cwd: ROOT })
   .toString().trim().split('\n')
   .filter((f) => f.includes('work/') || f.includes('public/examples') || f.includes('src/engine/test-fixtures'))

--- a/scripts/list-ops.ts
+++ b/scripts/list-ops.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import type { Project } from '../src/types/project.ts'
 
-const PROJECT_PATH = '/Users/frankp/Projects/purecutcnc/work/v-carve-skeleton-tests.camj'
+const PROJECT_PATH = process.argv[2] ?? 'work/v-carve-skeleton-tests.camj'
 const project = JSON.parse(fs.readFileSync(PROJECT_PATH, 'utf8')) as Project
 
 console.log('Available operations:')

--- a/scripts/profile-stl.ts
+++ b/scripts/profile-stl.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import { extractStlProfileAndBounds } from '../src/import/stl.ts'
 
 async function run() {
-  const filePath = '/Users/frankp/Projects/purecutcnc/work/horse.stl'
+  const filePath = process.argv[2] ?? 'work/horse.stl'
   const buffer = fs.readFileSync(filePath)
   const base64Data = buffer.toString('base64')
   

--- a/scripts/test-clipper-fallback.ts
+++ b/scripts/test-clipper-fallback.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import { extractStlProfileAndBounds } from '../src/import/stl.ts'
 
 async function run() {
-  const filePath = '/Users/frankp/Projects/purecutcnc/work/springycat-keyring.stl'
+  const filePath = process.argv[2] ?? 'work/springycat-keyring.stl'
   const buffer = fs.readFileSync(filePath)
   const base64Data = buffer.toString('base64')
   

--- a/scripts/test-dispatch-task.sh
+++ b/scripts/test-dispatch-task.sh
@@ -172,4 +172,56 @@ assert_contains "$failed_output" 'commit result: not-attempted (worker failed)'
 [[ "$(git -C "$failed_worktree" status --short)" == '?? failed-change.txt' ]] \
   || fail 'failed DSH worker changes were not left for inspection'
 
+# ---- issue #637: default base resolves outside any checkout, even when the ----
+# ---- invoked copy of dispatch-task.sh lives in a worktree                   ----
+prepare_committed_scripts_fixture() {
+  local fixture_repo="$TEMP_DIR/wtbase-repo"
+  mkdir -p "$fixture_repo/scripts"
+  git init -q "$fixture_repo"
+  git -C "$fixture_repo" config user.name test
+  git -C "$fixture_repo" config user.email test@example.com
+  printf 'fixture\n' > "$fixture_repo/README.md"
+  cp "$DISPATCH" "$SCRIPT_DIR/run-dsh-agent.sh" "$SCRIPT_DIR/dsh-progress-filter.jq" "$fixture_repo/scripts/"
+  chmod +x "$fixture_repo/scripts/dispatch-task.sh" "$fixture_repo/scripts/run-dsh-agent.sh"
+  git -C "$fixture_repo" add README.md scripts
+  git -C "$fixture_repo" commit -qm 'fixture base'
+  printf '%s' "$fixture_repo"
+}
+
+wtbase_repo="$(prepare_committed_scripts_fixture)"
+wtbase_base="$(git -C "$wtbase_repo" branch --show-current)"
+git -C "$wtbase_repo" worktree add -q "$TEMP_DIR/wtbase-invoking-wt" -b invoking-copy
+invoking_wt_resolved="$(cd "$TEMP_DIR/wtbase-invoking-wt" && pwd -P)"
+temp_resolved="$(cd "$TEMP_DIR" && pwd -P)"
+
+outside_base_output="$(printf 'implement\n' | PATH="$TEMP_DIR/bin:$PATH" HOME="$TEMP_DIR/home" \
+  FAKE_DSH_WRITE_FILE=worker-change.txt \
+  "$TEMP_DIR/wtbase-invoking-wt/scripts/dispatch-task.sh" --provider dsh --issue 104 \
+    --task-slug outside-base --base "$wtbase_base" --skip-build)"
+[[ -d "$TEMP_DIR/worktrees/wtbase-repo/outside-base" ]] \
+  || fail 'dispatch from a worktree copy did not use <parent-of-repo>/worktrees/<repo-name>'
+created_worktree_resolved="$(cd "$TEMP_DIR/worktrees/wtbase-repo/outside-base" && pwd -P)"
+case "$created_worktree_resolved" in
+  "$temp_resolved"/worktrees/wtbase-repo/*) ;;
+  *) fail "task worktree landed outside the shared sibling base: $created_worktree_resolved" ;;
+esac
+case "$created_worktree_resolved" in
+  "$invoking_wt_resolved"|"$invoking_wt_resolved"/*) fail 'task worktree nested inside the invoking worktree' ;;
+esac
+[[ ! -e "$TEMP_DIR/wtbase-invoking-wt/worktrees" ]] \
+  || fail 'a nested worktrees/ directory appeared inside the invoking worktree'
+
+# ---- issue #637: guard rejects a PURECUT_WORKTREE_BASE inside a checkout ----
+if inside_base_error="$(printf 'implement\n' | PATH="$TEMP_DIR/bin:$PATH" HOME="$TEMP_DIR/home" \
+  PURECUT_WORKTREE_BASE="$wtbase_repo/nested-worktrees" \
+  "$wtbase_repo/scripts/dispatch-task.sh" --provider dsh --issue 105 \
+    --task-slug inside-base --base "$wtbase_base" --skip-build 2>&1)"; then
+  fail 'dispatch unexpectedly accepted a worktree base inside a checkout'
+fi
+assert_contains "$inside_base_error" 'refusing to create a worktree inside a checkout'
+wtbase_repo_resolved="$(cd "$wtbase_repo" && pwd -P)"
+assert_contains "$inside_base_error" "$wtbase_repo_resolved/nested-worktrees"
+[[ ! -e "$wtbase_repo/nested-worktrees" ]] \
+  || fail 'guard rejected the base but side effects already happened'
+
 printf 'test-dispatch-task: passed\n'

--- a/scripts/test-rough-pipeline.ts
+++ b/scripts/test-rough-pipeline.ts
@@ -5,7 +5,7 @@
  * the same custom mesh-slicing algorithm as roughSurface.ts, and verifies
  * that different Z levels produce different cross-sections.
  *
- * Run: npx tsx scripts/test-rough-pipeline.ts "/Users/frankp/Projects/purecutcnc/work/springycat-keyring.stl"
+ * Run: npx tsx scripts/test-rough-pipeline.ts "work/springycat-keyring.stl"
  */
 
 import fs from 'node:fs'

--- a/scripts/test-stl-import.ts
+++ b/scripts/test-stl-import.ts
@@ -6,7 +6,7 @@ import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUti
 import ManifoldModule from 'manifold-3d'
 
 async function run() {
-  const filePath = '/Users/frankp/Projects/purecutcnc/work/springycat-keyring.stl'
+  const filePath = process.argv[2] ?? 'work/springycat-keyring.stl'
   const buffer = fs.readFileSync(filePath)
   
   console.log(`Loading STL: ${filePath} (${buffer.length} bytes)`)

--- a/scripts/test-stl-silhouette.ts
+++ b/scripts/test-stl-silhouette.ts
@@ -28,7 +28,7 @@ import { renderSilhouetteToDataUrl } from '../src/import/stl'
 import { profileVertices, getProfileBounds, polygonProfile, type Point, type SketchProfile } from '../src/types/project'
 
 // ── Configuration ──────────────────────────────────────────────────────────
-const STL_PATH = '/Users/frankp/Projects/purecutcnc/work/Oldman-splash-final.STL'
+const STL_PATH = process.argv[2] ?? 'work/Oldman-splash-final.STL'
 const STL_SCALE = 1
 const STL_AXIS_SWAP: 'none' | 'yz' | 'xz' | 'xy' = 'none'
 const OUTPUT_PNG = '/tmp/stl-silhouette.png'

--- a/scripts/trace-o-emission.ts
+++ b/scripts/trace-o-emission.ts
@@ -9,7 +9,7 @@ import { resolvePocketRegions } from '../src/engine/toolpaths/resolver.ts'
 import { buildInsetRegions } from '../src/engine/toolpaths/pocket.ts'
 import type { Operation, Project, Point } from '../src/types/project.ts'
 
-const PROJECT_PATH = '/Users/frankp/Projects/purecutcnc/work/v-carve-skeleton-tests.camj'
+const PROJECT_PATH = process.argv[2] ?? 'work/v-carve-skeleton-tests.camj'
 const project = JSON.parse(fs.readFileSync(PROJECT_PATH, 'utf8')) as Project
 const operation = project.operations.find(o => o.id === 'op0046')!
 

--- a/scripts/worker-status.sh
+++ b/scripts/worker-status.sh
@@ -10,7 +10,14 @@
 set -euo pipefail
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# REPO_ROOT is the repository (primary checkout), not the invoked copy's
+# worktree — see issue #637.
+if repo_common_dir="$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
+  readonly REPO_ROOT="$(dirname "$repo_common_dir")"
+else
+  printf 'worker-status: not inside a git repository: %s\n' "$SCRIPT_DIR" >&2
+  exit 1
+fi
 WORKTREE_BASE="${PURECUT_WORKTREE_BASE:-$(dirname "$REPO_ROOT")/worktrees/$(basename "$REPO_ROOT")}"
 
 usage() {


### PR DESCRIPTION
## Summary
Resolves #637. The worktree base is derived from the repository (via
`git rev-parse --path-format=absolute --git-common-dir`) rather than the
invoked copy's location, so dispatching from any checkout resolves to
`<parent-of-repo>/worktrees/<repo>/<slug>` — correct on a fresh clone with
zero configuration. `dispatch-task.sh` now refuses to create (or accept via
`PURECUT_WORKTREE_BASE`) a worktree inside any registered checkout, comparing
symlink-resolved paths and naming the offending parent.

## Notes for review
- **finish-task.sh semantics change:** with `REPO_ROOT` now anchored to the
  repository, `finish-task.sh` merges into the primary/anchor checkout instead
  of whichever worktree the manager invoked it from. This is intentional per the
  issue ("base identical from any checkout"); the integration branch is shared
  by all worktrees via refs anyway. Verified via a real dispatch->finish
  round-trip on a throwaway clone.
- **Full lane:** this touches `AGENTS.md` (protected, see `check-fast-lane.sh`)
  and exceeds the 3-file/25-line budget, so it cannot claim fast lane. No fast
  lane label is applied.
## Verification
- `bash scripts/test-dispatch-task.sh` -> passed (incl. two new #637 cases:
  default base resolves outside the invoking worktree, and guard rejects an
  inside-checkout `PURECUT_WORKTREE_BASE`).
- Fresh clone to a throwaway directory: dispatch from both the clone and a
  worktree-of-the-clone created the task worktree at `<clone-parent>/worktrees/purecutcnc/<slug>`,
  created no nesting, and the guard rejected a dot-dir inside-checkout base.
- End-to-end dispatch->finish round-trip merged cleanly and removed the worktree.

Closes #637
