### PR TITLE
Suppress native browser menu in project tree

### DIFF
--- a/e2e/bulkProperties.smoke.spec.ts
+++ b/e2e/bulkProperties.smoke.spec.ts
@@ -788,6 +788,19 @@ test.describe('Bulk properties browser smoke', () => {
   // ====================================================================
 
   test.describe('Context-menu routing and bulk delete with Undo', () => {
+    test('every rendered project-tree row prevents the native browser menu', async ({ app }) => {
+      await seedProject(app.page, BULK_FIXTURE_JSON)
+
+      const prevented = await app.page.locator('.tree-row').evaluateAll((rows) => rows.map((row) => {
+        const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+        row.dispatchEvent(event)
+        return event.defaultPrevented
+      }))
+
+      expect(prevented.length).toBeGreaterThan(0)
+      expect(prevented).not.toContain(false)
+    })
+
     test('desktop tab context-menu: multi-select hides singleton actions, Delete Selected + Undo restores', async ({ app, ui }) => {
       await seedProject(app.page, BULK_FIXTURE_JSON)
 

--- a/src/components/feature-tree/FeatureTree.tsx
+++ b/src/components/feature-tree/FeatureTree.tsx
@@ -986,7 +986,10 @@ function TreeRow({
       onDragEnd={onDragEnd}
       onDragOver={onDragOver}
       onDrop={onDrop}
-      onContextMenu={onContextMenu}
+      onContextMenu={(event) => {
+        event.preventDefault()
+        onContextMenu?.(event)
+      }}
       style={{ paddingLeft: `${depth * 8}px` }}
     >
       <span className={`tree-branch tree-branch--${kind}`}>


### PR DESCRIPTION
## Summary
- Suppress the native browser context menu for every project-tree row.
- Preserve feature, tab, clamp, and grouped-folder custom context menus.
- Add browser coverage for cancellable context-menu events across every rendered tree row.

Closes #736

## Verification
- npm run test:e2e:project-input -- --grep "every rendered project-tree row prevents the native browser menu"
- npm run check:fast-lane
- npm run build