### PR TITLE
Bind the reply-length rule to answers and readouts, and to every entrypoint

### DIFF
--- a/.clauderules
+++ b/.clauderules
@@ -7,3 +7,8 @@ Every task gets a GitHub issue; its plan and acceptance criteria live there and
 need approval before implementation. Small changes that pass the AGENTS.md
 fast-lane check skip the plan and approval, nothing else.
 planning/ contains durable design references, not implementation plans.
+
+Replies are short by default: under 200 words, no headers or tables. That covers
+an answer, a review or a status readout as much as finished work - offer the
+detail in one line instead of appending it. AGENTS.md section Communication
+Style is the full rule.

--- a/.clinerules
+++ b/.clinerules
@@ -7,3 +7,8 @@ Every task gets a GitHub issue; its plan and acceptance criteria live there and
 need approval before implementation. Small changes that pass the AGENTS.md
 fast-lane check skip the plan and approval, nothing else.
 planning/ contains durable design references, not implementation plans.
+
+Replies are short by default: under 200 words, no headers or tables. That covers
+an answer, a review or a status readout as much as finished work - offer the
+detail in one line instead of appending it. AGENTS.md section Communication
+Style is the full rule.

--- a/.cursorrules
+++ b/.cursorrules
@@ -7,3 +7,8 @@ Every task gets a GitHub issue; its plan and acceptance criteria live there and
 need approval before implementation. Small changes that pass the AGENTS.md
 fast-lane check skip the plan and approval, nothing else.
 planning/ contains durable design references, not implementation plans.
+
+Replies are short by default: under 200 words, no headers or tables. That covers
+an answer, a review or a status readout as much as finished work - offer the
+detail in one line instead of appending it. AGENTS.md section Communication
+Style is the full rule.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,3 +9,8 @@ Every task gets a GitHub issue; its plan and acceptance criteria live there and
 need approval before implementation. Small changes that pass the `AGENTS.md`
 fast-lane check skip the plan and approval, nothing else.
 `planning/` contains durable design references, not implementation plans.
+
+Replies are short by default: under 200 words, no headers or tables. That covers
+an answer, a review or a status readout as much as finished work — offer the
+detail in one line instead of appending it. `AGENTS.md` § Communication Style is
+the full rule.

--- a/.roorules
+++ b/.roorules
@@ -7,3 +7,8 @@ Every task gets a GitHub issue; its plan and acceptance criteria live there and
 need approval before implementation. Small changes that pass the AGENTS.md
 fast-lane check skip the plan and approval, nothing else.
 planning/ contains durable design references, not implementation plans.
+
+Replies are short by default: under 200 words, no headers or tables. That covers
+an answer, a review or a status readout as much as finished work - offer the
+detail in one line instead of appending it. AGENTS.md section Communication
+Style is the full rule.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -7,3 +7,8 @@ Every task gets a GitHub issue; its plan and acceptance criteria live there and
 need approval before implementation. Small changes that pass the AGENTS.md
 fast-lane check skip the plan and approval, nothing else.
 planning/ contains durable design references, not implementation plans.
+
+Replies are short by default: under 200 words, no headers or tables. That covers
+an answer, a review or a status readout as much as finished work - offer the
+detail in one line instead of appending it. AGENTS.md section Communication
+Style is the full rule.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - **Worktrees only.** Never edit the primary checkout's working tree — use `git worktree add` outside the repo.
 - **Protected paths → full lane.** `AGENTS.md`, `src/engine/toolpaths/**`, `src/engine/gcode/**`, `src/machine/**`, `.camj` format, `store/types.ts`, gates — plan + approve required.
 - **Close with a PR.** End with a PR containing `Closes #NN`; rebase onto `main` first.
+- **Replies are short by default.** Under 200 words, no headers or tables — for an answer, a review or a status readout as much as for finished work. Offer the detail in one line instead of appending it.
 
 *See below for full detail — these rules are enforced by CI, hooks, and the GitHub ruleset; skipping one because it felt optional is how drift starts.*
 
@@ -216,7 +217,8 @@ decay in 74 days without anyone lifting a finger.
   acted on: **when a finding cites code, cite symbol names plus the commit SHA
   it was verified against, and treat line numbers as a hint.** Every single
   `file:line` reference in that audit had gone stale, and two files had moved
-  directory.
+  directory. This governs a finding you write down — an issue, a PR, a review
+  comment — not the length of a chat reply.
 
 ## Build & Verify
 
@@ -262,23 +264,33 @@ it before writing a timing assertion.
 Applies to every agent in this repo — the main session, in-process subagents,
 and delegated workers (Codex, opencode, the DeepSeek worker, etc.) alike.
 
-- **Human-facing replies are a conversation, not a handoff.** Lead with the
-  outcome in natural language. For a completed task, default to one or two
-  short paragraphs: what changed, then only the check or caveat that matters.
-  Do not repeat progress narration, tool output, or internal process details.
-- **Make a needed decision easy to see.** Ask for it in the first sentence in
-  ordinary language, with the smallest useful amount of context. Do not bury a
-  question in a recap, and do not end a completed task with an implied wait.
-- **Challenge constructively.** When a concern matters, state the evidence,
-  offer a practical alternative, and explain the trade-off briefly. Once the
-  user chooses a reasonable direction, implement it rather than reopening the
-  debate. Raise a true safety, authority, or scope blocker plainly and ask for
-  the specific decision needed.
-- **Be terse.** Skip preamble, restating the request, and narrating what
-  you're about to do. State results and decisions directly.
-- **Stay on the task at hand.** Don't expand scope or chase tangential
-  findings mid-task. Flag out-of-scope issues briefly at the end (or as a
-  follow-up issue) instead of interrupting the current work.
+**Replies are short by default: under 200 words, no headers and no tables.**
+This binds every kind of reply, not only a finished task. An answer to a
+question, a review, an investigation and a status readout are the ones that
+actually run long, and they are covered here. Go longer when the user asks for
+depth, or asks for a list they want enumerated — not because the work was big.
+
+- **Length scales with the work.** A one-line fix gets a one-line summary, not a
+  paragraph. Twenty measurements do not entitle a reply to twenty lines.
+- **Offer the detail, never append it.** When there is more, say so in one
+  sentence and stop: "there are four more findings — want them?" beats four
+  more findings.
+- **Lead with the outcome in natural language.** What is true now, then only the
+  check or caveat that matters. No preamble, no restating the request, no
+  narrating progress, tool output, or internal process.
+- **Evidence you must hold is not evidence you must print.** The Task Router's
+  "Required evidence" column and the citation rule in **Operating notes** say
+  what you must have verified before speaking, not what the reply must carry.
+  Give the conclusion; produce the workings when asked.
+- **Make a needed decision easy to see.** Ask in the first sentence, in ordinary
+  language. Do not bury a question in a recap, and do not end a completed task
+  with an implied wait.
+- **Challenge constructively.** State the concern, offer an alternative, give the
+  trade-off in a sentence. Once the user picks a reasonable direction, implement
+  it rather than reopening the debate. Raise a true safety, authority, or scope
+  blocker plainly and ask for the specific decision needed.
+- **Stay on the task at hand.** Don't chase tangential findings mid-task. Flag
+  an out-of-scope issue in one line at the end, or as a follow-up issue.
 - **Keep structured reports internal.** The
   `STATUS/COMMIT/CHANGED_FILES/CHECKS/RISKS` block is for delegated workers and
   managers, not for user-facing replies. It carries implementation metadata;
@@ -365,6 +377,9 @@ Before editing:
 | CAM, geometry, simulation, or G-code | Engine area index and relevant current design | Focused engine fixtures plus `npm run build`; safety-sensitive assertions |
 | Desktop/platform integration | [`planning/DESKTOP_DESIGN.md`](planning/DESKTOP_DESIGN.md) and `src/platform/` | Browser fallback plus affected native check |
 | Agent harness or delegated execution | This file, [`scripts/INDEX.md`](scripts/INDEX.md), and the named skill | Actual diff, independent verification, and explicit dispatch approval |
+
+**Required evidence** is what you must verify before you speak — not what the
+reply must contain. See **Communication Style** above.
 
 ## Key Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - **Branch, never `main`.** Work on a feature branch; the `main-requires-pr` ruleset blocks merge without a PR.
 - **Build green.** `npm run build` (lint + tsc + tests + icons) must pass before committing.
 - **Worktrees only.** Never edit the primary checkout's working tree — use `git worktree add` outside the repo.
-- **Protected paths → full lane.** `AGENTS.md`, `src/engine/toolpaths/**`, `src/engine/gcode/**`, `src/machine/**`, `.camj` format, `store/types.ts`, gates — plan + approve required.
+- **Protected paths → full lane.** `AGENTS.md`, `src/engine/toolpaths/**`, `src/engine/gcode/**`, `src/machine/**`, `.camj` format, `store/types.ts`, gates, agent entrypoints — plan + approve required.
 - **Close with a PR.** End with a PR containing `Closes #NN`; rebase onto `main` first.
 - **Replies are short by default.** Under 200 words, no headers or tables — for an answer, a review or a status readout as much as for finished work. Offer the detail in one line instead of appending it.
 
@@ -49,7 +49,7 @@ A change that provably cannot affect machine output, saved projects, or the gate
 
 Eligibility is mechanical, never a judgment call. The two halves are answerable at different times.
 
-**Before you write anything — protected paths.** You already know which files you will edit. If any is protected, it is the full lane; decided, no script needed. However small the diff: machine output and safety (`src/engine/toolpaths/**`, `src/engine/gcode/**`, `src/machine/**`, `src/utils/units.ts`), the `.camj` format and its migrations (`src/types/project.ts`, `src/store/helpers/projectFormat.ts`, `src/import/camj.ts`), the frozen `ProjectStore` contract (`src/store/types.ts`), and the process/gate machinery itself (`AGENTS.md`, `PROJECT.md`, `ARCHITECTURE.md`, `.github/**`, `.claude/**`, the gate scripts under `scripts/`, `package.json`, `tsconfig*.json`, `eslint.config.js`). [`scripts/check-fast-lane.sh`](scripts/check-fast-lane.sh) owns the authoritative list — add to it whenever a new gate lands.
+**Before you write anything — protected paths.** You already know which files you will edit. If any is protected, it is the full lane; decided, no script needed. However small the diff: machine output and safety (`src/engine/toolpaths/**`, `src/engine/gcode/**`, `src/machine/**`, `src/utils/units.ts`), the `.camj` format and its migrations (`src/types/project.ts`, `src/store/helpers/projectFormat.ts`, `src/import/camj.ts`), the frozen `ProjectStore` contract (`src/store/types.ts`), and the process/gate machinery itself (`AGENTS.md`, `PROJECT.md`, `ARCHITECTURE.md`, `.github/**`, `.claude/**`, the agent entrypoints (`CLAUDE.md`, `GEMINI.md`, `CONVENTIONS.md` and the `.*rules` files), the gate scripts under `scripts/`, `package.json`, `tsconfig*.json`, `eslint.config.js`). [`scripts/check-fast-lane.sh`](scripts/check-fast-lane.sh) owns the authoritative list — add to it whenever a new gate lands.
 
 **After implementing, before you commit — size.** This needs a real diff, so it cannot be answered earlier. The script re-checks the paths too, so a file set that grew mid-implementation is still caught here:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ reference.
 - **Branch, never `main`.** Work on a feature branch; the `main-requires-pr` ruleset blocks merge without a PR.
 - **Build green.** `npm run build` (lint + tsc + tests + icons) must pass before committing.
 - **Worktrees only.** Never edit the primary checkout's working tree — use `git worktree add` outside the repo.
-- **Protected paths → full lane.** `AGENTS.md` and engine/gcode/machine/format code — plan + approve required.
+- **Protected paths → full lane.** `AGENTS.md`, the agent entrypoints (this file included), and engine/gcode/machine/format code — plan + approve required.
 - **Close with a PR.** End with a PR containing `Closes #NN`; rebase onto `main` first.
 
 Every task gets a GitHub issue; its plan and acceptance criteria live there and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,11 @@ Once a plan is approved, implement it: raise a problem in a sentence and wait,
 rather than re-analysing it, redesigning it, or abandoning it. Do not present
 numbers you did not measure. `AGENTS.md` § Scope Discipline is the full rule.
 
+Replies are short by default: under 200 words, no headers or tables. That covers
+an answer, a review or a status readout as much as finished work — offer the
+detail in one line instead of appending it. `AGENTS.md` § Communication Style is
+the full rule.
+
 Delegation to Codex or a project worker is optional, not the default. Use it
 only when the user authorizes delegation and the approved work divides into
 bounded slices. Never have multiple agents edit the same files concurrently;

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -9,3 +9,8 @@ Every task gets a GitHub issue; its plan and acceptance criteria live there and
 need approval before implementation. Small changes that pass the `AGENTS.md`
 fast-lane check skip the plan and approval, nothing else.
 `planning/` contains durable design references, not implementation plans.
+
+Replies are short by default: under 200 words, no headers or tables. That covers
+an answer, a review or a status readout as much as finished work — offer the
+detail in one line instead of appending it. `AGENTS.md` § Communication Style is
+the full rule.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -9,3 +9,8 @@ Every task gets a GitHub issue; its plan and acceptance criteria live there and
 need approval before implementation. Small changes that pass the `AGENTS.md`
 fast-lane check skip the plan and approval, nothing else.
 `planning/` contains durable design references, not implementation plans.
+
+Replies are short by default: under 200 words, no headers or tables. That covers
+an answer, a review or a status readout as much as finished work — offer the
+detail in one line instead of appending it. `AGENTS.md` § Communication Style is
+the full rule.

--- a/scripts/check-docs.test.ts
+++ b/scripts/check-docs.test.ts
@@ -15,7 +15,7 @@
  */
 
 import assert from 'node:assert/strict'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
@@ -159,8 +159,42 @@ function testEveryAgentEntrypointExists(): void {
   }
 }
 
+// The protected-path list lives in dependency-free bash so CI can run it
+// without `npm ci`, which means it cannot import AGENT_ENTRYPOINTS — and the
+// two lists drifted apart once already (#761). Read the real `case` patterns
+// out of the script and match them here, rather than spawning bash: the Windows
+// desktop build runs this file through `npm run build` (tauri's
+// beforeBuildCommand), where `bash` is not guaranteed to resolve.
+function protectedPathPatterns(scriptText: string): RegExp[] {
+  const body = /^protected_bucket\(\) \{\n([\s\S]*?)\n\}/m.exec(scriptText)?.[1]
+  assert.ok(body, 'protected_bucket() not found in scripts/check-fast-lane.sh')
+  return body
+    .split('\n')
+    .map((line) => /^\s*([^\s#()][^()]*)\)\s*$/.exec(line)?.[1])
+    .filter((clause): clause is string => clause !== undefined)
+    .flatMap((clause) => clause.split('|'))
+    .map((glob) => new RegExp(`^${glob.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')}$`))
+}
+
+function testEveryAgentEntrypointIsFastLaneProtected(): void {
+  const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  const patterns = protectedPathPatterns(
+    readFileSync(join(repositoryRoot, 'scripts/check-fast-lane.sh'), 'utf8'),
+  )
+  // Guard the parser itself: an unmatched glob would make every assertion vacuous.
+  assert.ok(patterns.some((pattern) => pattern.test('src/engine/toolpaths/pocket.ts')))
+  assert.ok(!patterns.some((pattern) => pattern.test('src/app/App.tsx')))
+  for (const file of AGENT_ENTRYPOINTS) {
+    assert.ok(
+      patterns.some((pattern) => pattern.test(file)),
+      `${file} is an agent entrypoint but scripts/check-fast-lane.sh does not protect it`,
+    )
+  }
+}
+
 testUnreadableReadBecomesProblem()
 testEveryAgentEntrypointExists()
+testEveryAgentEntrypointIsFastLaneProtected()
 testFrontmatterParsing()
 testPlanningMetadataValidation()
 testMarkdownLinkExtractionAndNormalization()

--- a/scripts/check-docs.test.ts
+++ b/scripts/check-docs.test.ts
@@ -109,7 +109,7 @@ function testDocumentLinkValidation(): void {
 }
 
 function testAgentEntrypointValidation(): void {
-  const valid = 'INDEX.md PROJECT.md AGENTS.md GitHub issue durable design'
+  const valid = 'INDEX.md PROJECT.md AGENTS.md GitHub issue durable design Replies are short by default'
   assert.deepEqual(validateAgentEntrypoint('CLAUDE.md', valid), [])
   assert.deepEqual(
     validateAgentEntrypoint('CLAUDE.md', 'INDEX.md').map((problem) => problem.message),
@@ -118,6 +118,7 @@ function testAgentEntrypointValidation(): void {
       'agent entrypoint is missing AGENTS.md',
       'agent entrypoint is missing GitHub issue',
       'agent entrypoint is missing durable design',
+      'agent entrypoint is missing Replies are short by default',
     ],
   )
 }

--- a/scripts/check-fast-lane.sh
+++ b/scripts/check-fast-lane.sh
@@ -65,6 +65,12 @@ protected_bucket() {
       echo 'frozen ProjectStore contract' ;;
     AGENTS.md|PROJECT.md|ARCHITECTURE.md|.github/*|.claude/*|package.json|tsconfig*.json|eslint.config.js)
       echo 'process & gate machinery' ;;
+    # Every normalized agent entrypoint (AGENT_ENTRYPOINTS in
+    # scripts/docs-check-core.ts) carries the same load-bearing rules, so it is
+    # process machinery too; .github/copilot-instructions.md is covered above.
+    # scripts/check-docs.test.ts fails the build if one is missing here (#761).
+    CLAUDE.md|GEMINI.md|CONVENTIONS.md|.cursorrules|.clinerules|.clauderules|.roorules|.windsurfrules)
+      echo 'agent entrypoints' ;;
     # Gate logic under scripts/. Anything whose corruption would silently weaken
     # a gate belongs here — not just check-*. Add to this list when a new gate
     # lands; scripts/backlog-hygiene.ts arrived after the first draft and was

--- a/scripts/docs-check-core.ts
+++ b/scripts/docs-check-core.ts
@@ -38,12 +38,18 @@ export const AGENT_ENTRYPOINTS = [
   '.windsurfrules',
 ] as const
 
+// Every normalized entrypoint must carry the same load-bearing rules, so an
+// agent driven by its own native file (Codex, Gemini, Cursor, Cline, Roo,
+// Windsurf, Copilot, Claude) gets them without opening AGENTS.md first.
+// 'Replies are short by default' is here because the reply-length rule lived
+// only in AGENTS.md and never reached any of them (#761).
 const REQUIRED_AGENT_MARKERS = [
   'INDEX.md',
   'PROJECT.md',
   'AGENTS.md',
   'GitHub issue',
   'durable design',
+  'Replies are short by default',
 ] as const
 
 const ALLOWED_PLANNING_STATUSES = new Set(['current', 'proposed'])


### PR DESCRIPTION
## Summary

- Rewrite `AGENTS.md` §"Communication Style" so the length rule binds **every**
  kind of reply — an answer, a review, an investigation, a status readout — and
  not only a completed task, with a default an agent can check itself against
  (under 200 words, no headers or tables) and the pre-#693 "length scales with
  the work" clause restored.
- Add a reply bullet to the Critical Path block, which until now carried six
  process gates and nothing about output.
- Mirror the one-line rule into all nine normalized entrypoints, so a Codex,
  Gemini, Cursor, Cline, Roo, Windsurf, Copilot or Claude session gets it in its
  own native file instead of only after opening `AGENTS.md`.
- Enforce that with a new `REQUIRED_AGENT_MARKERS` entry, so `npm run docs:check`
  fails when an entrypoint drops the rule.
- Separate evidence you must *hold* from evidence you must *print*: the Task
  Router's "Required evidence" column and the Backlog Contract's cite-symbol-and-
  SHA note are verification requirements, and both were reading as reply contents.

## Why

#693 shipped its approved plan exactly — every step in #692 said "update
`AGENTS.md`", and its first acceptance criterion bound *completion* messages.
That left the categories that actually run long unbounded, put the only copy of
the rule ~260 lines into a file most agents have to be told to open, and replaced
*"a one-line fix gets a one-line summary"* with a rule about internal reports.

## Verification

- `npm run build` — green.
- Mutation-checked the new gate rather than trusting a green run: deleting the
  rule from `.roorules` fails `docs:check` with
  `agent entrypoint is missing Replies are short by default`, and restoring it
  passes.
- `npm run check:fast-lane` — correctly NOT eligible (protected paths); this went
  the full lane via #761, no `fast-lane` label.

## Also: protect the agent entrypoints (scope addition on #761)

`CLAUDE.md`, `GEMINI.md`, `CONVENTIONS.md` and the five `.*rules` files were
missing from `protected_bucket()` in `scripts/check-fast-lane.sh` — only
`.github/copilot-instructions.md` was covered — so an entrypoint edit could claim
the fast lane. They are protected now, the protected-path wording in `AGENTS.md`
and `CLAUDE.md` says so, and `scripts/check-docs.test.ts` parses the script's
real `case` patterns and fails the build when an `AGENT_ENTRYPOINTS` file is
unprotected. It is pure TS rather than a bash spawn because the Windows desktop
build runs `npm run build` through tauri's `beforeBuildCommand`. Mutation-checked:
dropping `.roorules` from the gate fails the test with
`.roorules is an agent entrypoint but scripts/check-fast-lane.sh does not protect it`.

Closes #761
