### PR TITLE
docs(agents): require completion replies to name test surface and code location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,15 @@ depth, or asks for a list they want enumerated — not because the work was big.
 - **Lead with the outcome in natural language.** What is true now, then only the
   check or caveat that matters. No preamble, no restating the request, no
   narrating progress, tool output, or internal process.
+- **Close testable work with a testing handoff.** When a reply reports an
+  implementation or any other change the maintainer can test, it says briefly
+  what changed and what to test — the behaviour to check and where it shows up
+  (a UI panel or flow, a fixture, a spec) — then gives the exact worktree path
+  and branch and the code locations that matter (`file:line` or symbol names).
+  Describe the test surface only; do not add instructions for launching the
+  app. When nothing needs manual testing, say so in one line and name the
+  automated check that covers it, if one does. The handoff is prose inside the
+  short reply, not a report block.
 - **Evidence you must hold is not evidence you must print.** The Task Router's
   "Required evidence" column and the citation rule in **Operating notes** say
   what you must have verified before speaking, not what the reply must carry.


### PR DESCRIPTION
Closes #772

Adds a **Close testable work with a testing handoff** bullet to `AGENTS.md` § Communication Style, so every agent's completion reply says what changed and what to test (the behaviour and where it shows up), then the exact worktree path, branch, and code locations. It describes the test surface only, with no app-launch instructions. When nothing needs manual testing, the reply says so and names the covering check. The handoff stays inside the existing short-reply rule, written as prose.

The agent entrypoints are unchanged: each already sends readers to `AGENTS.md` § Communication Style for the full rule.

Full lane, not fast lane: `AGENTS.md` is a protected path. The plan and acceptance criteria are in the issue.

Verification: `npm run build` (includes `docs:check`) passes. No e2e: this is a docs-only change.
