### PR TITLE
fix(ci): tolerate CRLF checkouts in i18n format gate

### DIFF
--- a/scripts/check-i18n-format.ts
+++ b/scripts/check-i18n-format.ts
@@ -170,8 +170,20 @@ function readPrefix(trivia: string): string[] {
   return prefix
 }
 
+/**
+ * Read a locale file with line endings normalized to LF.
+ *
+ * The canonical form is LF, but a Windows checkout (`core.autocrlf`) supplies
+ * CRLF working-tree files, and the gate compares byte-for-byte. Normalizing
+ * here keeps the canonical comparison free of line-ending noise without
+ * changing what `--fix` writes (LF, as today).
+ */
+function readSource(path: string): string {
+  return readFileSync(path, 'utf8').replace(/\r\n?/g, '\n')
+}
+
 function parseFile(path: string): ParsedFile {
-  const text = readFileSync(path, 'utf8')
+  const text = readSource(path)
   const source = ts.createSourceFile(path, text, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TS)
 
   let valueImport: string | null = null
@@ -507,7 +519,7 @@ function run(fix: boolean): number {
         }
       }
 
-      const original = readFileSync(path, 'utf8')
+      const original = readSource(path)
       let canonical = render(parsed, order)
       if (parsed.valueImport) {
         canonical = canonicalizeImport(canonical, parsed.valueImport)


### PR DESCRIPTION
Closes #647

## What

`check-i18n-format.ts` compared its canonical LF render against the raw file bytes, so a Windows working tree (Git-for-Windows `core.autocrlf=true` converts checkout to CRLF; repo has no `.gitattributes`) flagged **every** locale line as non-canonical — `check-i18n-format: FAILED — 260 problem(s) in 65 file(s)` — and failed `deploy-windows.yml` (run 33020054445). Linux/macOS check out LF and passed.

## Fix

Normalize line endings to LF at read time via a `readSource()` helper (`readFileSync(...).replace(/\r\n?/g, '\n')`), used in `parseFile()` and the byte-compare against `original`. The gate stops caring about checkout line-ending policy; `--fix` output and the canonical form are unchanged (LF). No locale content changes.

## Verification

- `npx tsx scripts/check-i18n-format.ts` → OK on the LF checkout.
- Same check → OK against a CRLF copy of `src/i18n/locales` (reproduces the CI failure pre-fix, passes post-fix).
- Mutation test: reordering a key in the CRLF fixture still fails the gate — the check wasn't neutered.
- Full `npm run build` green locally (211 test files passed).

## Notes

No unit-test file exists for this gate (it `process.exit`s at module load; making it testable is a separate refactor, out of scope here).
