### PR TITLE
fix(cam): add key prop to Draft* inputs so store updates refresh inline panel

### DIFF
--- a/src/components/cam/CAMPanel.tsx
+++ b/src/components/cam/CAMPanel.tsx
@@ -102,6 +102,7 @@ function DraftTextInput({ value, onCommit }: DraftTextInputProps) {
 
   return (
     <input
+      key={value}
       type="text"
       defaultValue={value}
       spellCheck={false}
@@ -136,6 +137,7 @@ function DraftTextArea({ value, onCommit }: DraftTextInputProps) {
 
   return (
     <textarea
+      key={value}
       defaultValue={value}
       spellCheck
       onBlur={(event) => commit(event.currentTarget)}
@@ -186,6 +188,7 @@ function DraftLengthInput({ value, units, min, max, onCommit }: DraftLengthInput
 
   return (
     <input
+      key={value}
       type="text"
       inputMode="decimal"
       defaultValue={formatLength(value, units)}
@@ -242,6 +245,7 @@ function DraftNumberInput({ value, min, max, onCommit }: DraftNumberInputProps) 
 
   return (
     <input
+      key={value}
       type="text"
       inputMode="decimal"
       defaultValue={String(value)}


### PR DESCRIPTION
Closes #709

## What
Adds  to the four local  input components in  (, , , ).

## Why
These uncontrolled inputs used  without a key. When the expanded operation properties modal mutated the store, the inline panel's inputs kept showing stale values because React never re-applies  after initial mount.

## How
Adding  forces React to remount the input when the value changes — which only happens on blur/Enter after the input has already lost focus, so the remount is invisible. Same pattern already used throughout .