### PR TITLE
fix(resume-work): use os.tmpdir() instead of hardcoded /tmp in test

### DIFF
--- a/tools/resume-work/resume-work.test.ts
+++ b/tools/resume-work/resume-work.test.ts
@@ -18,6 +18,7 @@ import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
 import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -50,7 +51,9 @@ const hasZstdCli = spawnSync('zstd', ['--version'], { stdio: 'ignore' }).status 
 const here = dirname(fileURLToPath(import.meta.url))
 const fixtures = join(here, 'fixtures')
 const projectRoot = resolve(here, '../..')
-const root = mkdtempSync('/tmp/resume-work-test-')
+// os.tmpdir() rather than a hardcoded /tmp: POSIX-only, and Node on Windows
+// resolves `/tmp` to a drive-root `\tmp` that does not exist (ENOENT).
+const root = mkdtempSync(join(tmpdir(), 'resume-work-test-'))
 const cwd = join(root, 'worktree')
 mkdirSync(cwd)
 


### PR DESCRIPTION
Closes #649

## What

`tools/resume-work/resume-work.test.ts` hardcoded `mkdtempSync('/tmp/resume-work-test-')`. On Windows, Node resolves `/tmp` to a drive-root `\tmp` that does not exist → `ENOENT`, failing the test step of the Windows desktop build (`deploy-windows.yml` run 33029698145). Linux/macOS pass.

## Fix

Use `os.tmpdir()`: `mkdtempSync(join(tmpdir(), 'resume-work-test-'))`. Test-only change; the tool code has no other `/tmp` usage (verified by grep).

## Verification

- `npx tsx tools/resume-work/resume-work.test.ts` → passes locally.
- Full `npm run build` green locally (211 test files passed).
