### PR TITLE
Make 2D rapid preview strokes solid (#683 Phase 0)

### DIFF
--- a/e2e/toolpathVisibility.smoke.spec.ts
+++ b/e2e/toolpathVisibility.smoke.spec.ts
@@ -16,8 +16,84 @@
 
 import { test, expect } from './fixtures'
 import { seedToolpathVisProject } from './toolpathVisibility.helpers'
+import type { Project } from '../src/types/project'
+import type { ToolpathResult } from '../src/engine/toolpaths/types'
 
 test.describe('Toolpath visibility panel smoke', () => {
+  test('solid rapid styling renders in Canvas and booklet snapshots', async ({ app, ui }, testInfo) => {
+    await seedToolpathVisProject(app.page)
+    await expect(ui.toolpathVis.sketchPanel(app.page)).toBeVisible({ timeout: 15000 })
+    await ui.operations.rowByName(app.page, 'Route A').click()
+    const rendered = await app.page.evaluate(async () => {
+      const previewUrl = '/src/components/canvas/previewPrimitives.ts'
+      const snapshotUrl = '/src/components/canvas/operationSnapshot.ts'
+      const { drawToolpath } = await import(previewUrl) as typeof import('../src/components/canvas/previewPrimitives')
+      const { renderOperationSnapshotPng } = await import(snapshotUrl) as typeof import('../src/components/canvas/operationSnapshot')
+      const project = await (window as unknown as { __pcTest: { getProject: () => Promise<Project> } }).__pcTest.getProject()
+      // Synthetic display swatch: spaced horizontal moves make gaps observable.
+      // The sloped plunge/retract deliberately has an XY projection for inspection.
+      const toolpath: ToolpathResult = {
+        operationId: project.operations[0].id,
+        moves: [
+          { kind: 'cut', from: { x: 25, y: 20, z: 0 }, to: { x: 145, y: 20, z: 0 } },
+          { kind: 'lead_in', from: { x: 25, y: 35, z: 0 }, to: { x: 145, y: 35, z: 0 } },
+          { kind: 'rapid', from: { x: 25, y: 50, z: 5 }, to: { x: 145, y: 50, z: 5 } },
+          { kind: 'plunge', from: { x: 25, y: 65, z: 5 }, to: { x: 145, y: 65, z: 0 } },
+          { kind: 'rapid', from: { x: 25, y: 80, z: 0 }, to: { x: 145, y: 80, z: 5 } },
+        ],
+        warnings: [],
+        bounds: null,
+      }
+      const visibility = { cuts: true, leadIns: true, rapids: true, plunges: true, retractions: true, directions: false }
+      const canvas = document.createElement('canvas')
+      canvas.width = 360
+      canvas.height = 200
+      const ctx = canvas.getContext('2d')!
+      const rows: { emphasized: boolean; simplifyForDisplay: boolean; gaps: boolean[] }[] = []
+      for (const simplifyForDisplay of [true, false]) {
+        for (const emphasized of [true, false]) {
+          ctx.clearRect(0, 0, canvas.width, canvas.height)
+          drawToolpath(ctx, toolpath, { scale: 2, offsetX: 0, offsetY: 0 }, emphasized,
+            visibility, 0.4, { simplifyForDisplay })
+          rows.push({ emphasized, simplifyForDisplay, gaps: [20, 35, 50, 65, 80].map(y => {
+            const pixels = ctx.getImageData(60, y * 2, 220, 1).data
+            return pixels.some((value, index) => index % 4 === 3 && value === 0)
+          }) })
+        }
+      }
+      ctx.fillStyle = '#18212f'
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+      drawToolpath(ctx, toolpath, { scale: 2, offsetX: 0, offsetY: 0 }, true, visibility)
+      const swatch = canvas.toDataURL('image/png').split(',')[1]
+      // Observe the actual booklet call, not just its full-detail option above.
+      const strokes: { width: number; dash: number[] }[] = []
+      const originalStroke = CanvasRenderingContext2D.prototype.stroke
+      let snapshot: Uint8Array
+      CanvasRenderingContext2D.prototype.stroke = new Proxy(originalStroke, {
+        apply(original, context: CanvasRenderingContext2D, args: unknown[]) {
+          strokes.push({ width: context.lineWidth, dash: context.getLineDash() })
+          return Reflect.apply(original, context, args)
+        },
+      })
+      try {
+        snapshot = await renderOperationSnapshotPng(project, project.operations[0], toolpath, { pixelRatio: 1 })
+      } finally {
+        CanvasRenderingContext2D.prototype.stroke = originalStroke
+      }
+      return { rows, swatch, snapshot: Array.from(snapshot), strokes }
+    })
+    for (const row of rendered.rows) {
+      expect(row.gaps, JSON.stringify(row)).toEqual([false, false, false, true, false])
+    }
+    const rapidStrokes = rendered.strokes.filter(stroke => Math.abs(stroke.width - 1.65) < 0.001)
+    expect(rapidStrokes).toHaveLength(2)
+    expect(rapidStrokes.map(stroke => stroke.dash)).toEqual([[], []])
+    expect(rendered.strokes.filter(stroke => Math.abs(stroke.width - 1.85) < 0.001).map(stroke => stroke.dash)).toEqual([[3, 4]])
+    await testInfo.attach('phase-0-display-swatch', { body: Buffer.from(rendered.swatch, 'base64'), contentType: 'image/png' })
+    await testInfo.attach('phase-0-booklet-snapshot', { body: Buffer.from(rendered.snapshot), contentType: 'image/png' })
+    await testInfo.attach('phase-0-live-sketch', { body: await app.page.locator('canvas.sketch-canvas').screenshot(), contentType: 'image/png' })
+  })
+
   test('gcode icon toggle expands and collapses the panel', async ({ app, ui }) => {
     await seedToolpathVisProject(app.page)
 

--- a/src/components/canvas/previewPrimitives.test.ts
+++ b/src/components/canvas/previewPrimitives.test.ts
@@ -21,6 +21,7 @@ import type { ToolpathVisibility } from '../toolpathVisibility'
 import type { ToolpathResult } from '../../engine/toolpaths/types'
 import type { ViewTransform } from './viewTransform'
 import { toolpathDisplayGeometry } from './toolpathDisplay'
+import { canvasColors } from './canvasPalette'
 
 function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(`Assertion failed: ${message}`)
@@ -182,6 +183,59 @@ function testDrawToolpathDrawsDescendingRapids(): void {
 
 testDrawToolpathLayerSplit()
 testDrawToolpathDrawsDescendingRapids()
+
+// Issue #683 Phase 0: interactive and full-detail booklet paths share styling.
+function testSolidRapidStyles(): void {
+  const toolpath: ToolpathResult = {
+    operationId: 'rapid-style-test',
+    moves: [
+      { kind: 'cut', from: { x: 0, y: 0, z: 0 }, to: { x: 20, y: 0, z: 0 } },
+      { kind: 'lead_in', from: { x: 0, y: 10, z: 0 }, to: { x: 20, y: 10, z: 0 } },
+      { kind: 'rapid', from: { x: 0, y: 20, z: 5 }, to: { x: 20, y: 20, z: 5 } },
+      { kind: 'plunge', from: { x: 0, y: 30, z: 5 }, to: { x: 20, y: 30, z: 0 } },
+      { kind: 'rapid', from: { x: 0, y: 40, z: 0 }, to: { x: 20, y: 40, z: 5 } },
+    ],
+    warnings: [],
+    bounds: null,
+  }
+  const allOff: ToolpathVisibility = {
+    cuts: false, leadIns: false, rapids: false, plunges: false, retractions: false, directions: false,
+  }
+  const colors = canvasColors()
+  const cases = [
+    { key: 'cuts', stroke: colors.toolpathCut, width: 2.1, dash: [] },
+    { key: 'leadIns', stroke: colors.toolpathCut, width: 2.1, dash: [] },
+    { key: 'rapids', stroke: colors.toolpathRapid, width: 1.3, dash: [] },
+    { key: 'plunges', stroke: colors.toolpathPlunge, width: 1.5, dash: [3, 4] },
+    { key: 'retractions', stroke: colors.toolpathRapid, width: 1.3, dash: [] },
+  ] as const
+  for (const simplifyForDisplay of [true, false]) {
+    for (const emphasized of [true, false]) {
+      for (const expected of cases) {
+        const { ctx: mockCtx } = recordingContext()
+        let dash: number[] = []
+        let strokes = 0
+        mockCtx.setLineDash = value => { dash = [...value] }
+        mockCtx.stroke = () => {
+          strokes++
+          assert(JSON.stringify(dash) === JSON.stringify(expected.dash), `${expected.key} dash pattern`)
+          assert(mockCtx.strokeStyle === expected.stroke, `${expected.key} keeps its colour`)
+          const width = emphasized ? expected.width + 0.35 : Math.max(1, expected.width - 0.35)
+          assert(mockCtx.lineWidth === width, `${expected.key} keeps its line weight`)
+          assert(mockCtx.globalAlpha === (emphasized ? 1 : 0.34), `${expected.key} keeps its emphasis`)
+        }
+        drawToolpath(mockCtx, toolpath, { scale: 1, offsetX: 0, offsetY: 0 }, emphasized,
+          { ...allOff, [expected.key]: true }, 0.4, { simplifyForDisplay })
+        assert(strokes === 1, `${expected.key} strokes exactly once when visible`)
+        assert(dash.length === 0 && mockCtx.globalAlpha === 1, 'dash and alpha reset after drawing')
+        drawToolpath(mockCtx, toolpath, { scale: 1, offsetX: 0, offsetY: 0 }, emphasized,
+          allOff, 0.4, { simplifyForDisplay })
+        assert(strokes === 1, 'hidden layers do not stroke')
+      }
+    }
+  }
+}
+testSolidRapidStyles()
 
 function testFullDetailDisplaySkipsInteractiveMerging(): void {
   const toolpath: ToolpathResult = {

--- a/src/components/canvas/previewPrimitives.ts
+++ b/src/components/canvas/previewPrimitives.ts
@@ -615,9 +615,9 @@ export function drawToolpath(
   const styleFor: Record<ToolpathOverlayLayerKey, { stroke: string; lineWidth: number; dash: number[] }> = {
     cuts: { stroke: canvasColors().toolpathCut, lineWidth: 2.1, dash: [] },
     leadIns: { stroke: canvasColors().toolpathCut, lineWidth: 2.1, dash: [] },
-    rapids: { stroke: canvasColors().toolpathRapid, lineWidth: 1.3, dash: [8, 6] },
+    rapids: { stroke: canvasColors().toolpathRapid, lineWidth: 1.3, dash: [] },
     plunges: { stroke: canvasColors().toolpathPlunge, lineWidth: 1.5, dash: [3, 4] },
-    retractions: { stroke: canvasColors().toolpathRapid, lineWidth: 1.3, dash: [8, 6] },
+    retractions: { stroke: canvasColors().toolpathRapid, lineWidth: 1.3, dash: [] },
   }
   // Feed colours are on when the toggle says so, or by default for the
   // selected engagement-mode operation (issue #498 S4). A move whose


### PR DESCRIPTION
## Summary

Implements Phase 0 of #683 after prerequisite PR #681 merged.

- Render Canvas rapids and retractions as solid strokes, matching the existing 3D convention.
- Preserve existing colours, line weights, selection alpha, plunge dashes, and visibility behaviour.
- Apply the same intentional restyle to booklet snapshots through the existing shared `drawToolpath` call.
- Add structural style/visibility coverage and browser pixel checks plus actual booklet-renderer assertions in the existing workflow-ui E2E lane.

Refs #683. **Parent issue must remain open:** this delivers only Phase 0, not the GPU POC or production renderer. The issue explicitly requires the parent to stay open.

## Verification

- `npx tsx src/components/canvas/previewPrimitives.test.ts`
- `npm run build`
- `npm run check:fast-lane` — one production file, four changed lines; tests exempt.
- `PURECUT_E2E_ISOLATED=1 PURECUT_E2E_PORT=1683 PLAYWRIGHT_HTML_OPEN=never npx playwright test e2e/toolpathVisibility.smoke.spec.ts --workers=1 --reporter=list,html`
- `git diff --check`

Visual evidence: inspected a five-layer synthetic rendering swatch and its real booklet PNG output. Cuts/lead-ins remain thicker coral strokes, rapids/retractions are thinner solid blue strokes, and plunges retain magenta dashes. Browser pixel assertions cover selected/unselected rendering and simplified/full-detail paths. The synthetic swatch tests display styling only, not machining safety. The smoke suite also covers real project navigation, layer controls, and both viewport panels.

## Boundaries

No changes to CAM moves, safe-Z/retract motion, G-code, simulation, project serialization, or the 3D renderer. No performance claims or GPU POC results are implied by these Canvas browser tests.

Before Phase 1, settle the snapshot-renderer choice and verify the real-GPU A/B measurement lane and accepted Canvas baseline. The prototype remains opt-in and production replacement remains separately approval-gated.
