### PR TITLE
test(toolpaths): skip arc-search scaling ratio when baseline is below timer resolution

### DIFF
--- a/src/engine/toolpaths/arcReconstruction.test.ts
+++ b/src/engine/toolpaths/arcReconstruction.test.ts
@@ -209,13 +209,32 @@ function testBoundsLargeNonFittingSearch(): void {
   // regressions in the table fail `testSplitsLargeCircularRunWithoutChanging-
   // ItsCircle` before reaching this point), so this assertion only has to guard
   // a structural return to unbounded scanning.
+  //
+  // Warm each size once so JIT tiering/compilation stays out of the measured
+  // region (mirrors the guidance in src/test/cpuRatio.ts).
+  findArcRunsInPoints(nonFittingPoints(400), FIT_OPTIONS)
+  findArcRunsInPoints(nonFittingPoints(800), FIT_OPTIONS)
+
   const small = bestNonFittingCpuMs(400)
   const large = bestNonFittingCpuMs(800)
-  const ratio = large / small
 
-  assert(ratio < 4,
-    `expected sub-cubic scaling for 2x the input (linear ~2x, cubic ~8x), got ${ratio.toFixed(1)}x `
-    + `(${small.toFixed(1)}ms -> ${large.toFixed(1)}ms CPU)`)
+  // On Windows, process.cpuUsage() rounds to whole milliseconds, so a sub-ms
+  // baseline reads exactly 0 and `large / small` is undefined (Infinity) — a
+  // measurement floor, not a regression (the assertion passed there on
+  // 2026-08-12 and failed spuriously on 2026-08-27). The deterministic
+  // window-contract tests above are the primary guard and run on every
+  // platform; this ratio only backstops a structural return to unbounded
+  // scanning, so skip it where it cannot be measured, loudly.
+  if (small === 0) {
+    console.log(`arc-search scaling ratio skipped: baseline below timer resolution `
+      + `(${small.toFixed(1)}ms -> ${large.toFixed(1)}ms CPU)`)
+  } else {
+    const ratio = large / small
+
+    assert(ratio < 4,
+      `expected sub-cubic scaling for 2x the input (linear ~2x, cubic ~8x), got ${ratio.toFixed(1)}x `
+      + `(${small.toFixed(1)}ms -> ${large.toFixed(1)}ms CPU)`)
+  }
 }
 
 testFindsLongestValidArcRun()


### PR DESCRIPTION
Closes #652

## What

`testBoundsLargeNonFittingSearch` in `arcReconstruction.test.ts` flaked on the Windows build (run 33032057194): `got Infinityx (0.0ms -> 47.0ms CPU)`. On Windows, `process.cpuUsage()` rounds to whole milliseconds, so the ~0.2ms 400-point baseline reads exactly `0.0` and the ratio is `Infinity`. The assertion passed the last green Windows build (2026-08-12) — a latent measurement-floor flake, not a regression in the search code.

## Fix

- Warm each input size once before measuring (mirrors `src/test/cpuRatio.ts` guidance).
- When the baseline is at the timer floor (`small === 0`), the ratio is unmeasurable: log a loud skip instead of asserting Infinity.
- Otherwise assert exactly as before (`ratio < 4`).

The deterministic window-contract tests (`testSplitsLargeCircularRunWithoutChangingItsCircle`) remain the primary guard and run on every platform; this ratio is only a backstop for a structural return to unbounded scanning.

## Verification

- Test passes locally on macOS (ratio path unchanged).
- Mutation check: forcing `small = 0` logs `arc-search scaling ratio skipped: baseline below timer resolution` and passes instead of failing.
- Full `npm run build` green locally.
