### PR TITLE
fix: correct grblHAL coolant field names

### DIFF
--- a/src/engine/gcode/definitions/grblhal.json
+++ b/src/engine/gcode/definitions/grblhal.json
@@ -76,9 +76,9 @@
   },
   "cannedCycles": null,
   "coolant": {
-    "floodOn": "M8",
-    "mistOn": "M7",
-    "off": "M9"
+    "floodOnCommand": "M8",
+    "mistOnCommand": "M7",
+    "coolantOffCommand": "M9"
   },
   "stop": {
     "programEndCommand": "M30"


### PR DESCRIPTION
The `grblhal.json` coolant block used `floodOn`/`mistOn`/`off` instead of the schema-expected `floodOnCommand`/`mistOnCommand`/`coolantOffCommand`, so the postprocessor read `undefined` for every coolant command and emitted the literal string `undefined` into the G-code.

Closes #687