### PR TITLE
docs: add Critical Path cheat sheet and extract perf assertions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # AGENTS.md — PureCutCNC
 
+## Critical Path (read this first)
+
+- **Issue first.** Open a GitHub issue (#NN) before any code. Fast lane skips Plan/Approve **only** if `npm run check:fast-lane` is green.
+- **Branch, never `main`.** Work on a feature branch; the `main-requires-pr` ruleset blocks merge without a PR.
+- **Build green.** `npm run build` (lint + tsc + tests + icons) must pass before committing.
+- **Worktrees only.** Never edit the primary checkout's working tree — use `git worktree add` outside the repo.
+- **Protected paths → full lane.** `AGENTS.md`, `src/engine/toolpaths/**`, `src/engine/gcode/**`, `src/machine/**`, `.camj` format, `store/types.ts`, gates — plan + approve required.
+- **Close with a PR.** End with a PR containing `Closes #NN`; rebase onto `main` first.
+
+*See below for full detail — these rules are enforced by CI, hooks, and the GitHub ruleset; skipping one because it felt optional is how drift starts.*
+
 ## What This Is
 
 PureCutCNC is a browser-based 2.5D CAD/CAM application for CNC hobbyists. It collapses CAD sketching and CAM operation definition into a single workflow. Built with Vite + React + TypeScript, state managed by Zustand, with a Tauri wrapper for desktop builds. Read [`PROJECT.md`](PROJECT.md) for the product contract and safety boundaries.
@@ -228,37 +239,13 @@ Always run `npm run build` from the project root to verify changes compile befor
 
 **A known-failing test is annotated, never deleted or left out of a lane.** Both annotations take the test declaration — `test.fixme('title', fn)` — because a bare `test.fixme()` is a *scope* modifier that silently disables every test in the enclosing `describe`. Use `test.fail()` only when the failure is genuinely deterministic: it reports "expected to fail, but passed" the moment the test succeeds, which is a useful prompt to remove the annotation but a false alarm if the test is merely flaky. When in doubt use `test.fixme()`, and prove determinism before choosing `test.fail()` — a failure that depends on `--workers` is a flake, not a deterministic failure. Either way the annotation carries its issue number in a comment so it stays greppable and cannot decay into an anonymous permanent skip.
 
-### Performance assertions compare against invariant work, never against a millisecond constant
+### Performance assertions
 
-**Scope: this section applies only when you are writing a timing assertion into
-a test.** It is a recipe for one narrow act, not a house style. Nothing in it
-licenses measuring anything else, tabulating anything else, or re-measuring to
-check a previous figure. If the user asked a question, answer the question — see
-**Scope Discipline**.
-
-`build` is a required status check, so any timing assertion that drifts blocks merges for everyone. Three issues have now been spent here (#383, #386, #508). Each of the first two fixed the *units* and left the *shape* of the assertion alone, and each decayed within weeks. The rule below is the third answer; read the whole of it before writing a timing assertion.
-
-**No absolute millisecond budget survives.** Not in wall clock, and not in CPU time either:
-
-- Wall clock counts time the process spends descheduled while `scripts/run-tests.ts` runs its pool (`min(10, cores - 2)`), so it moves with unrelated load. This is what #383/#386 diagnosed, correctly.
-- `process.cpuUsage()` fixes only that. It measures **time on CPU, not work done**, so it still moves with the effective clock rate — turbo limits, thermal throttling, SMT sibling contention. Measured for #508 on `classifier.test.ts`, against this project's own test pool: wall clock 569ms → 942ms, CPU time 156ms → 325ms (**2.1x**), while a ratio against invariant work moved 1.16x. An allocation-free reference loop inflated 1.6x in lockstep over the same runs, which rules out GC as the cause.
-
-The earlier claim in this section that CPU time "is NOT contention dependent" was wrong, and both budgets written under it had already drifted past their recorded baselines before anyone noticed.
-
-**So: measure the guarded work against the same code path on a fixture that provably cannot benefit from the optimization being guarded, and assert the ratio.** Both halves then share machine, clock rate, allocator and microarchitecture, so only the optimization itself moves the number. Use `cpuRatio` from [`src/test/cpuRatio.ts`](src/test/cpuRatio.ts); it takes the **minimum** across repetitions, since contention and GC can only ever add cost.
-
-Finding the invariant half is the design work, and it is usually a fixture, not a code change — never add a test-only toggle to production code for this, because if the toggle breaks the ratio silently collapses to 1 and the test passes while measuring nothing. Two worked examples:
-
-| test | guards | subject | invariant reference |
-|---|---|---|---|
-| `classifier.test.ts` | bbox reject gating pairwise nesting | 2,980 **disjoint** rects — gate rejects nearly every pair | 200 **concentric** rects — every bbox pair overlaps, so the gate never rejects |
-| `importBulk.test.ts` | suffix cursor in `createNameAllocator` | 2,980 **repeated** names — every one hits the suffix loop | 2,980 **unique** names — never `taken`, so they return before the loop |
-
-**A ratio between two input sizes is a different instrument, and not this one.** It sees a complexity change but is blind to a constant factor: on the classifier, dropping the bbox gate cost ~10x in absolute CPU but moved the size ratio only 3.19x → 4.07x, inside the baseline's own spread. Use a size ratio only when the property under test genuinely *is* the shape of the cost curve — `bestNonFittingCpuMs` in `src/engine/toolpaths/arcReconstruction.test.ts` is the correct use of it, and needs no change.
-
-Whichever you write, record in the test the measured baseline row, the measured regressed row, and the headroom either side, so the next reader can re-derive the constant instead of guessing at it. Set the threshold at the geometric mid-point of the *worst* pair — highest observed baseline against lowest observed regression — not of the averages.
-
-**Verify by mutation, not by a green run.** Temporarily delete the optimization, confirm the assertion fails, and restore. A perf test that has never been shown to fail against its own regression is not evidence of anything. Check the reference column stayed put across that mutation too: if both columns moved, the reference is contaminated and the ratio understates the regression.
+**Scope:** applies *only* when writing a timing assertion into a test. A ratio
+against invariant work, never an absolute millisecond budget. The full recipe
+(including why CPU time still drifts, the `cpuRatio` helper, and two worked
+examples) lives in [`docs/PERF_ASSERTIONS.md`](docs/PERF_ASSERTIONS.md) — read
+it before writing a timing assertion.
 
 ## Git & Branching
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@ coding rules, and verification. Read `ARCHITECTURE.md` only for technical
 contracts and the one matching `planning/*.md` document for a durable design
 reference.
 
+**Critical Path — read this first, then the full AGENTS.md:**
+- **Issue first.** Open a GitHub issue (#NN) before any code. Fast lane skips Plan/Approve **only** if `npm run check:fast-lane` is green.
+- **Branch, never `main`.** Work on a feature branch; the `main-requires-pr` ruleset blocks merge without a PR.
+- **Build green.** `npm run build` (lint + tsc + tests + icons) must pass before committing.
+- **Worktrees only.** Never edit the primary checkout's working tree — use `git worktree add` outside the repo.
+- **Protected paths → full lane.** `AGENTS.md` and engine/gcode/machine/format code — plan + approve required.
+- **Close with a PR.** End with a PR containing `Closes #NN`; rebase onto `main` first.
+
 Every task gets a GitHub issue; its plan and acceptance criteria live there and
 need approval before implementation. Small changes that pass the `AGENTS.md`
 fast-lane check skip the plan and approval, nothing else.

--- a/docs/PERF_ASSERTIONS.md
+++ b/docs/PERF_ASSERTIONS.md
@@ -1,0 +1,79 @@
+# Performance Assertions (timing tests only)
+
+> **Scope:** This document applies *only* when writing a timing assertion into a
+> test. It is a recipe for one narrow act, not a house style. If the user asked a
+> question, answer it in prose — see `AGENTS.md` § Scope Discipline.
+
+`build` is a required status check, so any timing assertion that drifts blocks
+merges for everyone. Three issues have now been spent here (#383, #386, #508).
+Each of the first two fixed the *units* and left the *shape* of the assertion
+alone, and each decayed within weeks. The rule below is the third answer; read
+the whole of it before writing a timing assertion.
+
+## No absolute millisecond budget survives
+
+Not in wall clock, and not in CPU time either:
+
+- **Wall clock** counts time the process spends descheduled while
+  `scripts/run-tests.ts` runs its pool (`min(10, cores - 2)`), so it moves with
+  unrelated load. This is what #383/#386 diagnosed, correctly.
+- **`process.cpuUsage()`** fixes only that. It measures **time on CPU, not work
+  done**, so it still moves with the effective clock rate — turbo limits, thermal
+  throttling, SMT sibling contention. Measured for #508 on
+  `classifier.test.ts`, against this project's own test pool: wall clock 569ms →
+  942ms, CPU time 156ms → 325ms (**2.1x**), while a ratio against invariant work
+  moved 1.16x. An allocation-free reference loop inflated 1.6x in lockstep over
+  the same runs, which rules out GC as the cause.
+
+The earlier claim that CPU time "is NOT contention dependent" was wrong, and both
+budgets written under it had already drifted past their recorded baselines before
+anyone noticed.
+
+## Measure the guarded work against an invariant reference
+
+**Measure the guarded work against the same code path on a fixture that provably
+cannot benefit from the optimization being guarded, and assert the ratio.** Both
+halves then share machine, clock rate, allocator and microarchitecture, so only
+the optimization itself moves the number. Use `cpuRatio` from
+[`src/test/cpuRatio.ts`](../src/test/cpuRatio.ts); it takes the **minimum**
+across repetitions, since contention and GC can only ever add cost.
+
+Finding the invariant half is the design work, and it is usually a fixture, not a
+code change — never add a test-only toggle to production code for this, because
+if the toggle breaks the ratio silently collapses to 1 and the test passes while
+measuring nothing. Two worked examples:
+
+| test | guards | subject | invariant reference |
+|---|---|---|---|
+| `classifier.test.ts` | bbox reject gating pairwise nesting | 2,980 **disjoint** rects — gate rejects nearly every pair | 200 **concentric** rects — every bbox pair overlaps, so the gate never rejects |
+| `importBulk.test.ts` | suffix cursor in `createNameAllocator` | 2,980 **repeated** names — every one hits the suffix loop | 2,980 **unique** names — never `taken`, so they return before the loop |
+
+## A ratio between two input sizes is a different instrument
+
+A size ratio sees a complexity change but is blind to a constant factor: on the
+classifier, dropping the bbox gate cost ~10x in absolute CPU but moved the size
+ratio only 3.19x → 4.07x, inside the baseline's own spread. Use a size ratio
+only when the property under test genuinely *is* the shape of the cost curve —
+`bestNonFittingCpuMs` in `src/engine/toolpaths/arcReconstruction.test.ts` is the
+correct use of it, and needs no change.
+
+## Record your numbers and verify by mutation
+
+Whichever you write, record in the test the measured baseline row, the measured
+regressed row, and the headroom either side, so the next reader can re-derive the
+constant instead of guessing at it. Set the threshold at the geometric mid-point
+of the *worst* pair — highest observed baseline against lowest observed
+regression — not of the averages.
+
+**Verify by mutation, not by a green run.** Temporarily delete the optimization,
+confirm the assertion fails, and restore. A perf test that has never been shown
+to fail against its own regression is not evidence of anything. Check the
+reference column stayed put across that mutation too: if both columns moved, the
+reference is contaminated and the ratio understates the regression.
+
+## Worked examples (from the original AGENTS.md)
+
+| test | guards | subject | invariant reference |
+|---|---|---|---|
+| `classifier.test.ts` | bbox reject gating pairwise nesting | 2,980 **disjoint** rects — gate rejects nearly every pair | 200 **concentric** rects — every bbox pair overlaps, so the gate never rejects |
+| `importBulk.test.ts` | suffix cursor in `createNameAllocator` | 2,980 **repeated** names — every one hits the suffix loop | 2,980 **unique** names — never `taken`, so they return before the loop |


### PR DESCRIPTION
Restructures AGENTS.md to reduce agent cherry-picking (issue #595 found violations of rules that were documented but easy to skim past).

## Changes

- **AGENTS.md**: Added a Critical Path cheat sheet (6 bullets, ~95 words) at the top before What This Is, so the rules agents most commonly violate are unmissable on first read.
- **docs/PERF_ASSERTIONS.md** (new): Extracted the ~30-line Performance Assertions deep-dive out of AGENTS.md Build & Verify section into a standalone reference. That section (21% of AGENTS.md by word count) only matters when writing timing tests; extracting it reduces the main doc from 4,575 to 4,339 words while keeping all guidance reachable.
- **CLAUDE.md**: Mirrored the same Critical Path cheat sheet, since it was only 3 lines pointing to AGENTS.md and Claude Code agents often start there.

## Verification

- npm run build -- green (245 test files pass, docs-check OK -- 64 active docs, 9 agent entrypoints, link to docs/PERF_ASSERTIONS.md resolves).
- npm run check:fast-lane -- correctly NOT ELIGIBLE (AGENTS.md is a protected path). Full lane.
- CLAUDE.md retains all required agent-entrypoint markers.

Closes #728
