### PR TITLE
fix(cam): fold non-target subtracts into the cleared region (#526)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -175,7 +175,10 @@ area `INDEX.md` files rather than being restated here.
    1. `resolveFeatureInstance` (`src/store/helpers/resolveFeatures.ts`) —
       definition + transform into world geometry (§4 resolver boundary).
    2. `resolvePocketRegions` / `resolveInsideEdgeRegions` (`resolver.ts`) —
-      features and operation into Clipper input regions.
+      features and operation into Clipper input regions. The fold they
+      apply — feature order, parent material, non-target subtracts, and the
+      material silhouette — is owned by
+      [`planning/BAND_RESOLVER_SEMANTICS.md`](planning/BAND_RESOLVER_SEMANTICS.md).
    3. `buildRegionMask` (`regions.ts`) — compose the region mask.
    4. `resolveRegionDomainArea` / `…Centre` / `…Curve` (`regionDomain.ts`) —
       mask into a typed operation domain. Which resolver a kind uses is owned

--- a/planning/BAND_RESOLVER_SEMANTICS.md
+++ b/planning/BAND_RESOLVER_SEMANTICS.md
@@ -1,0 +1,112 @@
+---
+status: current
+authoritative-for: how the depth-band resolvers turn features into the region an operation clears
+last-verified: 2026-09-07
+---
+
+# Band Resolver Semantics
+
+## Purpose
+
+`resolvePocketRegions` and `resolveInsideEdgeRegions`
+([`src/engine/toolpaths/resolver.ts`](../src/engine/toolpaths/resolver.ts)) answer one
+question for every depth band:
+
+> Where, in this band, is the material that the model says is not there?
+
+Everything downstream — pocket, V-carve, V-carve medial, inside Edge Route, and both
+rest-region drafts — consumes their answer. This document owns the rule they use. It
+existed only as code until issue #526, which is how a wrong answer survived unexamined
+for so long.
+
+## The void fold
+
+The region a band clears is the **void** the boolean model leaves in that band. It is
+computed by folding `expandedFeaturesInOrder` — project feature order, the same order
+`buildBooleanModel` ([`src/engine/csg.ts`](../src/engine/csg.ts)) uses — over an
+initially empty void:
+
+| feature | effect on the void |
+| --- | --- |
+| target subtract | union, unclipped |
+| qualifying non-target subtract | union, clipped to the band's material silhouette |
+| add | difference |
+| closed line target | resolved separately, even-odd, then unioned (issue #270 S2) |
+
+**Order is load-bearing.** A subtract before an add means something different from one
+after it: the add fills back in what the subtract carved. Any change here that stops
+consuming feature order is a bug, not a simplification.
+
+**An add reached while the void is still empty is parent material, not an island.** This
+is the `resolvedPaths.length > 0` guard in the fold, and it is what stops a body add that
+encloses the whole pocket from differencing the pocket away to nothing. It mirrors
+`buildBooleanModel`, which likewise lets only the first `add` seed the solid. Reordering a
+body add to sit after the target subtract will empty the region — correctly, because that
+is what the model then describes.
+
+## Non-target subtracts (issue #526)
+
+A subtract that is not the operation's target still changes the solid. Before #526 the
+fold applied a subtract only when it *was* a target, so the two representations disagreed:
+the 3D view showed an island eaten away while the toolpath still machined around it. The
+error direction was under-cutting — material left standing that is not there.
+
+Three consequences follow from folding them in, and all three are intended:
+
+1. **Islands shrink.** A subtract crossing an island removes that much of the island from
+   the region.
+2. **The boundary can open past the target.** The region is a union, so a subtract that
+   breaks through the target's wall opens a channel out of it.
+3. **Bands can extend past the target's Z range**, in both directions. A subtract whose
+   floor is below the target's adds bands below it; one whose top is above adds bands
+   above. The operation follows the void as far as it goes.
+
+Accepted cost: a non-target subtract that has its own operation is machined twice, and the
+second pass cuts air. Wasted time beats a part that comes out wrong.
+
+### Which subtracts qualify
+
+Discovery mirrors island discovery: expanded, closed geometry, `operation === 'subtract'`,
+not a target, footprint intersecting the **target union**.
+
+Deliberately **one hop**. A subtract that reaches the target only through another
+qualifying subtract does not join. The void is connected, so a transitive closure would be
+defensible, but one overlap could then walk the whole project and make the area an
+operation clears unpredictable from the target the user picked.
+
+Deliberately **no "owned by an add" exclusion**, unlike `relatedSubtractFeatures`
+([`src/engine/toolpaths/modelProtection.ts`](../src/engine/toolpaths/modelProtection.ts)).
+That rule exists for 3D operations, where a subtract inside an add would drag the whole
+operation's Z range deeper. Here the effect is scoped to one band and one footprint, and a
+pocket cut into an island is a real void inside the region.
+
+Islands and tabs are then discovered against the **widened** union — target plus qualifying
+subtracts — so an add standing in newly-opened area is still found. Widening uses the
+unclipped subtract footprints: discovery is conservative across every band, and an add that
+turns out not to overlap the resolved void differences nothing.
+
+### The material silhouette
+
+A non-target subtract's contribution is clipped to the union of the **add features standing
+in that band**. Outside the model there is nothing the model says must be gone — that
+material belongs to an outside profile operation — so the region does not follow a subtract
+out into waste stock. Target subtracts are never clipped; that is unchanged.
+
+`buildBooleanModel` does not include the stock: only the first `add` seeds the solid, so a
+project of stock plus subtracts has no model silhouette at all. Clipping to an empty
+silhouette would there silently drop every non-target subtract, so **a band with no active
+add falls back to the stock footprint**.
+
+### What the user is told
+
+`regionExtendedBySubtractDepth` fires only when the resolved bands reach below the deepest
+target. That is the one consequence a user cannot predict from the operation's own target.
+Eating an island or widening the boundary is the operation simply being correct; warning on
+those would leave a permanent warning on every project that has an overlapping subtract.
+
+## Guarantee for existing projects
+
+When no non-target subtract intersects the target union, discovery is empty and every path
+above short-circuits: the resolved bands are identical to their pre-#526 values. This was
+verified across all 14 fixtures in `src/engine/test-fixtures/` — the parity corpus behind
+issue #675 — which produce byte-identical bands before and after.

--- a/planning/INDEX.md
+++ b/planning/INDEX.md
@@ -29,6 +29,7 @@ architecture contracts.
 - [DESKTOP_DESIGN.md](DESKTOP_DESIGN.md) — desktop shell and platform-adapter boundaries.
 - [TABLET_UX_DESIGN.md](TABLET_UX_DESIGN.md) — tablet interaction, command-surface, layout, and focus contracts.
 - [REGION_FEATURE_SEMANTICS.md](REGION_FEATURE_SEMANTICS.md) — regions as machining filters rather than material or standalone targets.
+- [BAND_RESOLVER_SEMANTICS.md](BAND_RESOLVER_SEMANTICS.md) — the depth-band void fold: feature order, parent material, non-target subtracts, and the material silhouette.
 - [TROCHOIDAL_EDGE_DESIGN.md](TROCHOIDAL_EDGE_DESIGN.md) — trochoidal Edge Route roughing: guide-domain fragmentation, the clearance budget, and the pipeline stages it must bypass.
 - [INTEGRATION_HANDOFF_TEMPLATE.md](INTEGRATION_HANDOFF_TEMPLATE.md) — optional execution-ledger template for explicitly delegated, multi-slice work.
 - [ISSUE_633_INTEGRATION_HANDOFF.md](ISSUE_633_INTEGRATION_HANDOFF.md) — active execution ledger for issue #633 (wall-corner cleanup on `rough_surface`) on `feat/issue-633-wall-cleanup`.

--- a/src/engine/toolpaths/resolver.ts
+++ b/src/engine/toolpaths/resolver.ts
@@ -17,9 +17,9 @@
 import ClipperLib from 'clipper-lib'
 import type { ToolpathWarning } from './warningCodes'
 import type { Operation, Project, SketchFeature } from '../../types/project'
-import { rectProfile } from '../../types/project'
+import { getEffectiveStockProfile, rectProfile } from '../../types/project'
 import { expandFeatureGeometry, featureHasClosedGeometry } from '../../text'
-import { resolveProject } from '../../store/helpers/resolveFeatures'
+import { resolveProject, type ResolvedProject } from '../../store/helpers/resolveFeatures'
 import type {
   ClipperPath,
   ResolvedFeatureZSpan,
@@ -191,6 +191,164 @@ function pathsIntersect(subjectPaths: ClipperPath[], clipPaths: ClipperPath[]): 
   return executeClipPaths(subjectPaths, clipPaths, ClipperLib.ClipType.ctIntersection).length > 0
 }
 
+function intersectPaths(subjectPaths: ClipperPath[], clipPaths: ClipperPath[]): ClipperPath[] {
+  if (subjectPaths.length === 0 || clipPaths.length === 0) {
+    return []
+  }
+
+  return executeClipPaths(subjectPaths, clipPaths, ClipperLib.ClipType.ctIntersection)
+}
+
+/**
+ * Subtract features the operation does not target but which carve into the
+ * region it does (issue #526).
+ *
+ * The boolean model folds every add and subtract in feature order, so a
+ * subtract that eats part of an island — or opens the region's wall, or
+ * reaches below the target's bottom Z — leaves a void the 3D model shows.
+ * Before #526 the band loop applied a subtract only when it was a *target*, so
+ * the operation machined around those voids and left material that is not
+ * there.
+ *
+ * Discovery mirrors island discovery and is deliberately one hop: a subtract
+ * qualifies by overlapping the *target* union, not by overlapping another
+ * qualifying subtract. The void is connected, so a transitive closure would be
+ * defensible, but one overlap could then walk the whole project and make the
+ * area an operation clears unpredictable from the target the user picked.
+ *
+ * Unlike `relatedSubtractFeatures` (`modelProtection.ts`), a subtract that
+ * lives entirely inside an add is NOT excluded here. That rule exists for 3D
+ * operations, where such a subtract would drag the whole operation's Z range
+ * deeper; here the effect is scoped to one band and one footprint, and a
+ * pocket cut into an island is a real void inside the region.
+ */
+function discoverNonTargetSubtracts(
+  project: ResolvedProject,
+  targetUnionPaths: ClipperPath[],
+  targetIdSet: Set<string>,
+): FeatureWithSpan[] {
+  return project.features
+    .flatMap((feature) => expandFeatureGeometry(feature))
+    .filter((feature) => feature.operation === 'subtract' && !targetIdSet.has(feature.id))
+    .filter((feature) => featureHasClosedGeometry(feature))
+    .filter((feature) => pathsIntersect(targetUnionPaths, [flattenFeatureToClipperPath(feature)]))
+    .map((feature) => ({
+      feature,
+      span: resolveFeatureZSpan(project, feature),
+    }))
+}
+
+/**
+ * The union a band's islands and tabs are discovered against: the target union
+ * widened by the qualifying non-target subtracts, which can open the region
+ * past its target boundary.
+ *
+ * Unclipped by the material silhouette on purpose — discovery is conservative
+ * across every band, and an add that turns out not to overlap the resolved
+ * void differences nothing.
+ */
+function reachableUnionForDiscovery(
+  targetUnionPaths: ClipperPath[],
+  nonTargetSubtracts: FeatureWithSpan[],
+): ClipperPath[] {
+  if (nonTargetSubtracts.length === 0) {
+    return targetUnionPaths
+  }
+
+  return unionPaths([
+    ...targetUnionPaths,
+    ...nonTargetSubtracts.map(({ feature }) => flattenFeatureToClipperPath(feature)),
+  ])
+}
+
+function closedAddFeaturesWithSpans(project: ResolvedProject): FeatureWithSpan[] {
+  return project.features
+    .flatMap((feature) => expandFeatureGeometry(feature))
+    .filter((feature) => feature.operation === 'add' && featureHasClosedGeometry(feature))
+    .map((feature) => ({
+      feature,
+      span: resolveFeatureZSpan(project, feature),
+    }))
+}
+
+function stockFootprintPaths(project: ResolvedProject): ClipperPath[] {
+  const flattened = flattenProfile(getEffectiveStockProfile(project.stock))
+  if (flattened.points.length === 0) {
+    return []
+  }
+
+  return [toClipperPath(normalizeWinding(flattened.points, false), DEFAULT_CLIPPER_SCALE)]
+}
+
+/**
+ * The material a non-target subtract is allowed to carve in this band.
+ *
+ * Outside the model there is nothing the model says must be gone — that
+ * material belongs to an outside profile operation — so a non-target
+ * subtract's contribution is clipped to the adds standing in the band rather
+ * than followed out into waste stock.
+ *
+ * `buildBooleanModel` (`csg.ts`) does not include the stock: only the first
+ * `add` seeds the solid, so a project of stock plus subtracts has no model
+ * silhouette at all. Clipping to an empty silhouette there would silently drop
+ * every non-target subtract, so a band with no active add falls back to the
+ * stock footprint.
+ */
+function bandMaterialSilhouette(
+  addFeatures: FeatureWithSpan[],
+  stockPaths: ClipperPath[],
+  topZ: number,
+  bottomZ: number,
+): ClipperPath[] {
+  const activeAdds = activeForBand(addFeatures, topZ, bottomZ)
+  if (activeAdds.length === 0) {
+    return stockPaths
+  }
+
+  return unionPaths(activeAdds.map(({ feature }) => flattenFeatureToClipperPath(feature)))
+}
+
+/**
+ * Raised when qualifying non-target subtracts pulled the resolved bands below
+ * the deepest target — the one consequence of #526 a user cannot predict from
+ * the operation's own target. Eating an island or widening the boundary is the
+ * operation simply being correct and stays quiet, or every project with an
+ * overlapping subtract would carry a permanent warning.
+ */
+function appendDepthExtensionWarning(
+  warnings: ToolpathWarning[],
+  operationLabel: string,
+  closedTargetFeatures: FeatureWithSpan[],
+  nonTargetSubtracts: FeatureWithSpan[],
+  bands: ResolvedPocketBand[],
+): void {
+  if (closedTargetFeatures.length === 0 || bands.length === 0) {
+    return
+  }
+
+  const targetBottomZ = Math.min(...closedTargetFeatures.map(({ span }) => span.min))
+  const deepestBandBottomZ = Math.min(...bands.map((band) => band.bottomZ))
+  if (deepestBandBottomZ >= targetBottomZ) {
+    return
+  }
+
+  const deepeningNames = nonTargetSubtracts
+    .filter(({ span }) => span.min < targetBottomZ)
+    .map(({ feature }) => feature.name)
+  if (deepeningNames.length === 0) {
+    return
+  }
+
+  warnings.push({
+    code: 'regionExtendedBySubtractDepth',
+    params: {
+      operation: operationLabel,
+      features: deepeningNames.join(', '),
+      bottomZ: deepestBandBottomZ,
+    },
+  })
+}
+
 function polyTreeToRegions(
   node: PolyTreeNode,
   targetFeatureIds: string[],
@@ -322,10 +480,17 @@ export function resolvePocketRegions(authoritativeProject: Project, operation: O
   ]
   const targetUnionPaths = unionPaths(allTargetPathsForDiscovery)
 
+  const targetIdSet = new Set(closedSubtractFeatures.map(({ feature }) => feature.id))
+  const nonTargetSubtracts = discoverNonTargetSubtracts(project, targetUnionPaths, targetIdSet)
+  const nonTargetSubtractIdSet = new Set(nonTargetSubtracts.map(({ feature }) => feature.id))
+  const reachableUnionPaths = reachableUnionForDiscovery(targetUnionPaths, nonTargetSubtracts)
+  const closedAddFeatures = nonTargetSubtracts.length > 0 ? closedAddFeaturesWithSpans(project) : []
+  const stockPaths = nonTargetSubtracts.length > 0 ? stockFootprintPaths(project) : []
+
   const candidateIslands = project.features
     .flatMap((feature) => expandFeatureGeometry(feature))
     .filter((feature) => feature.operation === 'add' && featureHasClosedGeometry(feature))
-    .filter((feature) => pathsIntersect(targetUnionPaths, [flattenFeatureToClipperPath(feature)]))
+    .filter((feature) => pathsIntersect(reachableUnionPaths, [flattenFeatureToClipperPath(feature)]))
     .map((feature) => ({
       feature,
       span: resolveFeatureZSpan(project, feature),
@@ -339,15 +504,15 @@ export function resolvePocketRegions(authoritativeProject: Project, operation: O
         max: Math.max(tab.z_bottom, tab.z_top),
       },
     }))
-    .filter((tab) => pathsIntersect(targetUnionPaths, [tab.path]))
+    .filter((tab) => pathsIntersect(reachableUnionPaths, [tab.path]))
 
   const depths = uniqueSortedDepthsFromSpans([
     ...closedTargetFeatures.map(({ span }) => span),
+    ...nonTargetSubtracts.map(({ span }) => span),
     ...candidateIslands.map(({ span }) => span),
     ...candidateTabIslands.map(({ span }) => span),
   ])
   const bands: ResolvedPocketBand[] = []
-  const targetIdSet = new Set(closedSubtractFeatures.map(({ feature }) => feature.id))
   const lineIdSet = new Set(closedLineFeatures.map(({ feature }) => feature.id))
   const expandedFeaturesInOrder = project.features.flatMap((feature) => expandFeatureGeometry(feature))
 
@@ -359,7 +524,8 @@ export function resolvePocketRegions(authoritativeProject: Project, operation: O
     }
 
     const activeTargets = activeForBand(closedTargetFeatures, topZ, bottomZ)
-    if (activeTargets.length === 0) {
+    const activeNonTargetSubtracts = activeForBand(nonTargetSubtracts, topZ, bottomZ)
+    if (activeTargets.length === 0 && activeNonTargetSubtracts.length === 0) {
       continue
     }
 
@@ -367,8 +533,12 @@ export function resolvePocketRegions(authoritativeProject: Project, operation: O
     const activeTabIslands = activeObstaclesForBand(candidateTabIslands, topZ, bottomZ)
     const activeBandFeatureIds = new Set([
       ...activeTargets.map(({ feature }) => feature.id),
+      ...activeNonTargetSubtracts.map(({ feature }) => feature.id),
       ...activeIslands.map(({ feature }) => feature.id),
     ])
+    const bandSilhouettePaths = activeNonTargetSubtracts.length > 0
+      ? bandMaterialSilhouette(closedAddFeatures, stockPaths, topZ, bottomZ)
+      : []
     let resolvedPaths: ClipperPath[] = []
 
     for (const feature of expandedFeaturesInOrder) {
@@ -383,8 +553,21 @@ export function resolvePocketRegions(authoritativeProject: Project, operation: O
       }
 
       const featurePath = flattenFeatureToClipperPath(feature)
-      if (feature.operation === 'subtract' && targetIdSet.has(feature.id)) {
-        resolvedPaths = unionPaths([...resolvedPaths, featurePath])
+      if (feature.operation === 'subtract') {
+        if (targetIdSet.has(feature.id)) {
+          resolvedPaths = unionPaths([...resolvedPaths, featurePath])
+          continue
+        }
+
+        // A non-target subtract carves only where there is material to carve,
+        // so its contribution is clipped to the band's material silhouette
+        // rather than followed out into waste stock (issue #526).
+        if (nonTargetSubtractIdSet.has(feature.id)) {
+          const carvedPaths = intersectPaths([featurePath], bandSilhouettePaths)
+          if (carvedPaths.length > 0) {
+            resolvedPaths = unionPaths([...resolvedPaths, ...carvedPaths])
+          }
+        }
         continue
       }
 
@@ -445,9 +628,13 @@ export function resolvePocketRegions(authoritativeProject: Project, operation: O
 
     const polyTree = executeClip(resolvedPaths, [], ClipperLib.ClipType.ctUnion)
 
+    const bandTargetFeatureIds = [
+      ...activeTargets.map(({ feature }) => feature.id),
+      ...activeNonTargetSubtracts.map(({ feature }) => feature.id),
+    ]
     const regions = polyTreeToRegions(
       polyTree,
-      activeTargets.map(({ feature }) => feature.id),
+      bandTargetFeatureIds,
       [
         ...activeIslands.map(({ feature }) => feature.id),
         ...activeTabIslands.map((tab) => tab.id),
@@ -462,7 +649,7 @@ export function resolvePocketRegions(authoritativeProject: Project, operation: O
     bands.push({
       topZ,
       bottomZ,
-      targetFeatureIds: activeTargets.map(({ feature }) => feature.id),
+      targetFeatureIds: bandTargetFeatureIds,
       islandFeatureIds: [
         ...activeIslands.map(({ feature }) => feature.id),
         ...activeTabIslands.map((tab) => tab.id),
@@ -474,6 +661,8 @@ export function resolvePocketRegions(authoritativeProject: Project, operation: O
   if (bands.length === 0) {
     warnings.push({ code: 'resolverNoBands', params: { operation: operationLabel } })
   }
+
+  appendDepthExtensionWarning(warnings, operationLabel, closedTargetFeatures, nonTargetSubtracts, bands)
 
   return {
     operationId: operation.id,
@@ -542,6 +731,13 @@ export function resolveInsideEdgeRegions(authoritativeProject: Project, operatio
 
   const targetUnionPaths = unionPaths(closedTargetFeatures.map(({ feature }) => flattenFeatureToClipperPath(feature)))
 
+  const targetIdSet = new Set(closedTargetFeatures.map(({ feature }) => feature.id))
+  const nonTargetSubtracts = discoverNonTargetSubtracts(project, targetUnionPaths, targetIdSet)
+  const nonTargetSubtractIdSet = new Set(nonTargetSubtracts.map(({ feature }) => feature.id))
+  const reachableUnionPaths = reachableUnionForDiscovery(targetUnionPaths, nonTargetSubtracts)
+  const closedAddFeatures = nonTargetSubtracts.length > 0 ? closedAddFeaturesWithSpans(project) : []
+  const stockPaths = nonTargetSubtracts.length > 0 ? stockFootprintPaths(project) : []
+
   const candidateIslands = project.features
     .flatMap((feature) => expandFeatureGeometry(feature))
     .filter((feature) => feature.operation === 'add' && featureHasClosedGeometry(feature))
@@ -549,8 +745,8 @@ export function resolveInsideEdgeRegions(authoritativeProject: Project, operatio
       feature,
       path: flattenFeatureToClipperPath(feature),
     }))
-    .filter(({ path }) => pathsIntersect(targetUnionPaths, [path]))
-    .filter(({ path }) => differencePaths([path], targetUnionPaths).length > 0)
+    .filter(({ path }) => pathsIntersect(reachableUnionPaths, [path]))
+    .filter(({ path }) => differencePaths([path], reachableUnionPaths).length > 0)
     .map(({ feature }) => ({
       feature,
       span: resolveFeatureZSpan(project, feature),
@@ -558,10 +754,10 @@ export function resolveInsideEdgeRegions(authoritativeProject: Project, operatio
 
   const depths = uniqueSortedDepthsFromSpans([
     ...closedTargetFeatures.map(({ span }) => span),
+    ...nonTargetSubtracts.map(({ span }) => span),
     ...candidateIslands.map(({ span }) => span),
   ])
   const bands: ResolvedPocketBand[] = []
-  const targetIdSet = new Set(closedTargetFeatures.map(({ feature }) => feature.id))
   const expandedFeaturesInOrder = project.features.flatMap((feature) => expandFeatureGeometry(feature))
 
   for (let index = 0; index < depths.length - 1; index += 1) {
@@ -572,15 +768,20 @@ export function resolveInsideEdgeRegions(authoritativeProject: Project, operatio
     }
 
     const activeTargets = activeForBand(closedTargetFeatures, topZ, bottomZ)
-    if (activeTargets.length === 0) {
+    const activeNonTargetSubtracts = activeForBand(nonTargetSubtracts, topZ, bottomZ)
+    if (activeTargets.length === 0 && activeNonTargetSubtracts.length === 0) {
       continue
     }
 
     const activeIslands = activeForBand(candidateIslands, topZ, bottomZ)
     const activeBandFeatureIds = new Set([
       ...activeTargets.map(({ feature }) => feature.id),
+      ...activeNonTargetSubtracts.map(({ feature }) => feature.id),
       ...activeIslands.map(({ feature }) => feature.id),
     ])
+    const bandSilhouettePaths = activeNonTargetSubtracts.length > 0
+      ? bandMaterialSilhouette(closedAddFeatures, stockPaths, topZ, bottomZ)
+      : []
     let resolvedPaths: ClipperPath[] = []
 
     for (const feature of expandedFeaturesInOrder) {
@@ -589,8 +790,21 @@ export function resolveInsideEdgeRegions(authoritativeProject: Project, operatio
       }
 
       const featurePath = flattenFeatureToClipperPath(feature)
-      if (feature.operation === 'subtract' && targetIdSet.has(feature.id)) {
-        resolvedPaths = unionPaths([...resolvedPaths, featurePath])
+      if (feature.operation === 'subtract') {
+        if (targetIdSet.has(feature.id)) {
+          resolvedPaths = unionPaths([...resolvedPaths, featurePath])
+          continue
+        }
+
+        // A non-target subtract carves only where there is material to carve,
+        // so its contribution is clipped to the band's material silhouette
+        // rather than followed out into waste stock (issue #526).
+        if (nonTargetSubtractIdSet.has(feature.id)) {
+          const carvedPaths = intersectPaths([featurePath], bandSilhouettePaths)
+          if (carvedPaths.length > 0) {
+            resolvedPaths = unionPaths([...resolvedPaths, ...carvedPaths])
+          }
+        }
         continue
       }
 
@@ -606,9 +820,13 @@ export function resolveInsideEdgeRegions(authoritativeProject: Project, operatio
 
     const polyTree = executeClip(resolvedPaths, [], ClipperLib.ClipType.ctUnion)
 
+    const bandTargetFeatureIds = [
+      ...activeTargets.map(({ feature }) => feature.id),
+      ...activeNonTargetSubtracts.map(({ feature }) => feature.id),
+    ]
     const regions = polyTreeToRegions(
       polyTree,
-      activeTargets.map(({ feature }) => feature.id),
+      bandTargetFeatureIds,
       activeIslands.map(({ feature }) => feature.id),
     )
 
@@ -620,7 +838,7 @@ export function resolveInsideEdgeRegions(authoritativeProject: Project, operatio
     bands.push({
       topZ,
       bottomZ,
-      targetFeatureIds: activeTargets.map(({ feature }) => feature.id),
+      targetFeatureIds: bandTargetFeatureIds,
       islandFeatureIds: activeIslands.map(({ feature }) => feature.id),
       regions,
     })
@@ -629,6 +847,8 @@ export function resolveInsideEdgeRegions(authoritativeProject: Project, operatio
   if (bands.length === 0) {
     warnings.push({ code: 'resolverNoBands', params: { operation: operationLabel } })
   }
+
+  appendDepthExtensionWarning(warnings, operationLabel, closedTargetFeatures, nonTargetSubtracts, bands)
 
   return {
     operationId: operation.id,

--- a/src/engine/toolpaths/resolverNonTargetSubtract.test.ts
+++ b/src/engine/toolpaths/resolverNonTargetSubtract.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Run with: npx tsx src/engine/toolpaths/resolverNonTargetSubtract.test.ts
+ */
+
+/**
+ * Non-target subtract features in the band resolvers (issue #526).
+ *
+ * A subtract the operation does not target still changes the solid model, so
+ * the region an operation clears must fold it in: it eats islands, it can open
+ * the region past its target boundary, and it can pull bands below the
+ * target's bottom Z. It is clipped to the material silhouette so the operation
+ * does not follow it out into waste stock.
+ *
+ * Geometry is sized for the default 100 x 80 x 20 mm stock. Every fixture
+ * shares one shape — a body add, a pocket subtract target inside it, and an
+ * island add inside that — so each case differs only in the non-target
+ * subtract under test.
+ */
+
+import { rectProfile } from '../../types/project'
+import type { Operation, Point, Project, SketchFeature } from '../../types/project'
+import { newProject } from '../../types/project'
+import { projectWithFeatures } from '../../test/projectFixtures'
+import { resolveInsideEdgeRegions, resolvePocketRegions } from './resolver'
+import type { ResolvedPocketResult } from './types'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`FAIL: ${message}`)
+}
+
+function approx(left: number, right: number, epsilon = 1e-6): boolean {
+  return Math.abs(left - right) <= epsilon
+}
+
+// ── Fixture helpers ────────────────────────────────────────────────
+
+function feature(
+  id: string,
+  operation: SketchFeature['operation'],
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  zBottom: number,
+  zTop = 20,
+): SketchFeature {
+  return {
+    id,
+    name: id,
+    kind: 'rect',
+    folderId: null,
+    sketch: {
+      profile: rectProfile(x, y, w, h),
+      origin: { x: 0, y: 0 },
+      orientationAngle: 0,
+      dimensions: [],
+      constraints: [],
+    },
+    operation,
+    z_top: zTop,
+    z_bottom: zBottom,
+    visible: true,
+    locked: false,
+  }
+}
+
+/** Body add: x 10..90, y 10..70, full stock height. */
+const body = (): SketchFeature => feature('body', 'add', 10, 10, 80, 60, 0)
+/** Pocket target: x 20..80, y 20..60, floor at Z 14. */
+const pocket = (): SketchFeature => feature('pocket', 'subtract', 20, 20, 60, 40, 14)
+/** Island add inside the pocket: x 40..60, y 35..45. */
+const island = (width = 20): SketchFeature => feature('island', 'add', 40, 35, width, 10, 0)
+
+function makeProject(features: SketchFeature[]): Project {
+  // Explicitly mm: newProject defaults to inch, whose 4 x 3 x 0.75 stock would
+  // clip this geometry away wherever the silhouette falls back to the stock.
+  return projectWithFeatures(newProject('non-target-subtract', 'mm'), features.map((row) => ({
+    ...row,
+    definitionId: row.id,
+  })))
+}
+
+function makeOperation(kind: Operation['kind'], featureIds: string[]): Operation {
+  return {
+    id: 'op1',
+    name: 'op1',
+    kind,
+    pass: 'rough',
+    enabled: true,
+    showToolpath: true,
+    debugToolpath: false,
+    target: { source: 'features', featureIds },
+    toolRef: null,
+    stepdown: 2,
+    stepover: 0.5,
+    feed: 100,
+    plungeFeed: 50,
+    rpm: 10000,
+    pocketPattern: 'offset',
+    pocketAngle: 0,
+    stockToLeaveRadial: 0,
+    stockToLeaveAxial: 0,
+    finishWalls: false,
+    finishFloor: false,
+    carveDepth: 0,
+    maxCarveDepth: 0,
+  }
+}
+
+function resolvePocket(features: SketchFeature[]): ResolvedPocketResult {
+  return resolvePocketRegions(makeProject(features), makeOperation('pocket', ['pocket']))
+}
+
+// ── Measurement helpers ────────────────────────────────────────────
+
+function area(points: Point[]): number {
+  let total = 0
+  for (let index = 0; index < points.length; index += 1) {
+    const current = points[index]
+    const next = points[(index + 1) % points.length]
+    total += current.x * next.y - next.x * current.y
+  }
+  return Math.abs(total) / 2
+}
+
+interface Bounds { minX: number; minY: number; maxX: number; maxY: number }
+
+function bounds(points: Point[]): Bounds {
+  return {
+    minX: Math.min(...points.map((p) => p.x)),
+    minY: Math.min(...points.map((p) => p.y)),
+    maxX: Math.max(...points.map((p) => p.x)),
+    maxY: Math.max(...points.map((p) => p.y)),
+  }
+}
+
+function boundsText(value: Bounds): string {
+  return `[${value.minX}, ${value.minY} .. ${value.maxX}, ${value.maxY}]`
+}
+
+/** Every band and region, rounded, as one comparable string. */
+function serialize(result: ResolvedPocketResult): string {
+  return result.bands.map((band) => [
+    band.topZ,
+    band.bottomZ,
+    band.targetFeatureIds.join('+'),
+    band.islandFeatureIds.join('+'),
+    band.regions.map((region) => [
+      region.outer.map((p) => `${p.x.toFixed(6)},${p.y.toFixed(6)}`).join(';'),
+      region.islands.map((hole) => hole.map((p) => `${p.x.toFixed(6)},${p.y.toFixed(6)}`).join(';')).join('/'),
+    ].join('|')).join('#'),
+  ].join(' ')).join('\n')
+}
+
+function hasDepthWarning(result: ResolvedPocketResult): boolean {
+  return result.warnings.some((warning) => warning.code === 'regionExtendedBySubtractDepth')
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+// Control for the whole suite. Issue #526 records that the first probe for
+// this bug passed without a control and was meaningless: if island size does
+// not move the resolved region at all, every comparison below is vacuous.
+{
+  console.log('1. Control: island width changes the resolved region...')
+
+  const wide = resolvePocket([body(), pocket(), island(20)])
+  const narrow = resolvePocket([body(), pocket(), island(10)])
+
+  assert(wide.bands.length === 1 && narrow.bands.length === 1, 'both controls resolve one band')
+  const wideHole = area(wide.bands[0].regions[0].islands[0])
+  const narrowHole = area(narrow.bands[0].regions[0].islands[0])
+  assert(approx(wideHole, 200), `20 x 10 island should hole 200 mm², got ${wideHole}`)
+  assert(approx(narrowHole, 100), `10 x 10 island should hole 100 mm², got ${narrowHole}`)
+
+  console.log(`   ✓ island area reaches the region (${wideHole} vs ${narrowHole} mm²)`)
+}
+
+// The bug itself: a subtract eats part of an island, and the pocket must stop
+// machining around material that is not there.
+{
+  console.log('2. A non-target subtract eats an island...')
+
+  const withoutBite = resolvePocket([body(), pocket(), island()])
+  // x 45..55, y 30..38, same Z span as the pocket, wholly inside it.
+  const bite = feature('bite', 'subtract', 45, 30, 10, 8, 14)
+  const withBite = resolvePocket([body(), pocket(), island(), bite])
+
+  assert(withBite.bands.length === 1, `bite at pocket depth adds no band, got ${withBite.bands.length}`)
+  const before = area(withoutBite.bands[0].regions[0].islands[0])
+  const after = area(withBite.bands[0].regions[0].islands[0])
+  // The island is 20 x 10; the bite overlaps it over x 45..55, y 35..38.
+  assert(approx(before, 200), `island hole should start at 200 mm², got ${before}`)
+  assert(approx(after, 170), `bite should leave 170 mm² of island, got ${after}`)
+
+  console.log(`   ✓ island shrank 200 -> ${after} mm² where the subtract crosses it`)
+}
+
+// A subtract that carves an island the resolver already sees must resolve to
+// the same region as an island that was never that large — the same shape by
+// two routes, which pins the fold rather than the arithmetic above.
+{
+  console.log('3. Eating an island matches an island that small to begin with...')
+
+  // Bite the right half of the island away, x 50..60 over the island's full height.
+  const bite = feature('bite', 'subtract', 50, 35, 10, 10, 14)
+  const eaten = resolvePocket([body(), pocket(), island(20), bite])
+  const born = resolvePocket([body(), pocket(), island(10)])
+
+  const eatenHole = area(eaten.bands[0].regions[0].islands[0])
+  const bornHole = area(born.bands[0].regions[0].islands[0])
+  assert(approx(eatenHole, bornHole),
+    `eaten island (${eatenHole}) should match a natively half-width island (${bornHole})`)
+
+  console.log(`   ✓ both routes resolve ${eatenHole} mm² of island`)
+}
+
+// Depth: a non-target subtract below the target's floor adds its own band.
+{
+  console.log('4. A deeper non-target subtract adds a band below the target...')
+
+  // x 45..55, y 0..25, floor at Z 10 — four below the pocket's Z 14.
+  const channel = feature('channel', 'subtract', 45, 0, 10, 25, 10)
+  const result = resolvePocket([body(), pocket(), island(), channel])
+
+  assert(result.bands.length === 2, `expected 2 bands, got ${result.bands.length}`)
+  assert(approx(result.bands[0].topZ, 20) && approx(result.bands[0].bottomZ, 14),
+    `first band should be 20 -> 14, got ${result.bands[0].topZ} -> ${result.bands[0].bottomZ}`)
+  assert(approx(result.bands[1].topZ, 14) && approx(result.bands[1].bottomZ, 10),
+    `second band should be 14 -> 10, got ${result.bands[1].topZ} -> ${result.bands[1].bottomZ}`)
+  // No target stands in the lower band; it is machining the subtract alone.
+  assert(result.bands[1].targetFeatureIds.join(',') === 'channel',
+    `lower band should be attributed to the channel, got ${result.bands[1].targetFeatureIds.join(',')}`)
+
+  console.log('   ✓ bands 20 -> 14 and 14 -> 10, the lower one owned by the subtract')
+}
+
+// Boundary: the region unions past the target wall, and the silhouette clip
+// stops it at the body edge instead of following the subtract into waste stock.
+{
+  console.log('5. The region unions past the target, clipped to the model silhouette...')
+
+  const channel = feature('channel', 'subtract', 45, 0, 10, 25, 10)
+  const result = resolvePocket([body(), pocket(), island(), channel])
+
+  // The pocket wall is at y 20, the body edge at y 10, the subtract reaches y 0.
+  const upper = bounds(result.bands[0].regions[0].outer)
+  assert(approx(upper.minY, 10),
+    `upper band should open to the body edge at y 10, not the target wall (20) or the subtract (0); got ${boundsText(upper)}`)
+  assert(approx(upper.minX, 20) && approx(upper.maxX, 80) && approx(upper.maxY, 60),
+    `upper band should keep the pocket's other three sides, got ${boundsText(upper)}`)
+
+  const lower = bounds(result.bands[1].regions[0].outer)
+  assert(approx(lower.minX, 45) && approx(lower.maxX, 55)
+    && approx(lower.minY, 10) && approx(lower.maxY, 25),
+    `lower band should be the channel clipped to the body, got ${boundsText(lower)}`)
+
+  console.log(`   ✓ upper ${boundsText(upper)}, lower ${boundsText(lower)}`)
+}
+
+// The clip is the model silhouette, not the stock — so with no add feature in
+// the project there is no silhouette, and the stock footprint stands in.
+{
+  console.log('6. With no add feature the stock footprint is the silhouette...')
+
+  const channel = feature('channel', 'subtract', 45, 0, 10, 25, 10)
+  const result = resolvePocket([pocket(), channel])
+
+  assert(result.bands.length === 2, `expected 2 bands, got ${result.bands.length}`)
+  const lower = bounds(result.bands[1].regions[0].outer)
+  assert(approx(lower.minY, 0),
+    `without a model to clip against the channel keeps its own extent to y 0, got ${boundsText(lower)}`)
+
+  console.log(`   ✓ unclipped to ${boundsText(lower)} when no add stands in the band`)
+}
+
+// Feature order is load-bearing: an add after the subtract fills it back in.
+{
+  console.log('7. An add after the subtract fills the void back in...')
+
+  const channel = feature('channel', 'subtract', 45, 0, 10, 25, 10)
+  // x 40..60, y 0..18 — covers the lower part of the channel, listed after it.
+  const plug = feature('plug', 'add', 40, 0, 20, 18, 0)
+  const result = resolvePocket([body(), pocket(), island(), channel, plug])
+
+  assert(result.bands.length === 2, `expected 2 bands, got ${result.bands.length}`)
+  const lower = bounds(result.bands[1].regions[0].outer)
+  assert(approx(lower.minY, 18),
+    `the plug should fill the channel below y 18, got ${boundsText(lower)}`)
+
+  console.log(`   ✓ lower band starts at the plug's edge, ${boundsText(lower)}`)
+}
+
+// Qualification is one hop from the target: a subtract reachable only through
+// another non-target subtract does not join the region.
+{
+  console.log('8. Qualification does not chain through another subtract...')
+
+  const channel = feature('channel', 'subtract', 45, 0, 10, 25, 10)
+  // x 30..70, y 0..6 — crosses the channel, never the pocket.
+  const distant = feature('distant', 'subtract', 30, 0, 40, 6, 10)
+  const withoutDistant = resolvePocket([body(), pocket(), island(), channel])
+  const withDistant = resolvePocket([body(), pocket(), island(), channel, distant])
+
+  assert(serialize(withoutDistant) === serialize(withDistant),
+    'a subtract that only touches another subtract must not change the region')
+
+  console.log('   ✓ one hop only')
+}
+
+// The guarantee for every existing project: a non-target subtract that misses
+// the target union changes nothing at all.
+{
+  console.log('9. A non-target subtract clear of the target changes nothing...')
+
+  const baseline = resolvePocket([body(), pocket(), island()])
+  // x 5..13, y 65..73 — outside the pocket entirely.
+  const elsewhere = feature('elsewhere', 'subtract', 5, 65, 8, 8, 4)
+  const withElsewhere = resolvePocket([body(), pocket(), island(), elsewhere])
+
+  assert(serialize(baseline) === serialize(withElsewhere),
+    'a subtract clear of the target must leave the resolved bands identical')
+  assert(withElsewhere.warnings.length === 0,
+    `no warning is owed here, got ${JSON.stringify(withElsewhere.warnings)}`)
+
+  console.log('   ✓ bands identical, no warning')
+}
+
+// The advisory speaks only for the consequence the target cannot predict.
+{
+  console.log('10. The depth advisory fires on depth and stays quiet otherwise...')
+
+  const bite = feature('bite', 'subtract', 45, 30, 10, 8, 14)
+  const shallow = resolvePocket([body(), pocket(), island(), bite])
+  assert(!hasDepthWarning(shallow),
+    `eating an island at target depth must not warn, got ${JSON.stringify(shallow.warnings)}`)
+
+  // Same footprint as the bite, but reaching below the pocket floor.
+  const deepBite = feature('bite', 'subtract', 45, 30, 10, 8, 9)
+  const deep = resolvePocket([body(), pocket(), island(), deepBite])
+  const warning = deep.warnings.find((entry) => entry.code === 'regionExtendedBySubtractDepth')
+  assert(warning !== undefined,
+    `cutting below the target must warn, got ${JSON.stringify(deep.warnings)}`)
+  assert(warning!.params?.features === 'bite' && approx(Number(warning!.params?.bottomZ), 9),
+    `warning should name the feature and the depth reached, got ${JSON.stringify(warning!.params)}`)
+
+  console.log('   ✓ quiet at target depth, names the feature and Z when it goes deeper')
+}
+
+// The inside edge-route resolver carries the identical shape and the identical
+// fix (issue #526 lists both).
+{
+  console.log('11. resolveInsideEdgeRegions folds non-target subtracts too...')
+
+  const channel = feature('channel', 'subtract', 45, 0, 10, 25, 10)
+  const project = makeProject([body(), pocket(), island(), channel])
+  const result = resolveInsideEdgeRegions(project, makeOperation('edge_route_inside', ['pocket']))
+
+  assert(result.bands.length === 2, `expected 2 bands, got ${result.bands.length}`)
+  const upper = bounds(result.bands[0].regions[0].outer)
+  assert(approx(upper.minY, 10),
+    `inside edge should open to the body edge at y 10, got ${boundsText(upper)}`)
+  const lower = bounds(result.bands[1].regions[0].outer)
+  assert(approx(lower.minX, 45) && approx(lower.maxX, 55)
+    && approx(lower.minY, 10) && approx(lower.maxY, 25),
+    `inside edge lower band should be the clipped channel, got ${boundsText(lower)}`)
+  assert(hasDepthWarning(result), 'inside edge should raise the depth advisory too')
+
+  console.log(`   ✓ upper ${boundsText(upper)}, lower ${boundsText(lower)}, advisory raised`)
+}
+
+console.log('\nAll non-target subtract resolver tests passed.')

--- a/src/engine/toolpaths/warningCodes.ts
+++ b/src/engine/toolpaths/warningCodes.ts
@@ -30,6 +30,11 @@ export type ToolpathWarningCode =
   | 'bandEmptySubject'
   | 'bandNoRegions'
   | 'resolverNoBands'
+  /** Non-target subtract features carved below the deepest target, so the
+   *  operation resolved bands past its target's bottom Z (issue #526). Eating
+   *  an island or widening the boundary stays quiet — only the depth the user
+   *  cannot predict from the target is worth saying. */
+  | 'regionExtendedBySubtractDepth'
   // shared helpers
   | 'cutDepthExceedsToolMax'
   // clearing-operation entry strategies

--- a/src/i18n/locales/de/warnings.ts
+++ b/src/i18n/locales/de/warnings.ts
@@ -34,6 +34,7 @@ export const warningsDe: Record<keyof typeof warningsEn, string> = {
   'warnings.bandEmptySubject': 'Band {topZ} -> {bottomZ} ergab leere Subjektgeometrie',
   'warnings.bandNoRegions': 'Band {topZ} -> {bottomZ} ergab keine bearbeitbaren Bereiche',
   'warnings.resolverNoBands': '{operation}-Resolver erzeugte keine Tiefenbänder',
+  'warnings.regionExtendedBySubtractDepth': '{features} schneidet unter das {operation}-Ziel, daher wurde der Vorgang bis Z {bottomZ} erweitert',
   'warnings.resolverOnlyInsideEdge': 'Nur Innenkontur-Operationen können von diesem Bereichs-Resolver aufgelöst werden',
   'warnings.resolverOnlyPocketVcarve': 'Nur Tasche- und V-Gravur-Operationen können von diesem Bereichs-Resolver aufgelöst werden',
   'warnings.resolverNoValidKindTargets': 'Keine gültigen {kind}-Features für diese {operation}-Operation gefunden',

--- a/src/i18n/locales/en/warnings.ts
+++ b/src/i18n/locales/en/warnings.ts
@@ -34,6 +34,7 @@ export const warningsEn = {
   'warnings.bandEmptySubject': 'Band {topZ} -> {bottomZ} resolved to empty subject geometry',
   'warnings.bandNoRegions': 'Band {topZ} -> {bottomZ} resolved to no machinable regions',
   'warnings.resolverNoBands': '{operation} resolver produced no depth bands',
+  'warnings.regionExtendedBySubtractDepth': '{features} cuts below the {operation} target, so the operation was extended down to Z {bottomZ}',
   'warnings.resolverOnlyInsideEdge': 'Only inside edge-route operations can be resolved by this region resolver',
   'warnings.resolverOnlyPocketVcarve': 'Only pocket and V-carve operations can be resolved by this region resolver',
   'warnings.resolverNoValidKindTargets': 'No valid {kind} features were found for this {operation} operation',

--- a/src/i18n/locales/es/warnings.ts
+++ b/src/i18n/locales/es/warnings.ts
@@ -28,6 +28,7 @@ export const warningsEs: Record<keyof typeof warningsEn, string> = {
   'warnings.bandEmptySubject': 'Banda {topZ} -> {bottomZ} resuelta a geometría de sujeto vacía',
   'warnings.bandNoRegions': 'Banda {topZ} -> {bottomZ} resuelta a regiones sin mecanizar',
   'warnings.resolverNoBands': 'El resolutor de {operation} no produjo bandas de profundidad',
+  'warnings.regionExtendedBySubtractDepth': '{features} corta por debajo del objetivo de {operation}, por lo que la operación se extendió hasta Z {bottomZ}',
   'warnings.resolverOnlyInsideEdge': 'Solo las operaciones de fresado de borde interior pueden resolverse con este resolutor de regiones.',
   'warnings.resolverOnlyPocketVcarve': 'Este resolutor de regiones solo puede resolver operaciones de cajera y V-carve.',
   'warnings.resolverNoValidKindTargets': 'No se encontraron elementos {kind} válidos para la operación de {operation}.',

--- a/src/i18n/locales/fr/warnings.ts
+++ b/src/i18n/locales/fr/warnings.ts
@@ -28,6 +28,7 @@ export const warningsFr: Record<keyof typeof warningsEn, string> = {
   'warnings.bandEmptySubject': 'La bande {topZ} -> {bottomZ} ne contient aucune géométrie sujet',
   'warnings.bandNoRegions': 'La bande {topZ} -> {bottomZ} ne contient aucune région usinable',
   'warnings.resolverNoBands': 'Le résolveur {operation} n’a produit aucune bande de profondeur',
+  'warnings.regionExtendedBySubtractDepth': "{features} coupe sous la cible {operation}, l'opération a donc été étendue jusqu'à Z {bottomZ}",
   'warnings.resolverOnlyInsideEdge': 'Seules les opérations de contournage intérieur peuvent être résolues par ce résolveur de région',
   'warnings.resolverOnlyPocketVcarve': 'Seules les opérations de poche et de gravure en V peuvent être résolues par ce résolveur de région',
   'warnings.resolverNoValidKindTargets': 'Aucune entité {kind} valide n’a été trouvée pour cette opération {operation}',

--- a/src/i18n/locales/zh-CN/warnings.ts
+++ b/src/i18n/locales/zh-CN/warnings.ts
@@ -32,6 +32,7 @@ export const warningsZhCN: Record<keyof typeof warningsEn, string> = {
   'warnings.bandEmptySubject': '深度带 {topZ} -> {bottomZ} 解析结果为空几何',
   'warnings.bandNoRegions': '深度带 {topZ} -> {bottomZ} 未解析出可加工区域',
   'warnings.resolverNoBands': '{operation}解析器未生成任何深度带',
+  'warnings.regionExtendedBySubtractDepth': '{features} 切削深度低于{operation}目标，因此该工序已延伸至 Z {bottomZ}',
   'warnings.resolverOnlyInsideEdge': '此区域解析器仅支持内侧沿边加工操作',
   'warnings.resolverOnlyPocketVcarve': '此区域解析器仅支持挖槽和V雕加工操作',
   'warnings.resolverNoValidKindTargets': '未找到适用于此{operation}加工操作的有效{kind}特征',

--- a/src/i18n/warningsCoverage.test.ts
+++ b/src/i18n/warningsCoverage.test.ts
@@ -30,6 +30,7 @@ function assert(condition: boolean, message: string): void {
 const ALL_CODES = [
   'finishScallopHeightOutOfRange', 'finishSlopeInvalid', 'finishSlopeEmpty', 'finishSlopeTooComplex',
   'targetsMissingOrWrongRole', 'closedProfilesOnly', 'bandEmptySubject', 'bandNoRegions', 'resolverNoBands',
+  'regionExtendedBySubtractDepth',
   'resolverOnlyInsideEdge', 'resolverOnlyPocketVcarve', 'resolverNoValidKindTargets', 'resolverNoValidSubtracts', 'resolverNoTargets',
   'cutDepthExceedsToolMax', 'cutDepthExceedsToolMaxForFeature',
   'entryStrategyFallback', 'entryHelixDiameterClamped', 'debug',


### PR DESCRIPTION
Closes #526

A subtract that is not an operation's target changed the solid model but not the
toolpath. If it ate part of an island sitting in a pocket, the 3D preview showed the
island cut away while the pocket still machined around it — under-cutting, so the part
came out wrong and the discrepancy was invisible unless you compared the two views.

Both band resolvers now fold qualifying non-target subtracts into the void they resolve,
in feature order, alongside the targets and adds.

## Decisions

Recorded in [the issue](https://github.com/PureCutCNC/purecutcnc/issues/526#issuecomment-5564282014);
they supersede design questions 1 and 3 in the issue body, which had argued against
unioning non-target subtracts at all.

1. **The boundary can open past the target.** Accepted cost: a non-target subtract that
   has its own operation is machined twice, and the second pass cuts air. Wasted time
   beats a wrong part.
2. **Depth is unbounded**, in both directions — the operation follows the void as far as
   it goes.
3. **XY is bounded by the material silhouette** — the adds standing in that band. Outside
   the model there is nothing the model says must be gone; that is the profile
   operation's job.
4. **Both resolvers**, so all five call sites: pocket, V-carve, V-carve medial, inside
   Edge Route, and both rest-region drafts.

## Notes on the implementation

`buildBooleanModel` does not include the stock — only the first `add` seeds the solid —
so a project of stock plus subtracts has no model silhouette at all. Clipping to an empty
one would have dropped every non-target subtract silently, so a band with no active add
falls back to the stock footprint.

Qualification is **one hop** off the target union: a subtract reachable only through
another qualifying subtract does not join, or a single overlap could walk the whole
project and make the area an operation clears unpredictable from the target the user
picked.

Unlike `relatedSubtractFeatures` in `modelProtection.ts`, a subtract living entirely
inside an add is **not** excluded. That rule guards a 3D operation's whole Z range; here
the effect is scoped to one band and one footprint, and a pocket cut into an island is a
real void.

`regionExtendedBySubtractDepth` reports only the depth extension — the one consequence a
user cannot predict from the operation's own target. Eating an island or widening the
boundary is the operation simply being correct, and warning on those would leave a
permanent warning on every project with an overlapping subtract.

The fold rule had no durable home, which is how the target-only gate survived unexamined.
`planning/BAND_RESOLVER_SEMANTICS.md` now owns it.

## Effect

On the reporter's fixture — a pocket at Z 0.60..0.75 with a circular island, and a
non-target subtract that eats the island, breaks through the pocket wall, and reaches
down to Z 0.50:

| | before | after |
| --- | --- | --- |
| moves | 2,769 | 3,681 |
| distinct Z levels | 0.95, 0.625, 0.60 | 0.95, 0.625, 0.60, **0.50** |
| resolved bands | 1 | 2 |
| warning | none | names the feature and Z 0.5 |

Both bands stop at the body edge rather than the subtract's own extent, so the channel
opens through the pocket wall without chasing the subtract into waste stock.

## Verification

- `npm run build` green; 248 test files pass, 0 skipped.
- 11 new tests in `resolverNonTargetSubtract.test.ts`, including the `A !== C` control the
  issue warned about — the first probe for this bug passed without one and was meaningless.
- Every assertion mutation-checked: 8 deliberate breaks (drop the silhouette clip, drop
  the spans from the depth list, restore the target-only band gate, skip the fold, drop
  the one-hop filter, drop the advisory, un-widen island discovery, drop band
  attribution), each caught by the test that should catch it.
- **No behaviour change without an overlapping subtract**: all 14 fixtures in
  `src/engine/test-fixtures/` resolve byte-identical bands before and after. That also
  clears the parity baseline in #734 (worker CAM pipeline) — none of its corpus cases
  moves, in either merge order.
- Playwright not run (outside `npm run build`); the only e2e seed with more than one
  subtract is `camOperations.helpers.ts`, whose two subtracts do not overlap in XY and so
  cannot reach the new path.
- Reporter confirmed the behaviour in the app.
