### PR TITLE
fix(onboarding): keep the empty-state card off a newly created project (#769)

### DIFF
--- a/e2e/canvasWorkflowPanel.smoke.spec.ts
+++ b/e2e/canvasWorkflowPanel.smoke.spec.ts
@@ -171,3 +171,22 @@ test('a qualifying selection joins with no panel at all (issue #522)', async ({ 
   await expect.poll(() => getFeatureCount(app.page)).toBe(1)
   await expect(app.page.locator('.canvas-workflow-panel--join')).toHaveCount(0)
 })
+
+test('a new project lands on the sketch view with no empty-state card (issue #769)', async ({ app, ui }) => {
+  const card = app.page.locator('.empty-state-card')
+
+  // The blank document the app opens with still gets the first-run nudge.
+  await expect(card).toBeVisible()
+
+  await ui.toolbar.newProjectButton(app.page).click()
+  const dialog = ui.newProjectDialog.root(app.page)
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Create project' }).click()
+
+  await expect(dialog).toHaveCount(0)
+
+  // The nudge belongs to the boot document only. A project the user deliberately
+  // created must land on the sketch view drawable, not behind the card.
+  await expect(card).toHaveCount(0)
+  await expect(app.page.locator('#workspace-panel-sketch')).toHaveClass(/centre-view--active/)
+})

--- a/src/app/useEmptyStateEngagement.ts
+++ b/src/app/useEmptyStateEngagement.ts
@@ -48,11 +48,16 @@ export function useEmptyStateEngagement({
   onDismiss: () => void
   frameOpenedProject: () => void
 } {
-  // The empty-state overlay is a one-time nudge per project. Once the user has
-  // engaged (started any draw, opened import, or the project has features), it
-  // stays dismissed — so cancelling a draw or deleting the last feature keeps
-  // them on the sketch view instead of popping the overlay back up.
+  // The empty-state overlay is a one-time nudge for the blank document the app
+  // opens with. Once the user has engaged (started any draw, opened import, or
+  // the project has features), it stays dismissed — so cancelling a draw or
+  // deleting the last feature keeps them on the sketch view instead of popping
+  // the overlay back up.
   const [emptyStateEngaged, setEmptyStateEngaged] = useState(false)
+
+  // Keyed to the boot document: a project the user created or opened must land
+  // on the sketch view unobstructed, never behind the card (issue #769).
+  const [bootProjectKey] = useState(projectKey)
 
   function handleEmptyStateDraw() {
     setCenterTab('sketch')
@@ -79,12 +84,6 @@ export function useEmptyStateEngagement({
     })
   }
 
-  // Reset the one-time empty-state nudge for each new/opened project.
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setEmptyStateEngaged(false)
-  }, [projectKey])
-
   // Latch engagement once the project has any feature or a draw is in progress
   // (covers toolbar draws too), so the overlay doesn't reappear after a cancel
   // or after deleting the last feature.
@@ -96,7 +95,7 @@ export function useEmptyStateEngagement({
   }, [featureCount, pendingAdd])
 
   return {
-    emptyStateEngaged,
+    emptyStateEngaged: emptyStateEngaged || projectKey !== bootProjectKey,
     onDraw: handleEmptyStateDraw,
     onImport: handleEmptyStateImport,
     onDismiss: handleDismiss,


### PR DESCRIPTION
Closes #769

`useEmptyStateEngagement` reset the one-time nudge on every `projectKey` change, so a project created from the New Project dialog — or opened — got the card back over the sketch view the dialog had just framed. The nudge is now keyed to the boot document, so any later project lands on the sketch view unobstructed. First-run behaviour is unchanged: the blank document the app opens with still shows the card.

## Verification

- `npm run build` — green (docs, lint, icons, tsc, structural tests, vite).
- `e2e/canvasWorkflowPanel.smoke.spec.ts` — whole file 7 passed on an isolated server (`PURECUT_E2E_ISOLATED=1 PURECUT_E2E_PORT=1431 npx playwright test e2e/canvasWorkflowPanel.smoke.spec.ts`), including the new test `a new project lands on the sketch view with no empty-state card (issue #769)`.
- Mutation check: with `src/app/useEmptyStateEngagement.ts` reverted to `HEAD`, the new test fails on `expect(card).toHaveCount(0)` with the card still rendering (1 element); the boot `toBeVisible()` assertion passes in both runs, so it is the fix the test detects.

Fast lane: `npm run check:fast-lane` green — 1 counted file, 21/25 lines.
