### PR TITLE
Add planar Z-level preview filter

### DIFF
--- a/e2e/toolpathVisibility.smoke.spec.ts
+++ b/e2e/toolpathVisibility.smoke.spec.ts
@@ -750,6 +750,54 @@ test.describe('Toolpath visibility panel smoke', () => {
     await expect(ui.toolpathVis.view3dItems(app.page).first()).toBeAttached()
   })
 
+  test.describe('planar Z-level rail', () => {
+    test.use({ hasTouch: true, viewport: { width: 1024, height: 768 } })
+
+    test('shares a touch-sized stepped selection between sketch and 3D without saving it', async ({ app }) => {
+      const page = app.page
+      await seedToolpathVisProject(page)
+      // Tablet layout keeps the operations rail in its drawer, but this test
+      // needs only to establish the selected toolpath before exercising the
+      // preview-local touch control.
+      await page.getByText('Route A', { exact: true }).evaluate((element) => element.dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ))
+
+      const snapshot = () => page.evaluate(async () => {
+        const url = '/src/store/projectStore.ts'
+        const { useProjectStore } = await import(url) as typeof import('../src/store/projectStore')
+        const state = useProjectStore.getState()
+        return { project: JSON.stringify(state.project), history: JSON.stringify(state.history), dirty: state.dirty }
+      })
+      const before = await snapshot()
+      const sketchRail = page.locator('#workspace-panel-sketch .toolpath-level-rail')
+      const sketchSlider = sketchRail.getByRole('slider', { name: 'Toolpath level' })
+      await expect(sketchRail).toBeVisible({ timeout: 15000 })
+      await expect(sketchSlider).toHaveAttribute('min', '0')
+      await expect(sketchSlider).toHaveAttribute('max', /[1-9]\d*/)
+      await expect(sketchRail.locator('.toolpath-level-rail__marks span')).toHaveCount(Number(await sketchSlider.getAttribute('max')) + 1)
+      const sketchBox = (await sketchSlider.boundingBox())!
+      expect(sketchBox.width).toBeGreaterThanOrEqual(44)
+      expect(sketchBox.height).toBeGreaterThan(sketchBox.width)
+
+      await sketchSlider.tap({ position: { x: sketchBox.width / 2, y: sketchBox.height / 2 } })
+      await sketchSlider.press('ArrowRight')
+      await expect(sketchSlider).toHaveAttribute('aria-valuetext', /^Z /)
+      expect(await snapshot()).toEqual(before)
+
+      await page.getByRole('button', { name: '3D', exact: true }).click()
+      const view3dSlider = page.locator('#workspace-panel-preview3d .toolpath-level-rail').getByRole('slider', { name: 'Toolpath level' })
+      await expect(view3dSlider).toBeVisible({ timeout: 15000 })
+      await expect(view3dSlider).toHaveAttribute('aria-valuetext', /^Z /)
+      await view3dSlider.press('Home')
+      await expect(view3dSlider).toHaveAttribute('aria-valuetext', 'All')
+
+      await page.getByRole('button', { name: 'Sketch', exact: true }).click()
+      await expect(sketchSlider).toHaveAttribute('aria-valuetext', 'All')
+      expect(await snapshot()).toEqual(before)
+    })
+  })
+
   test('navigation defers arrow rendering and restores the user setting', async ({ app, ui }) => {
     const page = app.page
     await seedToolpathVisProject(page)

--- a/e2e/toolpathVisibility.smoke.spec.ts
+++ b/e2e/toolpathVisibility.smoke.spec.ts
@@ -776,13 +776,22 @@ test.describe('Toolpath visibility panel smoke', () => {
       await expect(sketchSlider).toHaveAttribute('min', '0')
       await expect(sketchSlider).toHaveAttribute('max', /[1-9]\d*/)
       await expect(sketchRail.locator('.toolpath-level-rail__marks span')).toHaveCount(Number(await sketchSlider.getAttribute('max')) + 1)
+      await expect(sketchRail.locator('.toolpath-level-rail__all')).toHaveCount(0)
+      await expect(sketchRail.locator('.toolpath-level-rail__axis')).toHaveText('Z')
+      await expect(sketchRail.locator('.toolpath-level-rail__value')).toHaveText('All')
       const sketchBox = (await sketchSlider.boundingBox())!
+      const railBox = (await sketchRail.boundingBox())!
       expect(sketchBox.width).toBeGreaterThanOrEqual(44)
       expect(sketchBox.height).toBeGreaterThan(sketchBox.width)
+      expect(railBox.width).toBeLessThanOrEqual(46)
+      expect(await sketchSlider.inputValue()).toBe(await sketchSlider.getAttribute('max'))
+      expect(await sketchSlider.evaluate((element) => getComputedStyle(element).direction)).toBe('rtl')
 
       await sketchSlider.tap({ position: { x: sketchBox.width / 2, y: sketchBox.height / 2 } })
-      await sketchSlider.press('ArrowRight')
+      await sketchSlider.press('ArrowDown')
       await expect(sketchSlider).toHaveAttribute('aria-valuetext', /^Z /)
+      await expect(sketchRail.locator('.toolpath-level-rail__value')).toHaveText(/^-?\d/)
+      await expect(sketchSlider).toHaveCSS('outline-style', 'none')
       expect(await snapshot()).toEqual(before)
 
       await page.getByRole('button', { name: '3D', exact: true }).click()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { CreationToolbar, GlobalToolbar } from './components/layout/Toolbar'
 import { SimulationViewport, type SimulationViewportHandle } from './components/simulation/SimulationViewport'
 import { Viewport3D, type Viewport3DHandle } from './components/viewport3d/Viewport3D'
 import { type ToolpathVisibility, DEFAULT_TOOLPATH_VISIBILITY, ALL_TOOLPATH_HIDDEN } from './components/toolpathVisibility'
+import { useToolpathLevelSelection } from './components/useToolpathLevelSelection'
 import { ExportDialog } from './components/export/ExportDialog'
 import { ModelExportDialog } from './components/export/ModelExportDialog'
 import { PrintDesignDialog } from './components/export/PrintDesignDialog'
@@ -170,36 +171,27 @@ function App() {
     [project.clamps]
   )
 
-  const selectedClampId =
-    selection.selectedNode?.type === 'clamp'
-      ? selection.selectedNode.clampId
-      : null
+  const selectedClampId = selection.selectedNode?.type === 'clamp' ? selection.selectedNode.clampId : null
 
-  const handleCenterTabChange = useCallback(
-    (tab: 'sketch' | 'preview3d' | 'simulation') => {
-      if (tab === 'simulation') {
-        startSimulationTransition(() => setCenterTab(tab))
-      } else {
-        setCenterTab(tab)
-      }
-    },
-    [startSimulationTransition]
-  )
+  const handleCenterTabChange = useCallback((tab: 'sketch' | 'preview3d' | 'simulation') => {
+    if (tab === 'simulation') {
+      startSimulationTransition(() => setCenterTab(tab))
+      return
+    }
+    setCenterTab(tab)
+  }, [startSimulationTransition])
 
   // Selecting a different operation while the simulation tab is active drives
   // the heavy simulationResult/playbackInput recompute. Wrapping in a
   // transition shows the existing isComputing spinner; in other views the
   // selection is cheap so we don't pay the transition overhead.
-  const handleSelectedOperationIdChange = useCallback(
-    (id: string | null) => {
-      if (centerTab === 'simulation') {
-        startSimulationTransition(() => setSelectedOperationId(id))
-      } else {
-        setSelectedOperationId(id)
-      }
-    },
-    [centerTab, startSimulationTransition],
-  )
+  const handleSelectedOperationIdChange = useCallback((id: string | null) => {
+    if (centerTab === 'simulation') {
+      startSimulationTransition(() => setSelectedOperationId(id))
+      return
+    }
+    setSelectedOperationId(id)
+  }, [centerTab, startSimulationTransition])
 
   const featureActions = useFeatureTreeActions({
     setCenterTab,
@@ -256,6 +248,8 @@ function App() {
     generationBackend.resolved,
   )
   void toolpathMap
+
+  const toolpathLevelSelection = useToolpathLevelSelection(selectedOperation, selectedToolpath)
 
   const { simulationResult, simulationOperationCount, simulationPlaybackInput } = useSimulationModel({
     project,
@@ -412,6 +406,9 @@ function App() {
               onToolpathVisibilityChange={setToolpathVisibility}
               toolpathPanelExpanded={toolpathPanelExpanded}
               onToolpathPanelExpandedChange={setToolpathPanelExpanded}
+              toolpathLevel={toolpathLevelSelection.level}
+              toolpathLevelValues={toolpathLevelSelection.levels}
+              onToolpathLevelChange={toolpathLevelSelection.setLevel}
               operationHighlightKind={operationHighlightKind}
             />
             {project.features.length === 0 && !pendingAdd && !emptyStateEngaged ? (
@@ -438,6 +435,9 @@ function App() {
             onToolpathVisibilityChange={setToolpathVisibility}
             toolpathPanelExpanded={toolpathPanelExpanded}
             onToolpathPanelExpandedChange={setToolpathPanelExpanded}
+            toolpathLevel={toolpathLevelSelection.level}
+            toolpathLevelValues={toolpathLevelSelection.levels}
+            onToolpathLevelChange={toolpathLevelSelection.setLevel}
           />
         }
         simulationViewport={

--- a/src/components/INDEX.md
+++ b/src/components/INDEX.md
@@ -9,6 +9,7 @@ React UI. Components are organized by feature area. Plain CSS for styling — no
 - `IconGallery.tsx` — dev/debug grid of all available icons
 - `Select.tsx` — shared styled `<select>` wrapper
 - `ToolpathVisibilityPanel.tsx` — toggles for showing/hiding toolpath layers
+- `ToolpathLevelRail.tsx` / `toolpathLevels.ts` / `useToolpathLevelSelection.ts` — transient, display-only level selection for planar multi-level operations; shared by the 2D and 3D previews while surface and waterline paths fail closed to the complete view
 - `ToolpathRendererControl.tsx` — first inline GPU toggle (off selects Canvas) and visible fallback/retry status
 - `ToolpathGpuSuggestion.tsx` — non-blocking GPU opt-in tip, outside the toggle row; `canvas/toolpathGpuSuggestion.ts` detects repeated slow navigation draws, and `canvas/useToolpathGpuSuggestion.ts` owns browser-local dismissal and result-scoped suggestion state.
 - `toolpathVisibility.ts` — `ToolpathVisibility` type, default visibility constants, and the cached feed-colour legend steps (issue #535) (kept out of the panel component for fast refresh)

--- a/src/components/ToolpathLevelRail.tsx
+++ b/src/components/ToolpathLevelRail.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { useId } from 'react'
 import { useI18n } from '../i18n/i18nContext'
 import { formatLength, type Units } from '../utils/units'
 
@@ -31,17 +30,17 @@ interface ToolpathLevelRailProps {
  */
 export function ToolpathLevelRail({ levels, selectedLevel, onChange, units }: ToolpathLevelRailProps) {
   const { t } = useI18n()
-  const labelId = useId()
   const selectedIndex = selectedLevel === null ? 0 : Math.max(0, levels.indexOf(selectedLevel) + 1)
-  const selectedLabel = selectedLevel === null
+  const sliderValue = levels.length - selectedIndex
+  const selectedValue = selectedLevel === null
     ? t('appShell.toolpath.levelAll')
-    : `Z ${formatLength(selectedLevel, units)}`
+    : formatLength(selectedLevel, units)
+  const selectedLabel = selectedLevel === null ? selectedValue : `Z ${selectedValue}`
   const height = Math.min(Math.max((levels.length + 1) * 32, 112), 260)
 
   return (
-    <div className="toolpath-level-rail" aria-labelledby={labelId}>
-      <span id={labelId} className="sr-only">{t('appShell.toolpath.level')}</span>
-      <span className="toolpath-level-rail__all" aria-hidden="true">{t('appShell.toolpath.levelAll')}</span>
+    <div className="toolpath-level-rail">
+      <span className="toolpath-level-rail__axis" aria-hidden="true">Z</span>
       <div className="toolpath-level-rail__slider" style={{ height }}>
         <div className="toolpath-level-rail__marks" aria-hidden="true">
           {Array.from({ length: levels.length + 1 }, (_, index) => (
@@ -54,16 +53,25 @@ export function ToolpathLevelRail({ levels, selectedLevel, onChange, units }: To
           min={0}
           max={levels.length}
           step={1}
-          value={selectedIndex}
+          value={sliderValue}
           aria-label={t('appShell.toolpath.level')}
           aria-valuetext={selectedLabel}
+          onKeyDown={(event) => {
+            if (event.key === 'Home') {
+              event.preventDefault()
+              onChange(null)
+            } else if (event.key === 'End') {
+              event.preventDefault()
+              onChange(levels.at(-1) ?? null)
+            }
+          }}
           onChange={(event) => {
-            const next = Number(event.currentTarget.value)
-            onChange(next === 0 ? null : levels[next - 1] ?? null)
+            const nextIndex = levels.length - Number(event.currentTarget.value)
+            onChange(nextIndex === 0 ? null : levels[nextIndex - 1] ?? null)
           }}
         />
       </div>
-      <output className="toolpath-level-rail__value" aria-live="polite">{selectedLabel}</output>
+      <output className="toolpath-level-rail__value" aria-live="polite">{selectedValue}</output>
     </div>
   )
 }

--- a/src/components/ToolpathLevelRail.tsx
+++ b/src/components/ToolpathLevelRail.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useId } from 'react'
+import { useI18n } from '../i18n/i18nContext'
+import { formatLength, type Units } from '../utils/units'
+
+interface ToolpathLevelRailProps {
+  levels: readonly number[]
+  selectedLevel: number | null
+  onChange: (level: number | null) => void
+  units: Units
+}
+
+/**
+ * A native range control presented vertically: it retains keyboard, drag, and
+ * touch behaviour while the adjacent marks make every discrete Z stop visible.
+ */
+export function ToolpathLevelRail({ levels, selectedLevel, onChange, units }: ToolpathLevelRailProps) {
+  const { t } = useI18n()
+  const labelId = useId()
+  const selectedIndex = selectedLevel === null ? 0 : Math.max(0, levels.indexOf(selectedLevel) + 1)
+  const selectedLabel = selectedLevel === null
+    ? t('appShell.toolpath.levelAll')
+    : `Z ${formatLength(selectedLevel, units)}`
+  const height = Math.min(Math.max((levels.length + 1) * 32, 112), 260)
+
+  return (
+    <div className="toolpath-level-rail" aria-labelledby={labelId}>
+      <span id={labelId} className="sr-only">{t('appShell.toolpath.level')}</span>
+      <span className="toolpath-level-rail__all" aria-hidden="true">{t('appShell.toolpath.levelAll')}</span>
+      <div className="toolpath-level-rail__slider" style={{ height }}>
+        <div className="toolpath-level-rail__marks" aria-hidden="true">
+          {Array.from({ length: levels.length + 1 }, (_, index) => (
+            <span key={index} className={index === selectedIndex ? 'toolpath-level-rail__mark--selected' : ''} />
+          ))}
+        </div>
+        <input
+          className="toolpath-level-rail__input"
+          type="range"
+          min={0}
+          max={levels.length}
+          step={1}
+          value={selectedIndex}
+          aria-label={t('appShell.toolpath.level')}
+          aria-valuetext={selectedLabel}
+          onChange={(event) => {
+            const next = Number(event.currentTarget.value)
+            onChange(next === 0 ? null : levels[next - 1] ?? null)
+          }}
+        />
+      </div>
+      <output className="toolpath-level-rail__value" aria-live="polite">{selectedLabel}</output>
+    </div>
+  )
+}

--- a/src/components/ToolpathVisibilityPanel.tsx
+++ b/src/components/ToolpathVisibilityPanel.tsx
@@ -24,6 +24,8 @@ import { Icon } from './Icon'
 import { ToolpathRendererControl } from './ToolpathRendererControl'
 import { ToolpathGpuSuggestion } from './ToolpathGpuSuggestion'
 import type { ToolpathRendererControl as RendererControl } from './canvas/toolpathRendererPreference'
+import { ToolpathLevelRail } from './ToolpathLevelRail'
+import type { Units } from '../utils/units'
 
 interface ToolpathVisibilityPanelProps {
   visibility: ToolpathVisibility
@@ -47,6 +49,11 @@ interface ToolpathVisibilityPanelProps {
   legendSteps?: ReadonlyArray<FeedColourLegendStep>
   /** Present only in the sketch; the 3D renderer has no backend selector. */
   renderer?: RendererControl
+  /** Eligible planar cut depths, high to low. Empty leaves the rail hidden. */
+  levelValues?: readonly number[]
+  selectedLevel?: number | null
+  onLevelChange?: (level: number | null) => void
+  units?: Units
 }
 
 const ITEMS: Array<{ key: keyof ToolpathVisibility; labelKey: MessageKey; swatch: string }> = [
@@ -60,7 +67,7 @@ const ITEMS: Array<{ key: keyof ToolpathVisibility; labelKey: MessageKey; swatch
   { key: 'feedColours', labelKey: 'appShell.toolpath.feedColours', swatch: 'viewport-toolpath-vis__swatch--cuts' },
 ]
 
-export function ToolpathVisibilityPanel({ visibility, onChange, className, expanded, onExpandedChange, feedColoursDefault, legendSteps, renderer }: ToolpathVisibilityPanelProps) {
+export function ToolpathVisibilityPanel({ visibility, onChange, className, expanded, onExpandedChange, feedColoursDefault, legendSteps, renderer, levelValues = [], selectedLevel = null, onLevelChange, units }: ToolpathVisibilityPanelProps) {
   const { t } = useI18n()
   const { palette } = useTheme()
 
@@ -90,6 +97,14 @@ export function ToolpathVisibilityPanel({ visibility, onChange, className, expan
       </button>
       {expanded && renderer ? <ToolpathRendererControl renderer={renderer} /> : null}
       {renderer?.suggestion && <ToolpathGpuSuggestion {...renderer.suggestion} />}
+      {expanded && levelValues.length > 0 && onLevelChange && units && (
+        <ToolpathLevelRail
+          levels={levelValues}
+          selectedLevel={selectedLevel}
+          onChange={onLevelChange}
+          units={units}
+        />
+      )}
       {expanded ? (
         ITEMS.map(({ key, labelKey, swatch }) => {
           const selected = key === 'feedColours'

--- a/src/components/canvas/SketchCanvas.tsx
+++ b/src/components/canvas/SketchCanvas.tsx
@@ -15,11 +15,9 @@
  */
 
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
-import { ToolpathVisibilityPanel } from '../ToolpathVisibilityPanel'
+import { SketchToolpathControls } from './SketchToolpathControls'
 import { useSketchToolpathRenderer } from './useSketchToolpathRenderer'
 import { renderSketchToolpaths } from './renderSketchToolpaths'
-import { pocketSlotFeedPercent } from '../../theme/palette'
-import { toolpathHasEngagementTelemetry, feedColourLegendSteps as getFeedColourLegendSteps } from '../toolpathVisibility'
 import type { OpenProfileEndpoint, SketchControlRef } from '../../store/types'
 import { useProjectStore } from '../../store/projectStore'
 import { previewOffsetFeatures } from '../../store/helpers/derivedFeatures'
@@ -190,6 +188,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
     toolpathVisibility,
     onToolpathVisibilityChange,
     toolpathPanelExpanded, onToolpathPanelExpandedChange,
+    toolpathLevel = null, toolpathLevelValues = [], onToolpathLevelChange,
     operationHighlightKind = null,
   },
   ref
@@ -867,7 +866,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
 
   useEffect(() => {
     scheduleDraw()
-  }, [scheduleDraw, project, selection, pendingAdd, pendingMove, pendingTransform, pendingOffset, pendingClipboardPlacement, pendingTextLayout, viewState, backdropImage, stlImageRevision, toolpaths, selectedOperationId, collidingClampIds, snapSettings, copyCountDraft, dimEdit.dimensionEdit, toolpathVisibility, operationHighlightKind, canvasPalette])
+  }, [scheduleDraw, project, selection, pendingAdd, pendingMove, pendingTransform, pendingOffset, pendingClipboardPlacement, pendingTextLayout, viewState, backdropImage, stlImageRevision, toolpaths, selectedOperationId, collidingClampIds, snapSettings, copyCountDraft, dimEdit.dimensionEdit, toolpathVisibility, toolpathLevel, operationHighlightKind, canvasPalette])
 
   useEffect(() => {
     sketchEditPreviewRef.current = null
@@ -1244,7 +1243,7 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       }
     }
 
-    ctx = renderSketchToolpaths(toolpathRenderer.surface.current, ctx, project, toolpaths, selectedOperationId, vt, toolpathVisibility, navigation.active, toolpathRenderer.observeCanvasDraw)
+    ctx = renderSketchToolpaths(toolpathRenderer.surface.current, ctx, project, toolpaths, selectedOperationId, toolpathLevel, vt, toolpathVisibility, navigation.active, toolpathRenderer.observeCanvasDraw)
 
     if (marqueeStartRef.current && marqueeCurrentRef.current) {
       const x = Math.min(marqueeStartRef.current.cx, marqueeCurrentRef.current.cx)
@@ -3007,18 +3006,6 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       })()
     : null
 
-  // Feed-colour legend steps for the selected operation's toolpath (issue #622).
-  // One ladder per selection — no union across operations, so duplicate labels
-  // and non-monotonic ramps are unreachable. The per-toolpath scan is cached by
-  // toolpath identity, so no move scan runs on this render path.
-  const selectedToolpathForLegend = toolpaths?.find((tp) => tp.operationId === selectedOperationId) ?? null
-  const feedColourLegendSteps = selectedToolpathForLegend !== null
-    ? getFeedColourLegendSteps(selectedToolpathForLegend, (() => {
-        const percent = pocketSlotFeedPercent(project.operations.find((op) => op.id === selectedOperationId))
-        return percent === null ? 1 : percent / 100
-      })())
-    : []
-
   return (
     <div ref={containerRef} className="sketch-canvas-container">
       <canvas
@@ -3037,20 +3024,19 @@ export const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(fu
       <OverlapFeaturePicker picker={overlapFeaturePicker} />
       <CreationTargetBadge />
       {!depthLegendCollapsed ? <DepthLegend onToggleDepthLegend={onToggleDepthLegend} /> : null}
-      {(toolpaths && toolpaths.some((tp) => tp.moves.length > 0)) && toolpathVisibility && onToolpathVisibilityChange && toolpathPanelExpanded !== undefined && onToolpathPanelExpandedChange && (
-        <ToolpathVisibilityPanel
-          visibility={toolpathVisibility}
-          onChange={onToolpathVisibilityChange}
-          className="sketch-toolpath-vis"
-          expanded={toolpathPanelExpanded}
-          onExpandedChange={onToolpathPanelExpandedChange}
-          feedColoursDefault={
-            toolpaths.some((toolpath) => toolpath.operationId === selectedOperationId && toolpathHasEngagementTelemetry(toolpath))
-          }
-          legendSteps={feedColourLegendSteps}
-          renderer={toolpathRenderer.control}
-        />
-      )}
+      <SketchToolpathControls
+        project={project}
+        toolpaths={toolpaths}
+        selectedOperationId={selectedOperationId}
+        visibility={toolpathVisibility}
+        onVisibilityChange={onToolpathVisibilityChange}
+        expanded={toolpathPanelExpanded}
+        onExpandedChange={onToolpathPanelExpandedChange}
+        renderer={toolpathRenderer.control}
+        level={toolpathLevel}
+        levelValues={toolpathLevelValues}
+        onLevelChange={onToolpathLevelChange}
+      />
       <ConstraintEditPanel constraint={constraint} />
       <DrivingDimensionPanel driving={drivingWf} />
       {pendingFeatureDistribution && featureDistributionPanelState && (

--- a/src/components/canvas/SketchCanvas.types.ts
+++ b/src/components/canvas/SketchCanvas.types.ts
@@ -79,6 +79,10 @@ export interface SketchCanvasProps {
   onToolpathVisibilityChange?: (visibility: ToolpathVisibility) => void
   toolpathPanelExpanded?: boolean
   onToolpathPanelExpandedChange?: (expanded: boolean) => void
+  /** Transient display filter for the selected planar, multi-level toolpath. */
+  toolpathLevel?: number | null
+  toolpathLevelValues?: readonly number[]
+  onToolpathLevelChange?: (level: number | null) => void
   /**
    * A1.3: when an operation kind is armed/hovered in the CAM "Add operation"
    * menu, the canvas highlights features that operation could act on and dims

--- a/src/components/canvas/SketchToolpathControls.tsx
+++ b/src/components/canvas/SketchToolpathControls.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ToolpathVisibilityPanel } from '../ToolpathVisibilityPanel'
+import { pocketSlotFeedPercent } from '../../theme/palette'
+import { feedColourLegendSteps, toolpathHasEngagementTelemetry, type ToolpathVisibility } from '../toolpathVisibility'
+import type { ToolpathResult } from '../../engine/toolpaths/types'
+import type { Project } from '../../types/project'
+import type { ToolpathRendererControl } from './toolpathRendererPreference'
+
+interface SketchToolpathControlsProps {
+  project: Project
+  toolpaths: readonly ToolpathResult[]
+  selectedOperationId: string | null
+  visibility?: ToolpathVisibility
+  onVisibilityChange?: (visibility: ToolpathVisibility) => void
+  expanded?: boolean
+  onExpandedChange?: (expanded: boolean) => void
+  renderer: ToolpathRendererControl
+  level: number | null
+  levelValues: readonly number[]
+  onLevelChange?: (level: number | null) => void
+}
+
+/** Floating 2D controls, kept out of the canvas interaction shell. */
+export function SketchToolpathControls({
+  project, toolpaths, selectedOperationId, visibility, onVisibilityChange,
+  expanded, onExpandedChange, renderer, level, levelValues, onLevelChange,
+}: SketchToolpathControlsProps) {
+  const selectedToolpath = toolpaths.find((toolpath) => toolpath.operationId === selectedOperationId) ?? null
+  const legendSteps = selectedToolpath === null ? [] : feedColourLegendSteps(selectedToolpath, (() => {
+    const percent = pocketSlotFeedPercent(project.operations.find((operation) => operation.id === selectedOperationId))
+    return percent === null ? 1 : percent / 100
+  })())
+
+  if (!toolpaths.some((toolpath) => toolpath.moves.length > 0) || !visibility || !onVisibilityChange || expanded === undefined || !onExpandedChange) {
+    return null
+  }
+
+  return (
+    <ToolpathVisibilityPanel
+      visibility={visibility}
+      onChange={onVisibilityChange}
+      className="sketch-toolpath-vis"
+      expanded={expanded}
+      onExpandedChange={onExpandedChange}
+      feedColoursDefault={toolpaths.some((toolpath) => toolpath.operationId === selectedOperationId && toolpathHasEngagementTelemetry(toolpath))}
+      legendSteps={legendSteps}
+      renderer={renderer}
+      levelValues={levelValues}
+      selectedLevel={level}
+      onLevelChange={onLevelChange}
+      units={project.meta.units}
+    />
+  )
+}

--- a/src/components/canvas/gpuToolpathAnnotations.ts
+++ b/src/components/canvas/gpuToolpathAnnotations.ts
@@ -39,7 +39,7 @@ export class GpuToolpathAnnotations {
 
   render(renderer: WebGLRenderer, camera: Camera, toolpath: ToolpathResult, emphasized: boolean,
     vt: ViewTransform, width: number, height: number, visibility: ToolpathVisibility,
-    palette: CanvasThemePalette, deferArrows: boolean): void {
+    palette: CanvasThemePalette, deferArrows: boolean, selectedLevel: number | null = null): void {
     if (!emphasized || !toolpath.bounds || !visibility.directions) return
     if (deferArrows && !toolpath.debugToolpath) return
     if (!this.canvas) {
@@ -60,7 +60,7 @@ export class GpuToolpathAnnotations {
       this.geometry = new PlaneGeometry(2, 2)
       this.scene.add(new Mesh(this.geometry, this.material))
     }
-    const key = JSON.stringify([vt.scale, vt.offsetX, vt.offsetY, width, height, visibility, palette, deferArrows])
+    const key = JSON.stringify([vt.scale, vt.offsetX, vt.offsetY, width, height, visibility, palette, deferArrows, selectedLevel])
     if (this.toolpath !== toolpath || this.key !== key) {
       if (this.canvas.width !== width || this.canvas.height !== height) {
         // Texture storage dimensions are immutable after the first upload.
@@ -76,7 +76,7 @@ export class GpuToolpathAnnotations {
       this.canvas.height = height
       const ctx = this.canvas.getContext('2d')
       if (!ctx) throw new Error('Toolpath annotation canvas is unavailable')
-      drawToolpathAnnotations(ctx, toolpath, vt, true, visibility, { deferArrows })
+      drawToolpathAnnotations(ctx, toolpath, vt, true, visibility, { deferArrows, selectedLevel })
       this.texture!.needsUpdate = true
       this.toolpath = toolpath
       this.key = key

--- a/src/components/canvas/gpuToolpathRenderer.ts
+++ b/src/components/canvas/gpuToolpathRenderer.ts
@@ -28,15 +28,21 @@ import { toolpathLayerStyles, toolpathStrokeWidth } from './toolpathStyles'
 import type { ViewTransform } from './viewTransform'
 import { maskVertexShader, maskFragmentShader, compositeVertexShader, compositeFragmentShader } from './gpuToolpathShaders'
 import { GpuToolpathAnnotations } from './gpuToolpathAnnotations'
+import { movesAtToolpathLevel } from '../toolpathLevels'
 
 interface LayerBatch { scene: Scene; geometries: InstancedBufferGeometry[] }
-interface PreparedToolpath {
-  slotScale: number
+interface PreparedLayers {
   layers: Record<ToolpathOverlayLayerKey, LayerBatch>
   feeds: Map<number, LayerBatch>
-  collisions: LayerBatch
 }
-export interface GpuToolpathEntry { toolpath: ToolpathResult; emphasized: boolean; slotScale: number }
+interface PreparedToolpath extends PreparedLayers {
+  slotScale: number
+  collisions: LayerBatch
+  levels: Map<number, PreparedLayers>
+}
+export interface GpuToolpathEntry { toolpath: ToolpathResult; emphasized: boolean; selectedLevel?: number | null; slotScale: number }
+
+const MAX_CACHED_LEVELS_PER_TOOLPATH = 2
 
 /** Retained, full-resolution XY buffers. Pan/zoom only change uniforms.
  * Opaque MSAA coverage is resolved before applying layer alpha exactly once.
@@ -141,6 +147,7 @@ export class GpuToolpathRenderer {
       },
       feeds: new Map([...feeds].map(([step, moves]) => [step, this.batch(moves)])),
       collisions: this.batch((toolpath.collidingMoveIndices ?? []).map(i => toolpath.moves[i]).filter(Boolean)),
+      levels: new Map(),
     }
     this.cache.set(toolpath, prepared)
     if (import.meta.env.DEV) {
@@ -148,6 +155,48 @@ export class GpuToolpathRenderer {
       this.stats.preparationMs += performance.now() - start
     }
     return prepared
+  }
+
+  /** Keep full retained buffers intact; selected Z levels get a small LRU beside them. */
+  private prepareLevel(toolpath: ToolpathResult, prepared: PreparedToolpath, level: number): PreparedLayers {
+    const cached = prepared.levels.get(level)
+    if (cached) {
+      prepared.levels.delete(level)
+      prepared.levels.set(level, cached)
+      return cached
+    }
+    const buckets = toolpathLayerBuckets(toolpath)
+    const levelMoves = {
+      cuts: movesAtToolpathLevel(buckets.cuts, level),
+      leadIns: movesAtToolpathLevel(buckets.leadIns, level),
+      rapids: movesAtToolpathLevel(buckets.rapids, level),
+      plunges: movesAtToolpathLevel(buckets.plunges, level),
+      retractions: movesAtToolpathLevel(buckets.retractions, level),
+    }
+    const feeds = new Map<number, ToolpathMove[]>()
+    for (const move of levelMoves.cuts) {
+      const step = feedColourStep(move.feedScale, prepared.slotScale)
+      const group = feeds.get(step)
+      if (group) group.push(move)
+      else feeds.set(step, [move])
+    }
+    const selected: PreparedLayers = {
+      layers: {
+        cuts: this.batch(levelMoves.cuts), leadIns: this.batch(levelMoves.leadIns),
+        rapids: this.batch(levelMoves.rapids), plunges: this.batch(levelMoves.plunges),
+        retractions: this.batch(levelMoves.retractions),
+      },
+      feeds: new Map([...feeds].map(([step, moves]) => [step, this.batch(moves)])),
+    }
+    if (prepared.levels.size >= MAX_CACHED_LEVELS_PER_TOOLPATH) {
+      const oldest = prepared.levels.entries().next().value
+      if (oldest) {
+        this.releaseLayers(oldest[1])
+        prepared.levels.delete(oldest[0])
+      }
+    }
+    prepared.levels.set(level, selected)
+    return selected
   }
 
   private paint(batch: LayerBatch, stroke: string, width: number, alpha: number, dashed = false): void {
@@ -181,8 +230,11 @@ export class GpuToolpathRenderer {
     this.renderer.setRenderTarget(null)
     this.renderer.clear()
     const styles = toolpathLayerStyles(palette)
-    for (const { toolpath, emphasized, slotScale } of entries) {
+    for (const { toolpath, emphasized, selectedLevel = null, slotScale } of entries) {
       const prepared = this.prepare(toolpath, slotScale)
+      const layers = emphasized && selectedLevel !== null
+        ? this.prepareLevel(toolpath, prepared, selectedLevel)
+        : prepared
       const feedOn = visibility.feedColours ?? (emphasized && toolpathHasEngagementTelemetry(toolpath))
       for (const layer of buildToolpathOverlayLayers(visibility)) {
         if (!layer.visible) continue
@@ -190,16 +242,16 @@ export class GpuToolpathRenderer {
         const width = toolpathStrokeWidth(style.lineWidth, emphasized)
         const alpha = emphasized ? 1 : .34
         if (layer.key === 'cuts' && feedOn) {
-          for (const [step, batch] of prepared.feeds) this.paint(batch, canvasFeedColour(step, palette), width, alpha)
+          for (const [step, batch] of layers.feeds) this.paint(batch, canvasFeedColour(step, palette), width, alpha)
         } else {
-          this.paint(prepared.layers[layer.key], style.stroke, width, alpha, style.dash.length > 0)
+          this.paint(layers.layers[layer.key], style.stroke, width, alpha, style.dash.length > 0)
         }
       }
       this.paint(prepared.collisions, palette.toolpathCollision, emphasized ? 3 : 2.2, emphasized ? 1 : .55)
       // Canvas owns the annotation rules for both backends. Composite the
       // selected operation's cached raster here, before the next operation.
       this.annotations.render(this.renderer, this.camera, toolpath, emphasized,
-        vt, width, height, visibility, palette, deferArrows)
+        vt, width, height, visibility, palette, deferArrows, selectedLevel)
     }
     if (import.meta.env.DEV) {
       this.stats.submissions++
@@ -219,11 +271,18 @@ export class GpuToolpathRenderer {
     this.annotations.retain(active)
   }
 
-  private release(prepared: PreparedToolpath): void {
-    for (const batch of [...Object.values(prepared.layers), ...prepared.feeds.values(), prepared.collisions]) {
+  private releaseLayers(prepared: PreparedLayers): void {
+    for (const batch of [...Object.values(prepared.layers), ...prepared.feeds.values()]) {
       for (const geometry of batch.geometries) geometry.dispose()
       batch.scene.clear()
     }
+  }
+
+  private release(prepared: PreparedToolpath): void {
+    this.releaseLayers(prepared)
+    for (const selected of prepared.levels.values()) this.releaseLayers(selected)
+    for (const geometry of prepared.collisions.geometries) geometry.dispose()
+    prepared.collisions.scene.clear()
   }
 
   dispose(): void {

--- a/src/components/canvas/previewPrimitives.ts
+++ b/src/components/canvas/previewPrimitives.ts
@@ -50,6 +50,7 @@ import { worldToCanvas } from './viewTransform'
 import type { ViewTransform } from './viewTransform'
 import { canvasColors, canvasRgba, parseRgb } from './canvasPalette'
 import { canvasFeedColour, feedColourStep } from '../../theme/palette'
+import { zMatchesToolpathLevel } from '../toolpathLevels'
 
 export function featureUsesSketchFill(operation: SketchFeature['operation']): boolean {
   return operation !== 'line' && operation !== 'construction'
@@ -595,6 +596,8 @@ export interface ToolpathDisplayRenderOptions {
   deferArrows?: boolean
   /** Static exports retain every move instead of using the interactive merge. */
   simplifyForDisplay?: boolean
+  /** Selected planar Z level, or All when null. Display-only (issue #752). */
+  selectedLevel?: number | null
 }
 
 export function drawToolpath(
@@ -607,7 +610,7 @@ export function drawToolpath(
   // operation (issue #498 S5). Optional for un-threaded callers, which keep
   // the pre-S5 40% ladder; the renderers pass the operation's real slot feed.
   slotScale = 0.4,
-  { deferArrows = false, simplifyForDisplay = true }: ToolpathDisplayRenderOptions = {},
+  { deferArrows = false, simplifyForDisplay = true, selectedLevel = null }: ToolpathDisplayRenderOptions = {},
 ): void {
   // Layer membership comes from the shared declaration both renderers use; only
   // the styling below is 2D's own. This file used to re-declare the five layers
@@ -632,7 +635,10 @@ export function drawToolpath(
     if (!schemaLayer.visible) continue
 
     const layer = styleFor[schemaLayer.key]
-    const moves = visibleDisplaySegments(display.layers[schemaLayer.key], viewport)
+    const visibleMoves = visibleDisplaySegments(display.layers[schemaLayer.key], viewport)
+    const moves = emphasized && selectedLevel !== null
+      ? visibleMoves.filter((move) => zMatchesToolpathLevel(move.fromZ, move.toZ, selectedLevel))
+      : visibleMoves
 
     if (moves.length === 0) {
       continue
@@ -692,7 +698,7 @@ export function drawToolpath(
     ctx.globalAlpha = 1
   }
 
-  drawToolpathAnnotations(ctx, toolpath, vt, emphasized, visibility, { deferArrows, simplifyForDisplay })
+  drawToolpathAnnotations(ctx, toolpath, vt, emphasized, visibility, { deferArrows, simplifyForDisplay, selectedLevel })
 }
 
 /** Shared annotation rules: direct Canvas output or an ordered GPU texture. */
@@ -702,7 +708,7 @@ export function drawToolpathAnnotations(
   vt: ViewTransform,
   emphasized: boolean,
   visibility: ToolpathVisibility,
-  { deferArrows = false, simplifyForDisplay = true }: ToolpathDisplayRenderOptions = {},
+  { deferArrows = false, simplifyForDisplay = true, selectedLevel = null }: ToolpathDisplayRenderOptions = {},
 ): void {
   const viewport = expandDisplayViewport(canvasDisplayViewport(ctx.canvas, vt), 12)
   if (!emphasized || !toolpath.bounds || !visibility.directions) {
@@ -722,7 +728,7 @@ export function drawToolpathAnnotations(
     // 26.7 ms to draw the arrows it chose (issue #664). Placements come back in
     // scaled-world space, so panning only shifts them by the view offset and the
     // cache still hits.
-    const placements = toolpathArrowPlacements(toolpath, vt.scale, visibility)
+    const placements = toolpathArrowPlacements(toolpath, vt.scale, visibility, selectedLevel)
 
     const drawArrowSet = (packed: Float32Array, offsets: readonly number[] | null, color: string): void => {
       if (packed.length === 0 || (offsets !== null && offsets.length === 0)) return
@@ -795,6 +801,7 @@ export function drawToolpathAnnotations(
     const display = toolpathDisplayGeometry(toolpath, vt.scale, simplifyForDisplay)
     const markerR = Math.max(3.5, Math.min(9, span * vt.scale * 0.025))
     for (const move of visibleDisplaySegments(display.debug, viewport)) {
+      if (!zMatchesToolpathLevel(move.fromZ, move.toZ, selectedLevel)) continue
       if (!move.source) continue
       const mx = (move.fromX + move.toX) / 2 + vt.offsetX
       const my = (move.fromY + move.toY) / 2 + vt.offsetY

--- a/src/components/canvas/renderSketchToolpaths.ts
+++ b/src/components/canvas/renderSketchToolpaths.ts
@@ -26,14 +26,15 @@ import type { CanvasDrawSample } from './toolpathGpuSuggestion'
 
 export function renderSketchToolpaths(
   surface: SketchToolpathSurface | null, ctx: CanvasRenderingContext2D,
-  project: Project, toolpaths: readonly ToolpathResult[], selectedId: string | null,
+  project: Project, toolpaths: readonly ToolpathResult[], selectedId: string | null, selectedLevel: number | null,
   vt: ViewTransform, visibility: ToolpathVisibility | undefined, deferArrows: boolean,
   observeCanvasDraw?: (sample: CanvasDrawSample) => void,
 ): CanvasRenderingContext2D {
   const visible = visibility ?? { cuts: true, leadIns: true, rapids: true, plunges: true, retractions: true, directions: true }
   const entries = toolpaths.filter(tp => tp.moves.length > 0).map(toolpath => {
     const percent = pocketSlotFeedPercent(project.operations.find(op => op.id === toolpath.operationId))
-    return { toolpath, emphasized: toolpath.operationId === selectedId, slotScale: percent === null ? 1 : percent / 100 }
+    const emphasized = toolpath.operationId === selectedId
+    return { toolpath, emphasized, selectedLevel: emphasized ? selectedLevel : null, slotScale: percent === null ? 1 : percent / 100 }
   })
   let gpuActive = false
   if (surface) {
@@ -53,8 +54,8 @@ export function renderSketchToolpaths(
   }
   if (!gpuActive) {
     const start = observeCanvasDraw && entries.length > 0 ? performance.now() : null
-    for (const { toolpath, emphasized, slotScale } of entries) {
-      drawToolpath(ctx, toolpath, vt, emphasized, visible, slotScale, { deferArrows })
+    for (const { toolpath, emphasized, selectedLevel: entryLevel, slotScale } of entries) {
+      drawToolpath(ctx, toolpath, vt, emphasized, visible, slotScale, { deferArrows, selectedLevel: entryLevel })
     }
     if (start !== null) {
       const now = performance.now()

--- a/src/components/canvas/toolpathArrows.test.ts
+++ b/src/components/canvas/toolpathArrows.test.ts
@@ -137,6 +137,18 @@ test('each visibility flag the pass reads rebuilds the cache', () => {
   )
 })
 
+test('a selected Z level filters arrows and is part of the cache key', () => {
+  const toolpath = toolpathOf([
+    { kind: 'cut', from: { x: 0, y: 0, z: 0 }, to: { x: 100, y: 0, z: 0 } },
+    { kind: 'cut', from: { x: 200, y: 0, z: -1 }, to: { x: 300, y: 0, z: -1 } },
+  ])
+  const all = toolpathArrowPlacements(toolpath, 1, ALL_ON)
+  const atMinusOne = toolpathArrowPlacements(toolpath, 1, ALL_ON, -1)
+  assert(atMinusOne !== all, 'a selected level must not reuse the All placement cache entry')
+  assert(atMinusOne.cut.length === 4, 'only the selected level should place one long-cut arrow')
+  assert(atMinusOne.cut[0] === 200 && atMinusOne.cut[2] === 300, 'arrow endpoints belong to the selected level')
+})
+
 test('positions are pan-independent: scaled world, no offset', () => {
   const toolpath = straightRun(10)
   const scale = 3

--- a/src/components/canvas/toolpathArrows.ts
+++ b/src/components/canvas/toolpathArrows.ts
@@ -40,6 +40,7 @@
 import type { ToolpathMove, ToolpathResult } from '../../engine/toolpaths/types'
 import type { ToolpathVisibility } from '../toolpathVisibility'
 import { moveMatchesZFilter } from '../viewport3d/toolpathOverlay'
+import { moveMatchesToolpathLevel } from '../toolpathLevels'
 
 /** Kinds that can carry a direction arrow. */
 export type ArrowKind = 'cut' | 'rapid'
@@ -58,6 +59,7 @@ interface CachedPlacements extends ToolpathArrowPlacements {
   cuts: boolean
   rapids: boolean
   retractions: boolean
+  level: number | null
 }
 
 /**
@@ -80,6 +82,7 @@ export function computeToolpathArrowPlacements(
   toolpath: ToolpathResult,
   scale: number,
   visibility: ToolpathVisibility,
+  level: number | null = null,
 ): ToolpathArrowPlacements {
   const bounds = toolpath.bounds
   if (!bounds) {
@@ -101,7 +104,7 @@ export function computeToolpathArrowPlacements(
   let neighbourX = 0
   let neighbourY = 0
   function loadNeighbourDirection(move: ToolpathMove | undefined): boolean {
-    if (!move || (move.kind !== 'cut' && move.kind !== 'rapid')) return false
+    if (!move || (move.kind !== 'cut' && move.kind !== 'rapid') || !moveMatchesToolpathLevel(move, level)) return false
     const dx = (move.to.x - move.from.x) * scale
     const dy = (move.to.y - move.from.y) * scale
     const length = distance(dx, dy)
@@ -115,6 +118,7 @@ export function computeToolpathArrowPlacements(
   for (let moveIndex = 0; moveIndex < moves.length; moveIndex += 1) {
     const move = moves[moveIndex]
     if (move.kind !== 'cut' && move.kind !== 'rapid') continue
+    if (!moveMatchesToolpathLevel(move, level)) continue
 
     if (move.kind === 'cut' && !visibility.cuts) continue
     if (move.kind === 'rapid') {
@@ -193,6 +197,7 @@ export function toolpathArrowPlacements(
   toolpath: ToolpathResult,
   scale: number,
   visibility: ToolpathVisibility,
+  level: number | null = null,
 ): ToolpathArrowPlacements {
   const cached = placementCache.get(toolpath)
   if (
@@ -201,11 +206,12 @@ export function toolpathArrowPlacements(
     && cached.cuts === visibility.cuts
     && cached.rapids === visibility.rapids
     && cached.retractions === visibility.retractions
+    && cached.level === level
   ) {
     return cached
   }
 
-  const placements = computeToolpathArrowPlacements(toolpath, scale, visibility)
+  const placements = computeToolpathArrowPlacements(toolpath, scale, visibility, level)
   // Store and return the same object, so a cache hit is observably a hit.
   const entry: CachedPlacements = {
     cut: placements.cut,
@@ -214,6 +220,7 @@ export function toolpathArrowPlacements(
     cuts: visibility.cuts,
     rapids: visibility.rapids,
     retractions: visibility.retractions,
+    level,
   }
   placementCache.set(toolpath, entry)
   return entry

--- a/src/components/canvas/toolpathDisplay.ts
+++ b/src/components/canvas/toolpathDisplay.ts
@@ -48,8 +48,10 @@ export interface DisplayViewport {
 export interface DisplaySegment {
   fromX: number
   fromY: number
+  fromZ: number
   toX: number
   toY: number
+  toZ: number
   feedScale: number | undefined
   source: string | undefined
 }
@@ -124,8 +126,10 @@ function makeSegment(move: ToolpathMove, scale: number): DisplaySegment {
   return {
     fromX: move.from.x * scale,
     fromY: move.from.y * scale,
+    fromZ: move.from.z,
     toX: move.to.x * scale,
     toY: move.to.y * scale,
+    toZ: move.to.z,
     feedScale: move.feedScale,
     source: move.source,
   }
@@ -160,11 +164,12 @@ function displaySegments(moves: readonly ToolpathMove[], scale: number, simplify
       continue
     }
 
-    const isConnected = pending.toX === next.fromX && pending.toY === next.fromY
+    const isConnected = pending.toX === next.fromX && pending.toY === next.fromY && pending.toZ === next.fromZ
     const hasSameFeed = pending.feedScale === next.feedScale
     if (isConnected && hasSameFeed && pendingLength + length <= DISPLAY_PATH_LENGTH) {
       pending.toX = next.toX
       pending.toY = next.toY
+      pending.toZ = next.toZ
       pendingLength += length
       continue
     }
@@ -362,8 +367,10 @@ function packedSegments(packed: Float32Array): DisplaySegment[] {
     out.push({
       fromX: packed[offset],
       fromY: packed[offset + 1],
+      fromZ: 0,
       toX: packed[offset + 2],
       toY: packed[offset + 3],
+      toZ: 0,
       feedScale: undefined,
       source: undefined,
     })

--- a/src/components/toolpathLevels.test.ts
+++ b/src/components/toolpathLevels.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ToolpathMove } from '../engine/toolpaths/types'
+import { moveMatchesToolpathLevel, movesAtToolpathLevel, toolpathLevels } from './toolpathLevels'
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+}
+
+function cut(fromZ: number, toZ = fromZ): ToolpathMove {
+  return { kind: 'cut', from: { x: 0, y: 0, z: fromZ }, to: { x: 10, y: 0, z: toZ } }
+}
+
+function testPlanarLevelsAreHighToLow(): void {
+  const levels = toolpathLevels({ moves: [cut(-2), cut(0), cut(-1), cut(-1 + 1e-8)] })
+  assert(levels.length === 3, 'distinct planar levels are retained')
+  assert(levels[0] === 0 && levels[1] === -1 && levels[2] === -2, 'levels are high to low')
+}
+
+function testNonPlanarCutsAreIneligible(): void {
+  assert(toolpathLevels({ moves: [cut(0), cut(-1, -1.25)] }).length === 0, 'surface-style Z motion is ineligible')
+  assert(toolpathLevels({ moves: [cut(-1)] }).length === 0, 'one level has no useful selector')
+  assert(toolpathLevels({ moves: [cut(0), cut(-1)] }, { kind: 'finish_surface' }).length === 0, 'waterline and other finish-surface operations stay ineligible')
+}
+
+function testLevelFilterKeepsOnlyCompleteLevelMoves(): void {
+  const levelMove = cut(-1)
+  const transition = { kind: 'rapid' as const, from: { x: 0, y: 0, z: 0 }, to: { x: 0, y: 0, z: -1 } }
+  const otherLevel = cut(-2)
+  const moves = [levelMove, transition, otherLevel]
+  assert(moveMatchesToolpathLevel(levelMove, -1), 'planar move matches its level')
+  assert(!moveMatchesToolpathLevel(transition, -1), 'vertical transition is hidden')
+  const selected = movesAtToolpathLevel(moves, -1)
+  assert(selected.length === 1 && selected[0] === levelMove, 'only selected-level moves remain')
+  assert(movesAtToolpathLevel(moves, null) === moves, 'All preserves the original move list')
+}
+
+testPlanarLevelsAreHighToLow()
+testNonPlanarCutsAreIneligible()
+testLevelFilterKeepsOnlyCompleteLevelMoves()

--- a/src/components/toolpathLevels.ts
+++ b/src/components/toolpathLevels.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Display-only Z-level filtering for planar, multi-level toolpaths (issue #752).
+ *
+ * The test is deliberately strict: every cut must remain on one Z plane. That
+ * makes the selector meaningful for stepped 2.5D work, while declining surface
+ * and waterline paths whose cut moves follow a changing Z surface.
+ */
+
+import type { ToolpathMove } from '../engine/toolpaths/types'
+import type { Operation } from '../types/project'
+
+/** Numeric tolerance for generated coordinates that represent one Z level. */
+export const TOOLPATH_LEVEL_Z_TOLERANCE = 1e-7
+
+function sameLevel(a: number, b: number): boolean {
+  return Math.abs(a - b) <= TOOLPATH_LEVEL_Z_TOLERANCE
+}
+
+/** Endpoint form used by the Canvas display cache as well as raw moves. */
+export function zMatchesToolpathLevel(fromZ: number, toZ: number, level: number | null): boolean {
+  return level === null || (sameLevel(fromZ, level) && sameLevel(toZ, level))
+}
+
+/** A move belongs to a selected level only when both endpoints are on it. */
+export function moveMatchesToolpathLevel(move: Pick<ToolpathMove, 'from' | 'to'>, level: number | null): boolean {
+  return zMatchesToolpathLevel(move.from.z, move.to.z, level)
+}
+
+/**
+ * High-to-low planar cut levels, or none when the toolpath is not a stepped
+ * planar operation. Returning no levels is fail-closed: the preview remains
+ * on its complete, unfiltered machining record.
+ */
+export function toolpathLevels(
+  toolpath: Pick<{ moves: readonly ToolpathMove[] }, 'moves'>,
+  operation: Pick<Operation, 'kind'> | null = null,
+): number[] {
+  // Finish operations include waterline and curved CL-surface strategies. They
+  // stay disabled even when a particular fixture happens to contain planar
+  // segments, because their level semantics are not the 2.5D pass contract.
+  if (operation?.kind === 'surface_clean' || operation?.kind === 'rough_surface' || operation?.kind === 'finish_surface' || operation?.kind === 'finish_surface_cleanup') {
+    return []
+  }
+  const levels: number[] = []
+  let cutCount = 0
+
+  for (const move of toolpath.moves) {
+    if (move.kind !== 'cut') continue
+    cutCount += 1
+    if (!Number.isFinite(move.from.z) || !Number.isFinite(move.to.z) || !sameLevel(move.from.z, move.to.z)) {
+      return []
+    }
+    if (!levels.some((level) => sameLevel(level, move.from.z))) {
+      levels.push(move.from.z)
+    }
+  }
+
+  return cutCount > 0 && levels.length > 1 ? levels.sort((a, b) => b - a) : []
+}
+
+/** Keep the generated toolpath immutable while deriving a view-only subset. */
+export function movesAtToolpathLevel(
+  moves: readonly ToolpathMove[],
+  level: number | null,
+): readonly ToolpathMove[] {
+  return level === null ? moves : moves.filter((move) => moveMatchesToolpathLevel(move, level))
+}

--- a/src/components/useToolpathLevelSelection.ts
+++ b/src/components/useToolpathLevelSelection.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2026 Franja (Frank) Povazanj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useMemo, useState } from 'react'
+import type { ToolpathResult } from '../engine/toolpaths/types'
+import type { Operation } from '../types/project'
+import { toolpathLevels } from './toolpathLevels'
+
+interface Selection {
+  operationId: string | null
+  toolpath: ToolpathResult | null
+  level: number | null
+}
+
+/**
+ * View-only selection scoped to the exact generated result. A changed
+ * operation/result derives All immediately, avoiding an effect-driven reset.
+ */
+export function useToolpathLevelSelection(operation: Operation | null, toolpath: ToolpathResult | null) {
+  const operationId = operation?.id ?? null
+  const [selection, setSelection] = useState<Selection>({ operationId: null, toolpath: null, level: null })
+  const levels = useMemo(() => toolpath ? toolpathLevels(toolpath, operation) : [], [operation, toolpath])
+  const level = selection.operationId === operationId && selection.toolpath === toolpath
+    ? selection.level
+    : null
+  const setLevel = useCallback((nextLevel: number | null) => {
+    setSelection({ operationId, toolpath, level: nextLevel })
+  }, [operationId, toolpath])
+
+  return { level, levels, setLevel }
+}

--- a/src/components/viewport3d/Viewport3D.tsx
+++ b/src/components/viewport3d/Viewport3D.tsx
@@ -21,6 +21,7 @@ import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 import { ToolpathVisibilityPanel } from '../ToolpathVisibilityPanel'
 import { toolpathHasEngagementTelemetry, feedColourLegendSteps as getFeedColourLegendSteps, type ToolpathVisibility } from '../toolpathVisibility'
+import { moveMatchesToolpathLevel, movesAtToolpathLevel } from '../toolpathLevels'
 import type { ToolpathResult } from '../../engine/toolpaths/types'
 import { useProjectStore } from '../../store/projectStore'
 import { modelFeatures } from '../../store/helpers/featureRoles'
@@ -74,6 +75,9 @@ interface Viewport3DProps {
   onToolpathVisibilityChange: (visibility: ToolpathVisibility) => void
   toolpathPanelExpanded: boolean
   onToolpathPanelExpandedChange: (expanded: boolean) => void
+  toolpathLevel?: number | null
+  toolpathLevelValues?: readonly number[]
+  onToolpathLevelChange?: (level: number | null) => void
 }
 
 function disposeObject3D(object: THREE.Object3D) {
@@ -97,13 +101,14 @@ function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value))
 }
 
-function buildToolpathEndpointMarkers(toolpath: ToolpathResult, emphasized: boolean, palette: ThreeThemePalette): THREE.Object3D[] {
-  if (toolpath.moves.length === 0) {
+function buildToolpathEndpointMarkers(toolpath: ToolpathResult, emphasized: boolean, palette: ThreeThemePalette, selectedLevel: number | null): THREE.Object3D[] {
+  const moves = movesAtToolpathLevel(toolpath.moves, selectedLevel)
+  if (moves.length === 0) {
     return []
   }
 
-  const firstPoint = toolpathPointToWorld(toolpath.moves[0].from)
-  const lastPoint = toolpathPointToWorld(toolpath.moves[toolpath.moves.length - 1].to)
+  const firstPoint = toolpathPointToWorld(moves[0].from)
+  const lastPoint = toolpathPointToWorld(moves[moves.length - 1].to)
   const bounds = toolpath.bounds
   const span = bounds
     ? Math.max(bounds.maxX - bounds.minX, bounds.maxY - bounds.minY, bounds.maxZ - bounds.minZ)
@@ -153,6 +158,7 @@ function buildToolpathDirectionMarkers(
   emphasized: boolean,
   visibility: ToolpathVisibility,
   palette: ThreeThemePalette,
+  selectedLevel: number | null,
 ): THREE.Object3D[] {
   if (!emphasized || toolpath.moves.length === 0) {
     return []
@@ -173,7 +179,7 @@ function buildToolpathDirectionMarkers(
   const placements: Record<'cut' | 'rapid', ArrowPlacement[]> = { cut: [], rapid: [] }
 
   function getHorizontalDirection(move: ToolpathResult['moves'][number] | undefined): THREE.Vector3 | null {
-    if (!move || (move.kind !== 'cut' && move.kind !== 'rapid')) {
+    if (!move || (move.kind !== 'cut' && move.kind !== 'rapid') || !moveMatchesToolpathLevel(move, selectedLevel)) {
       return null
     }
 
@@ -192,6 +198,7 @@ function buildToolpathDirectionMarkers(
     if (move.kind !== 'cut' && move.kind !== 'rapid') {
       continue
     }
+    if (!moveMatchesToolpathLevel(move, selectedLevel)) continue
 
     // Respect visibility toggles
     if (move.kind === 'cut' && !visibility.cuts) continue
@@ -272,6 +279,7 @@ function buildToolpathOverlay(
   palette: ThreeThemePalette,
   resolution: THREE.Vector2,
   slotScale: number,
+  selectedLevel: number | null,
 ): THREE.Object3D[] {
   const schemaLayers = buildToolpathOverlayLayers(visibility)
   const layers: Array<{
@@ -311,13 +319,13 @@ function buildToolpathOverlay(
   for (const layer of layers) {
     if (!layer.visible) continue
 
-    const moves = buckets[layer.key]
+    const moves = movesAtToolpathLevel(buckets[layer.key], emphasized ? selectedLevel : null)
 
     if (moves.length === 0) {
       continue
     }
 
-    const pushLines = (layerMoves: ToolpathResult['moves'], color: number): void => {
+    const pushLines = (layerMoves: readonly ToolpathResult['moves'][number][], color: number): void => {
       const material = new LineMaterial({
         color,
         linewidth: layer.linewidth,
@@ -359,8 +367,8 @@ function buildToolpathOverlay(
   }
 
   if (emphasized && visibility.directions) {
-    objects.push(...buildToolpathDirectionMarkers(toolpath, emphasized, visibility, palette))
-    objects.push(...buildToolpathEndpointMarkers(toolpath, emphasized, palette))
+    objects.push(...buildToolpathDirectionMarkers(toolpath, emphasized, visibility, palette, selectedLevel))
+    objects.push(...buildToolpathEndpointMarkers(toolpath, emphasized, palette, selectedLevel))
   }
 
   return objects
@@ -378,6 +386,9 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
   onToolpathVisibilityChange,
   toolpathPanelExpanded,
   onToolpathPanelExpandedChange,
+  toolpathLevel = null,
+  toolpathLevelValues = [],
+  onToolpathLevelChange,
 }, ref) {
   const { palette } = useTheme()
   const threePalette = palette.three
@@ -849,6 +860,7 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
         threePalette,
         resolution,
         slotFeedPercent === null ? 1 : slotFeedPercent / 100,
+        toolpathLevel,
       )
     })
     if (nextObjects.length === 0) {
@@ -863,7 +875,7 @@ export const Viewport3D = forwardRef<Viewport3DHandle, Viewport3DProps>(function
       clearToolpathObjects(scene)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- threePalette is stable per theme; adding would recreate overlay on theme toggle
-  }, [clearToolpathObjects, selectedOperationId, toolpaths, toolpathVisibility])
+  }, [clearToolpathObjects, selectedOperationId, toolpaths, toolpathVisibility, toolpathLevel])
 
   useEffect(() => {
     const scene = sceneRef.current
@@ -1003,6 +1015,10 @@ useImperativeHandle(ref, () => ({
           onExpandedChange={onToolpathPanelExpandedChange}
           feedColoursDefault={feedColoursDefault}
           legendSteps={feedColourLegendSteps}
+          levelValues={toolpathLevelValues}
+          selectedLevel={toolpathLevel}
+          onLevelChange={onToolpathLevelChange}
+          units={project.meta.units}
         />
       )}
       <div className="viewport-presets">

--- a/src/i18n/locales/de/appShell.ts
+++ b/src/i18n/locales/de/appShell.ts
@@ -153,6 +153,8 @@ export const appShellDe: Record<keyof typeof appShellEn, string> = {
   'appShell.toolpath.directions': 'Richtungen',
   'appShell.toolpath.feedColours': 'Vorschubfarben',
   'appShell.toolpath.feedLegend': 'Vorschubprozentsatz',
+  'appShell.toolpath.level': 'Werkzeugwegsebene',
+  'appShell.toolpath.levelAll': 'Alle',
 
   // ── ToolRail ──
   'appShell.toolRail.shapes': 'Formen',

--- a/src/i18n/locales/en/appShell.ts
+++ b/src/i18n/locales/en/appShell.ts
@@ -158,6 +158,8 @@ export const appShellEn = {
   'appShell.toolpath.directions': 'Directions',
   'appShell.toolpath.feedColours': 'Feed colours',
   'appShell.toolpath.feedLegend': 'Feed percentage',
+  'appShell.toolpath.level': 'Toolpath level',
+  'appShell.toolpath.levelAll': 'All',
 
   // ── ToolRail ──
   'appShell.toolRail.shapes': 'Shapes',

--- a/src/i18n/locales/es/appShell.ts
+++ b/src/i18n/locales/es/appShell.ts
@@ -114,6 +114,8 @@ export const appShellEs: Record<keyof typeof appShellEn, string> = {
   'appShell.toolpath.directions': 'Direcciones',
   'appShell.toolpath.feedColours': 'Colores de avance',
   'appShell.toolpath.feedLegend': 'Porcentaje de avance',
+  'appShell.toolpath.level': 'Nivel de trayectoria',
+  'appShell.toolpath.levelAll': 'Todos',
   'appShell.toolRail.shapes': 'formas',
   'appShell.toolRail.align': 'Alinear',
   'appShell.toolRail.distribute': 'Distribuir',

--- a/src/i18n/locales/fr/appShell.ts
+++ b/src/i18n/locales/fr/appShell.ts
@@ -114,6 +114,8 @@ export const appShellFr: Record<keyof typeof appShellEn, string> = {
   'appShell.toolpath.directions': 'Sens',
   'appShell.toolpath.feedColours': "Couleurs d'avance",
   'appShell.toolpath.feedLegend': "Pourcentage d'avance",
+  'appShell.toolpath.level': 'Niveau de parcours',
+  'appShell.toolpath.levelAll': 'Tous',
   'appShell.toolRail.shapes': 'Formes',
   'appShell.toolRail.align': 'Aligner',
   'appShell.toolRail.distribute': 'Répartir',

--- a/src/i18n/locales/zh-CN/appShell.ts
+++ b/src/i18n/locales/zh-CN/appShell.ts
@@ -159,6 +159,8 @@ export const appShellZhCN: Record<keyof typeof appShellEn, string> = {
   'appShell.toolpath.directions': '方向',
   'appShell.toolpath.feedColours': '进给颜色',
   'appShell.toolpath.feedLegend': '进给百分比',
+  'appShell.toolpath.level': '刀路层级',
+  'appShell.toolpath.levelAll': '全部',
 
   // ── ToolRail ──
   'appShell.toolRail.shapes': '形状',

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2736,6 +2736,102 @@
   z-index: 10;
 }
 
+/* Display-only stepped Z selector (issue #752). The real range input handles
+ * keyboard, drag, and touch; the tick rail makes its discrete stops legible. */
+.toolpath-level-rail {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: -1px;
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  grid-template-rows: auto auto auto;
+  column-gap: 6px;
+  width: 102px;
+  padding: 7px 8px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: var(--surface-translucent);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  color: var(--text);
+  font-size: 11px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.toolpath-level-rail__all {
+  grid-column: 2;
+  grid-row: 1;
+  align-self: center;
+  min-height: 24px;
+  color: var(--text-dim);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  line-height: 24px;
+  text-transform: uppercase;
+}
+
+.toolpath-level-rail__slider {
+  position: relative;
+  grid-column: 1;
+  grid-row: 1 / span 3;
+  width: 36px;
+}
+
+.toolpath-level-rail__marks {
+  position: absolute;
+  top: 12px;
+  bottom: 12px;
+  left: 18px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 10px;
+  pointer-events: none;
+}
+
+.toolpath-level-rail__marks span {
+  width: 5px;
+  height: 1px;
+  background: var(--line-strong);
+}
+
+.toolpath-level-rail__marks .toolpath-level-rail__mark--selected {
+  width: 9px;
+  height: 2px;
+  background: var(--accent);
+}
+
+.toolpath-level-rail__input {
+  position: absolute;
+  inset: 0;
+  width: 36px;
+  height: 100%;
+  margin: 0;
+  appearance: slider-vertical;
+  -webkit-appearance: slider-vertical;
+  writing-mode: vertical-lr;
+  direction: rtl;
+  cursor: ns-resize;
+  touch-action: none;
+}
+
+.toolpath-level-rail__input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.toolpath-level-rail__value {
+  grid-column: 2;
+  grid-row: 2 / span 2;
+  align-self: end;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+
 .viewport-toolpath-renderer__status {
   display: inline-flex;
   align-items: center;
@@ -2837,6 +2933,15 @@
   .app-shell .viewport-toolpath-vis__item.viewport-toolpath-vis__gpu,
   .viewport-toolpath-renderer__status button {
     min-height: 44px;
+  }
+
+  .toolpath-level-rail__slider,
+  .toolpath-level-rail__input {
+    width: 44px;
+  }
+
+  .toolpath-level-rail {
+    grid-template-columns: 44px minmax(0, 1fr);
   }
 }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2739,15 +2739,18 @@
 /* Display-only stepped Z selector (issue #752). The real range input handles
  * keyboard, drag, and touch; the tick rail makes its discrete stops legible. */
 .toolpath-level-rail {
+  --toolpath-level-active: var(--accent-strong);
   position: absolute;
   top: calc(100% + 8px);
   left: -1px;
-  display: grid;
-  grid-template-columns: 36px minmax(0, 1fr);
-  grid-template-rows: auto auto auto;
-  column-gap: 6px;
-  width: 102px;
-  padding: 7px 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: max-content;
+  min-width: 46px;
+  box-sizing: border-box;
+  padding: 5px 0 6px;
   border: 1px solid var(--line-strong);
   border-radius: 8px;
   background: var(--surface-translucent);
@@ -2759,31 +2762,28 @@
   -webkit-user-select: none;
 }
 
-.toolpath-level-rail__all {
-  grid-column: 2;
-  grid-row: 1;
-  align-self: center;
-  min-height: 24px;
-  color: var(--text-dim);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  line-height: 24px;
-  text-transform: uppercase;
+:root[data-theme='light'] .toolpath-level-rail {
+  --toolpath-level-active: color-mix(in srgb, var(--accent) 72%, var(--surface-panel));
 }
 
 .toolpath-level-rail__slider {
   position: relative;
-  grid-column: 1;
-  grid-row: 1 / span 3;
-  width: 36px;
+  width: 32px;
+}
+
+.toolpath-level-rail__axis {
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
 }
 
 .toolpath-level-rail__marks {
   position: absolute;
   top: 12px;
   bottom: 12px;
-  left: 18px;
+  left: calc(50% + 2px);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -2800,36 +2800,33 @@
 .toolpath-level-rail__marks .toolpath-level-rail__mark--selected {
   width: 9px;
   height: 2px;
-  background: var(--accent);
+  background: var(--toolpath-level-active);
 }
 
 .toolpath-level-rail__input {
   position: absolute;
   inset: 0;
-  width: 36px;
+  width: 32px;
+  min-width: 0;
+  min-inline-size: 0;
   height: 100%;
   margin: 0;
   appearance: slider-vertical;
   -webkit-appearance: slider-vertical;
   writing-mode: vertical-lr;
+  outline: none;
   direction: rtl;
+  accent-color: var(--toolpath-level-active);
   cursor: ns-resize;
   touch-action: none;
 }
 
-.toolpath-level-rail__input:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
 .toolpath-level-rail__value {
-  grid-column: 2;
-  grid-row: 2 / span 2;
-  align-self: end;
   color: var(--text);
   font-family: var(--font-mono);
   font-size: 11px;
-  overflow-wrap: anywhere;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .viewport-toolpath-renderer__status {
@@ -2938,10 +2935,6 @@
   .toolpath-level-rail__slider,
   .toolpath-level-rail__input {
     width: 44px;
-  }
-
-  .toolpath-level-rail {
-    grid-template-columns: 44px minmax(0, 1fr);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a transient All-or-Z-level rail for planar multi-pass toolpaths in both sketch and 3D previews.
- Keep generated paths, collision warnings, simulation, saved projects, and exported G-code unchanged; surface and waterline paths remain ineligible.
- Cover planar-level eligibility, filtered direction markers, and touch/keyboard behavior across the two views.

## Verification
- npm run build
- PURECUT_E2E_ISOLATED=1 PURECUT_E2E_PORT=4615 npx playwright test e2e/toolpathVisibility.smoke.spec.ts --grep "planar Z-level rail" --workers=1

Closes #752