### PR TITLE
fix(resume-work): port session-dir slug across drive letters and separators

### DIFF
--- a/tools/resume-work/lib/adapters.ts
+++ b/tools/resume-work/lib/adapters.ts
@@ -69,6 +69,23 @@ function safeStat(path: string): number {
   }
 }
 
+/**
+ * cwd → store directory slug, portable across drive letters and separators.
+ *
+ * The dsh and claude-code store layouts name a session's directory after the
+ * worktree path. The old `slice(1).replaceAll('/', '-')` was POSIX-only: on
+ * Windows the drive-letter colon and the backslashes survived, producing an
+ * invalid directory segment (`--:\Users\...--`) that could never be created or
+ * found. `resolve()` makes the input absolute first, so the slug is stable
+ * regardless of how the cwd was spelled.
+ */
+export function sessionDirSlug(cwd: string): string {
+  return resolve(cwd)
+    .replace(/^[A-Za-z]:/, '') // drive prefix (Windows)
+    .replace(/^[\\/]/, '') // leading separator (matches the old slice(1))
+    .replace(/[\\/]/g, '-') // remaining separators
+}
+
 function candidatesFromFiles(agent: Agent, paths: string[]): SessionCandidate[] {
   return paths.map((path) => ({
     agent,
@@ -258,7 +275,7 @@ function findJsonlFiles(root: string, depth: number): string[] {
 const dshAdapter: Adapter = {
   agent: 'dsh',
   locate(cwd, config) {
-    const encoded = `--${resolve(cwd).slice(1).replaceAll('/', '-')}--`
+    const encoded = `--${sessionDirSlug(cwd)}--`
     const root = join(expandHome(config.stores.dsh), encoded)
     if (!existsSync(root)) return []
     return readdirSync(root, { withFileTypes: true }).flatMap<SessionCandidate>((entry) => {
@@ -275,7 +292,7 @@ const dshAdapter: Adapter = {
 const claudeAdapter: Adapter = {
   agent: 'claude-code',
   locate(cwd, config) {
-    const encoded = `-${resolve(cwd).slice(1).replaceAll('/', '-')}`
+    const encoded = `-${sessionDirSlug(cwd)}`
     const root = join(expandHome(config.stores['claude-code']), encoded)
     if (!existsSync(root)) return []
     return candidatesFromFiles('claude-code', readdirSync(root)

--- a/tools/resume-work/resume-work.test.ts
+++ b/tools/resume-work/resume-work.test.ts
@@ -22,7 +22,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { ADAPTERS, formatCommonEvents, locateSessions } from './lib/adapters.ts'
+import { ADAPTERS, formatCommonEvents, locateSessions, sessionDirSlug } from './lib/adapters.ts'
 import { appendClaim, detectCycle, readLedger } from './lib/ledger.ts'
 import { runResumeWork } from './run.ts'
 import type { ResumeConfig, SessionCandidate } from './lib/types.ts'
@@ -158,10 +158,10 @@ try {
     assert.deepEqual(openCode.todos, ['Run build'])
   }
 
-  const dshArtifact = join(config.stores.dsh, `--${cwd.slice(1).replaceAll('/', '-')}--`, 'session-fixture')
+  const dshArtifact = join(config.stores.dsh, `--${sessionDirSlug(cwd)}--`, 'session-fixture')
   mkdirSync(dshArtifact, { recursive: true })
   cpSync(join(fixtures, 'dsh.jsonl'), join(dshArtifact, 'session.jsonl.zstd'))
-  const claudeDirectory = join(config.stores['claude-code'], `-${cwd.slice(1).replaceAll('/', '-')}`)
+  const claudeDirectory = join(config.stores['claude-code'], `-${sessionDirSlug(cwd)}`)
   mkdirSync(claudeDirectory, { recursive: true })
   cpSync(join(fixtures, 'claude-code.jsonl'), join(claudeDirectory, 'claude-fixture.jsonl'))
   const codexDirectory = join(config.stores.codex, '2026', '08', '26')


### PR DESCRIPTION
Closes #651

## What

The dsh and claude-code resume-work store directories are named from the worktree path via `resolve(cwd).slice(1).replaceAll('/', '-')` — POSIX-only. On Windows the drive-letter colon and backslashes survive (`--:\Users\...--`), an invalid directory segment that can never be created or found. It broke `tools\resume-work\resume-work.test.ts` on the Windows build (run 33032057194) and would break real resume-work session lookup on Windows.

## Fix

New `sessionDirSlug(cwd)` in `tools/resume-work/lib/adapters.ts`, used by the dsh + claude-code adapters and mirrored in the test:

```ts
export function sessionDirSlug(cwd: string): string {
  return resolve(cwd)
    .replace(/^[A-Za-z]:/, '')  // drive prefix (Windows)
    .replace(/^[\\/]/, '')      // leading separator (matches old slice(1))
    .replace(/[\\/]/g, '-')     // remaining separators
}
```

macOS output is byte-identical to the old code (verified), so existing store layouts keep working.

## Verification

- Slug transform on a Windows absolute path yields `Users-RUNNER~1-...` — no colon, no backslash.
- POSIX path: new slug === old slug.
- `npx tsx tools/resume-work/resume-work.test.ts` passes.
- Full `npm run build` green locally.
