### PR TITLE
fix(toolpaths): append generated arrays in a loop instead of spreading into push

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -81,4 +81,23 @@ export default defineConfig([
       'max-lines': ['error', { max: 3800, skipBlankLines: true, skipComments: true }],
     },
   },
+  // Toolpath generation routinely builds arrays of hundreds of thousands of
+  // moves or points, and `target.push(...source)` passes one *argument* per
+  // element — it throws `RangeError: Maximum call stack size exceeded` past the
+  // engine's argument limit (124,413 on node v26.0.0, stack-size dependent).
+  // One trochoidal Edge Route fragment on a 60 x 40 in guide emits 203,232 cut
+  // moves inside the 500,000-point budget, and the spread threw instead of
+  // producing a path (issue #668). `appendAll` from
+  // src/engine/toolpaths/appendAll.ts appends in a loop instead; tests are
+  // exempt because their arrays are fixtures, not generated geometry.
+  {
+    files: ['src/engine/toolpaths/**/*.ts'],
+    ignores: ['src/engine/toolpaths/**/*.test.ts'],
+    rules: {
+      'no-restricted-syntax': ['error', {
+        selector: 'CallExpression[callee.type="MemberExpression"][callee.property.name="push"] > SpreadElement',
+        message: 'Spreading into push() throws RangeError past ~124k elements — use appendAll(target, source) from src/engine/toolpaths/appendAll.ts (issue #668).',
+      }],
+    },
+  },
 ])

--- a/src/engine/toolpaths/INDEX.md
+++ b/src/engine/toolpaths/INDEX.md
@@ -53,6 +53,7 @@ Toolpath generators. Each file owns one strategy. `index.ts` re-exports everythi
 - `meshSlicing.ts` — slices a mesh at Z heights (used by surface strategies)
 - `modelProtection.ts` — keeps cuts from violating the imported model
 - `clamps.ts` — clamp clearance / avoidance regions
+- `appendAll.ts` — `appendAll(target, source)`, the one way this folder splices a generated array onto another (issue #668). `target.push(...source)` passes one *argument* per element and throws `RangeError: Maximum call stack size exceeded` past the engine's argument limit — 124,413 on node v26.0.0, stack-size dependent — and generation routinely builds arrays past that: one trochoidal Edge Route fragment on a 60 x 40 in guide emits 204,696 cut moves, inside the 500,000-point budget and well past the limit. A scoped `no-restricted-syntax` rule in `eslint.config.js` keeps the spread from coming back here
 
 ## Tests
 - `cornerRelief.test.ts` — corner relief asserted on **coverage of the emitted motion**, never on "the region changed": a swept-envelope model decides whether the corner wedge is cut, because a region-level assertion passes on the silent no-op that region union produces. The same model is run with the excursion ending at `1.2r` and must *fail*, which is what makes the touch-the-corner rule falsifiable rather than merely satisfied. Also covers the corner-qualification sets (convex boundary, reflex island, concave part outline), tessellated arcs and fillets producing nothing, `'none'`/legacy identity, the tool-derived stepdown, every guard path, the rough-big-then-finish-small workflow, `optimizeLinearMoves` preserving the out-and-back (it survives only because the collinear merge requires `dot > 0`), and mm/inch plus a cross-unit tool
@@ -94,6 +95,9 @@ Toolpath generators. Each file owns one strategy. `index.ts` re-exports everythi
 - `pocketTessellationConsistency.test.ts` — regression for circle/arc sampling consistency (issue #359): full-circle and broken-circle pockets must have identical chord sagitta
 - `arcReconstruction.test.ts` — direct partial-run arc-search coverage: greedy longest valid runs, sweep direction, and the bounded large non-fitting path (issue #369)
 - additional arc-reconstruction coverage lives with its store-level callers: `store/helpers/offsetSimplify.test.ts` (offset simplification) and `store/second_cut_test.ts` (segment-preserving boolean reconstruction)
+
+- `appendAll.test.ts` — appends 200,000 elements, a size checked against the spread limit measured on the running engine (`src/test/spreadLimit.ts`) so the fixture cannot decay into an array a spread would have handled anyway; plus order, object identity, empty source, and a non-array iterable
+- `edgeTrochoidalEmission.test.ts` — the issue #668 regression through the real generator: a 60 x 40 in outside trochoidal route emits one fragment of 204,696 cut moves, which must be generated rather than thrown on or refused. Asserts against the measured spread limit rather than a constant, so a fixture that stopped exceeding it fails loudly instead of passing quietly
 
 ## Adding a new strategy
 1. New file `myStrategy.ts` exporting a generator function.

--- a/src/engine/toolpaths/appendAll.test.ts
+++ b/src/engine/toolpaths/appendAll.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * `appendAll` tests — issue #668.
+ *
+ * The point of the helper is the one case a spread cannot do: an array past
+ * the engine's argument limit. The size below is checked against the limit
+ * measured on the running engine, so the test cannot decay into appending an
+ * array the spread would have handled anyway.
+ *
+ * Run with: npx tsx src/engine/toolpaths/appendAll.test.ts
+ */
+
+import { maxSpreadableLength } from '../../test/spreadLimit'
+import { appendAll } from './appendAll'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+let passed = 0
+let failed = 0
+
+function test(name: string, fn: () => void): void {
+  try {
+    fn()
+    passed += 1
+    console.log(`   ✓ ${name}`)
+  } catch (err: unknown) {
+    failed += 1
+    console.log(`   ✗ ${name}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+/** Comfortably past the 124,413 measured on node v26.0.0, and past its spread on any engine we run. */
+const OVERSIZE = 200_000
+
+test('the fixture size really does exceed this engine\'s argument limit', () => {
+  const limit = maxSpreadableLength()
+  assert(OVERSIZE > limit,
+    `fixture no longer exceeds the engine's spread limit (${limit}) — grow OVERSIZE past it`)
+
+  const source = new Array<number>(OVERSIZE).fill(0)
+  let threw = false
+  try {
+    const target: number[] = []
+    target.push(...source)
+  } catch (err: unknown) {
+    threw = err instanceof RangeError
+  }
+  assert(threw, 'spreading the oversize fixture into push() must still throw RangeError')
+})
+
+test('appends an array past the argument limit without throwing', () => {
+  const source = Array.from({ length: OVERSIZE }, (_, index) => ({ index }))
+  const target = [{ index: -3 }, { index: -2 }, { index: -1 }]
+
+  appendAll(target, source)
+
+  assert(target.length === OVERSIZE + 3, `expected ${OVERSIZE + 3} elements, got ${target.length}`)
+  assert(target[0].index === -3, 'existing elements must stay in front')
+  assert(target[3] === source[0], 'appended elements must be the same objects, in order')
+  assert(target[OVERSIZE / 2 + 3] === source[OVERSIZE / 2], 'mid-array order must be preserved')
+  assert(target.at(-1) === source.at(-1), 'last appended element must be the source\'s last')
+})
+
+test('appends nothing for an empty source and returns the target', () => {
+  const target = [1, 2, 3]
+  const returned = appendAll(target, [])
+  assert(returned === target, 'must return the same array it appended onto')
+  assert(target.length === 3, 'empty source must leave the target untouched')
+})
+
+test('accepts any iterable, not just arrays', () => {
+  const source = new Map([['a', 1], ['b', 2]])
+  const target: number[] = [0]
+  appendAll(target, source.values())
+  assert(target.join(',') === '0,1,2', `expected 0,1,2, got ${target.join(',')}`)
+})
+
+console.log(`\nappendAll: ${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/src/engine/toolpaths/appendAll.ts
+++ b/src/engine/toolpaths/appendAll.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Appends every element of `source` onto `target`, in order.
+ *
+ * This exists because `target.push(...source)` passes one *argument* per
+ * element, so it dies with `RangeError: Maximum call stack size exceeded` once
+ * the source outgrows the engine's argument limit — 124,413 elements measured
+ * on node v26.0.0 at the default stack size, and stack-size dependent rather
+ * than a fixed constant. Toolpath generation routinely builds arrays past that:
+ * one trochoidal Edge Route fragment on a 60 x 40 in guide emits 203,232 cut
+ * moves, well inside the 500,000-point budget and well past the limit, and the
+ * spread threw instead of producing a path (issue #668).
+ *
+ * Order and object identity are preserved, so emitted output is unchanged.
+ * `Iterable` rather than an array because callers pass Map iterators and lazily
+ * filtered lists as well as plain arrays.
+ */
+export function appendAll<T>(target: T[], source: Iterable<T>): T[] {
+  for (const item of source) {
+    target.push(item)
+  }
+  return target
+}

--- a/src/engine/toolpaths/arcReconstruction.ts
+++ b/src/engine/toolpaths/arcReconstruction.ts
@@ -43,6 +43,7 @@ import {
 import type { ClipperPath } from './types'
 import { bezierPoint, polygonProfile } from '../../types/project'
 import type { Point, Segment, SketchFeature, SketchProfile } from '../../types/project'
+import { appendAll } from './appendAll'
 
 export interface KnownCircle {
   center: Point
@@ -437,7 +438,7 @@ export function clipperContourToProfilePreserving(
       })
       // Adjust: we'll treat indices >= n as wrapping (mod n)
       runs.length = 0
-      runs.push(...merged)
+      appendAll(runs, merged)
     }
   }
 

--- a/src/engine/toolpaths/carving.ts
+++ b/src/engine/toolpaths/carving.ts
@@ -40,6 +40,7 @@ import {
   trochoidalEntryMoveCount,
   type TrochoidalOperationBudget,
 } from './trochoidalPath'
+import { appendAll } from './appendAll'
 
 function updateBounds(bounds: ToolpathBounds | null, point: ToolpathPoint): ToolpathBounds {
   if (!bounds) {
@@ -470,7 +471,7 @@ export function generateFollowLineToolpath(project: Project, operation: Operatio
         }
 
         const cutMoves = toProfileCutMoves(built.points, z, closed)
-        moves.push(...cutMoves)
+        appendAll(moves, cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
       }
     } else {
@@ -480,7 +481,7 @@ export function generateFollowLineToolpath(project: Project, operation: Operatio
           const entryPoint = profileStartPoint(fragment.points, levelZ)
           currentPosition = pushRapidAndPlunge(moves, currentPosition, entryPoint, safeZ)
           const cutMoves = toProfileCutMoves(fragment.points, levelZ, fragment.closed)
-          moves.push(...cutMoves)
+          appendAll(moves, cutMoves)
           currentPosition = cutMoves.at(-1)?.to ?? currentPosition
           currentPosition = retractToSafe(moves, currentPosition, safeZ)
         }

--- a/src/engine/toolpaths/clamps.ts
+++ b/src/engine/toolpaths/clamps.ts
@@ -18,6 +18,7 @@ import type { Clamp, Operation, Project } from '../../types/project'
 import type { ToolpathWarning } from './warningCodes'
 import type { ToolpathBounds, ToolpathMove, ToolpathPoint, ToolpathResult } from './types'
 import { normalizeToolForProject } from './geometry'
+import { appendAll } from './appendAll'
 
 interface ExpandedClampBounds {
   clamp: Clamp
@@ -230,7 +231,7 @@ export function applyClampWarnings(project: Project, result: ToolpathResult, ope
         }
       }
     } else if (canAutoLiftRapid(move, unsafe)) {
-      adjustedMoves.push(...liftRapidMove(move, requiredZ))
+      appendAll(adjustedMoves, liftRapidMove(move, requiredZ))
       continue
     }
 
@@ -260,7 +261,7 @@ export function applyClampWarnings(project: Project, result: ToolpathResult, ope
   }
 
   const warnings = [...result.warnings]
-  warnings.push(...travelLimitWarnings.values())
+  appendAll(warnings, travelLimitWarnings.values())
   for (const entry of warningCounts.values()) {
     warnings.push({
       code: entry.count === 1 ? 'clampCrossedOne' : 'clampCrossedMany',

--- a/src/engine/toolpaths/drilling.ts
+++ b/src/engine/toolpaths/drilling.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_ENTRY_RAMP_ANGLE,
   emitCenterLockedCircularBore,
 } from './entry'
+import { appendAll } from './appendAll'
 
 const CHIP_BREAK_CLEARANCE = 0.5    // tiny retract between pecks in chip-breaking mode (project units)
 
@@ -509,7 +510,7 @@ export function generateDrillingToolpath(project: Project, operation: Operation)
 
   // Precompute and sort targets by nearest-neighbor travel
   const { targets: drillTargets, warnings: precomputeWarnings } = precomputeDrillTargets(targetFeatures, project, regionMask)
-  warnings.push(...precomputeWarnings)
+  appendAll(warnings, precomputeWarnings)
 
   if (drillTargets.length === 0) {
     return {
@@ -672,7 +673,7 @@ export function generateDrillingToolpath(project: Project, operation: Operation)
           if (!result.warnings.some((w) => w.code === 'drillHelicalBoreUnmachinable')) {
             currentPosition = result.position
           }
-          warnings.push(...result.warnings)
+          appendAll(warnings, result.warnings)
         }
       } else {
         // Should not reach here (getCircleCenter already passed), but be safe

--- a/src/engine/toolpaths/edge.ts
+++ b/src/engine/toolpaths/edge.ts
@@ -62,6 +62,7 @@ import { buildTrochoidalContour, DEFAULT_TROCHOIDAL_POINT_BUDGET } from './troch
 import { createTrochoidalPathStore } from './trochoidalLevelPaths'
 import type { TrochoidalPathParams } from './trochoidalLevelPaths'
 import { expandedTabFootprints } from './tabs'
+import { appendAll } from './appendAll'
 
 const TROCHOIDAL_GUIDE_SAFETY_FRACTION = 0.01
 
@@ -683,7 +684,7 @@ function appendFragmentedContoursAtLevels(
           const entry = contourStartPoint(ff.points, z)
           nextPosition = transitionToCutEntry(moves, nextPosition, entry, safeZ, maxLinkDistance)
           const cutMoves = toClosedCutMoves(ff.points, z)
-          moves.push(...cutMoves)
+          appendAll(moves, cutMoves)
           nextPosition = cutMoves.at(-1)?.to ?? nextPosition
         } else {
           // Open span: retract to safe Z, rapid to the start, descend.  This
@@ -692,7 +693,7 @@ function appendFragmentedContoursAtLevels(
           const entry = { x: ff.points[0].x, y: ff.points[0].y, z }
           nextPosition = retractToSafe(moves, nextPosition, safeZ)
           nextPosition = pushRapidAndPlunge(moves, nextPosition, entry, safeZ)
-          moves.push(...toOpenCutMoves(ff.points, z))
+          appendAll(moves, toOpenCutMoves(ff.points, z))
           nextPosition = moves.at(-1)?.to ?? nextPosition
           nextPosition = retractToSafe(moves, nextPosition, safeZ)
         }
@@ -897,7 +898,7 @@ export function appendTrochoidalContoursAtLevels(
       )
     }
     const cutMoves = closed ? toClosedCutMoves(built.points, z) : toOpenCutMoves(built.points, z)
-    moves.push(...cutMoves)
+    appendAll(moves, cutMoves)
     nextPosition = cutMoves.at(-1)?.to ?? nextPosition
   }
   return nextPosition
@@ -992,12 +993,12 @@ function appendEdgeCornerRelief(
       ...(operation.debugToolpath ? { source: 'cornerRelief' } : {}),
     })
     pass.warnings.forEach((warning) => appendUniqueWarning(warnings, warning))
-    reliefMoves.push(...pass.moves)
+    appendAll(reliefMoves, pass.moves)
     position = pass.endPosition
   }
 
   retractToSafe(reliefMoves, position, safeZ)
-  moves.push(...reliefMoves)
+  appendAll(moves, reliefMoves)
 }
 
 export function generateEdgeRouteToolpath(project: Project, operation: Operation): ToolpathResult {
@@ -1276,7 +1277,7 @@ function generateEdgeRouteToolpathSingle(
 
   if (operation.kind === 'edge_route_inside') {
     const resolved = resolveInsideEdgeRegions(project, operation)
-    warnings.push(...resolved.warnings)
+    appendAll(warnings, resolved.warnings)
     const insideInset = isTrochoidal ? trochoidalGuideOffset : tool.radius + radialLeave
 
     for (const band of resolved.bands) {
@@ -1374,7 +1375,7 @@ function generateEdgeRouteToolpathSingle(
             const entry = { x: frag.points[0].x, y: frag.points[0].y, z }
             currentPosition = retractToSafe(moves, currentPosition, safeZ)
             currentPosition = pushRapidAndPlunge(moves, currentPosition, entry, safeZ)
-            moves.push(...toOpenCutMoves(frag.points, z))
+            appendAll(moves, toOpenCutMoves(frag.points, z))
             currentPosition = moves.at(-1)?.to ?? currentPosition
             currentPosition = retractToSafe(moves, currentPosition, safeZ)
           }

--- a/src/engine/toolpaths/edgeTrochoidalEmission.test.ts
+++ b/src/engine/toolpaths/edgeTrochoidalEmission.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Trochoidal Edge Route emission past the engine's argument limit — issue #668.
+ *
+ * One trochoidal fragment is emitted as a whole array of cut moves, and its
+ * size is bounded only by the 500,000-point operation budget. Splicing it in
+ * with `moves.push(...cutMoves)` therefore threw `RangeError: Maximum call
+ * stack size exceeded` on a real 60 x 40 in outside route — no toolpath, no
+ * warning, a thrown generator. This asserts the emitted fragment really does
+ * exceed the limit and that generation survives it.
+ *
+ * Run with: npx tsx src/engine/toolpaths/edgeTrochoidalEmission.test.ts
+ */
+
+import { defaultTool, newProject, rectProfile, type Operation, type Project } from '../../types/project'
+import { projectWithFeatures } from '../../test/projectFixtures'
+import { maxSpreadableLength } from '../../test/spreadLimit'
+import { generateEdgeRouteToolpath } from './edge'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+const TOOL_DIAMETER = 6
+// 60 x 40 in, the reported job, in mm.
+const PART_WIDTH = 60 * 25.4
+const PART_HEIGHT = 40 * 25.4
+const DEPTH = 4
+const STOCK_TOP = DEPTH + 2
+
+function bigPartProject(): Project {
+  const base = newProject('oversize', 'mm')
+  const project: Project = {
+    ...base,
+    meta: { ...base.meta, units: 'mm' },
+    stock: {
+      ...base.stock,
+      profile: rectProfile(-50, -50, PART_WIDTH + 100, PART_HEIGHT + 100),
+      thickness: STOCK_TOP,
+    },
+    tools: [{ ...defaultTool('mm', 1), id: 't1', name: 'em6', diameter: TOOL_DIAMETER, units: 'mm' }],
+  }
+  return projectWithFeatures(project, [
+    {
+      id: 'part',
+      name: 'Part',
+      kind: 'rect',
+      folderId: null,
+      sketch: {
+        profile: rectProfile(0, 0, PART_WIDTH, PART_HEIGHT),
+        origin: { x: 0, y: 0 },
+        orientationAngle: 0,
+        dimensions: [],
+        constraints: [],
+      },
+      operation: 'add',
+      z_top: STOCK_TOP,
+      z_bottom: STOCK_TOP - DEPTH,
+      visible: true,
+      locked: false,
+    },
+  ])
+}
+
+/** Trochoidal outside route, one Z level, so a single fragment carries the whole path. */
+function trochoidalOutsideOperation(): Operation {
+  return {
+    id: 'op1',
+    name: 'Edge',
+    kind: 'edge_route_outside',
+    pass: 'rough',
+    enabled: true,
+    showToolpath: true,
+    debugToolpath: false,
+    target: { source: 'features', featureIds: ['part'] },
+    toolRef: 't1',
+    stepdown: DEPTH,
+    stepover: 0.4,
+    feed: 800,
+    plungeFeed: 300,
+    rpm: 18000,
+    pocketPattern: 'offset',
+    pocketAngle: 0,
+    roundOutsideCorners: false,
+    stockToLeaveRadial: 0,
+    stockToLeaveAxial: 0,
+    finishWalls: true,
+    finishFloor: true,
+    carveDepth: DEPTH,
+    maxCarveDepth: DEPTH,
+    cutDirection: 'conventional',
+    machiningOrder: 'level_first',
+    edgeStrategy: 'trochoidal',
+    trochoidalCutWidth: TOOL_DIAMETER * 1.5,
+    trochoidalAdvance: 0.1,
+  }
+}
+
+const started = Date.now()
+const result = generateEdgeRouteToolpath(bigPartProject(), trochoidalOutsideOperation())
+const elapsed = Date.now() - started
+
+const cuts = result.moves.filter((move) => move.kind === 'cut')
+const limit = maxSpreadableLength()
+
+assert(cuts.length > 0, `oversize trochoidal route emitted no cuts (warnings: ${
+  result.warnings.map((w) => w.code).join(', ') || 'none'})`)
+assert(cuts.length > limit,
+  `fixture emits ${cuts.length} cut moves, which no longer exceeds this engine's spread limit (${limit}) — grow the part`)
+
+const budgetWarnings = result.warnings.filter((warning) => (
+  warning.code === 'edgeTrochoidalMoveBudget'
+  || warning.code === 'edgeTrochoidalEntryBudget'
+  || warning.code === 'edgeTrochoidalInvalidGuide'
+  || warning.code === 'edgeTrochoidalSafetyCheck'
+))
+assert(budgetWarnings.length === 0,
+  `oversize route must be generated, not refused: ${budgetWarnings.map((w) => w.code).join(', ')}`)
+
+console.log(`   ✓ emitted ${cuts.length} cut moves past the ${limit}-argument spread limit in ${elapsed} ms`)
+console.log('\nedgeTrochoidalEmission: 1 passed, 0 failed')

--- a/src/engine/toolpaths/finishSurfaceCleanup.ts
+++ b/src/engine/toolpaths/finishSurfaceCleanup.ts
@@ -66,6 +66,7 @@ import { splitFeatureTargets } from './regions'
 import { resolve3DSurfaceStepdown } from './surfaceStepdown3d'
 import type { Resolved3DSurfaceLevel } from './surfaceStepdown3d'
 import type { ClipperPath } from './types'
+import { appendAll } from './appendAll'
 
 const KEY_SCALE = 1_000
 const CLEANUP_SAMPLE_LEVEL_COUNT = 32
@@ -820,7 +821,7 @@ export function generateFinishSurfaceCleanupToolpath(
           resolved.maxLinkDistance,
         )
         const cutMoves = toClosedCutMoves(contour, z)
-        moves.push(...cutMoves)
+        appendAll(moves, cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
       }
 
@@ -842,7 +843,7 @@ export function generateFinishSurfaceCleanupToolpath(
           resolved.maxLinkDistance,
         )
         const cutMoves = toOpenCutMoves(segment, z)
-        moves.push(...cutMoves)
+        appendAll(moves, cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
       }
 
@@ -951,7 +952,7 @@ export function generateFinishSurfaceCleanupToolpath(
           circleMoves = splice.cutMoves
           currentPosition = splice.nextPosition
         }
-        moves.push(...circleMoves)
+        appendAll(moves, circleMoves)
         currentPosition = circleMoves.at(-1)?.to ?? currentPosition
         previousCircleEnd = currentPosition
       }
@@ -982,7 +983,7 @@ export function generateFinishSurfaceCleanupToolpath(
         cutMoves = splice.cutMoves
         currentPosition = splice.nextPosition
       }
-      moves.push(...cutMoves)
+      appendAll(moves, cutMoves)
       currentPosition = cutMoves.at(-1)?.to ?? currentPosition
     }
 
@@ -1000,7 +1001,7 @@ export function generateFinishSurfaceCleanupToolpath(
         resolved.maxLinkDistance,
       )
       const cutMoves = toOpenCutMoves(segment, z)
-      moves.push(...cutMoves)
+      appendAll(moves, cutMoves)
       currentPosition = cutMoves.at(-1)?.to ?? currentPosition
     }
 

--- a/src/engine/toolpaths/finishSurfaceParallel.ts
+++ b/src/engine/toolpaths/finishSurfaceParallel.ts
@@ -23,6 +23,7 @@ import { buildRegionMask } from './regions'
 import { resolveRegionDomainCentre } from './regionDomain'
 import { significantSilhouettePaths } from './silhouette'
 import { buildProtectedFootprintPaths, clipperPathsToTupleContours, differenceClipperPaths, unionClipperPaths } from './modelProtection'
+import { appendAll } from './appendAll'
 
 function computeContourBounds(
   contours: Iterable<Array<Array<[number, number]>>>,
@@ -665,7 +666,7 @@ export function generateFinishSurfaceParallel(
       for (const [x1, x2] of intervals) {
         const segment = buildTopSurfaceSegment(x1, x2, rotY, cosPos, sinPos, heightMap, topSurfaceSampleDistance)
         if (segment.length >= 2) {
-          scanSegments.push(...splitAndClampSurfaceSegmentToMinZ(segment, minCutZAtPoint))
+          appendAll(scanSegments, splitAndClampSurfaceSegmentToMinZ(segment, minCutZAtPoint))
         }
       }
 
@@ -716,7 +717,7 @@ export function generateFinishSurfaceParallel(
         const entryPoint = cutPoints3D[0]
 
         pos = transitionToCutEntry(moves, pos, entryPoint, safeZ, linkMaxDistance, safeLinkCheck)
-        moves.push(...toOpenCutMoves3D(cutPoints3D))
+        appendAll(moves, toOpenCutMoves3D(cutPoints3D))
         pos = cutPoints3D[cutPoints3D.length - 1]
       }
     }

--- a/src/engine/toolpaths/finishSurfaceWaterline.ts
+++ b/src/engine/toolpaths/finishSurfaceWaterline.ts
@@ -57,6 +57,7 @@ import { retractToSafe, rotateContourToNearestEntry, toClosedCutMoves, toOpenCut
 import { resolveRegionDomainCentre } from './regionDomain'
 import { buildRegionMask } from './regions'
 import type { ClipperPath, NormalizedTool, ToolpathMove, ToolpathPoint } from './types'
+import { appendAll } from './appendAll'
 
 const WATERLINE_LENGTH_EPSILON_MM = 0.01
 const WATERLINE_PROJECTED_MAX_RINGS_PER_BAND = 96
@@ -1316,7 +1317,7 @@ export function generateFinishSurfaceWaterline(
     const addPaths: ClipperPath[] = []
     for (const add of intersectingAdds) {
       if (z > add.topZ + 1e-9 || z < add.bottomZ - 1e-9) continue
-      addPaths.push(...add.paths)
+      appendAll(addPaths, add.paths)
     }
     if (addPaths.length === 0) return meshPaths
     if (meshPaths.length === 0) return unionClipperPaths(addPaths)
@@ -1972,7 +1973,7 @@ export function generateFinishSurfaceWaterline(
               ? toClosedCutMoves(safeRun.contour, ringEntry.z)
               : toOpenCutMoves(safeRun.contour, ringEntry.z)
           const simplified = simplifyContiguousCutMoves(cutMovesForContour)
-          allMoves.push(...simplified)
+          appendAll(allMoves, simplified)
           for (const move of simplified) {
             allStepLevels.add(move.from.z)
             allStepLevels.add(move.to.z)

--- a/src/engine/toolpaths/guideFragments.ts
+++ b/src/engine/toolpaths/guideFragments.ts
@@ -17,6 +17,7 @@
 import type { Point } from '../../types/project'
 import { DEFAULT_CLIPPER_SCALE, XY_EPSILON, samePointXY } from './geometry'
 import type { ClipperPath } from './types'
+import { appendAll } from './appendAll'
 
 const EPSILON = XY_EPSILON
 
@@ -185,7 +186,7 @@ export function splitClosedGuideByForbiddenPaths(
     const parameters = [0, 1]
     for (const path of forbidden) {
       for (let edgeIndex = 0; edgeIndex < path.length; edgeIndex += 1) {
-        parameters.push(...segmentIntersectionParameters(
+        appendAll(parameters, segmentIntersectionParameters(
           from,
           to,
           path[edgeIndex],

--- a/src/engine/toolpaths/modelProtection.ts
+++ b/src/engine/toolpaths/modelProtection.ts
@@ -26,6 +26,7 @@ import {
 } from './geometry'
 import { significantSilhouettePaths } from './silhouette'
 import { resolvedProjectFeatures } from '../../store/helpers/resolveFeatures'
+import { appendAll } from './appendAll'
 
 // clipper-lib exposes pftEvenOdd at runtime, but its TS type only includes pftNonZero.
 const POLY_FILL_EVEN_ODD = 0
@@ -144,7 +145,7 @@ function isActiveAtZ(project: Project, feature: SketchFeature, z: number | undef
 }
 
 function appendExpanded(paths: ClipperPath[], nextPaths: ClipperPath[], expansion: number): void {
-  paths.push(...offsetClipperPaths(nextPaths, Math.max(0, expansion)))
+  appendAll(paths, offsetClipperPaths(nextPaths, Math.max(0, expansion)))
 }
 
 export function pathsContainEnvelope(candidatePaths: ClipperPath[], envelopePaths: ClipperPath[] | undefined): boolean {
@@ -453,7 +454,7 @@ export function buildProtectedFootprintPaths(
 
     const expandedFootprints = offsetClipperPaths(featureFootprintPaths(feature), featureExpansion)
     if (pathsContainEnvelope(expandedFootprints, options.machiningEnvelopePaths)) continue
-    protectedPaths.push(...expandedFootprints)
+    appendAll(protectedPaths, expandedFootprints)
   }
 
   if (options.includeTabs !== false) {

--- a/src/engine/toolpaths/multiFeature.ts
+++ b/src/engine/toolpaths/multiFeature.ts
@@ -19,6 +19,7 @@ import { resolvedFeatureMap } from '../../store/helpers/resolveFeatures'
 import type { Operation, Project } from '../../types/project'
 import type { PocketToolpathResult, ToolpathBounds, ToolpathPoint, ToolpathResult } from './types'
 import { greedyNearestNeighbor } from './geometry'
+import { appendAll } from './appendAll'
 
 interface MergeToolpathOptions {
   orderBlocks?: 'input' | 'nearest'
@@ -143,7 +144,7 @@ function mergeMoves(parts: ToolpathResult[], normalizeTransitions: boolean): Too
     } else {
       moves.push(firstMove)
     }
-    moves.push(...remainingMoves)
+    appendAll(moves, remainingMoves)
     previousEnd = part.moves.at(-1)?.to ?? previousEnd
   }
 

--- a/src/engine/toolpaths/offsetSmoothing.ts
+++ b/src/engine/toolpaths/offsetSmoothing.ts
@@ -66,6 +66,7 @@
 import type { Point } from '../../types/project'
 import { findBroadCornerArc, type BroadCornerArc } from './broadCornerArc'
 import { DEFAULT_FLATTEN_ARC_STEP } from './geometry'
+import { appendAll } from './appendAll'
 
 export interface RoundContourOptions {
   /** Only round turns whose accumulated deflection (0 = straight, 180 = full
@@ -669,7 +670,7 @@ function buildSpanGeometry(
       && (inner.end !== last
         || edgeParameter(ring, arc.exitEdge, inner.exit) < exitLimit - EPS)
     if (inner && spliceable) {
-      points.push(...inner.points)
+      appendAll(points, inner.points)
       offset += innerLength + 1
       continue
     }
@@ -929,14 +930,14 @@ export function planContourSmoothing(
     : [...planned].sort((a, b) => a.start - b.start)
   const out: Point[] = []
   let cursor = wrapped ? wrapped.end + 1 : 0
-  if (wrapped) out.push(...wrapped.points)
+  if (wrapped) appendAll(out, wrapped.points)
   for (const transition of walkOrder) {
     if (transition === wrapped) continue
     while (cursor < transition.start) {
       out.push(ring[cursor])
       cursor += 1
     }
-    out.push(...transition.points)
+    appendAll(out, transition.points)
     cursor = transition.end + 1
   }
   while (cursor < (wrapped ? wrapped.start : count)) {

--- a/src/engine/toolpaths/pocket.ts
+++ b/src/engine/toolpaths/pocket.ts
@@ -91,6 +91,7 @@ import {
 import { resolveRegionDomainArea } from './regionDomain'
 import { unionClipperPaths } from './modelProtection'
 import { resolveFeatureInstance } from '../../store/helpers/resolveFeatures'
+import { appendAll } from './appendAll'
 
 const MAX_ROUND_JOIN_ARC_TOLERANCE = DEFAULT_CLIPPER_SCALE * 0.01
 const ROUND_JOIN_ARC_TOLERANCE_RATIO = 0.01
@@ -190,7 +191,7 @@ export function polyTreeToRegions(
   }
 
   for (const child of getChildren(node)) {
-    regions.push(...polyTreeToRegions(child, targetFeatureIds, islandFeatureIds, scale))
+    appendAll(regions, polyTreeToRegions(child, targetFeatureIds, islandFeatureIds, scale))
   }
 
   return regions
@@ -1415,7 +1416,7 @@ export function buildPocketFloorContours(
       break
     }
 
-    contours.push(...loops)
+    appendAll(contours, loops)
     currentRegions = currentRegions.flatMap((region) => buildInsetRegions(region, effectiveStepover))
   }
 
@@ -1921,7 +1922,7 @@ export function cutClosedContours(
       cutMoves = tangentSplice.cutMoves
       nextPosition = tangentSplice.nextPosition
     }
-    moves.push(...cutMoves)
+    appendAll(moves, cutMoves)
     nextPosition = cutMoves.at(-1)?.to ?? nextPosition
   }
 
@@ -1987,11 +1988,11 @@ function neighbourCentrelines(
     // these starved corners live — the loop running along the island is the
     // pass that reaches the tip, and leaving it out declines every corner
     // there.
-    lines.push(...region.islands.filter((island) => island.length >= 3))
+    appendAll(lines, region.islands.filter((island) => island.length >= 3))
   }
   if (parent) add(parent.region)
   for (const child of node.children) add(child.region)
-  lines.push(...node.region.islands.filter((island) => island.length >= 3))
+  appendAll(lines, node.region.islands.filter((island) => island.length >= 3))
   return lines
 }
 
@@ -2888,7 +2889,7 @@ export function cutSeedLeftoverExcursions(
     const cutMoves = excursion.closed
       ? toClosedCutMoves(excursion.points, z)
       : toOpenCutMoves(excursion.points, z)
-    moves.push(...cutMoves)
+    appendAll(moves, cutMoves)
     position = cutMoves.at(-1)?.to ?? position
   }
   return position
@@ -2982,7 +2983,7 @@ function generateRoughBandMoves(
           levelEntryPolicy,
         )
         const cutMoves = toClosedCutMoves(contour, z)
-        moves.push(...cutMoves)
+        appendAll(moves, cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
       }
 
@@ -3003,7 +3004,7 @@ function generateRoughBandMoves(
           levelEntryPolicy,
         )
         const cutMoves = toOpenCutMoves(segment, z)
-        moves.push(...cutMoves)
+        appendAll(moves, cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
       }
 
@@ -3178,7 +3179,7 @@ function generateRoughBandMoves(
           circleMoves = tangentSplice.cutMoves
           currentPosition = tangentSplice.nextPosition
         }
-        moves.push(...circleMoves)
+        appendAll(moves, circleMoves)
         currentPosition = circleMoves.at(-1)?.to ?? currentPosition
         previousCircleEnd = currentPosition
       }
@@ -3635,7 +3636,7 @@ function generateFinishBandMoves(
             circleMoves = tangentSplice.cutMoves
             currentPosition = tangentSplice.nextPosition
           }
-          moves.push(...circleMoves)
+          appendAll(moves, circleMoves)
           currentPosition = circleMoves.at(-1)?.to ?? currentPosition
           previousCircleEnd = currentPosition
         }
@@ -3722,7 +3723,7 @@ function generateFinishBandMoves(
         entryPolicy,
       )
       const cutMoves = toOpenCutMoves(segment, z)
-      moves.push(...cutMoves)
+      appendAll(moves, cutMoves)
       currentPosition = cutMoves.at(-1)?.to ?? currentPosition
     }
 
@@ -3761,7 +3762,7 @@ function generateFinishBandMoves(
           entryPolicy,
         )
         const cutMoves = toOpenCutMoves(segment, z)
-        moves.push(...cutMoves)
+        appendAll(moves, cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
       }
       currentPosition = cutClosedContours(
@@ -3905,12 +3906,12 @@ function appendPocketCornerRelief(
       ...(operation.debugToolpath ? { source: 'cornerRelief' } : {}),
     })
     pass.warnings.forEach((warning) => appendUniqueWarning(warnings, warning))
-    reliefMoves.push(...pass.moves)
+    appendAll(reliefMoves, pass.moves)
     position = pass.endPosition
   }
 
   retractToSafe(reliefMoves, position, safeZ)
-  allMoves.push(...reliefMoves)
+  appendAll(allMoves, reliefMoves)
 }
 
 export function generatePocketToolpath(project: Project, operation: Operation): PocketToolpathResult {
@@ -4115,7 +4116,7 @@ function generatePocketToolpathSingle(
     const { moves, stepLevels, warnings: bandWarnings } = result
     moves.forEach((move) => allMoves.push(move))
     stepLevels.forEach((level) => allStepLevels.add(level))
-    warnings.push(...bandWarnings)
+    appendAll(warnings, bandWarnings)
     if (reliefStepdown !== null && moves.length > 0) {
       const reliefBottom = resolveBandBottomZ(band, operation)
       if (reliefBottom !== null) {

--- a/src/engine/toolpaths/regionDomain.ts
+++ b/src/engine/toolpaths/regionDomain.ts
@@ -28,6 +28,7 @@ import {
 import { differenceClipperPaths, intersectClipperPaths, offsetClipperPaths, unionClipperPaths } from './modelProtection'
 import type { RegionMask } from './regions'
 import type { ClipperPath } from './types'
+import { appendAll } from './appendAll'
 
 /**
  * Resolve a region mask into an area domain (polygon set) so the generator
@@ -267,7 +268,7 @@ function splitOpenGuideByAllowedPaths(guide: Point[], allowed: ClipperPath[]): C
       for (let j = 0; j < path.length; j += 1) {
         const edgeFrom = path[j]
         const edgeTo = path[(j + 1) % path.length]
-        params.push(...segmentIntersectionParameters(from, to, edgeFrom, edgeTo))
+        appendAll(params, segmentIntersectionParameters(from, to, edgeFrom, edgeTo))
       }
     }
 

--- a/src/engine/toolpaths/resolver.ts
+++ b/src/engine/toolpaths/resolver.ts
@@ -35,6 +35,7 @@ import {
   resolveFeatureZSpan,
   toClipperPath,
 } from './geometry'
+import { appendAll } from './appendAll'
 
 interface FeatureWithSpan {
   feature: SketchFeature
@@ -214,7 +215,7 @@ function polyTreeToRegions(
   }
 
   for (const child of getChildren(node)) {
-    regions.push(...polyTreeToRegions(child, targetFeatureIds, islandFeatureIds, scale))
+    appendAll(regions, polyTreeToRegions(child, targetFeatureIds, islandFeatureIds, scale))
   }
 
   return regions

--- a/src/engine/toolpaths/restRegions.ts
+++ b/src/engine/toolpaths/restRegions.ts
@@ -39,6 +39,7 @@ import { resolveRegionDomainCentre } from './regionDomain'
 import { resolveInsideEdgeRegions, resolvePocketRegions } from './resolver'
 import { significantSilhouettePaths } from './silhouette'
 import type { ClipperPath, ClipperPoint, ResolvedPocketRegion, ResolvedPocketResult } from './types'
+import { appendAll } from './appendAll'
 
 export interface RestRegionDraft {
   profile: SketchFeature['sketch']['profile']
@@ -135,7 +136,7 @@ function rebuildOriginalRestComponents(restPaths: ClipperPath[], splitPaths: Cli
     const bounds = clipperPathBounds(path)
     if (!bounds) continue
     const localRest = intersectClipperPaths(restPaths, [rectanglePath(bounds, expansion)])
-    rebuilt.push(...localRest)
+    appendAll(rebuilt, localRest)
   }
 
   const rebuiltUnion = unionClipperPaths(rebuilt)
@@ -454,14 +455,14 @@ function generateAreaRestRegionDrafts(
 
   for (const band of resolved.bands) {
     for (const region of band.regions) {
-      sourceAreaPaths.push(...pocketRegionToAreaPaths(region))
-      islandPaths.push(...region.islands
+      appendAll(sourceAreaPaths, pocketRegionToAreaPaths(region))
+      appendAll(islandPaths, region.islands
         .filter((island) => island.length >= 3)
         .map((island) => toClipperPath(normalizeWinding(island, false), DEFAULT_CLIPPER_SCALE)))
 
       const centerRegions = buildInsetRegions(region, centerInset)
       const centerAreaPaths = centerRegions.flatMap(pocketRegionToAreaPaths)
-      reachableAreaPaths.push(...offsetClosedPaths(centerAreaPaths, toolRadius, ClipperLib.JoinType.jtRound))
+      appendAll(reachableAreaPaths, offsetClosedPaths(centerAreaPaths, toolRadius, ClipperLib.JoinType.jtRound))
     }
   }
 
@@ -505,7 +506,7 @@ function generateAreaRestRegionDrafts(
     for (const region of band.regions) {
       for (const loop of [region.outer, ...region.islands]) {
         if (loop.length >= 3) {
-          cornerTriangles.push(...cornerCuspTriangles(loop, sourceUnion, centerInset, backExtension))
+          appendAll(cornerTriangles, cornerCuspTriangles(loop, sourceUnion, centerInset, backExtension))
         }
       }
     }
@@ -524,7 +525,7 @@ function generateAreaRestRegionDrafts(
     const remainingArea = remaining.reduce((sum, path) => sum + pathArea(path), 0)
     if (remainingArea < gateArea) continue
 
-    cornerRegions.push(...intersectClipperPaths([triangle], safeSourceUnion))
+    appendAll(cornerRegions, intersectClipperPaths([triangle], safeSourceUnion))
   }
 
   // Corners alone don't cover unreachable material away from a convex corner —

--- a/src/engine/toolpaths/roughSurface.ts
+++ b/src/engine/toolpaths/roughSurface.ts
@@ -54,6 +54,7 @@ import { isFeatureFirst, perFeatureOperations, mergePocketToolpathResults } from
 import { createSharedEngagementTelemetry } from './pocket'
 import { resolvedFeatureMap } from '../../store/helpers/resolveFeatures'
 import { clearingControlApplies } from './clearingControls'
+import { appendAll } from './appendAll'
 
 function appendUniqueWarning(warnings: ToolpathWarning[], warning: ToolpathWarning): void {
   const key = `${warning.code}:${JSON.stringify(warning.params ?? {})}`
@@ -272,7 +273,7 @@ function generateRoughSurfaceToolpathSingle(
           entryPolicy,
         )
         const cutMoves = toClosedCutMoves(contour, level.z)
-        allMoves.push(...cutMoves)
+        appendAll(allMoves, cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
       }
 
@@ -291,7 +292,7 @@ function generateRoughSurfaceToolpathSingle(
           entryPolicy,
         )
         const cutMoves = toOpenCutMoves(segment, level.z)
-        allMoves.push(...cutMoves)
+        appendAll(allMoves, cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
       }
 
@@ -364,7 +365,7 @@ function generateRoughSurfaceToolpathSingle(
             entryPolicy,
           )
           const circleMoves = toClosedCutMoves(circle, level.z)
-          allMoves.push(...circleMoves)
+          appendAll(allMoves, circleMoves)
           currentPosition = circleMoves.at(-1)?.to ?? currentPosition
           previousCircleEnd = currentPosition
         }

--- a/src/engine/toolpaths/seedLeftover.ts
+++ b/src/engine/toolpaths/seedLeftover.ts
@@ -53,6 +53,7 @@
 
 import { buildSweptCoverage, type SweptCoverage } from './sweptCoverage'
 import type { Point } from '../../types/project'
+import { appendAll } from './appendAll'
 
 /**
  * Sampling pitch of the per-vertex disc test, as a fraction of the tool
@@ -211,13 +212,13 @@ export function planSeedLeftovers(
       }
     }
     if (planned.length === 0) continue
-    excursions.push(...planned)
+    appendAll(excursions, planned)
     // Fold the new excursions into the coverage before the next candidate is
     // judged. Without this the deeper candidates re-answer "uncut?" against a
     // stream that no longer matches what will be cut, and every level of the
     // pre-extension tree emits its own pass over the same ridge — which cost
     // more than the graze rings the extension removed on a coarse stepover.
-    swept.push(...planned.map((excursion) => excursion.points))
+    appendAll(swept, planned.map((excursion) => excursion.points))
     coverage = buildSweptCoverage(swept, toolRadius)
   }
   return excursions

--- a/src/engine/toolpaths/surface.ts
+++ b/src/engine/toolpaths/surface.ts
@@ -96,6 +96,7 @@ import { unionClipperPaths } from './modelProtection'
 import { expandFeatureGeometry, featureHasClosedGeometry } from '../../text'
 import { resolvedProjectFeatures } from '../../store/helpers/resolveFeatures'
 import { isFeatureFirst, perFeatureOperations, mergePocketToolpathResults } from './multiFeature'
+import { appendAll } from './appendAll'
 
 interface PolyTreeNode {
   IsHole(): boolean
@@ -462,7 +463,7 @@ function generateRoughBandMoves(
           levelEntryPolicy,
         )
         const cutMoves = toClosedCutMoves(contour, z)
-        moves.push(...cutMoves)
+        appendAll(moves, cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
       }
 
@@ -483,7 +484,7 @@ function generateRoughBandMoves(
           levelEntryPolicy,
         )
         const cutMoves = toOpenCutMoves(segment, z)
-        moves.push(...cutMoves)
+        appendAll(moves, cutMoves)
         currentPosition = cutMoves.at(-1)?.to ?? currentPosition
       }
 
@@ -636,7 +637,7 @@ function generateRoughBandMoves(
           circleMoves = tangentSplice.cutMoves
           currentPosition = tangentSplice.nextPosition
         }
-        moves.push(...circleMoves)
+        appendAll(moves, circleMoves)
         currentPosition = circleMoves.at(-1)?.to ?? currentPosition
         previousCircleEnd = currentPosition
       }
@@ -1067,7 +1068,7 @@ function generateFinishBandMoves(
             circleMoves = tangentSplice.cutMoves
             currentPosition = tangentSplice.nextPosition
           }
-          moves.push(...circleMoves)
+          appendAll(moves, circleMoves)
           currentPosition = circleMoves.at(-1)?.to ?? currentPosition
           previousCircleEnd = currentPosition
         }
@@ -1154,7 +1155,7 @@ function generateFinishBandMoves(
         entryPolicy,
       )
       const cutMoves = toOpenCutMoves(segment, z)
-      moves.push(...cutMoves)
+      appendAll(moves, cutMoves)
       currentPosition = cutMoves.at(-1)?.to ?? currentPosition
     }
 
@@ -1183,7 +1184,7 @@ function generateFinishBandMoves(
         entryPolicy,
       )
       const cutMoves = toClosedCutMoves(contour, z)
-      moves.push(...cutMoves)
+      appendAll(moves, cutMoves)
       currentPosition = cutMoves.at(-1)?.to ?? currentPosition
     }
 
@@ -1319,7 +1320,7 @@ function generateSurfaceCleanToolpathSingle(
     const { moves, stepLevels, warnings: bandWarnings } = result
     moves.forEach((move) => allMoves.push(move))
     stepLevels.forEach((level) => allStepLevels.add(level))
-    warnings.push(...bandWarnings)
+    appendAll(warnings, bandWarnings)
   }
 
   let bounds: ToolpathBounds | null = null

--- a/src/engine/toolpaths/tabs.ts
+++ b/src/engine/toolpaths/tabs.ts
@@ -29,6 +29,7 @@ import {
 import { unionClipperPaths } from './modelProtection'
 import { planSmoothTabMotion, splitCutMoveWithSmoothTabs } from './tabSmoothing'
 import { convertLength } from '../../utils/units'
+import { appendAll } from './appendAll'
 
 interface PreservedObstacle {
   id: string
@@ -486,7 +487,7 @@ export function applyTabsToEdgeRoute(project: Project, operation: Operation, res
       ) {
         changed = true
       }
-      adjustedMoves.push(...splitMoves)
+      appendAll(adjustedMoves, splitMoves)
       continue
     }
 

--- a/src/engine/toolpaths/vcarve.ts
+++ b/src/engine/toolpaths/vcarve.ts
@@ -24,6 +24,7 @@ import { buildContourLoops, buildInsetRegions, contourStartPoint, executeDiffere
 import { resolveRegionDomainArea } from './regionDomain'
 import { buildRegionMask, splitFeatureTargets } from './regions'
 import { resolvePocketRegions } from './resolver'
+import { appendAll } from './appendAll'
 
 function regionCentroid(region: { outer: Point[] }): { x: number; y: number } {
   let sx = 0
@@ -254,7 +255,7 @@ function generateVCarveToolpathSingle(project: Project, operation: Operation): T
           const linkBudget = isCrossZ ? stepoverDistance * 8 : 0
           currentPosition = transitionToCutEntry(moves, currentPosition, entryPoint, safeZ, linkBudget)
           const cutMoves = toClosedCutMoves(contour, z)
-          moves.push(...cutMoves)
+          appendAll(moves, cutMoves)
           currentPosition = cutMoves.at(-1)?.to ?? currentPosition
         }
         currentDepth += stepoverDistance / slope

--- a/src/test/INDEX.md
+++ b/src/test/INDEX.md
@@ -4,6 +4,7 @@ Shared test-only infrastructure.
 
 ## Files
 
+- `spreadLimit.ts` — `maxSpreadableLength()`, the largest array this engine can spread into a call, measured by search rather than hard-coded (issue #668). Tests that must exceed the argument limit assert against the measured value, so a fixture that quietly stopped exceeding it fails instead of passing while proving nothing
 - `projectFixtures.ts` — constructs authoritative format 3.0 projects from concise geometry-bearing test drafts, replaces strict feature sets, and resolves instance geometry for assertions
 
 These helpers are for tests only. Production code must use the normal store creation paths or the project-format decoder.

--- a/src/test/spreadLimit.ts
+++ b/src/test/spreadLimit.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Ceiling for the search — an engine that spreads this much has no limit worth testing against. */
+const SEARCH_CEILING = 1_048_576
+
+/**
+ * The largest array this engine can spread into a call, measured by search.
+ *
+ * `target.push(...source)` passes one *argument* per element and throws
+ * `RangeError: Maximum call stack size exceeded` past the engine's argument
+ * limit — 124,413 on node v26.0.0 at the default stack size (issue #668).
+ *
+ * The limit moves with the stack size and the engine, so a test that must
+ * exceed it measures it rather than hard-coding it. A fixture that quietly
+ * stopped exceeding the real limit would otherwise keep passing while proving
+ * nothing; measured, it fails and says so.
+ *
+ * The value depends slightly on how deep the stack already is at the call, so
+ * treat it as approximate and leave real headroom rather than sitting on it.
+ */
+export function maxSpreadableLength(): number {
+  if (cached !== null) return cached
+
+  let low = 1
+  let high = 2
+  while (high < SEARCH_CEILING && canSpread(high)) {
+    low = high
+    high *= 2
+  }
+  if (high >= SEARCH_CEILING && canSpread(SEARCH_CEILING)) {
+    cached = SEARCH_CEILING
+    return cached
+  }
+  while (low < high - 1) {
+    const mid = Math.floor((low + high) / 2)
+    if (canSpread(mid)) low = mid
+    else high = mid
+  }
+  cached = low
+  return cached
+}
+
+let cached: number | null = null
+
+function canSpread(length: number): boolean {
+  const source = new Array<number>(length).fill(0)
+  try {
+    const target: number[] = []
+    target.push(...source)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Closes #668.

`target.push(...source)` passes one *argument* per element, so it throws `RangeError: Maximum call stack size exceeded` past the engine's argument limit — **124,413** measured on node v26.0.0 at the default stack, and stack-size dependent rather than a fixed constant.

Toolpath generation routinely builds arrays past that. One trochoidal Edge Route fragment on a 60 x 40 in guide emits **204,696** cut moves — inside the 500,000-point budget and well past the limit — and a real outside route on that part threw instead of producing a path. The budget cannot catch it either: `appendTrochoidalContours` budget-checks every fragment in one pass and emits in a second, so the guard has already said yes by the time the spread runs. Found while implementing #661, pre-existing and out of scope there.

## Changes

- **`src/engine/toolpaths/appendAll.ts`** — `appendAll(target, source)`, a loop append over any `Iterable`. Order- and object-identity-preserving, so emitted output is unchanged.
- **All 67 spread-into-push sites** under `src/engine/toolpaths/**` routed through it, across 21 files. 61 spread generated geometry; the remaining 6 are `warnings.push(...)` and are swept too, because "is this source bounded?" is a per-site judgment that decays while a blanket rule is mechanical.
- **`eslint.config.js`** — a scoped `no-restricted-syntax` rule banning a spread argument to `.push()` under `src/engine/toolpaths/**` (tests exempt). Without it the pattern returns on the next generator; it was already the house idiom in 67 places.
- **`src/test/spreadLimit.ts`** — `maxSpreadableLength()`, the limit measured by search on the running engine. Tests assert against it rather than a constant, so a fixture that quietly stopped exceeding the real limit fails and says so instead of passing while proving nothing.

## Tests

- `appendAll.test.ts` — appends 200,000 elements onto a non-empty target; order, object identity, empty source, non-array iterable. The size is checked against the measured limit, and the spread control is asserted to still throw at it.
- `edgeTrochoidalEmission.test.ts` — the regression through the real generator: a 60 x 40 in outside trochoidal route emits one fragment of 204,696 cut moves, which must be generated rather than thrown on or refused (no budget or safety warning). ~1 s.

**Verified by mutation, not by a green run** — each reverted in turn, confirmed red, restored:

| mutation | result |
| --- | --- |
| `appendAll` back to a spread | `✗ appends an array past the argument limit` |
| the `edge.ts` emission site back to a spread | `RangeError: Maximum call stack size exceeded` |
| a spread reintroduced in `vcarve.ts` | lint error from the new rule |

## Output is unchanged

`npm run build` green — 215 test files, 0 skipped.

Beyond the suite, every `.camj` under `src/engine/test-fixtures/` and `public/examples/` was generated on both trees and the move stream hashed (moves + warning codes + bounds + drill cycles): **34 operations across 15 projects, byte-identical** between `main` and this branch — pocket x15, edge_route_outside x5, finish_surface x4, v_carve_medial x3, drilling x3, rough_surface x2, v_carve, finish_surface_cleanup. G-code is a pure function of that stream, so export cannot differ either.

No e2e: engine-internal, with no rendered DOM, menu wiring, or dialog behavior touched. Structural tests are sufficient here and the omission is deliberate.

## Notes

Full lane — `src/engine/toolpaths/**` is a protected path; plan approved on #668 before implementation. Rebased onto `main` after #665 landed, which touches the same emitter; no stragglers, and its new `trochoidalLevelPaths.ts` is inside the guarded scope going forward.

#669 tracks the same pattern outside `src/engine/toolpaths/**`, with what is already measured there recorded on it. This change does not move the 500,000-point ceiling — #662 owns that; it removes the reason the ceiling cannot be raised safely.
