### PR TITLE
fix: suppress toolpath generation spinner while deferGeneration is active

### DIFF
--- a/src/app/useToolpathGeneration.ts
+++ b/src/app/useToolpathGeneration.ts
@@ -439,7 +439,10 @@ export function useToolpathGeneration(
   // the very first render after a parameter change, not one frame late.
   // toolpathMap is included as a dependency so the memo recomputes when the
   // async pipeline finishes and updates the map (which also updates the cache).
+  // When generation is deferred (issue #680) no computation runs, so the
+  // spinner must not show: the cache is stale by design until the defer ends.
   const generatingOperationIds = useMemo(() => {
+    if (deferGeneration) return new Set<string>()
     const ids = new Set<string>()
     for (const id of neededOperationIds) {
       const op = project.operations.find((o) => o.id === id)
@@ -455,7 +458,7 @@ export function useToolpathGeneration(
   // toolpathMap when the async pipeline finishes. Dropping it would leave the
   // generating spinner stuck on. `project` does not change when generation completes.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [neededOperationIds, project, toolpathMap])
+  }, [neededOperationIds, project, toolpathMap, deferGeneration])
 
   // Async toolpath pipeline: resolves cached results immediately, defers
   // uncached operations one-per-frame with a paint gap in between so the


### PR DESCRIPTION
Closes #680

Diagnosed in the issue: the defer mechanism holds correctly during node
drags (transactionStart stays non-null for the whole gesture), so one
gesture produces exactly one regeneration. The spinner was cosmetic.

## What changed

`generatingOperationIds` now returns an empty set when
`deferGeneration` is true. Previously it checked cache staleness
during render without consulting the defer flag, so every pointermove
during a drag recalculated staleness and the CAM tree spinner appeared
even though no generation was running.

## Verification

- `npx tsx src/app/useToolpathGeneration.test.ts` — all cache/diff tests pass
- `npx tsx src/app/useToolpathGenerationScheduling.test.ts` — defer coalescing test passes
- `npx tsx src/app/useToolpathGenerationToolNarrowing.test.ts` — tool narrowing tests pass
- Manual: loading `src/engine/test-fixtures/trochoidal-249k.camj` and dragging the Rect node — spinner no longer appears mid-drag; appears only after commit.